### PR TITLE
[BEAM-6165] send metrics to Flink in portable Flink runner

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionCell.java
@@ -57,6 +57,11 @@ public class DistributionCell implements Distribution, MetricCell<DistributionDa
     update(DistributionData.singleton(n));
   }
 
+  @Override
+  public void update(long sum, long count, long min, long max) {
+    update(DistributionData.create(sum, count, min, max));
+  }
+
   void update(DistributionData data) {
     DistributionData original;
     do {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.flink;
 
+import static org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.getDefaultLocalParallelism;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import java.util.List;
@@ -132,7 +134,9 @@ public class FlinkExecutionEnvironments {
 
     // depending on the master, create the right environment.
     if ("[local]".equals(masterUrl)) {
-      flinkStreamEnv = StreamExecutionEnvironment.createLocalEnvironment();
+      flinkStreamEnv =
+          StreamExecutionEnvironment.createLocalEnvironment(
+              getDefaultLocalParallelism(), flinkConfig);
     } else if ("[auto]".equals(masterUrl)) {
       flinkStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     } else if (masterUrl.matches(".*:\\d*")) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FileReporter.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FileReporter.java
@@ -27,7 +27,8 @@ import org.apache.flink.metrics.reporter.AbstractReporter;
 
 /**
  * Flink {@link org.apache.flink.metrics.reporter.MetricReporter metrics reporter} for writing
- * metrics to a file (specified via the "metrics.reporter.test.file" config key).
+ * metrics to a file specified via the "metrics.reporter.file.path" config key (assuming an alias of
+ * "file" for this reporter in the "metrics.reporters" setting).
  */
 public class FileReporter extends AbstractReporter {
   @Override
@@ -35,20 +36,20 @@ public class FileReporter extends AbstractReporter {
     return input;
   }
 
-  private String file;
+  private String path;
   private PrintStream ps;
 
   @Override
   public void open(MetricConfig config) {
     synchronized (this) {
-      if (file == null) {
-        file = config.getString("file", null);
-        log.info("Opening file: {}", file);
-        if (file == null) {
-          throw new IllegalStateException("FileReporter metrics config needs 'file' key");
+      if (path == null) {
+        path = config.getString("path", null);
+        log.info("Opening file: {}", path);
+        if (path == null) {
+          throw new IllegalStateException("FileReporter metrics config needs 'path' key");
         }
         try {
-          FileOutputStream fos = new FileOutputStream(file);
+          FileOutputStream fos = new FileOutputStream(path);
           ps = new PrintStream(fos);
         } catch (FileNotFoundException e) {
           throw new IllegalStateException("FileReporter couldn't open file", e);
@@ -69,6 +70,6 @@ public class FileReporter extends AbstractReporter {
   @Override
   public void close() {
     ps.close();
-    log.info("wrote metrics to {}", file);
+    log.info("wrote metrics to {}", path);
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FileReporter.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FileReporter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.metrics;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.reporter.AbstractReporter;
+
+/**
+ * Flink {@link org.apache.flink.metrics.reporter.MetricReporter metrics reporter} for writing
+ * metrics to a file (specified via the "metrics.reporter.test.file" config key).
+ */
+public class FileReporter extends AbstractReporter {
+  @Override
+  public String filterCharacters(String input) {
+    return input;
+  }
+
+  private String file;
+  private PrintStream ps;
+
+  @Override
+  public void open(MetricConfig config) {
+    synchronized (this) {
+      if (file == null) {
+        file = config.getString("file", null);
+        log.info("Opening file: {}", file);
+        if (file == null) {
+          throw new IllegalStateException("FileReporter metrics config needs 'file' key");
+        }
+        try {
+          FileOutputStream fos = new FileOutputStream(file);
+          ps = new PrintStream(fos);
+        } catch (FileNotFoundException e) {
+          throw new IllegalStateException("FileReporter couldn't open file", e);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void notifyOfRemovedMetric(Metric metric, String metricName, MetricGroup group) {
+    final String name = group.getMetricIdentifier(metricName, this);
+    super.notifyOfRemovedMetric(metric, metricName, group);
+    synchronized (this) {
+      ps.printf("%s: %s%n", name, Metrics.toString(metric));
+    }
+  }
+
+  @Override
+  public void close() {
+    ps.close();
+    log.info("wrote metrics to {}", file);
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/Metrics.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/Metrics.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.metrics;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.Metric;
+
+/** Helper for pretty-printing {@link Metric Flink metrics}. */
+public class Metrics {
+  public static String toString(Metric metric) {
+    if (metric instanceof Counter) {
+      return Long.toString(((Counter) metric).getCount());
+    } else if (metric instanceof Gauge) {
+      return ((Gauge) metric).getValue().toString();
+    } else if (metric instanceof Meter) {
+      return Double.toString(((Meter) metric).getRate());
+    } else if (metric instanceof Histogram) {
+      HistogramStatistics stats = ((Histogram) metric).getStatistics();
+      return String.format(
+          "count=%d, min=%d, max=%d, mean=%f, stddev=%f, p50=%f, p75=%f, p95=%f",
+          stats.size(),
+          stats.getMin(),
+          stats.getMax(),
+          stats.getMean(),
+          stats.getStdDev(),
+          stats.getQuantile(0.5),
+          stats.getQuantile(0.75),
+          stats.getQuantile(0.95));
+    } else {
+      throw new IllegalStateException(
+          String.format(
+              "Cannot remove unknown metric type %s. This indicates that the reporter "
+                  + "does not support this metric type.",
+              metric.getClass().getName()));
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -148,7 +148,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
 
   protected transient FlinkStateInternals<?> keyedStateInternals;
 
-  private final String stepName;
+  protected final String stepName;
 
   private final Coder<WindowedValue<InputT>> windowedInputCoder;
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DeltaDistributionCell.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DeltaDistributionCell.java
@@ -53,6 +53,11 @@ public class DeltaDistributionCell implements Distribution, MetricCell<Distribut
   }
 
   @Override
+  public void update(long sum, long count, long min, long max) {
+    update(DistributionData.create(sum, count, min, max));
+  }
+
+  @Override
   public DirtyState getDirty() {
     throw new UnsupportedOperationException(
         String.format("%s doesn't support the getDirty", getClass().getSimpleName()));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Distribution.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Distribution.java
@@ -25,4 +25,6 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
 public interface Distribution extends Metric {
   /** Add an observation to this distribution. */
   void update(long value);
+
+  void update(long sum, long count, long min, long max);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Metrics.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Metrics.java
@@ -158,6 +158,14 @@ public class Metrics {
     }
 
     @Override
+    public void update(long sum, long count, long min, long max) {
+      MetricsContainer container = MetricsEnvironment.getCurrentContainer();
+      if (container != null) {
+        container.getDistribution(name).update(sum, count, min, max);
+      }
+    }
+
+    @Override
     public MetricName getName() {
       return name;
     }

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -19,12 +19,16 @@ from __future__ import print_function
 
 import argparse
 import logging
-import shutil
 import sys
-import tempfile
 import unittest
+from os import linesep
+from os import path
+from os.path import exists
+from shutil import rmtree
+from tempfile import mkdtemp
 
 import apache_beam as beam
+from apache_beam.metrics import Metrics
 from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import FlinkOptions
 from apache_beam.options.pipeline_options import PortableOptions
@@ -65,19 +69,58 @@ if __name__ == '__main__':
     _use_grpc = True
     _use_subprocesses = True
 
+    conf_dir = None
+
+    @classmethod
+    def tearDownClass(cls):
+      if cls.conf_dir and exists(cls.conf_dir):
+        logging.info("removing conf dir: %s" % cls.conf_dir)
+        rmtree(cls.conf_dir)
+      super(FlinkRunnerTest, cls).tearDownClass()
+
+    @classmethod
+    def _create_conf_dir(cls):
+      """Create (and save a static reference to) a "conf dir", used to provide
+       metrics configs and verify metrics output
+
+       It gets cleaned up when the suite is done executing"""
+
+      if hasattr(cls, 'conf_dir'):
+        cls.conf_dir = mkdtemp(prefix='flinktest-conf')
+
+        # path for a FileReporter to write metrics to
+        cls.test_metrics_path = path.join(cls.conf_dir, 'test-metrics.txt')
+
+        # path to write Flink configuration to
+        conf_path = path.join(cls.conf_dir, 'flink-conf.yaml')
+        file_reporter = 'org.apache.beam.runners.flink.metrics.FileReporter'
+        with open(conf_path, 'w') as f:
+          f.write(linesep.join([
+              'metrics.reporters: test',
+              'metrics.reporter.test.class: %s' % file_reporter,
+              'metrics.reporter.test.file: %s' % cls.test_metrics_path
+          ]))
+
     @classmethod
     def _subprocess_command(cls, port):
-      tmp_dir = tempfile.mkdtemp(prefix='flinktest')
+      # will be cleaned up at the end of this method, and recreated and used by
+      # the job server
+      tmp_dir = mkdtemp(prefix='flinktest')
+
+      cls._create_conf_dir()
+
       try:
         return [
             'java',
             '-jar', flink_job_server_jar,
+            '--flink-master-url', '[local]',
+            '--flink-conf-dir', cls.conf_dir,
             '--artifacts-dir', tmp_dir,
             '--job-port', str(port),
             '--artifact-port', '0',
         ]
       finally:
-        shutil.rmtree(tmp_dir)
+        rmtree(tmp_dir)
 
     @classmethod
     def get_runner(cls):
@@ -119,6 +162,45 @@ if __name__ == '__main__':
 
     def test_error_traceback_includes_user_code(self):
       raise unittest.SkipTest("BEAM-6019")
+
+    def test_metrics(self):
+      """Run a simple DoFn that increments a counter, and verify that its
+       expected value is written to a temporary file by the FileReporter"""
+
+      counter_name = 'elem_counter'
+
+      class DoFn(beam.DoFn):
+        def __init__(self):
+          self.counter = Metrics.counter(self.__class__, counter_name)
+          logging.info('counter: %s' % self.counter.metric_name)
+
+        def process(self, v):
+          self.counter.inc()
+
+      p = self.create_pipeline()
+      n = 100
+
+      # pylint: disable=expression-not-assigned
+      p \
+      | beam.Create(list(range(n))) \
+      | beam.ParDo(DoFn())
+
+      result = p.run()
+      result.wait_until_finish()
+
+      with open(self.test_metrics_path, 'r') as f:
+        lines = [line for line in f.readlines() if counter_name in line]
+        self.assertEqual(
+            len(lines), 1,
+            msg='Expected 1 line matching "%s":\n%s' % (
+                counter_name, '\n'.join(lines))
+        )
+        line = lines[0]
+        self.assertTrue(
+            '%s: 100' % counter_name in line,
+            msg='Failed to find expected counter %s in line %s' % (
+                counter_name, line)
+        )
 
     # Inherits all other tests.
 

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -96,9 +96,9 @@ if __name__ == '__main__':
         file_reporter = 'org.apache.beam.runners.flink.metrics.FileReporter'
         with open(conf_path, 'w') as f:
           f.write(linesep.join([
-              'metrics.reporters: test',
-              'metrics.reporter.test.class: %s' % file_reporter,
-              'metrics.reporter.test.file: %s' % cls.test_metrics_path
+              'metrics.reporters: file',
+              'metrics.reporter.file.class: %s' % file_reporter,
+              'metrics.reporter.file.path: %s' % cls.test_metrics_path
           ]))
 
     @classmethod


### PR DESCRIPTION
The Python SDK plumbs user metrics back in `ProgressBundle{Progress,}Response`, but the portable Flink runner doesn't send them on to Flink when executing stages.

This fixes that, and adds a test (in the python SDK) that increments a `Counter` in a `DoFn` and verifies that the result is written to a file by a Flink metrics reporter (`FileReporter`).

R: @angoenka 
CC: @robertwb @tweise @mxm who I've discussed this with
CC: @ajamato who is doing related metrics work (cf. #6799)

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




