### PR TITLE
[BEAM-6032] Move PortableValidatesRunner configuration out of BeamModulePlugin

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -251,23 +251,9 @@ class BeamModulePlugin implements Plugin<Project> {
     // Categories for tests to run.
     Closure testCategories = {
       includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
-      excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
-      excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesAttemptedMetrics'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesCounterMetrics'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesDistributionMetrics'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesFailureMessage'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesGaugeMetrics'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
-      //SplitableDoFnTests
-      excludeCategories 'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+      // Use the following to include / exclude categories:
+      // includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+      // excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
     }
     // Configuration for the classpath when running the test.
     Configuration testClasspathConfiguration

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -157,4 +157,27 @@ createJavaExamplesArchetypeValidationTask(type: 'MobileGaming',
   bqDataset: bqDataset,
   pubsubTopic: pubsubTopic)
 
-createPortableValidatesRunnerTask(jobServerDriver: "org.apache.beam.runners.direct.portable.job.ReferenceRunnerJobServer", testClasspathConfiguration: configurations.validatesPortableRunner)
+createPortableValidatesRunnerTask(
+        jobServerDriver: "org.apache.beam.runners.direct.portable.job.ReferenceRunnerJobServer",
+        testClasspathConfiguration: configurations.validatesPortableRunner,
+        testCategories: {
+          includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+          excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
+          excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesAttemptedMetrics'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesCounterMetrics'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesDistributionMetrics'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesFailureMessage'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesGaugeMetrics'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
+          //SplitableDoFnTests
+          excludeCategories 'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+        },
+)

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -81,7 +81,27 @@ def portableValidatesRunnerTask(String name, Boolean streaming) {
           jobServerConfig: "--clean-artifacts-per-job,--job-host=localhost,--job-port=0,--artifact-port=0",
           testClasspathConfiguration: configurations.validatesPortableRunner,
           parallelism: 2,
-          pipelineOpts: streaming ? ["--streaming"] : []
+          pipelineOpts: streaming ? ["--streaming"] : [],
+          testCategories: {
+            includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+            excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
+            excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesAttemptedMetrics'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesCounterMetrics'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesDistributionMetrics'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesFailureMessage'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesGaugeMetrics'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
+            //SplitableDoFnTests
+            excludeCategories 'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs'
+            excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+          },
   )
 }
 


### PR DESCRIPTION
This moves the test inclusions/exclusion from the BeamModulePlugin into the
specific Runner Gradle file.

CC: @angoenka @ryan-williams @tweise 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




