### PR TITLE
[BEAM-6167] Add class ReadFromTextWithFilename (Python)

### DIFF
--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -543,7 +543,7 @@ class ReadFromTextWithFilename(ReadFromText):
   r"""A :class:`~apache_beam.io.ReadFromText` for reading text
   files returning the name of the file and the content of the file.
 
-  This class extend ReadFromText class just setting a different 
+  This class extend ReadFromText class just setting a different
   _source_class attribute.
   """
 

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -540,7 +540,7 @@ class ReadFromText(PTransform):
 
 
 class ReadFromTextWithFilename(ReadFromText):
-  r"""A :class:`~apache_beam.io.ReadFromText` for reading text
+  r"""A :class:`~apache_beam.io.textio.ReadFromText` for reading text
   files returning the name of the file and the content of the file.
 
   This class extend ReadFromText class just setting a different

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -38,7 +38,7 @@ from apache_beam.io.iobase import Write
 from apache_beam.transforms import PTransform
 from apache_beam.transforms.display import DisplayDataItem
 
-__all__ = ['ReadFromText', 'ReadAllFromText', 'WriteToText']
+__all__ = ['ReadFromText', 'ReadFromTextWithFilename', 'ReadAllFromText', 'WriteToText']
 
 
 class _TextSource(filebasedsource.FileBasedSource):
@@ -320,6 +320,12 @@ class _TextSource(filebasedsource.FileBasedSource):
               sep_bounds[1] - record_start_position_in_buffer)
 
 
+class _FilenameTextSource(_TextSource):
+  def read_records(self, file_name, range_tracker):
+    for record in super(_FilenameTextSource, self).read_records(file_name, range_tracker):
+      yield (file_name, record)
+
+
 class _TextSink(filebasedsink.FileBasedSink):
   """A sink to a GCS or local text file or files."""
 
@@ -383,7 +389,7 @@ class _TextSink(filebasedsink.FileBasedSink):
     if self._header is not None:
       file_handle.write(self._header)
       if self._append_trailing_newlines:
-        file_handle.write(b'\n')
+        file_handle.write('\n')
     return file_handle
 
   def display_data(self):
@@ -397,7 +403,7 @@ class _TextSink(filebasedsink.FileBasedSink):
     """Writes a single encoded record."""
     file_handle.write(encoded_value)
     if self._append_trailing_newlines:
-      file_handle.write(b'\n')
+      file_handle.write('\n')
 
 
 def _create_text_source(
@@ -525,6 +531,61 @@ class ReadFromText(PTransform):
 
   def expand(self, pvalue):
     return pvalue.pipeline | Read(self._source)
+
+
+class ReadFromTextWithFilename(PTransform):
+  r"""A :class:`~apache_beam.transforms.ptransform.PTransform` for reading text
+  files returning the name of the file and the content of the file.
+
+  Parses a text file as newline-delimited elements, by default assuming
+  ``UTF-8`` encoding. Supports newline delimiters ``\n`` and ``\r\n``.
+
+  This implementation only supports reading text encoded using ``UTF-8`` or
+  ``ASCII``.
+  This does not support other encodings such as ``UTF-16`` or ``UTF-32``.
+  """
+  def __init__(
+      self,
+      file_pattern=None,
+      min_bundle_size=0,
+      compression_type=CompressionTypes.AUTO,
+      strip_trailing_newlines=True,
+      coder=coders.StrUtf8Coder(),
+      validate=True,
+      skip_header_lines=0,
+      **kwargs):
+    """Initialize the :class:`ReadFromTextWithFilename` transform.
+
+    Args:
+      file_pattern (str): The file path to read from as a local file path or a
+        GCS ``gs://`` path. The path can contain glob characters
+        (``*``, ``?``, and ``[...]`` sets).
+      min_bundle_size (int): Minimum size of bundles that should be generated
+        when splitting this source into bundles. See
+        :class:`~apache_beam.io.filebasedsource.FileBasedSource` for more
+        details.
+      compression_type (str): Used to handle compressed input files.
+        Typical value is :attr:`CompressionTypes.AUTO
+        <apache_beam.io.filesystem.CompressionTypes.AUTO>`, in which case the
+        underlying file_path's extension will be used to detect the compression.
+      strip_trailing_newlines (bool): Indicates whether this source should
+        remove the newline char in each line it reads before decoding that line.
+      validate (bool): flag to verify that the files exist during the pipeline
+        creation time.
+      skip_header_lines (int): Number of header lines to skip. Same number is
+        skipped from each source file. Must be 0 or higher. Large number of
+        skipped lines might impact performance.
+      coder (~apache_beam.coders.coders.Coder): Coder used to decode each line.
+    """
+
+    super(ReadFromTextWithFilename, self).__init__(**kwargs)
+    self._source = _FilenameTextSource(
+        file_pattern, min_bundle_size, compression_type,
+        strip_trailing_newlines, coder, validate=validate,
+        skip_header_lines=skip_header_lines)
+
+  def expand(self, pvalue):
+    return pvalue.pipeline | Read(self._source)  
 
 
 class WriteToText(PTransform):

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -38,7 +38,8 @@ from apache_beam.io.iobase import Write
 from apache_beam.transforms import PTransform
 from apache_beam.transforms.display import DisplayDataItem
 
-__all__ = ['ReadFromText', 'ReadFromTextWithFilename', 'ReadAllFromText', 'WriteToText']
+__all__ = ['ReadFromText', 'ReadFromTextWithFilename', 'ReadAllFromText',
+           'WriteToText']
 
 
 class _TextSource(filebasedsource.FileBasedSource):
@@ -322,7 +323,8 @@ class _TextSource(filebasedsource.FileBasedSource):
 
 class _TextSourceWithFilename(_TextSource):
   def read_records(self, file_name, range_tracker):
-    for record in super(_TextSourceWithFilename, self).read_records(file_name, range_tracker):
+    for record in super(_TextSourceWithFilename, self).read_records(file_name,
+                                                                    range_tracker):
       yield (file_name, record)
 
 
@@ -540,7 +542,8 @@ class ReadFromTextWithFilename(ReadFromText):
   r"""A :class:`~apache_beam.io.ReadFromText` for reading text
   files returning the name of the file and the content of the file.
 
-  This class extend ReadFromText class just setting a different _source_class attribute.
+  This class extend ReadFromText class just setting a different 
+  _source_class attribute.
   """
 
   _source_class = _TextSourceWithFilename

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -323,8 +323,9 @@ class _TextSource(filebasedsource.FileBasedSource):
 
 class _TextSourceWithFilename(_TextSource):
   def read_records(self, file_name, range_tracker):
-    for record in super(_TextSourceWithFilename, self).read_records(file_name,
-                                                                    range_tracker):
+    records = super(_TextSourceWithFilename, self).read_records(file_name,
+                                                                range_tracker)
+    for record in records:
       yield (file_name, record)
 
 


### PR DESCRIPTION
At the moment the ReadFromText class return the content of the file losing the file source of the element. In some scenario, you have to implement transformation based on information recorded in the name of the file.

I created an additional class: "ReadFromTextWithFilename" that return a tuple:

(u'gs://bucket-namet/test1.csv', u'hello,hello') 

instead of the just the element of the file. I tested the change, it works and continue to support all features supported by ReadFromText (coder, skip_header_lines, ...).
 
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




