### PR TITLE
 [BEAM-4454] Add remaining functionality for AVRO schemas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ rat {
     "**/.github/**/*",
 
     "**/package-list",
+    "**/test.avsc",
     "**/user.avsc",
     "**/test/resources/**/*.txt",
     "**/test/**/.placeholder",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroSpecificRecordGetterFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroSpecificRecordGetterFactory.java
@@ -15,18 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.schemas.utils;
+package org.apache.beam.sdk.schemas;
 
 import java.util.List;
-import org.apache.beam.sdk.schemas.FieldValueGetter;
-import org.apache.beam.sdk.schemas.FieldValueGetterFactory;
-import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.SerializableFunctions;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
 
-/** A factory for creating {@link FieldValueGetter} objects for a JavaBean object. */
-public class JavaBeanGetterFactory implements FieldValueGetterFactory {
+/** A {@link FieldValueGetterFactory} for AVRO-generated specific records. */
+public class AvroSpecificRecordGetterFactory implements FieldValueGetterFactory {
   @Override
   public List<FieldValueGetter> create(Class<?> targetClass, Schema schema) {
-    return JavaBeanUtils.getGetters(targetClass, schema, SerializableFunctions.identity());
+    return AvroUtils.getGetters((Class<? extends SpecificRecord>) targetClass, schema);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroSpecificRecordSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroSpecificRecordSchema.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas;
+
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.beam.sdk.schemas.utils.AvroSpecificRecordTypeInformationFactory;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/**
+ * A {@link SchemaProvider} for AVRO generated SpecificRecords.
+ *
+ * <p>This provider infers a schema from generates SpecificRecord objects, and creates schemas and
+ * rows that bind to the appropriate fields.
+ */
+public class AvroSpecificRecordSchema extends GetterBasedSchemaProvider {
+  @Override
+  public <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
+    return AvroUtils.getSchema((Class<? extends SpecificRecord>) typeDescriptor.getRawType());
+  }
+
+  @Override
+  public FieldValueGetterFactory fieldValueGetterFactory() {
+    return new AvroSpecificRecordGetterFactory();
+  }
+
+  @Override
+  public UserTypeCreatorFactory schemaTypeCreatorFactory() {
+    return new AvroSpecificRecordUserTypeCreatorFactory();
+  }
+
+  @Override
+  public FieldValueTypeInformationFactory fieldValueTypeInformationFactory() {
+    return new AvroSpecificRecordTypeInformationFactory();
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroSpecificRecordUserTypeCreatorFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroSpecificRecordUserTypeCreatorFactory.java
@@ -15,18 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.schemas.utils;
+package org.apache.beam.sdk.schemas;
 
-import java.util.List;
-import org.apache.beam.sdk.schemas.FieldValueGetter;
-import org.apache.beam.sdk.schemas.FieldValueGetterFactory;
-import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.SerializableFunctions;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
 
-/** A factory for creating {@link FieldValueGetter} objects for a JavaBean object. */
-public class JavaBeanGetterFactory implements FieldValueGetterFactory {
+/** A {@link UserTypeCreatorFactory} for AVRO-generated specific records. */
+public class AvroSpecificRecordUserTypeCreatorFactory implements UserTypeCreatorFactory {
   @Override
-  public List<FieldValueGetter> create(Class<?> targetClass, Schema schema) {
-    return JavaBeanUtils.getGetters(targetClass, schema, SerializableFunctions.identity());
+  public SchemaUserTypeCreator create(Class<?> clazz, Schema schema) {
+    return AvroUtils.getCreator((Class<? extends SpecificRecord>) clazz, schema);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.schemas.utils.JavaBeanGetterFactory;
 import org.apache.beam.sdk.schemas.utils.JavaBeanSetterFactory;
 import org.apache.beam.sdk.schemas.utils.JavaBeanTypeInformationFactory;
 import org.apache.beam.sdk.schemas.utils.JavaBeanUtils;
+import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
@@ -42,7 +43,8 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 public class JavaBeanSchema extends GetterBasedSchemaProvider {
   @Override
   public <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
-    return JavaBeanUtils.schemaFromJavaBeanClass(typeDescriptor.getRawType());
+    return JavaBeanUtils.schemaFromJavaBeanClass(
+        typeDescriptor.getRawType(), SerializableFunctions.identity());
   }
 
   @Override
@@ -51,8 +53,8 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
   }
 
   @Override
-  public FieldValueSetterFactory fieldValueSetterFactory() {
-    return new JavaBeanSetterFactory();
+  UserTypeCreatorFactory schemaTypeCreatorFactory() {
+    return new SetterBasedCreatorFactory(new JavaBeanSetterFactory());
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
@@ -21,7 +21,6 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.utils.POJOUtils;
 import org.apache.beam.sdk.schemas.utils.PojoValueGetterFactory;
-import org.apache.beam.sdk.schemas.utils.PojoValueSetterFactory;
 import org.apache.beam.sdk.schemas.utils.PojoValueTypeInformationFactory;
 import org.apache.beam.sdk.values.TypeDescriptor;
 
@@ -48,11 +47,6 @@ public class JavaFieldSchema extends GetterBasedSchemaProvider {
   @Override
   public FieldValueGetterFactory fieldValueGetterFactory() {
     return new PojoValueGetterFactory();
-  }
-
-  @Override
-  public FieldValueSetterFactory fieldValueSetterFactory() {
-    return new PojoValueSetterFactory();
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -540,6 +540,14 @@ public class Schema implements Serializable {
       return toBuilder().setMetadata(metadata.getBytes(StandardCharsets.UTF_8)).build();
     }
 
+    public String getMetadataString() {
+      if (getMetadata() != null) {
+        return new String(getMetadata(), StandardCharsets.UTF_8);
+      } else {
+        return "";
+      }
+    }
+
     public FieldType withNullable(boolean nullable) {
       return toBuilder().setNullable(nullable).build();
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SetterBasedCreatorFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SetterBasedCreatorFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+/**
+ * A {@link UserTypeCreatorFactory} that uses a default constructor and a list of setters to
+ * construct a class.
+ */
+class SetterBasedCreatorFactory implements UserTypeCreatorFactory {
+  private final Factory<List<FieldValueSetter>> setterFactory;
+
+  public SetterBasedCreatorFactory(Factory<List<FieldValueSetter>> setterFactory) {
+    this.setterFactory = new CachingFactory<>(setterFactory);
+  }
+
+  @Override
+  public SchemaUserTypeCreator create(Class<?> clazz, Schema schema) {
+    List<FieldValueSetter> setters = setterFactory.create(clazz, schema);
+    return new SchemaUserTypeCreator() {
+      @Override
+      public Object create(Object... params) {
+        Object object;
+        try {
+          object = clazz.getDeclaredConstructor().newInstance();
+        } catch (NoSuchMethodException
+            | IllegalAccessException
+            | InvocationTargetException
+            | InstantiationException e) {
+          throw new RuntimeException("Failed to instantiate object ", e);
+        }
+        for (int i = 0; i < params.length; ++i) {
+          FieldValueSetter setter = setters.get(i);
+          setter.set(object, params[i]);
+        }
+        return object;
+      }
+    };
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroByteBuddyUtils.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.utils;
+
+import com.google.common.collect.Maps;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.type.TypeDescription.ForLoadedType;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodCall;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.assign.TypeCasting;
+import net.bytebuddy.implementation.bytecode.collection.ArrayAccess;
+import net.bytebuddy.implementation.bytecode.constant.IntegerConstant;
+import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertType;
+import org.apache.beam.sdk.schemas.utils.ReflectUtils.ClassWithSchema;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+class AvroByteBuddyUtils {
+  private static final ByteBuddy BYTE_BUDDY = new ByteBuddy();
+
+  // Cache the generated constructors.
+  private static final Map<ClassWithSchema, SchemaUserTypeCreator> CACHED_CREATORS =
+      Maps.newConcurrentMap();
+
+  static <T extends SpecificRecord> SchemaUserTypeCreator getCreator(
+      Class<T> clazz, Schema schema) {
+    return CACHED_CREATORS.computeIfAbsent(
+        new ClassWithSchema(clazz, schema), c -> createCreator(clazz, schema));
+  }
+
+  private static <T> SchemaUserTypeCreator createCreator(Class<T> clazz, Schema schema) {
+    Constructor baseConstructor = null;
+    Constructor[] constructors = clazz.getDeclaredConstructors();
+    for (Constructor constructor : constructors) {
+      // TODO: This assumes that Avro only generates one constructor with this many fields.
+      if (constructor.getParameterCount() == schema.getFieldCount()) {
+        baseConstructor = constructor;
+      }
+    }
+    if (baseConstructor == null) {
+      throw new RuntimeException("No matching constructor found for class " + clazz);
+    }
+
+    // Generate a method call to create and invoke the SpecificRecord's constructor. .
+    MethodCall construct = MethodCall.construct(baseConstructor);
+    for (int i = 0; i < baseConstructor.getParameterTypes().length; ++i) {
+      Class<?> baseType = baseConstructor.getParameterTypes()[i];
+      construct = construct.with(readAndConvertParameter(baseType, i), baseType);
+    }
+
+    try {
+      DynamicType.Builder<SchemaUserTypeCreator> builder =
+          BYTE_BUDDY
+              .subclass(SchemaUserTypeCreator.class)
+              .method(ElementMatchers.named("create"))
+              .intercept(construct);
+
+      return builder
+          .make()
+          .load(ReflectHelpers.findClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+          .getLoaded()
+          .getDeclaredConstructor()
+          .newInstance();
+    } catch (InstantiationException
+        | IllegalAccessException
+        | NoSuchMethodException
+        | InvocationTargetException e) {
+      throw new RuntimeException(
+          "Unable to generate a getter for class " + clazz + " with schema " + schema);
+    }
+  }
+
+  private static StackManipulation readAndConvertParameter(
+      Class<?> constructorParameterType, int index) {
+    // The types in the AVRO-generated constructor might be the types returned by Beam's Row class,
+    // so we have to convert the types used by Beam's Row class.
+    // We know that AVRO generates constructor parameters in the same order as fields
+    // in the schema, so we can just add the parameters sequentially.
+    ConvertType convertType = new ConvertType(true);
+
+    // Map the AVRO-generated type to the one Beam will use.
+    ForLoadedType convertedType =
+        new ForLoadedType((Class) convertType.convert(TypeDescriptor.of(constructorParameterType)));
+
+    // This will run inside the generated creator. Read the parameter and convert it to the
+    // type required by the SpecificRecord constructor.
+    StackManipulation readParameter =
+        new StackManipulation.Compound(
+            MethodVariableAccess.REFERENCE.loadFrom(1),
+            IntegerConstant.forValue(index),
+            ArrayAccess.REFERENCE.load(),
+            TypeCasting.to(convertedType));
+
+    // Convert to the parameter accepted by the SpecificRecord constructor.
+    return new ByteBuddyUtils.ConvertValueForSetter(readParameter)
+        .convert(TypeDescriptor.of(constructorParameterType));
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroSpecificRecordTypeInformationFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroSpecificRecordTypeInformationFactory.java
@@ -18,15 +18,15 @@
 package org.apache.beam.sdk.schemas.utils;
 
 import java.util.List;
-import org.apache.beam.sdk.schemas.FieldValueGetter;
-import org.apache.beam.sdk.schemas.FieldValueGetterFactory;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
+import org.apache.beam.sdk.schemas.FieldValueTypeInformationFactory;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.SerializableFunctions;
 
-/** A factory for creating {@link FieldValueGetter} objects for a JavaBean object. */
-public class JavaBeanGetterFactory implements FieldValueGetterFactory {
+/** A {@link FieldValueTypeInformation} for AVRO-generated specific records. */
+public class AvroSpecificRecordTypeInformationFactory implements FieldValueTypeInformationFactory {
   @Override
-  public List<FieldValueGetter> create(Class<?> targetClass, Schema schema) {
-    return JavaBeanUtils.getGetters(targetClass, schema, SerializableFunctions.identity());
+  public List<FieldValueTypeInformation> create(Class<?> targetClass, Schema schema) {
+    return AvroUtils.getFieldTypes((Class<? extends SpecificRecord>) targetClass, schema);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -20,8 +20,9 @@ package org.apache.beam.sdk.schemas.utils;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.base.CaseFormat;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -35,17 +36,25 @@ import org.apache.avro.Conversions;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema.Type;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.schemas.FieldValueGetter;
+import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.Row;
 import org.joda.time.Instant;
 import org.joda.time.ReadableInstant;
@@ -53,6 +62,13 @@ import org.joda.time.ReadableInstant;
 /** Utils to convert AVRO records to Beam rows. */
 @Experimental(Experimental.Kind.SCHEMAS)
 public class AvroUtils {
+  static {
+    // This works around a bug in the Avro library (AVRO-1891) around SpecificRecord's handling
+    // of DateTime types.
+    SpecificData.get().addLogicalTypeConversion(new TimeConversions.TimestampConversion());
+    GenericData.get().addLogicalTypeConversion(new TimeConversions.TimestampConversion());
+  }
+
   // Unwrap an AVRO schema into the base type an whether it is nullable.
   static class TypeWithNullability {
     public final org.apache.avro.Schema type;
@@ -88,6 +104,53 @@ public class AvroUtils {
         type = avroSchema;
         nullable = false;
       }
+    }
+  }
+
+  /** Wrapper for fixed byte fields. */
+  public static class FixedBytesField {
+    private static final String PREFIX = "FIXED:";
+
+    private final int size;
+
+    private FixedBytesField(int size) {
+      this.size = size;
+    }
+
+    /** Create a {@link FixedBytesField} from a Beam {@link FieldType} */
+    @Nullable
+    public static FixedBytesField fromBeamFieldType(FieldType fieldType) {
+      String metadata = fieldType.getMetadataString();
+      if (fieldType.getTypeName().equals(TypeName.BYTES) && metadata.startsWith(PREFIX)) {
+        return new FixedBytesField(Integer.parseInt(metadata.substring(6)));
+      } else {
+        return null;
+      }
+    }
+
+    /** Create a {@link FixedBytesField} from an AVRO type. */
+    @Nullable
+    public static FixedBytesField fromAvroType(org.apache.avro.Schema type) {
+      if (type.getType().equals(Type.FIXED)) {
+        return new FixedBytesField(type.getFixedSize());
+      } else {
+        return null;
+      }
+    }
+
+    /** Get the size. */
+    public int getSize() {
+      return size;
+    }
+
+    /** Convert to a Beam type. */
+    public FieldType toBeamType() {
+      return Schema.FieldType.BYTES.withMetadata(PREFIX + Integer.toString(size));
+    }
+
+    /** Convert to an AVRO type. */
+    public org.apache.avro.Schema toAvroType() {
+      return org.apache.avro.Schema.createFixed(null, "", "", size);
     }
   }
 
@@ -142,12 +205,7 @@ public class AvroUtils {
     for (Schema.Field field : schema.getFields()) {
       Object value = record.get(field.getName());
       org.apache.avro.Schema fieldAvroSchema = avroSchema.getField(field.getName()).schema();
-
-      if (value == null) {
-        builder.addValue(null);
-      } else {
-        builder.addValue(convertAvroFieldStrict(value, fieldAvroSchema, field.getType()));
-      }
+      builder.addValue(convertAvroFieldStrict(value, fieldAvroSchema, field.getType()));
     }
 
     return builder.build();
@@ -182,6 +240,79 @@ public class AvroUtils {
               field.getType(), avroSchema.getField(field.getName()).schema(), row.getValue(i)));
     }
     return builder.build();
+  }
+
+  /**
+   * Returns a function mapping AVRO {@link GenericRecord}s to Beam {@link Row}s for use in {@link
+   * org.apache.beam.sdk.values.PCollection#setSchema}.
+   */
+  public static SerializableFunction<GenericRecord, Row> getGenericRecordToRowFunction(
+      @Nullable Schema schema) {
+    return g -> toBeamRowStrict(g, schema);
+  }
+
+  /**
+   * Returns a function mapping Beam {@link Row}s to AVRO {@link GenericRecord}s for use in {@link
+   * org.apache.beam.sdk.values.PCollection#setSchema}.
+   */
+  public static SerializableFunction<Row, GenericRecord> getRowToGenericRecordFunction(
+      @Nullable org.apache.avro.Schema avroSchema) {
+    return g -> toGenericRecord(g, avroSchema);
+  }
+
+  /** Infer a {@link Schema} from an AVRO-generated SpecificRecord. */
+  public static <T extends SpecificRecord> Schema getSchema(Class<T> clazz) {
+    try {
+      org.apache.avro.Schema avroSchema =
+          (org.apache.avro.Schema) (clazz.getDeclaredField("SCHEMA$").get(null));
+      return toBeamSchema(avroSchema);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalArgumentException(
+          "Class "
+              + clazz
+              + " is not an AVRO SpecificRecord. "
+              + "No public SCHEMA$ field was found.");
+    }
+  }
+
+  private static final class AvroSpecificRecordFieldNamePolicy
+      implements SerializableFunction<String, String> {
+    Schema schema;
+    Map<String, String> nameMapping = Maps.newHashMap();
+
+    AvroSpecificRecordFieldNamePolicy(Schema schema) {
+      this.schema = schema;
+      for (Field field : schema.getFields()) {
+        String getter = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, field.getName());
+        nameMapping.put(getter, field.getName());
+        // The Avro compiler might add a $ at the end of a getter to disambiguate.
+        nameMapping.put(getter + "$", field.getName());
+      }
+    }
+
+    @Override
+    public String apply(String input) {
+      return nameMapping.getOrDefault(input, input);
+    }
+  }
+
+  /** Get field types for an AVRO-generated SpecificRecord. */
+  public static <T extends SpecificRecord> List<FieldValueTypeInformation> getFieldTypes(
+      Class<T> clazz, Schema schema) {
+    return JavaBeanUtils.getFieldTypes(
+        clazz, schema, new AvroSpecificRecordFieldNamePolicy(schema));
+  }
+
+  /** Get generated getters for an AVRO-generated SpecificRecord. */
+  public static <T extends SpecificRecord> List<FieldValueGetter> getGetters(
+      Class<T> clazz, Schema schema) {
+    return JavaBeanUtils.getGetters(clazz, schema, new AvroSpecificRecordFieldNamePolicy(schema));
+  }
+
+  /** Get an object creator for an AVRO-generated SpecificRecord. */
+  public static <T extends SpecificRecord> SchemaUserTypeCreator getCreator(
+      Class<T> clazz, Schema schema) {
+    return AvroByteBuddyUtils.getCreator(clazz, schema);
   }
 
   /** Converts AVRO schema to Beam field. */
@@ -224,7 +355,7 @@ public class AvroUtils {
           break;
 
         case FIXED:
-          fieldType = Schema.FieldType.BYTES;
+          fieldType = FixedBytesField.fromAvroType(type.type).toBeamType();
           break;
 
         case STRING:
@@ -312,7 +443,12 @@ public class AvroUtils {
         break;
 
       case BYTES:
-        baseType = org.apache.avro.Schema.create(Type.BYTES);
+        FixedBytesField fixedBytesField = FixedBytesField.fromBeamFieldType(fieldType);
+        if (fixedBytesField != null) {
+          baseType = fixedBytesField.toAvroType();
+        } else {
+          baseType = org.apache.avro.Schema.create(Type.BYTES);
+        }
         break;
 
       case ARRAY:
@@ -340,81 +476,11 @@ public class AvroUtils {
     return fieldType.getNullable() ? ReflectData.makeNullable(baseType) : baseType;
   }
 
+  @Nullable
   private static Object genericFromBeamField(
-      Schema.FieldType fieldType, org.apache.avro.Schema avroSchema, Object value) {
-    org.apache.avro.Schema expectedSchema = getFieldSchema(fieldType);
-    switch (fieldType.getTypeName()) {
-      case BYTE:
-      case INT16:
-      case INT32:
-      case INT64:
-      case FLOAT:
-      case DOUBLE:
-      case BOOLEAN:
-        return checkValueType(avroSchema, value, fieldType, expectedSchema);
-
-      case STRING:
-        return new Utf8((String) value);
-
-      case DECIMAL:
-        BigDecimal decimal = (BigDecimal) value;
-        LogicalType logicalType = avroSchema.getLogicalType();
-        ByteBuffer byteBuffer =
-            new Conversions.DecimalConversion().toBytes(decimal, null, logicalType);
-        return checkValueType(avroSchema, byteBuffer, fieldType, expectedSchema);
-
-      case DATETIME:
-        ReadableInstant instant = (ReadableInstant) value;
-        return checkValueType(avroSchema, instant.getMillis(), fieldType, expectedSchema);
-
-      case BYTES:
-        return checkValueType(
-            avroSchema, ByteBuffer.wrap((byte[]) value), fieldType, expectedSchema);
-
-      case ARRAY:
-        List array = (List) checkValueType(avroSchema, value, fieldType, expectedSchema);
-        List<Object> translatedArray = Lists.newArrayListWithExpectedSize(array.size());
-        org.apache.avro.Schema avroArrayType = new TypeWithNullability(avroSchema).type;
-
-        for (Object arrayElement : array) {
-          translatedArray.add(
-              genericFromBeamField(
-                  fieldType.getCollectionElementType(),
-                  avroArrayType.getElementType(),
-                  arrayElement));
-        }
-        return checkValueType(avroSchema, translatedArray, fieldType, expectedSchema);
-
-      case MAP:
-        ImmutableMap.Builder builder = ImmutableMap.builder();
-        Map<Object, Object> valueMap =
-            (Map<Object, Object>) checkValueType(avroSchema, value, fieldType, expectedSchema);
-        org.apache.avro.Schema avroMapType = new TypeWithNullability(avroSchema).type;
-
-        for (Map.Entry entry : valueMap.entrySet()) {
-          Utf8 key = new Utf8((String) entry.getKey());
-          builder.put(
-              key,
-              genericFromBeamField(
-                  fieldType.getMapValueType(), avroMapType.getValueType(), entry.getValue()));
-        }
-        return checkValueType(avroSchema, builder.build(), fieldType, expectedSchema);
-
-      case ROW:
-        return checkValueType(
-            avroSchema, toGenericRecord((Row) value, avroSchema), fieldType, expectedSchema);
-
-      default:
-        throw new IllegalArgumentException("Unsupported type " + fieldType);
-    }
-  }
-
-  private static Object checkValueType(
-      org.apache.avro.Schema avroSchema,
-      Object o,
-      FieldType fieldType,
-      org.apache.avro.Schema expectedType) {
+      Schema.FieldType fieldType, org.apache.avro.Schema avroSchema, @Nullable Object value) {
     TypeWithNullability typeWithNullability = new TypeWithNullability(avroSchema);
+
     if (!fieldType.getNullable().equals(typeWithNullability.nullable)) {
       throw new IllegalArgumentException(
           "FieldType "
@@ -423,7 +489,78 @@ public class AvroUtils {
               + avroSchema
               + " don't have matching nullability");
     }
-    return o;
+
+    if (value == null) {
+      return value;
+    }
+
+    switch (fieldType.getTypeName()) {
+      case BYTE:
+      case INT16:
+      case INT32:
+      case INT64:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+        return value;
+
+      case STRING:
+        return new Utf8((String) value);
+
+      case DECIMAL:
+        BigDecimal decimal = (BigDecimal) value;
+        LogicalType logicalType = typeWithNullability.type.getLogicalType();
+        return new Conversions.DecimalConversion().toBytes(decimal, null, logicalType);
+
+      case DATETIME:
+        ReadableInstant instant = (ReadableInstant) value;
+        return instant.getMillis();
+
+      case BYTES:
+        FixedBytesField fixedBytesField = FixedBytesField.fromBeamFieldType(fieldType);
+        if (fixedBytesField != null) {
+          byte[] byteArray = (byte[]) value;
+          if (byteArray.length != fixedBytesField.getSize()) {
+            throw new IllegalArgumentException("Incorrectly sized byte array.");
+          }
+          return GenericData.get().createFixed(null, (byte[]) value, typeWithNullability.type);
+        } else {
+          return ByteBuffer.wrap((byte[]) value);
+        }
+
+      case ARRAY:
+        List array = (List) value;
+        List<Object> translatedArray = Lists.newArrayListWithExpectedSize(array.size());
+
+        for (Object arrayElement : array) {
+          translatedArray.add(
+              genericFromBeamField(
+                  fieldType.getCollectionElementType(),
+                  typeWithNullability.type.getElementType(),
+                  arrayElement));
+        }
+        return translatedArray;
+
+      case MAP:
+        Map map = Maps.newHashMap();
+        Map<Object, Object> valueMap = (Map<Object, Object>) value;
+        for (Map.Entry entry : valueMap.entrySet()) {
+          Utf8 key = new Utf8((String) entry.getKey());
+          map.put(
+              key,
+              genericFromBeamField(
+                  fieldType.getMapValueType(),
+                  typeWithNullability.type.getValueType(),
+                  entry.getValue()));
+        }
+        return map;
+
+      case ROW:
+        return toGenericRecord((Row) value, typeWithNullability.type);
+
+      default:
+        throw new IllegalArgumentException("Unsupported type " + fieldType);
+    }
   }
 
   /**
@@ -436,10 +573,14 @@ public class AvroUtils {
    * @return value converted for {@link Row}
    */
   @SuppressWarnings("unchecked")
+  @Nullable
   public static Object convertAvroFieldStrict(
-      @Nonnull Object value,
+      @Nullable Object value,
       @Nonnull org.apache.avro.Schema avroSchema,
       @Nonnull Schema.FieldType fieldType) {
+    if (value == null) {
+      return null;
+    }
 
     TypeWithNullability type = new TypeWithNullability(avroSchema);
     LogicalType logicalType = LogicalTypes.fromSchema(type.type);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -117,7 +117,7 @@ public class AvroUtils {
       this.size = size;
     }
 
-    /** Create a {@link FixedBytesField} from a Beam {@link FieldType} */
+    /** Create a {@link FixedBytesField} from a Beam {@link FieldType}. */
     @Nullable
     public static FixedBytesField fromBeamFieldType(FieldType fieldType) {
       String metadata = fieldType.getMetadataString();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanTypeInformationFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanTypeInformationFactory.java
@@ -21,11 +21,12 @@ import java.util.List;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformationFactory;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.SerializableFunctions;
 
 /** A {@link FieldValueTypeInformationFactory} for Java Bean objects. */
 public class JavaBeanTypeInformationFactory implements FieldValueTypeInformationFactory {
   @Override
   public List<FieldValueTypeInformation> create(Class<?> targetClass, Schema schema) {
-    return JavaBeanUtils.getFieldTypes(targetClass, schema);
+    return JavaBeanUtils.getFieldTypes(targetClass, schema, SerializableFunctions.identity());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.joda.time.ReadableInstant;
 
@@ -85,7 +86,8 @@ public class StaticSchemaInference {
     }
 
     /** Construct a {@link TypeInformation} from a class getter. */
-    public static TypeInformation forGetter(Method method) {
+    public static TypeInformation forGetter(
+        Method method, SerializableFunction<String, String> fieldNamePolicy) {
       String name;
       if (method.getName().startsWith("get")) {
         name = ReflectUtils.stripPrefix(method.getName(), "get");
@@ -94,6 +96,8 @@ public class StaticSchemaInference {
       } else {
         throw new RuntimeException("Getter has wrong prefix " + method.getName());
       }
+      name = fieldNamePolicy.apply(name);
+
       TypeDescriptor type = TypeDescriptor.of(method.getGenericReturnType());
       boolean nullable = method.isAnnotationPresent(Nullable.class);
       return new TypeInformation(name, type, nullable);

--- a/sdks/java/core/src/test/avro/org/apache/beam/sdk/schemas/test.avsc
+++ b/sdks/java/core/src/test/avro/org/apache/beam/sdk/schemas/test.avsc
@@ -1,0 +1,29 @@
+{
+  "namespace": "org.apache.beam.sdk.schemas",
+  "type": "record",
+  "name": "TestAvro",
+  "fields": [
+    { "name": "bool_non_nullable", "type": "boolean"},
+    { "name": "int", "type": ["int", "null"]},
+    { "name": "long", "type": ["long", "null"]},
+    { "name": "float", "type": ["float", "null"]},
+    { "name": "double", "type": ["double", "null"]},
+    { "name": "string", "type": ["string", "null"]},
+    { "name": "bytes", "type": ["bytes", "null"]},
+    { "name": "fixed", "type": {"type": "fixed", "size": 4, "name": "fixed4"} },
+    { "name": "timestampMillis", "type":
+      [ {"type": "long", "logicalType": "timestamp-millis"}, "null"]},
+    { "name": "row", "type": ["null", {
+     "type": "record",
+     "name": "TestAvroNested",
+      "fields": [
+        { "name": "bool_non_nullable", "type": "boolean"},
+        { "name": "int", "type": ["int", "null"]}
+         ]
+       }]
+    },
+    { "name": "array", "type":["null", {"type": "array", "items": ["null", "TestAvroNested"] }]},
+    { "name": "map", "type": ["null", {"type": "map", "values": ["null", "TestAvroNested"]}]}
+  ]
+}
+

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.ByteBuffer;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.util.Utf8;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+/** Tests for AVRO schema classes. */
+public class AvroSchemaTest {
+  private static final Schema SUBSCHEMA =
+      Schema.builder()
+          .addField("bool_non_nullable", FieldType.BOOLEAN)
+          .addNullableField("int", FieldType.INT32)
+          .build();
+  private static final FieldType SUB_TYPE = FieldType.row(SUBSCHEMA).withNullable(true);
+
+  private static final Schema SCHEMA =
+      Schema.builder()
+          .addField("bool_non_nullable", FieldType.BOOLEAN)
+          .addNullableField("int", FieldType.INT32)
+          .addNullableField("long", FieldType.INT64)
+          .addNullableField("float", FieldType.FLOAT)
+          .addNullableField("double", FieldType.DOUBLE)
+          .addNullableField("string", FieldType.STRING)
+          .addNullableField("bytes", FieldType.BYTES)
+          .addField("fixed", FieldType.BYTES.withMetadata("FIXED:4"))
+          .addNullableField("timestampMillis", FieldType.DATETIME)
+          .addNullableField("row", SUB_TYPE)
+          .addNullableField("array", FieldType.array(SUB_TYPE))
+          .addNullableField("map", FieldType.map(FieldType.STRING, SUB_TYPE))
+          .build();
+
+  @Test
+  public void testSpecificRecordSchema() {
+    assertEquals(
+        SCHEMA, new AvroSpecificRecordSchema().schemaFor(TypeDescriptor.of(TestAvro.class)));
+  }
+
+  private static final byte[] BYTE_ARRAY = new byte[] {1, 2, 3, 4};
+  private static final DateTime DATE_TIME =
+      new DateTime().withDate(1979, 03, 14).withTime(1, 2, 3, 4);
+  private static final TestAvroNested AVRO_NESTED_SPECIFIC_RECORD = new TestAvroNested(true, 42);
+  private static final TestAvro AVRO_SPECIFIC_RECORD =
+      new TestAvro(
+          true,
+          43,
+          44L,
+          (float) 44.1,
+          (double) 44.2,
+          "mystring",
+          ByteBuffer.wrap(BYTE_ARRAY),
+          new fixed4(BYTE_ARRAY),
+          DATE_TIME,
+          AVRO_NESTED_SPECIFIC_RECORD,
+          ImmutableList.of(AVRO_NESTED_SPECIFIC_RECORD, AVRO_NESTED_SPECIFIC_RECORD),
+          ImmutableMap.of("k1", AVRO_NESTED_SPECIFIC_RECORD, "k2", AVRO_NESTED_SPECIFIC_RECORD));
+  private static final GenericRecord AVRO_NESTED_GENERIC_RECORD =
+      new GenericRecordBuilder(TestAvroNested.SCHEMA$)
+          .set("bool_non_nullable", true)
+          .set("int", 42)
+          .build();
+  private static final GenericRecord AVRO_GENERIC_RECORD =
+      new GenericRecordBuilder(TestAvro.SCHEMA$)
+          .set("bool_non_nullable", true)
+          .set("int", 43)
+          .set("long", 44L)
+          .set("float", (float) 44.1)
+          .set("double", (double) 44.2)
+          .set("string", new Utf8("mystring"))
+          .set("bytes", ByteBuffer.wrap(BYTE_ARRAY))
+          .set(
+              "fixed",
+              GenericData.get()
+                  .createFixed(
+                      null, BYTE_ARRAY, org.apache.avro.Schema.createFixed("fixed4", "", "", 4)))
+          .set("timestampMillis", DATE_TIME.getMillis())
+          .set("row", AVRO_NESTED_GENERIC_RECORD)
+          .set("array", ImmutableList.of(AVRO_NESTED_GENERIC_RECORD, AVRO_NESTED_GENERIC_RECORD))
+          .set(
+              "map",
+              ImmutableMap.of(
+                  new Utf8("k1"), AVRO_NESTED_GENERIC_RECORD,
+                  new Utf8("k2"), AVRO_NESTED_GENERIC_RECORD))
+          .build();
+
+  private static final Row NESTED_ROW = Row.withSchema(SUBSCHEMA).addValues(true, 42).build();
+  private static final Row ROW =
+      Row.withSchema(SCHEMA)
+          .addValues(
+              true,
+              43,
+              44L,
+              (float) 44.1,
+              (double) 44.2,
+              "mystring",
+              ByteBuffer.wrap(BYTE_ARRAY),
+              ByteBuffer.wrap(BYTE_ARRAY),
+              DATE_TIME,
+              NESTED_ROW,
+              ImmutableList.of(NESTED_ROW, NESTED_ROW),
+              ImmutableMap.of("k1", NESTED_ROW, "k2", NESTED_ROW))
+          .build();
+
+  @Test
+  public void testSpecificRecordToRow() {
+    SerializableFunction<TestAvro, Row> toRow =
+        new AvroSpecificRecordSchema().toRowFunction(TypeDescriptor.of(TestAvro.class));
+    Row row = toRow.apply(AVRO_SPECIFIC_RECORD);
+    assertEquals(ROW, toRow.apply(AVRO_SPECIFIC_RECORD));
+  }
+
+  @Test
+  public void testRowToSpecificRecord() {
+    SerializableFunction<Row, TestAvro> fromRow =
+        new AvroSpecificRecordSchema().fromRowFunction(TypeDescriptor.of(TestAvro.class));
+    assertEquals(AVRO_SPECIFIC_RECORD, fromRow.apply(ROW));
+  }
+
+  @Test
+  public void testGenericRecordToRow() {
+    SerializableFunction<GenericRecord, Row> toRow =
+        AvroUtils.getGenericRecordToRowFunction(SCHEMA);
+    assertEquals(ROW, toRow.apply(AVRO_GENERIC_RECORD));
+  }
+
+  @Test
+  public void testRowToGenericRecord() {
+    SerializableFunction<Row, GenericRecord> fromRow =
+        AvroUtils.getRowToGenericRecordFunction(TestAvro.SCHEMA$);
+    GenericRecord generic = fromRow.apply(ROW);
+    assertEquals(AVRO_GENERIC_RECORD, fromRow.apply(ROW));
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
@@ -49,6 +49,7 @@ import org.apache.beam.sdk.schemas.utils.TestJavaBeans.NullableBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.PrimitiveArrayBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.PrimitiveMapBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.SimpleBean;
+import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,7 +61,8 @@ public class JavaBeanUtilsTest {
 
   @Test
   public void testNullable() {
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(NullableBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(NullableBean.class, SerializableFunctions.identity());
     assertTrue(schema.getField("str").getType().getNullable());
     assertFalse(schema.getField("anInt").getType().getNullable());
   }
@@ -68,48 +70,62 @@ public class JavaBeanUtilsTest {
   @Test
   public void testMismatchingNullable() {
     thrown.expect(RuntimeException.class);
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(MismatchingNullableBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(
+            MismatchingNullableBean.class, SerializableFunctions.identity());
   }
 
   @Test
   public void testSimpleBean() {
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(SimpleBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(SimpleBean.class, SerializableFunctions.identity());
     SchemaTestUtils.assertSchemaEquivalent(SIMPLE_BEAN_SCHEMA, schema);
   }
 
   @Test
   public void testNestedBean() {
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(NestedBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(NestedBean.class, SerializableFunctions.identity());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_BEAN_SCHEMA, schema);
   }
 
   @Test
   public void testPrimitiveArray() {
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(PrimitiveArrayBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(
+            PrimitiveArrayBean.class, SerializableFunctions.identity());
     SchemaTestUtils.assertSchemaEquivalent(PRIMITIVE_ARRAY_BEAN_SCHEMA, schema);
   }
 
   @Test
   public void testNestedArray() {
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(NestedArrayBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(
+            NestedArrayBean.class, SerializableFunctions.identity());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_ARRAY_BEAN_SCHEMA, schema);
   }
 
   @Test
   public void testNestedCollection() {
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(NestedCollectionBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(
+            NestedCollectionBean.class, SerializableFunctions.identity());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_COLLECTION_BEAN_SCHEMA, schema);
   }
 
   @Test
   public void testPrimitiveMap() {
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(PrimitiveMapBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(
+            PrimitiveMapBean.class, SerializableFunctions.identity());
     SchemaTestUtils.assertSchemaEquivalent(PRIMITIVE_MAP_BEAN_SCHEMA, schema);
   }
 
   @Test
   public void testNestedMap() {
-    Schema schema = JavaBeanUtils.schemaFromJavaBeanClass(NestedMapBean.class);
+    Schema schema =
+        JavaBeanUtils.schemaFromJavaBeanClass(
+            NestedMapBean.class, SerializableFunctions.identity());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_MAP_BEAN_SCHEMA, schema);
   }
 
@@ -129,7 +145,9 @@ public class JavaBeanUtilsTest {
     simpleBean.setBigDecimal(new BigDecimal(42));
     simpleBean.setStringBuilder(new StringBuilder("stringBuilder"));
 
-    List<FieldValueGetter> getters = JavaBeanUtils.getGetters(SimpleBean.class, SIMPLE_BEAN_SCHEMA);
+    List<FieldValueGetter> getters =
+        JavaBeanUtils.getGetters(
+            SimpleBean.class, SIMPLE_BEAN_SCHEMA, SerializableFunctions.identity());
     assertEquals(12, getters.size());
     assertEquals("str", getters.get(0).name());
 
@@ -198,7 +216,10 @@ public class JavaBeanUtilsTest {
     bean.setaBoolean(true);
 
     List<FieldValueGetter> getters =
-        JavaBeanUtils.getGetters(BeanWithBoxedFields.class, BEAN_WITH_BOXED_FIELDS_SCHEMA);
+        JavaBeanUtils.getGetters(
+            BeanWithBoxedFields.class,
+            BEAN_WITH_BOXED_FIELDS_SCHEMA,
+            SerializableFunctions.identity());
     assertEquals((byte) 41, getters.get(0).get(bean));
     assertEquals((short) 42, getters.get(1).get(bean));
     assertEquals((int) 43, getters.get(2).get(bean));


### PR DESCRIPTION
This includes ByteBuddy codegen for handling SpecificRecord classes, as well as utilities for GenericRecord. A follow PR adds support for Avro POJO objects and refactors these classes.

R: @kanterov 