### PR TITLE
[BEAM-3612] Closurize method invocations

### DIFF
--- a/sdks/go/pkg/beam/core/graph/fn.go
+++ b/sdks/go/pkg/beam/core/graph/fn.go
@@ -101,6 +101,17 @@ func NewFn(fn interface{}) (*Fn, error) {
 
 	case reflect.Struct:
 		methods := make(map[string]*funcx.Fn)
+		if methodsFuncs, ok := reflectx.WrapMethods(fn); ok {
+			for name, mfn := range methodsFuncs {
+				f, err := funcx.New(mfn)
+				if err != nil {
+					return nil, fmt.Errorf("method %v invalid: %v", name, err)
+				}
+				methods[name] = f
+			}
+			return &Fn{Recv: fn, methods: methods}, nil
+		}
+		// TODO(lostluck): Consider moving this into the reflectx package.
 		for i := 0; i < val.Type().NumMethod(); i++ {
 			m := val.Type().Method(i)
 			if m.PkgPath != "" {

--- a/sdks/go/pkg/beam/core/util/reflectx/call.go
+++ b/sdks/go/pkg/beam/core/util/reflectx/call.go
@@ -55,7 +55,7 @@ func RegisterFunc(t reflect.Type, maker func(interface{}) Func) {
 
 	key := t.String()
 	if _, exists := funcs[key]; exists {
-		log.Warnf(context.Background(), "Func for %v already registered. Overwriting.", key)
+		log.Debugf(context.Background(), "Func for %v already registered. Overwriting.", key)
 	}
 	funcs[key] = maker
 }

--- a/sdks/go/pkg/beam/core/util/reflectx/structs.go
+++ b/sdks/go/pkg/beam/core/util/reflectx/structs.go
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reflectx
+
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/log"
+)
+
+var (
+	structFuncs   = make(map[string]func(interface{}) map[string]Func)
+	structFuncsMu sync.Mutex
+)
+
+// RegisterStructWrapper takes in the reflect.Type of a structural DoFn, and
+// a wrapping function that will take an instance of that struct type and
+// produce a map of method names to of closured Funcs that call the method
+// on the instance of the struct.
+//
+// The goal is to avoid the implicit reflective method invocation penalty
+// that occurs when passing a method through the reflect package.
+func RegisterStructWrapper(t reflect.Type, wrapper func(interface{}) map[string]Func) {
+	structFuncsMu.Lock()
+	defer structFuncsMu.Unlock()
+
+	if t.Kind() != reflect.Struct {
+		log.Fatalf(context.Background(), "RegisterStructWrapper for %v should be a struct type, but was %v", t, t.Kind())
+	}
+
+	key := t.String()
+	if _, exists := funcs[key]; exists {
+		log.Warnf(context.Background(), "StructWrapper for %v already registered. Overwriting.", key)
+	}
+	structFuncs[key] = wrapper
+}
+
+// WrapMethods takes in a struct value as an interface, and returns a map of
+// method names to Funcs of those methods wrapped in a closure for the struct instance.
+func WrapMethods(fn interface{}) (map[string]Func, bool) {
+	return wrapMethodsKeyed(reflect.TypeOf(fn), fn)
+}
+
+// WrapMethodsKeyed takes in a struct value as an interface
+func wrapMethodsKeyed(t reflect.Type, fn interface{}) (map[string]Func, bool) {
+	structFuncsMu.Lock()
+	defer structFuncsMu.Unlock()
+	// Registering happens on the value, not the proto type.
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	key := t.String()
+	if f, exists := structFuncs[key]; exists {
+		log.Debugf(context.Background(), "EXTRACTING StructWrapper for %v", key)
+		return f(fn), true
+	}
+	return nil, false
+}

--- a/sdks/go/pkg/beam/util/shimx/generate_test.go
+++ b/sdks/go/pkg/beam/util/shimx/generate_test.go
@@ -215,3 +215,20 @@ func TestMktuplef(t *testing.T) {
 		}
 	}
 }
+
+func TestMkrets(t *testing.T) {
+	tests := []struct {
+		types  []string
+		format string
+		want   string
+	}{
+		{types: nil, format: "%v", want: ""},
+		{types: []string{}, format: "%v", want: ""},
+		{types: []string{"Foo", "baz", "*imp.Bar"}, format: "%v", want: "Foo, baz, *imp.Bar"},
+	}
+	for _, test := range tests {
+		if got := mkrets(test.format, test.types); got != test.want {
+			t.Errorf("mkrets(%v,%v) = %v, want %v", test.format, test.types, got, test.want)
+		}
+	}
+}

--- a/sdks/go/pkg/beam/util/starcgenx/starcgenx_test.go
+++ b/sdks/go/pkg/beam/util/starcgenx/starcgenx_test.go
@@ -43,8 +43,8 @@ func TestExtractor(t *testing.T) {
 			expected: []string{"runtime.RegisterFunction(iterFn)", "funcMakerStringIterIntГ", "iterMakerInt"},
 		},
 		{name: "structs1", files: []string{structs}, pkg: "structs", ids: []string{"myDoFn"},
-			expected: []string{"runtime.RegisterType(reflect.TypeOf((*myDoFn)(nil)).Elem())", "funcMakerEmitIntГ", "emitMakerInt", "funcMakerValTypeValTypeEmitIntГ", "runtime.RegisterType(reflect.TypeOf((*valType)(nil)).Elem())"},
-			excluded: []string{"funcMakerStringГ", "emitMakerString", "nonPipelineType"},
+			expected: []string{"runtime.RegisterType(reflect.TypeOf((*myDoFn)(nil)).Elem())", "funcMakerEmitIntГ", "emitMakerInt", "funcMakerValTypeValTypeEmitIntГ", "runtime.RegisterType(reflect.TypeOf((*valType)(nil)).Elem())", "reflectx.RegisterStructWrapper(reflect.TypeOf((*myDoFn)(nil)).Elem(), wrapMakerMyDoFn)"},
+			excluded: []string{"funcMakerStringГ", "emitMakerString", "nonPipelineType", "UnrelatedMethod1", "UnrelatedMethod2", "UnrelatedMethod3"},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
This wraps structuralDoFns in closures to avoid re-working the entire function analysis and binding stack. If we're going to generate code anyway, we may as well go all in.
Amends the benchmarks to include the "closurized" variation, and re-works the variable names to be (I hope) clearer than the previous iteration.

This is about the end of improving performance of StruturalDoFns invocation. Using the generation tool, it's possible to invoke methods ~20x faster than the reflective default path.

It's probably possible to do better by generating truly *per function/per method* specializations, rather than balancing with binary size, and always jump from the interface{} args straight to the actual function call, but I think we'd want to have that as an option in the shimx or starcgen packages, rather than do it all the time. That would permit users to balance binary size against speed.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




