### PR TITLE
[BEAM-1628] Allow empty port for flink master url

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.flink;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Splitter;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
@@ -77,17 +76,27 @@ public class FlinkExecutionEnvironments {
       flinkBatchEnv = new CollectionEnvironment();
     } else if ("[auto]".equals(masterUrl)) {
       flinkBatchEnv = ExecutionEnvironment.getExecutionEnvironment();
-    } else if (masterUrl.matches(".*:\\d*")) {
-      List<String> parts = Splitter.on(':').splitToList(masterUrl);
+    } else {
+      String[] hostAndPort = masterUrl.split(":", 2);
+      final String host = hostAndPort[0];
+      final int port;
+      if (hostAndPort.length > 1) {
+        try {
+          port = Integer.parseInt(hostAndPort[1]);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException("Provided port is malformed: " + hostAndPort[1]);
+        }
+        flinkConfiguration.setInteger(RestOptions.PORT, port);
+      } else {
+        port = flinkConfiguration.getInteger(RestOptions.PORT);
+      }
       flinkBatchEnv =
           ExecutionEnvironment.createRemoteEnvironment(
-              parts.get(0),
-              Integer.parseInt(parts.get(1)),
+              host,
+              port,
               flinkConfiguration,
               filesToStage.toArray(new String[filesToStage.size()]));
-    } else {
-      LOG.warn("Unrecognized Flink Master URL {}. Defaulting to [auto].", masterUrl);
-      flinkBatchEnv = ExecutionEnvironment.getExecutionEnvironment();
+      LOG.info("Using Flink Master URL {}:{}.", host, port);
     }
 
     // Set the execution more for data exchange.
@@ -147,10 +156,20 @@ public class FlinkExecutionEnvironments {
       flinkStreamEnv = StreamExecutionEnvironment.createLocalEnvironment();
     } else if ("[auto]".equals(masterUrl)) {
       flinkStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-    } else if (masterUrl.matches(".*:\\d*")) {
-      List<String> parts = Splitter.on(':').splitToList(masterUrl);
-      flinkConfig.setInteger(RestOptions.PORT, Integer.parseInt(parts.get(1)));
-
+    } else {
+      String[] hostAndPort = masterUrl.split(":", 2);
+      final String host = hostAndPort[0];
+      final int port;
+      if (hostAndPort.length > 1) {
+        try {
+          port = Integer.parseInt(hostAndPort[1]);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException("Provided port is malformed: " + hostAndPort[1]);
+        }
+        flinkConfig.setInteger(RestOptions.PORT, port);
+      } else {
+        port = flinkConfig.getInteger(RestOptions.PORT);
+      }
       final SavepointRestoreSettings savepointRestoreSettings;
       if (options.getSavepointPath() != null) {
         savepointRestoreSettings =
@@ -159,17 +178,14 @@ public class FlinkExecutionEnvironments {
       } else {
         savepointRestoreSettings = SavepointRestoreSettings.none();
       }
-
       flinkStreamEnv =
           new BeamFlinkRemoteStreamEnvironment(
-              parts.get(0),
-              Integer.parseInt(parts.get(1)),
+              host,
+              port,
               flinkConfig,
               savepointRestoreSettings,
               filesToStage.toArray(new String[filesToStage.size()]));
-    } else {
-      LOG.warn("Unrecognized Flink Master URL {}. Defaulting to [auto].", masterUrl);
-      flinkStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+      LOG.info("Using Flink Master URL {}:{}.", host, port);
     }
 
     // Set the parallelism, required by UnboundedSourceWrapper to generate consistent splits.

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
@@ -17,8 +17,9 @@
  */
 package org.apache.beam.runners.flink;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -28,12 +29,16 @@ import java.nio.file.Files;
 import java.util.Collections;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.LocalEnvironment;
+import org.apache.flink.api.java.RemoteEnvironment;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
 import org.apache.flink.streaming.api.environment.RemoteStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.internal.util.reflection.Whitebox;
 
@@ -41,6 +46,7 @@ import org.mockito.internal.util.reflection.Whitebox;
 public class FlinkExecutionEnvironmentsTest {
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldSetParallelismBatch() {
@@ -139,6 +145,7 @@ public class FlinkExecutionEnvironmentsTest {
         FlinkExecutionEnvironments.createBatchExecutionEnvironment(
             options, Collections.emptyList());
 
+    assertThat(bev, instanceOf(LocalEnvironment.class));
     assertThat(options.getParallelism(), is(LocalStreamEnvironment.getDefaultLocalParallelism()));
     assertThat(bev.getParallelism(), is(LocalStreamEnvironment.getDefaultLocalParallelism()));
   }
@@ -152,8 +159,153 @@ public class FlinkExecutionEnvironmentsTest {
         FlinkExecutionEnvironments.createStreamExecutionEnvironment(
             options, Collections.emptyList());
 
+    assertThat(sev, instanceOf(LocalStreamEnvironment.class));
     assertThat(options.getParallelism(), is(LocalStreamEnvironment.getDefaultLocalParallelism()));
     assertThat(sev.getParallelism(), is(LocalStreamEnvironment.getDefaultLocalParallelism()));
+  }
+
+  @Test
+  public void shouldParsePortForRemoteEnvironmentBatch() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+    options.setFlinkMaster("host:1234");
+
+    ExecutionEnvironment bev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+
+    assertThat(bev, instanceOf(RemoteEnvironment.class));
+    assertThat(Whitebox.getInternalState(bev, "host"), is("host"));
+    assertThat(Whitebox.getInternalState(bev, "port"), is(1234));
+  }
+
+  @Test
+  public void shouldParsePortForRemoteEnvironmentStreaming() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+    options.setFlinkMaster("host:1234");
+
+    StreamExecutionEnvironment sev =
+        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+            options, Collections.emptyList());
+
+    assertThat(sev, instanceOf(RemoteStreamEnvironment.class));
+    assertThat(Whitebox.getInternalState(sev, "host"), is("host"));
+    assertThat(Whitebox.getInternalState(sev, "port"), is(1234));
+  }
+
+  @Test
+  public void shouldAllowPortOmissionForRemoteEnvironmentBatch() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+    options.setFlinkMaster("host");
+
+    ExecutionEnvironment bev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+
+    assertThat(bev, instanceOf(RemoteEnvironment.class));
+    assertThat(Whitebox.getInternalState(bev, "host"), is("host"));
+    assertThat(Whitebox.getInternalState(bev, "port"), is(RestOptions.PORT.defaultValue()));
+  }
+
+  @Test
+  public void shouldAllowPortOmissionForRemoteEnvironmentStreaming() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+    options.setFlinkMaster("host");
+
+    StreamExecutionEnvironment sev =
+        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+            options, Collections.emptyList());
+
+    assertThat(sev, instanceOf(RemoteStreamEnvironment.class));
+    assertThat(Whitebox.getInternalState(sev, "host"), is("host"));
+    assertThat(Whitebox.getInternalState(sev, "port"), is(RestOptions.PORT.defaultValue()));
+  }
+
+  @Test
+  public void shouldTreatAutoAndEmptyHostTheSameBatch() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+
+    ExecutionEnvironment sev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+
+    options.setFlinkMaster("[auto]");
+
+    ExecutionEnvironment sev2 =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+
+    assertEquals(sev.getClass(), sev2.getClass());
+  }
+
+  @Test
+  public void shouldTreatAutoAndEmptyHostTheSameStreaming() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+
+    StreamExecutionEnvironment sev =
+        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+            options, Collections.emptyList());
+
+    options.setFlinkMaster("[auto]");
+
+    StreamExecutionEnvironment sev2 =
+        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+            options, Collections.emptyList());
+
+    assertEquals(sev.getClass(), sev2.getClass());
+  }
+
+  @Test
+  public void shouldDetectMalformedPortBatch() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+    options.setFlinkMaster("host:p0rt");
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Provided port is malformed");
+
+    FlinkExecutionEnvironments.createBatchExecutionEnvironment(options, Collections.emptyList());
+  }
+
+  @Test
+  public void shouldDetectMalformedPortStreaming() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+    options.setFlinkMaster("host:p0rt");
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Provided port is malformed");
+
+    FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, Collections.emptyList());
+  }
+
+  @Test
+  public void shouldFailOnEmptyPortBatch() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+    options.setFlinkMaster("host:");
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Provided port is malformed");
+
+    FlinkExecutionEnvironments.createBatchExecutionEnvironment(options, Collections.emptyList());
+  }
+
+  @Test
+  public void shouldFailOnEmptyPortStreaming() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+    options.setFlinkMaster("host:");
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Provided port is malformed");
+
+    FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, Collections.emptyList());
   }
 
   private String extractFlinkConfig() throws IOException {


### PR DESCRIPTION
This allows only specifying the host name without a port. It reads the port from
the configuration or uses the default Flink port if non configured. It does not
fall back to the special "[auto]" mode anymore if the port is omitted.


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




