### PR TITLE
[BEAM-6176] Support IPv6 addresses for Flink master url

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.flink;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.HostAndPort;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
@@ -77,26 +78,16 @@ public class FlinkExecutionEnvironments {
     } else if ("[auto]".equals(masterUrl)) {
       flinkBatchEnv = ExecutionEnvironment.getExecutionEnvironment();
     } else {
-      String[] hostAndPort = masterUrl.split(":", 2);
-      final String host = hostAndPort[0];
-      final int port;
-      if (hostAndPort.length > 1) {
-        try {
-          port = Integer.parseInt(hostAndPort[1]);
-        } catch (NumberFormatException e) {
-          throw new IllegalArgumentException("Provided port is malformed: " + hostAndPort[1]);
-        }
-        flinkConfiguration.setInteger(RestOptions.PORT, port);
-      } else {
-        port = flinkConfiguration.getInteger(RestOptions.PORT);
-      }
+      int defaultPort = flinkConfiguration.getInteger(RestOptions.PORT);
+      HostAndPort hostAndPort = HostAndPort.fromString(masterUrl).withDefaultPort(defaultPort);
+      flinkConfiguration.setInteger(RestOptions.PORT, hostAndPort.getPort());
       flinkBatchEnv =
           ExecutionEnvironment.createRemoteEnvironment(
-              host,
-              port,
+              hostAndPort.getHost(),
+              hostAndPort.getPort(),
               flinkConfiguration,
               filesToStage.toArray(new String[filesToStage.size()]));
-      LOG.info("Using Flink Master URL {}:{}.", host, port);
+      LOG.info("Using Flink Master URL {}:{}.", hostAndPort.getHost(), hostAndPort.getPort());
     }
 
     // Set the execution more for data exchange.
@@ -157,19 +148,9 @@ public class FlinkExecutionEnvironments {
     } else if ("[auto]".equals(masterUrl)) {
       flinkStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     } else {
-      String[] hostAndPort = masterUrl.split(":", 2);
-      final String host = hostAndPort[0];
-      final int port;
-      if (hostAndPort.length > 1) {
-        try {
-          port = Integer.parseInt(hostAndPort[1]);
-        } catch (NumberFormatException e) {
-          throw new IllegalArgumentException("Provided port is malformed: " + hostAndPort[1]);
-        }
-        flinkConfig.setInteger(RestOptions.PORT, port);
-      } else {
-        port = flinkConfig.getInteger(RestOptions.PORT);
-      }
+      int defaultPort = flinkConfig.getInteger(RestOptions.PORT);
+      HostAndPort hostAndPort = HostAndPort.fromString(masterUrl).withDefaultPort(defaultPort);
+      flinkConfig.setInteger(RestOptions.PORT, hostAndPort.getPort());
       final SavepointRestoreSettings savepointRestoreSettings;
       if (options.getSavepointPath() != null) {
         savepointRestoreSettings =
@@ -180,12 +161,12 @@ public class FlinkExecutionEnvironments {
       }
       flinkStreamEnv =
           new BeamFlinkRemoteStreamEnvironment(
-              host,
-              port,
+              hostAndPort.getHost(),
+              hostAndPort.getPort(),
               flinkConfig,
               savepointRestoreSettings,
               filesToStage.toArray(new String[filesToStage.size()]));
-      LOG.info("Using Flink Master URL {}:{}.", host, port);
+      LOG.info("Using Flink Master URL {}:{}.", hostAndPort.getHost(), hostAndPort.getPort());
     }
 
     // Set the parallelism, required by UnboundedSourceWrapper to generate consistent splits.

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
@@ -267,7 +267,7 @@ public class FlinkExecutionEnvironmentsTest {
     options.setFlinkMaster("host:p0rt");
 
     expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Provided port is malformed");
+    expectedException.expectMessage("Unparseable port number");
 
     FlinkExecutionEnvironments.createBatchExecutionEnvironment(options, Collections.emptyList());
   }
@@ -279,33 +279,93 @@ public class FlinkExecutionEnvironmentsTest {
     options.setFlinkMaster("host:p0rt");
 
     expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Provided port is malformed");
+    expectedException.expectMessage("Unparseable port number");
 
     FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, Collections.emptyList());
   }
 
   @Test
-  public void shouldFailOnEmptyPortBatch() {
+  public void shouldSupportIPv4Batch() {
     FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
     options.setRunner(FlinkRunner.class);
-    options.setFlinkMaster("host:");
 
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Provided port is malformed");
+    options.setFlinkMaster("192.168.1.1:1234");
+    ExecutionEnvironment bev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+    assertThat(Whitebox.getInternalState(bev, "host"), is("192.168.1.1"));
+    assertThat(Whitebox.getInternalState(bev, "port"), is(1234));
 
-    FlinkExecutionEnvironments.createBatchExecutionEnvironment(options, Collections.emptyList());
+    options.setFlinkMaster("192.168.1.1");
+    bev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+    assertThat(Whitebox.getInternalState(bev, "host"), is("192.168.1.1"));
+    assertThat(Whitebox.getInternalState(bev, "port"), is(RestOptions.PORT.defaultValue()));
   }
 
   @Test
-  public void shouldFailOnEmptyPortStreaming() {
+  public void shouldSupportIPv4Streaming() {
     FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
     options.setRunner(FlinkRunner.class);
-    options.setFlinkMaster("host:");
 
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Provided port is malformed");
+    options.setFlinkMaster("192.168.1.1:1234");
+    ExecutionEnvironment bev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+    assertThat(Whitebox.getInternalState(bev, "host"), is("192.168.1.1"));
+    assertThat(Whitebox.getInternalState(bev, "port"), is(1234));
 
-    FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, Collections.emptyList());
+    options.setFlinkMaster("192.168.1.1");
+    bev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+    assertThat(Whitebox.getInternalState(bev, "host"), is("192.168.1.1"));
+    assertThat(Whitebox.getInternalState(bev, "port"), is(RestOptions.PORT.defaultValue()));
+  }
+
+  @Test
+  public void shouldSupportIPv6Batch() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+
+    options.setFlinkMaster("[FE80:CD00:0000:0CDE:1257:0000:211E:729C]:1234");
+    ExecutionEnvironment bev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+    assertThat(
+        Whitebox.getInternalState(bev, "host"), is("FE80:CD00:0000:0CDE:1257:0000:211E:729C"));
+    assertThat(Whitebox.getInternalState(bev, "port"), is(1234));
+
+    options.setFlinkMaster("FE80:CD00:0000:0CDE:1257:0000:211E:729C");
+    bev =
+        FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+            options, Collections.emptyList());
+    assertThat(
+        Whitebox.getInternalState(bev, "host"), is("FE80:CD00:0000:0CDE:1257:0000:211E:729C"));
+    assertThat(Whitebox.getInternalState(bev, "port"), is(RestOptions.PORT.defaultValue()));
+  }
+
+  @Test
+  public void shouldSupportIPv6Streaming() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+
+    options.setFlinkMaster("[FE80:CD00:0000:0CDE:1257:0000:211E:729C]:1234");
+    StreamExecutionEnvironment sev =
+        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+            options, Collections.emptyList());
+    assertThat(
+        Whitebox.getInternalState(sev, "host"), is("FE80:CD00:0000:0CDE:1257:0000:211E:729C"));
+    assertThat(Whitebox.getInternalState(sev, "port"), is(1234));
+
+    options.setFlinkMaster("FE80:CD00:0000:0CDE:1257:0000:211E:729C");
+    sev =
+        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+            options, Collections.emptyList());
+    assertThat(
+        Whitebox.getInternalState(sev, "host"), is("FE80:CD00:0000:0CDE:1257:0000:211E:729C"));
+    assertThat(Whitebox.getInternalState(sev, "port"), is(RestOptions.PORT.defaultValue()));
   }
 
   private String extractFlinkConfig() throws IOException {


### PR DESCRIPTION
The previous port parsing logic assumed colons to indicate a port number. That
assumption clearly can't be made for IPv6 addresses.

CC @angoenka @tweise 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




