### PR TITLE
[BEAM-2939] Add support for backlog reporting to byte key and offset restriction trackers.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/Restrictions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/Restrictions.java
@@ -25,5 +25,5 @@ public final class Restrictions {
    * authors mark their restriction type with this interface if the restriction produces a bounded
    * amount of output.
    */
-  interface IsBounded {}
+  public interface IsBounded {}
 }

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
@@ -18,12 +18,15 @@
 package org.apache.beam.sdk.fn.splittabledofn;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.fn.splittabledofn.RestrictionTrackers.ClaimObserver;
+import org.apache.beam.sdk.transforms.splittabledofn.Backlog;
+import org.apache.beam.sdk.transforms.splittabledofn.Backlogs;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,5 +83,74 @@ public class RestrictionTrackersTest {
     observingTracker.tryClaim("badClaim");
 
     assertThat(positionsObserved, contains("goodClaim", "badClaim"));
+  }
+
+  private static class RestrictionTrackerWithBacklog extends RestrictionTracker<Object, Object>
+      implements Backlogs.HasBacklog {
+
+    @Override
+    public Backlog getBacklog() {
+      return null;
+    }
+
+    @Override
+    public boolean tryClaim(Object position) {
+      return false;
+    }
+
+    @Override
+    public Object currentRestriction() {
+      return null;
+    }
+
+    @Override
+    public Object checkpoint() {
+      return null;
+    }
+
+    @Override
+    public void checkDone() throws IllegalStateException {}
+  }
+
+  private static class RestrictionTrackerWithBacklogPartitionedBacklog
+      extends RestrictionTracker<Object, Object> implements Backlogs.HasPartitionedBacklog {
+
+    @Override
+    public Backlog getBacklog() {
+      return null;
+    }
+
+    @Override
+    public boolean tryClaim(Object position) {
+      return false;
+    }
+
+    @Override
+    public Object currentRestriction() {
+      return null;
+    }
+
+    @Override
+    public Object checkpoint() {
+      return null;
+    }
+
+    @Override
+    public void checkDone() throws IllegalStateException {}
+
+    @Override
+    public byte[] getBacklogPartition() {
+      return null;
+    }
+  }
+
+  @Test
+  public void testClaimObserversMaintainBacklogInterfaces() {
+    RestrictionTracker hasBacklog =
+        RestrictionTrackers.observe(new RestrictionTrackerWithBacklog(), null);
+    assertThat(hasBacklog, instanceOf(Backlogs.HasBacklog.class));
+    RestrictionTracker hasPartitionedBacklog =
+        RestrictionTrackers.observe(new RestrictionTrackerWithBacklogPartitionedBacklog(), null);
+    assertThat(hasPartitionedBacklog, instanceOf(Backlogs.HasPartitionedBacklog.class));
   }
 }


### PR DESCRIPTION
Make observing a restriction tracker support getting the backlog and partition identifier.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




