### PR TITLE
Add packageDeclaration Checkstyle check + fix an issue it threw up

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -155,6 +155,8 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
       <property name="severity" value="error"/>
     </module>
+ 
+    <module name="PackageDeclaration" />
 
     <module name="TypeNameCheck">
       <!-- Validates static, final fields against the

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/FieldTypeDescriptorsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/FieldTypeDescriptorsTest.java
@@ -15,13 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.schemas.transforms;
+package org.apache.beam.sdk.schemas;
 
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import org.apache.beam.sdk.schemas.FieldTypeDescriptors;
-import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;


### PR DESCRIPTION
One of the tests has a package name that doesn't match the directory location. This fixes the issue and ensures it can't happen again by adding the associated Checkstyle rule.