### PR TITLE
[BEAM-6155] Updates the GCS library the Go SDK uses.

### DIFF
--- a/sdks/go/pkg/beam/artifact/gcsproxy/staging.go
+++ b/sdks/go/pkg/beam/artifact/gcsproxy/staging.go
@@ -26,11 +26,11 @@ import (
 	"path"
 	"sync"
 
+	"cloud.google.com/go/storage"
 	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/gcsx"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
-	"google.golang.org/api/storage/v1"
 )
 
 // StagingServer is a artifact staging server backed by Google Cloud Storage
@@ -81,7 +81,7 @@ func (s *StagingServer) CommitManifest(ctx context.Context, req *pb.CommitManife
 		return nil, fmt.Errorf("failed to marshal proxy manifest: %v", err)
 	}
 
-	cl, err := gcsx.NewClient(ctx, storage.DevstorageReadWriteScope)
+	cl, err := gcsx.NewClient(ctx, storage.ScopeReadWrite)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GCS client: %v", err)
 	}
@@ -135,7 +135,7 @@ func (s *StagingServer) PutArtifact(ps pb.ArtifactStagingService_PutArtifactServ
 	// Stream content to GCS. We don't have to worry about partial
 	// or abandoned writes, because object writes are atomic.
 
-	cl, err := gcsx.NewClient(ps.Context(), storage.DevstorageReadWriteScope)
+	cl, err := gcsx.NewClient(ps.Context(), storage.ScopeReadWrite)
 	if err != nil {
 		return fmt.Errorf("failed to create GCS client: %v", err)
 	}

--- a/sdks/go/pkg/beam/io/filesystem/gcs/gcs.go
+++ b/sdks/go/pkg/beam/io/filesystem/gcs/gcs.go
@@ -18,17 +18,18 @@
 package gcs
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 
+	"cloud.google.com/go/storage"
 	"github.com/apache/beam/sdks/go/pkg/beam/io/filesystem"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/gcsx"
-	"google.golang.org/api/storage/v1"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 )
 
 func init() {
@@ -36,28 +37,27 @@ func init() {
 }
 
 type fs struct {
-	client *storage.Service
+	client *storage.Client
 }
 
 // New creates a new Google Cloud Storage filesystem using application
 // default credentials. If it fails, it falls back to unauthenticated
 // access.
 func New(ctx context.Context) filesystem.Interface {
-	client, err := gcsx.NewClient(ctx, storage.DevstorageReadWriteScope)
+	client, err := storage.NewClient(ctx, option.WithScopes(storage.ScopeReadWrite))
 	if err != nil {
 		log.Warnf(ctx, "Warning: falling back to unauthenticated GCS access: %v", err)
 
-		client, err = gcsx.NewUnauthenticatedClient(ctx)
+		client, err = storage.NewClient(ctx, option.WithoutAuthentication())
 		if err != nil {
-			panic(fmt.Sprintf("failed to create GCE client: %v", err))
+			panic(fmt.Sprintf("failed to create GCS client: %v", err))
 		}
 	}
 	return &fs{client: client}
 }
 
 func (f *fs) Close() error {
-	f.client = nil
-	return nil
+	return f.client.Close()
 }
 
 func (f *fs) List(ctx context.Context, glob string) ([]string, error) {
@@ -72,24 +72,28 @@ func (f *fs) List(ctx context.Context, glob string) ([]string, error) {
 		// For now, we assume * is the first matching character to make a
 		// prefix listing and not list the entire bucket.
 
-		err := f.client.Objects.List(bucket).Prefix(object[:index]).Pages(ctx, func(list *storage.Objects) error {
-			for _, obj := range list.Items {
-				match, err := filepath.Match(object, obj.Name)
-				if err != nil {
-					return err
-				}
-				if match {
-					candidates = append(candidates, obj.Name)
-				}
-			}
-			return nil
+		it := f.client.Bucket(bucket).Objects(ctx, &storage.Query{
+			Prefix: object[:index],
 		})
-		if err != nil {
-			return nil, err
+		for {
+			obj, err := it.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			match, err := filepath.Match(object, obj.Name)
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				candidates = append(candidates, obj.Name)
+			}
 		}
 	} else {
 		// Single object.
-
 		candidates = []string{object}
 	}
 
@@ -106,11 +110,7 @@ func (f *fs) OpenRead(ctx context.Context, filename string) (io.ReadCloser, erro
 		return nil, err
 	}
 
-	resp, err := f.client.Objects.Get(bucket, object).Download()
-	if err != nil {
-		return nil, err
-	}
-	return resp.Body, nil
+	return f.client.Bucket(bucket).Object(object).NewReader(ctx)
 }
 
 // TODO(herohde) 7/12/2017: should we create the bucket in OpenWrite? For now, "no".
@@ -120,20 +120,6 @@ func (f *fs) OpenWrite(ctx context.Context, filename string) (io.WriteCloser, er
 	if err != nil {
 		return nil, err
 	}
-	return &writer{client: f.client, bucket: bucket, object: object}, nil
-}
 
-type writer struct {
-	client         *storage.Service
-	bucket, object string
-
-	buf bytes.Buffer
-}
-
-func (w *writer) Write(data []byte) (n int, err error) {
-	return w.buf.Write(data)
-}
-
-func (w *writer) Close() error {
-	return gcsx.WriteObject(w.client, w.bucket, w.object, &w.buf)
+	return f.client.Bucket(bucket).Object(object).NewWriter(ctx), nil
 }

--- a/sdks/go/pkg/beam/runners/dataflow/dataflow.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/apache/beam/sdks/go/pkg/beam"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/hooks"
@@ -39,7 +40,6 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/util/gcsx"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/hooks/perf"
 	"github.com/golang/protobuf/proto"
-	"google.golang.org/api/storage/v1"
 )
 
 // TODO(herohde) 5/16/2017: the Dataflow flags should match the other SDKs.
@@ -178,7 +178,7 @@ func gcsRecorderHook(opts []string) perf.CaptureHook {
 	}
 
 	return func(ctx context.Context, spec string, r io.Reader) error {
-		client, err := gcsx.NewClient(ctx, storage.DevstorageReadWriteScope)
+		client, err := gcsx.NewClient(ctx, storage.ScopeReadWrite)
 		if err != nil {
 			return fmt.Errorf("couldn't establish GCS client: %v", err)
 		}

--- a/sdks/go/pkg/beam/util/gcsx/gcs_test.go
+++ b/sdks/go/pkg/beam/util/gcsx/gcs_test.go
@@ -13,44 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package dataflowlib
+package gcsx_test
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"io"
-	"os"
 
 	"cloud.google.com/go/storage"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/gcsx"
 )
 
-// StageModel uploads the pipeline model to GCS as a unique object.
-func StageModel(ctx context.Context, project, modelURL string, model []byte) error {
-	return upload(ctx, project, modelURL, bytes.NewReader(model))
-}
-
-// StageFile uploads a file to GCS.
-func StageFile(ctx context.Context, project, url, filename string) error {
-	fd, err := os.Open(filename)
+func Example() {
+	ctx := context.Background()
+	c, err := gcsx.NewClient(ctx, storage.ScopeReadOnly)
 	if err != nil {
-		return fmt.Errorf("failed to open file %s: %v", filename, err)
+		// do something
 	}
-	defer fd.Close()
 
-	return upload(ctx, project, url, fd)
-}
+	buckets, object, err := gcsx.ParseObject("gs://some-bucket/some-object")
+	if err != nil {
+		// do something
+	}
 
-func upload(ctx context.Context, project, object string, r io.Reader) error {
-	bucket, obj, err := gcsx.ParseObject(object)
+	bytes, err := gcsx.ReadObject(c, buckets, object)
 	if err != nil {
-		return fmt.Errorf("invalid staging location %v: %v", object, err)
+		// do something
 	}
-	client, err := gcsx.NewClient(ctx, storage.ScopeReadWrite)
-	if err != nil {
-		return err
-	}
-	_, err = gcsx.Upload(client, project, bucket, obj, r)
-	return err
+
+	_ = bytes
 }


### PR DESCRIPTION
Updates the GCS library the Go SDK uses. This keeps the API the same, but uses the modern GCS library which correctly supports contexts, exponential backoff, etc

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




