### PR TITLE
[BEAM-5419] Add Flink multi-version builds

### DIFF
--- a/runners/flink/1.6/build.gradle
+++ b/runners/flink/1.6/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def basePath = '..'
+
+/* All properties required for loading the Flink build script */
+project.ext {
+  // Set the version of all Flink-related dependencies here.
+  flink_version = '1.6.2'
+  // Look for the source code in the parent module
+  main_source_dirs = ["$basePath/src/main/java"]
+  test_source_dirs = ["$basePath/src/test/java"]
+  main_resources_dirs = ["$basePath/src/main/resources"]
+  test_resources_dirs = ["$basePath/src/test/resources"]
+}
+
+// Load the main build script which contains all build logic.
+apply from: "$basePath/flink_runner.gradle"

--- a/runners/flink/1.6/job-server-container/build.gradle
+++ b/runners/flink/1.6/job-server-container/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+project.ext {
+  docker_file = file('../../job-server-container/Dockerfile')
+  startup_script = file('../../job-server-container/flink-job-server.sh')
+}
+
+// Load the main build script which contains all build logic.
+apply from: '../../job-server-container/flink_job_server_container.gradle'

--- a/runners/flink/1.6/job-server/build.gradle
+++ b/runners/flink/1.6/job-server/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def basePath = '../../job-server'
+
+project.ext {
+  // Look for the source code in the parent module
+  main_source_dirs = ["$basePath/src/main/java"]
+  test_source_dirs = ["$basePath/src/test/java"]
+  main_resources_dirs = ["$basePath/src/main/resources"]
+  test_resources_dirs = ["$basePath/src/test/resources"]
+}
+
+// Load the main build script which contains all build logic.
+apply from: "$basePath/flink_job_server.gradle"

--- a/runners/flink/build.gradle
+++ b/runners/flink/build.gradle
@@ -16,123 +16,16 @@
  * limitations under the License.
  */
 
-import groovy.json.JsonOutput
-
-apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature()
-
-
-description = "Apache Beam :: Runners :: Flink"
-
-/*
- * We need to rely on manually specifying these evaluationDependsOn to ensure that
- * the following projects are evaluated before we evaluate this project. This is because
- * we are attempting to reference the "sourceSets.test.output" directly.
- */
-evaluationDependsOn(":beam-sdks-java-core")
-evaluationDependsOn(":beam-runners-core-java")
-
-
-test {
-  systemProperty "log4j.configuration", "log4j-test.properties"
-  //systemProperty "org.slf4j.simpleLogger.defaultLogLevel", "debug"
-  jvmArgs "-XX:-UseGCOverheadLimit"
-  if (System.getProperty("beamSurefireArgline")) {
-    jvmArgs System.getProperty("beamSurefireArgline")
-  }
+/* All properties required for loading the Flink build script. */
+project.ext {
+  // Set the version of all Flink-related dependencies here.
+  flink_version = '1.5.5'
+  // Look for the source code in the current module
+  main_source_dirs = ['./src/main/java']
+  test_source_dirs = ['./src/test/java']
+  main_resources_dirs = ['./src/main/resources']
+  test_resources_dirs = ['./src/test/resources']
 }
 
-configurations {
-  validatesRunner
-}
-
-def flink_version = "1.5.5"
-
-dependencies {
-  compile library.java.guava
-  shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
-  shadow project(path: ":beam-runners-core-java", configuration: "shadow")
-  shadow project(path: ":beam-runners-core-construction-java", configuration: "shadow")
-  shadow project(path: ":beam-runners-java-fn-execution", configuration: "shadow")
-  shadow library.java.vendored_grpc_1_13_1
-  shadow library.java.jackson_annotations
-  shadow library.java.slf4j_api
-  shadow library.java.joda_time
-  shadow library.java.commons_compress
-  shadow library.java.args4j
-  shadow "org.apache.flink:flink-clients_2.11:$flink_version"
-  shadow "org.apache.flink:flink-core:$flink_version"
-  shadow "org.apache.flink:flink-metrics-core:$flink_version"
-  shadow "org.apache.flink:flink-java:$flink_version"
-  shadow "org.apache.flink:flink-runtime_2.11:$flink_version"
-  shadow "org.apache.flink:flink-streaming-java_2.11:$flink_version"
-  shadowTest project(path: ":beam-sdks-java-core", configuration: "shadowTest")
-  // FlinkStateInternalsTest extends abstract StateInternalsTest
-  shadowTest project(path: ":beam-runners-core-java", configuration: "shadowTest")
-  shadowTest library.java.commons_lang3
-  shadowTest library.java.hamcrest_core
-  shadowTest library.java.junit
-  shadowTest library.java.mockito_core
-  shadowTest library.java.google_api_services_bigquery
-  shadowTest library.java.slf4j_simple
-  shadowTest project(path: ":beam-sdks-java-io-google-cloud-platform", configuration: "shadow")
-  shadowTest library.java.jackson_dataformat_yaml
-  shadowTest "org.apache.flink:flink-core:$flink_version:tests"
-  shadowTest "org.apache.flink:flink-runtime_2.11:$flink_version:tests"
-  shadowTest "org.apache.flink:flink-streaming-java_2.11:$flink_version:tests"
-  shadowTest "org.apache.flink:flink-test-utils_2.11:$flink_version"
-  shadowTest project(":beam-sdks-java-harness")
-  validatesRunner project(path: ":beam-sdks-java-core", configuration: "shadowTest")
-  validatesRunner project(path: ":beam-runners-core-java", configuration: "shadowTest")
-  validatesRunner project(path: project.path, configuration: "shadow")
-}
-
-class ValidatesRunnerConfig {
-  String name
-  boolean streaming
-}
-
-def createValidatesRunnerTask(Map m) {
-  def config = m as ValidatesRunnerConfig
-  tasks.create(name: config.name, type: Test) {
-    group = "Verification"
-    def runnerType = config.streaming ? "streaming" : "batch"
-    description = "Validates the ${runnerType} runner"
-    def pipelineOptions = JsonOutput.toJson(
-        ["--runner=TestFlinkRunner",
-         "--streaming=${config.streaming}",
-         // TODO This should be changed to > 1
-         "--parallelism=1",
-        ])
-    systemProperty "beamTestPipelineOptions", pipelineOptions
-    classpath = configurations.validatesRunner
-    testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs, project(":beam-runners-core-java").sourceSets.test.output.classesDirs)
-    // maxParallelForks decreased from 4 in order to avoid OOM errors
-    maxParallelForks 2
-    useJUnit {
-      includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
-      excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
-      excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
-      if (config.streaming) {
-        excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse'
-      } else {
-        excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
-      }
-      excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
-    }
-  }
-}
-
-createValidatesRunnerTask(name: "validatesRunnerBatch", streaming: false)
-createValidatesRunnerTask(name: "validatesRunnerStreaming", streaming: true)
-
-task validatesRunner {
-  group = "Verification"
-  description "Validates Flink runner"
-  dependsOn validatesRunnerBatch
-  dependsOn validatesRunnerStreaming
-}
-
-// Generates :beam-runners-flink_2.11:runQuickstartJavaFlinkLocal
-createJavaExamplesArchetypeValidationTask(type: 'Quickstart', runner: 'FlinkLocal')
+// Load the main build script which contains all build logic.
+apply from: 'flink_runner.gradle'

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Main Flink Runner build file shared by all of its build targets.
+ * The file needs to be parameterized by the Flink version and the source directories.
+ *
+ * See build.gradle files for an example of how to use this script.
+ */
+
+import groovy.json.JsonOutput
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+applyJavaNature()
+
+description = "Apache Beam :: Runners :: Flink $flink_version"
+
+/*
+ * We need to rely on manually specifying these evaluationDependsOn to ensure that
+ * the following projects are evaluated before we evaluate this project. This is because
+ * we are attempting to reference the "sourceSets.test.output" directly.
+ */
+evaluationDependsOn(":beam-sdks-java-core")
+evaluationDependsOn(":beam-runners-core-java")
+
+/*
+ * We have to explicitly set all directories here to make sure each
+ * version of Flink has the correct overrides set.
+ */
+sourceSets {
+  main {
+    java {
+      srcDirs = main_source_dirs
+    }
+    resources {
+      srcDirs = main_resources_dirs
+    }
+  }
+  test {
+    java {
+      srcDirs = test_source_dirs
+    }
+    resources {
+      srcDirs = test_resources_dirs
+    }
+  }
+}
+
+test {
+  systemProperty "log4j.configuration", "log4j-test.properties"
+  //systemProperty "org.slf4j.simpleLogger.defaultLogLevel", "debug"
+  jvmArgs "-XX:-UseGCOverheadLimit"
+  if (System.getProperty("beamSurefireArgline")) {
+    jvmArgs System.getProperty("beamSurefireArgline")
+  }
+}
+
+configurations {
+  validatesRunner
+}
+
+dependencies {
+  compile library.java.guava
+  shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
+  shadow project(path: ":beam-runners-core-java", configuration: "shadow")
+  shadow project(path: ":beam-runners-core-construction-java", configuration: "shadow")
+  shadow project(path: ":beam-runners-java-fn-execution", configuration: "shadow")
+  shadow library.java.vendored_grpc_1_13_1
+  shadow library.java.jackson_annotations
+  shadow library.java.slf4j_api
+  shadow library.java.joda_time
+  shadow library.java.commons_compress
+  shadow library.java.args4j
+  shadow "org.apache.flink:flink-clients_2.11:$flink_version"
+  shadow "org.apache.flink:flink-core:$flink_version"
+  shadow "org.apache.flink:flink-metrics-core:$flink_version"
+  shadow "org.apache.flink:flink-java:$flink_version"
+  shadow "org.apache.flink:flink-runtime_2.11:$flink_version"
+  shadow "org.apache.flink:flink-streaming-java_2.11:$flink_version"
+  shadowTest project(path: ":beam-sdks-java-core", configuration: "shadowTest")
+  // FlinkStateInternalsTest extends abstract StateInternalsTest
+  shadowTest project(path: ":beam-runners-core-java", configuration: "shadowTest")
+  shadowTest library.java.commons_lang3
+  shadowTest library.java.hamcrest_core
+  shadowTest library.java.junit
+  shadowTest library.java.mockito_core
+  shadowTest library.java.google_api_services_bigquery
+  shadowTest library.java.slf4j_simple
+  shadowTest project(path: ":beam-sdks-java-io-google-cloud-platform", configuration: "shadow")
+  shadowTest library.java.jackson_dataformat_yaml
+  shadowTest "org.apache.flink:flink-core:$flink_version:tests"
+  shadowTest "org.apache.flink:flink-runtime_2.11:$flink_version:tests"
+  shadowTest "org.apache.flink:flink-streaming-java_2.11:$flink_version:tests"
+  shadowTest "org.apache.flink:flink-test-utils_2.11:$flink_version"
+  shadowTest project(":beam-sdks-java-harness")
+  validatesRunner project(path: ":beam-sdks-java-core", configuration: "shadowTest")
+  validatesRunner project(path: ":beam-runners-core-java", configuration: "shadowTest")
+  validatesRunner project(path: project.path, configuration: "shadow")
+}
+
+class ValidatesRunnerConfig {
+  String name
+  boolean streaming
+}
+
+def createValidatesRunnerTask(Map m) {
+  def config = m as ValidatesRunnerConfig
+  tasks.create(name: config.name, type: Test) {
+    group = "Verification"
+    def runnerType = config.streaming ? "streaming" : "batch"
+    description = "Validates the ${runnerType} runner"
+    def pipelineOptions = JsonOutput.toJson(
+        ["--runner=TestFlinkRunner",
+         "--streaming=${config.streaming}",
+         // TODO This should be changed to > 1
+         "--parallelism=1",
+        ])
+    systemProperty "beamTestPipelineOptions", pipelineOptions
+    classpath = configurations.validatesRunner
+    testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs, project(":beam-runners-core-java").sourceSets.test.output.classesDirs)
+    // maxParallelForks decreased from 4 in order to avoid OOM errors
+    maxParallelForks 2
+    useJUnit {
+      includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+      excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
+      excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
+      excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+      if (config.streaming) {
+        excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse'
+      } else {
+        excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+      }
+      excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
+    }
+  }
+}
+
+createValidatesRunnerTask(name: "validatesRunnerBatch", streaming: false)
+createValidatesRunnerTask(name: "validatesRunnerStreaming", streaming: true)
+
+task validatesRunner {
+  group = "Verification"
+  description "Validates Flink runner"
+  dependsOn validatesRunnerBatch
+  dependsOn validatesRunnerStreaming
+}
+
+// Generates :beam-runners-flink_2.11:runQuickstartJavaFlinkLocal
+createJavaExamplesArchetypeValidationTask(type: 'Quickstart', runner: 'FlinkLocal')

--- a/runners/flink/job-server-container/build.gradle
+++ b/runners/flink/job-server-container/build.gradle
@@ -16,39 +16,10 @@
  * limitations under the License.
  */
 
-/**
- * Build a Docker image to bootstrap FlinkJobServerDriver which requires a Java environment.
- * Alternatively, it can also be bootstrapped through :beam-runners-flink_2.11-job-server:runShadow
- * or by directly running the generated JAR file.
- */
-
-apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyDockerNature()
-
-description = "Apache Beam :: Runners :: Flink :: Job Server :: Container"
-
-configurations {
-  dockerDependency
+project.ext {
+  docker_file = file('Dockerfile')
+  startup_script = file('flink-job-server.sh')
 }
 
-dependencies {
-  dockerDependency project(path: ":beam-runners-flink_2.11-job-server", configuration: "shadow")
-}
-
-task copyDockerfileDependencies(type: Copy) {
-  // Required Jars
-  from configurations.dockerDependency
-  rename 'beam-runners-flink_2.11-job-server.*.jar', 'beam-runners-flink-job-server.jar'
-  into "build/target"
-  // Entry script
-  from file("./flink-job-server.sh")
-  into "build/target"
-}
-
-docker {
-  name containerImageName(name: "flink-job-server")
-  files "./build/"
-}
-
-// Ensure that we build the required resources and copy and file dependencies from related projects
-dockerPrepare.dependsOn copyDockerfileDependencies
+// Load the main build script which contains all build logic.
+apply from: 'flink_job_server_container.gradle'

--- a/runners/flink/job-server-container/flink_job_server_container.gradle
+++ b/runners/flink/job-server-container/flink_job_server_container.gradle
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Build a Docker image to bootstrap FlinkJobServerDriver which requires a Java environment.
+ * Alternatively, it can also be bootstrapped through the runShadow goal
+ * or by directly running the generated JAR file.
+ */
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+applyDockerNature()
+
+// Resolve the Flink project name (and version) the job-server-container is based on
+def flinkJobServerProject = ":${project.name.replace('-container', '')}"
+
+description = project(flinkJobServerProject).description + " :: Container"
+
+configurations {
+  dockerDependency
+}
+
+dependencies {
+  dockerDependency project(path: flinkJobServerProject, configuration: "shadow")
+}
+
+task copyDockerfileDependencies(type: Copy) {
+  // Required Jars
+  from configurations.dockerDependency
+  rename 'beam-runners-flink.*-job-server.*.jar', 'beam-runners-flink-job-server.jar'
+  into "build/target"
+  // Entry script
+  from startup_script
+  into "build/target"
+  // Dockerfile
+  from docker_file
+  into "build/target"
+}
+
+docker {
+  name containerImageName(name: project.name)
+  files "./build/"
+}
+
+// Ensure that we build the required resources and copy and file dependencies from related projects
+dockerPrepare.dependsOn copyDockerfileDependencies

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -15,101 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import groovy.json.JsonOutput
 
-apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(
-  exportJavadoc: false,
-  validateShadowJar: false,
-  shadowClosure: {
-    append "reference.conf"
-  },
-)
+def basePath = '.'
 
-description = "Apache Beam :: Runners :: Flink :: Job Server"
-
-apply plugin: "application"
-
-mainClassName = "org.apache.beam.runners.flink.FlinkJobServerDriver"
-
-configurations {
-  validatesPortableRunner
+project.ext {
+  // Look for the source code in the parent module
+  main_source_dirs = ["$basePath/src/main/java"]
+  test_source_dirs = ["$basePath/src/test/java"]
+  main_resources_dirs = ["$basePath/src/main/resources"]
+  test_resources_dirs = ["$basePath/src/test/resources"]
 }
 
-configurations.all {
-    // replace commons logging with the jcl-over-slf4j bridge
-    exclude group: "commons-logging", module: "commons-logging"
-}
-
-dependencies {
-  compile project(path: ":beam-runners-flink_2.11", configuration: "shadow")
-  compile group: "org.slf4j", name: "jcl-over-slf4j", version: dependencies.create(project.library.java.slf4j_api).getVersion()
-  validatesPortableRunner project(path: ":beam-runners-flink_2.11", configuration: "shadowTest")
-  validatesPortableRunner project(path: ":beam-sdks-java-core", configuration: "shadowTest")
-  validatesPortableRunner project(path: ":beam-runners-core-java", configuration: "shadowTest")
-  validatesPortableRunner project(path: ":beam-runners-reference-java", configuration: "shadowTest")
-  compile project(path: ":beam-sdks-java-extensions-google-cloud-platform-core", configuration: "shadow")
-  compile library.java.slf4j_simple
-//  TODO: Enable AWS and HDFS file system.
-}
-
-// NOTE: runShadow must be used in order to run the job server. The standard run
-// task will not work because the flink runner classes only exist in the shadow
-// jar.
-runShadow {
-  args = []
-  if (project.hasProperty('jobHost'))
-    args += ["--job-host=${project.property('jobHost')}"]
-  if (project.hasProperty('artifactsDir'))
-    args += ["--artifacts-dir=${project.property('artifactsDir')}"]
-  if (project.hasProperty('cleanArtifactsPerJob'))
-    args += ["--clean-artifacts-per-job"]
-  if (project.hasProperty('flinkMasterUrl'))
-    args += ["--flink-master-url=${project.property('flinkMasterUrl')}"]
-  if (project.hasProperty('flinkConfDir'))
-    args += ["--flink-conf-dir=${project.property('flinkConfDir')}"]
-
-  // Enable remote debugging.
-  jvmArgs = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"]
-  if (project.hasProperty("logLevel"))
-    jvmArgs += ["-Dorg.slf4j.simpleLogger.defaultLogLevel=${project.property('logLevel')}"]
-}
-
-def portableValidatesRunnerTask(String name, Boolean streaming) {
-  createPortableValidatesRunnerTask(
-          name: "validatesPortableRunner${name}",
-          jobServerDriver: "org.apache.beam.runners.flink.FlinkJobServerDriver",
-          jobServerConfig: "--clean-artifacts-per-job,--job-host=localhost,--job-port=0,--artifact-port=0",
-          testClasspathConfiguration: configurations.validatesPortableRunner,
-          parallelism: 2,
-          pipelineOpts: streaming ? ["--streaming"] : [],
-          testCategories: {
-            includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
-            excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
-            excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesAttemptedMetrics'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesCounterMetrics'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesDistributionMetrics'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesFailureMessage'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesGaugeMetrics'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
-            //SplitableDoFnTests
-            excludeCategories 'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs'
-            excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
-          },
-  )
-}
-
-project.ext.validatesPortableRunnerBatch = portableValidatesRunnerTask("Batch", false)
-project.ext.validatesPortableRunnerStreaming = portableValidatesRunnerTask("Streaming", true)
-
-task validatesPortableRunner() {
-  dependsOn validatesPortableRunnerBatch
-  dependsOn validatesPortableRunnerStreaming
-}
+// Load the main build script which contains all build logic.
+apply from: "$basePath/flink_job_server.gradle"

--- a/runners/flink/job-server/flink_job_server.gradle
+++ b/runners/flink/job-server/flink_job_server.gradle
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Flink Runner JobServer build file shared by all of its build targets.
+ *
+ * See build.gradle files for an example of how to use this script.
+ */
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+applyJavaNature(
+  validateShadowJar: false,
+  exportJavadoc: false,
+  shadowClosure: {
+    append "reference.conf"
+  },
+)
+apply plugin: "application"
+
+// Resolve the Flink project name (and version) the job-server is based on
+def flinkRunnerProject = ":${project.name.replace("-job-server", "")}"
+
+description = project(flinkRunnerProject).description + " :: Job Server"
+
+/*
+ * We have to explicitly set all directories here to make sure each
+ * version of Flink has the correct overrides set.
+ */
+sourceSets {
+    main {
+        java {
+            srcDirs = main_source_dirs
+        }
+        resources {
+            srcDirs = main_resources_dirs
+        }
+    }
+    test {
+        java {
+            srcDirs = test_source_dirs
+        }
+        resources {
+            srcDirs = test_resources_dirs
+        }
+    }
+}
+
+mainClassName = "org.apache.beam.runners.flink.FlinkJobServerDriver"
+
+configurations {
+  validatesPortableRunner
+}
+
+configurations.all {
+  // replace commons logging with the jcl-over-slf4j bridge
+  exclude group: "commons-logging", module: "commons-logging"
+}
+
+dependencies {
+  compile project(path: flinkRunnerProject, configuration: "shadow")
+  compile group: "org.slf4j", name: "jcl-over-slf4j", version: dependencies.create(project.library.java.slf4j_api).getVersion()
+  validatesPortableRunner project(path: flinkRunnerProject, configuration: "shadowTest")
+  validatesPortableRunner project(path: ":beam-sdks-java-core", configuration: "shadowTest")
+  validatesPortableRunner project(path: ":beam-runners-core-java", configuration: "shadowTest")
+  validatesPortableRunner project(path: ":beam-runners-reference-java", configuration: "shadowTest")
+  compile project(path: ":beam-sdks-java-extensions-google-cloud-platform-core", configuration: "shadow")
+  compile library.java.slf4j_simple
+//  TODO: Enable AWS and HDFS file system.
+}
+
+// NOTE: runShadow must be used in order to run the job server. The standard run
+// task will not work because the flink runner classes only exist in the shadow
+// jar.
+runShadow {
+  args = []
+  if (project.hasProperty('jobHost'))
+    args += ["--job-host=${project.property('jobHost')}"]
+  if (project.hasProperty('artifactsDir'))
+    args += ["--artifacts-dir=${project.property('artifactsDir')}"]
+  if (project.hasProperty('cleanArtifactsPerJob'))
+    args += ["--clean-artifacts-per-job"]
+  if (project.hasProperty('flinkMasterUrl'))
+    args += ["--flink-master-url=${project.property('flinkMasterUrl')}"]
+  if (project.hasProperty('flinkConfDir'))
+    args += ["--flink-conf-dir=${project.property('flinkConfDir')}"]
+
+  // Enable remote debugging.
+  jvmArgs = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"]
+  if (project.hasProperty("logLevel"))
+    jvmArgs += ["-Dorg.slf4j.simpleLogger.defaultLogLevel=${project.property('logLevel')}"]
+}
+
+def portableValidatesRunnerTask(String name, Boolean streaming) {
+  createPortableValidatesRunnerTask(
+    name: "validatesPortableRunner${name}",
+    jobServerDriver: "org.apache.beam.runners.flink.FlinkJobServerDriver",
+    jobServerConfig: "--clean-artifacts-per-job,--job-host=localhost,--job-port=0,--artifact-port=0",
+    testClasspathConfiguration: configurations.validatesPortableRunner,
+      parallelism: 2,
+      pipelineOpts: streaming ? ["--streaming"] : [],
+      testCategories: {
+        includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+        excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
+        excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesAttemptedMetrics'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesCounterMetrics'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesDistributionMetrics'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesFailureMessage'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesGaugeMetrics'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
+        //SplitableDoFnTests
+        excludeCategories 'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+      },
+  )
+}
+
+project.ext.validatesPortableRunnerBatch = portableValidatesRunnerTask("Batch", false)
+project.ext.validatesPortableRunnerStreaming = portableValidatesRunnerTask("Streaming", true)
+
+task validatesPortableRunner() {
+  dependsOn validatesPortableRunnerBatch
+  dependsOn validatesPortableRunnerStreaming
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkKeyGroupStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkKeyGroupStateInternals.java
@@ -50,7 +50,6 @@ import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.KeyGroupsList;
 import org.apache.flink.runtime.state.KeyedStateBackend;
-import org.apache.flink.streaming.api.operators.HeapInternalTimerService;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
@@ -59,7 +58,7 @@ import org.apache.flink.util.Preconditions;
  *
  * <p>Note: Ignore index of key. Just implement BagState.
  *
- * <p>Reference from {@link HeapInternalTimerService} to the local key-group range.
+ * <p>Reference from Flink's HeapInternalTimerService to the local key-group range.
  */
 public class FlinkKeyGroupStateInternals<K> implements StateInternals {
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,6 +46,13 @@ include "beam-runners-flink_2.11-job-server"
 project(":beam-runners-flink_2.11-job-server").dir = file("runners/flink/job-server")
 include "beam-runners-flink_2.11-job-server-container"
 project(":beam-runners-flink_2.11-job-server-container").dir = file("runners/flink/job-server-container")
+// 1.6 version
+include "beam-runners-flink-1.6"
+project(":beam-runners-flink-1.6").dir = file("runners/flink/1.6")
+include "beam-runners-flink-1.6-job-server"
+project(":beam-runners-flink-1.6-job-server").dir = file("runners/flink/1.6/job-server")
+include "beam-runners-flink-1.6-job-server-container"
+project(":beam-runners-flink-1.6-job-server-container").dir = file("runners/flink/1.6/job-server-container")
 /* End Flink Runner related settings */
 include "beam-runners-gcp-gcemd"
 project(":beam-runners-gcp-gcemd").dir = file("runners/gcp/gcemd")

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,12 +38,15 @@ include "beam-runners-direct-java"
 project(":beam-runners-direct-java").dir = file("runners/direct-java")
 include "beam-runners-extensions-java-metrics"
 project(":beam-runners-extensions-java-metrics").dir = file("runners/extensions-java/metrics")
+/* Begin Flink Runner related settings */
+// 1.5 version with Scala 2.11 suffix
 include "beam-runners-flink_2.11"
 project(":beam-runners-flink_2.11").dir = file("runners/flink")
 include "beam-runners-flink_2.11-job-server"
 project(":beam-runners-flink_2.11-job-server").dir = file("runners/flink/job-server")
 include "beam-runners-flink_2.11-job-server-container"
 project(":beam-runners-flink_2.11-job-server-container").dir = file("runners/flink/job-server-container")
+/* End Flink Runner related settings */
 include "beam-runners-gcp-gcemd"
 project(":beam-runners-gcp-gcemd").dir = file("runners/gcp/gcemd")
 include "beam-runners-gcp-gcsproxy"


### PR DESCRIPTION
The PR contains three commits in this order:

## [BEAM-5419] Add Flink multi-version build layout

This enables to build against multiple Flink versions. Each version lives in a
separate project folder and loads the main 'flink_runner.gradle' script. Each
project can configure a custom Flink version and a custom source folder
location. This will allow to do overrides in the future when the source can not
be made compatible across different Flink versions.

## [BEAM-5267] Make source 1.6 compatible

## [BEAM-5267] Add Flink v1.6 target for FlinkRunner 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




