### PR TITLE
[BEAM-5167] Log unscheduled process bundle requests

### DIFF
--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -27,6 +27,7 @@ import logging
 import queue
 import sys
 import threading
+import time
 import traceback
 from builtins import object
 from builtins import range
@@ -45,9 +46,11 @@ from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor
 
 class SdkHarness(object):
   REQUEST_METHOD_PREFIX = '_request_'
+  SCHEDULING_DELAY_THRESHOLD_SEC = 5*60  # 5 Minutes
 
   def __init__(self, control_address, worker_count, credentials=None,
                profiler_factory=None):
+    self._alive = True
     self._worker_count = worker_count
     self._worker_index = 0
     if credentials is None:
@@ -74,11 +77,12 @@ class SdkHarness(object):
     self._progress_thread_pool = futures.ThreadPoolExecutor(max_workers=1)
     self._process_thread_pool = futures.ThreadPoolExecutor(
         max_workers=self._worker_count)
+    self._monitoring_thread_pool = futures.ThreadPoolExecutor(max_workers=1)
     self._instruction_id_vs_worker = {}
     self._fns = {}
     self._responses = queue.Queue()
     self._process_bundle_queue = queue.Queue()
-    self._unscheduled_process_bundle = set()
+    self._unscheduled_process_bundle = {}
     logging.info('Initializing SDKHarness with %s workers.', self._worker_count)
 
   def run(self):
@@ -102,6 +106,8 @@ class SdkHarness(object):
               fns=self._fns,
               profiler_factory=self._profiler_factory))
 
+    self._monitoring_thread_pool.submit(self._monitor_process_bundle)
+
     def get_responses():
       while True:
         response = self._responses.get()
@@ -119,9 +125,11 @@ class SdkHarness(object):
 
     logging.info('No more requests from control plane')
     logging.info('SDK Harness waiting for in-flight requests to complete')
+    self._alive = False
     # Wait until existing requests are processed.
     self._progress_thread_pool.shutdown()
     self._process_thread_pool.shutdown()
+    self._monitoring_thread_pool.shutdown(wait=False)
     # get_responses may be blocked on responses.get(), but we need to return
     # control to its caller.
     self._responses.put(no_more_work)
@@ -165,7 +173,7 @@ class SdkHarness(object):
       work = self._process_bundle_queue.get()
       # add the instuction_id vs worker map for progress reporting lookup
       self._instruction_id_vs_worker[work.instruction_id] = worker
-      self._unscheduled_process_bundle.discard(work.instruction_id)
+      self._unscheduled_process_bundle.pop(work.instruction_id, None)
       try:
         self._execute(lambda: worker.do_instruction(work), work)
       finally:
@@ -176,7 +184,7 @@ class SdkHarness(object):
 
     # Create a task for each process_bundle request and schedule it
     self._process_bundle_queue.put(request)
-    self._unscheduled_process_bundle.add(request.instruction_id)
+    self._unscheduled_process_bundle[request.instruction_id] = time.time()
     self._process_thread_pool.submit(task)
     logging.debug(
         "Currently using %s threads." % len(self._process_thread_pool._threads))
@@ -200,6 +208,28 @@ class SdkHarness(object):
                     instruction_reference)), request)
 
     self._progress_thread_pool.submit(task)
+
+  def _monitor_process_bundle(self):
+    """
+    Monitor the unscheduled bundles and log if a bundle is not scheduled for
+    more than SCHEDULING_DELAY_THRESHOLD_SEC.
+    """
+    while self._alive:
+      time.sleep(SdkHarness.SCHEDULING_DELAY_THRESHOLD_SEC)
+      # Check for bundles to be scheduled.
+      if self._unscheduled_process_bundle:
+        current_time = time.time()
+        for instruction_id in self._unscheduled_process_bundle:
+          request_time = None
+          try:
+            request_time = self._unscheduled_process_bundle[instruction_id]
+          except KeyError:
+            pass
+          if request_time:
+            scheduling_delay = current_time - request_time
+            if scheduling_delay > SdkHarness.SCHEDULING_DELAY_THRESHOLD_SEC:
+              logging.warn('Unable to schedule instruction %s for %s',
+                           instruction_id, scheduling_delay)
 
 
 class SdkWorker(object):


### PR DESCRIPTION
Log a warning message if we are not able to schedule a process bundle request for more than a certain amount of time.
This will be useful in detecting deadlock because of scheduling mismatch between runner and sdk. 
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




