### PR TITLE
 [BEAM-4453] Stop subclassing user POJOs.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/PojoTypeUserTypeCreatorFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/PojoTypeUserTypeCreatorFactory.java
@@ -17,14 +17,12 @@
  */
 package org.apache.beam.sdk.schemas;
 
-import java.lang.reflect.Constructor;
 import org.apache.beam.sdk.schemas.utils.POJOUtils;
 
 /** Vends constructors for POJOs. */
 class PojoTypeUserTypeCreatorFactory implements UserTypeCreatorFactory {
   @Override
   public SchemaUserTypeCreator create(Class<?> clazz, Schema schema) {
-    Constructor<?> constructor = POJOUtils.getConstructor(clazz, schema);
-    return new SchemaUserTypeConstructorCreator(clazz, constructor);
+    return POJOUtils.getCreator(clazz, schema);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -150,7 +150,6 @@ public class POJOUtils {
               .method(ElementMatchers.named("create"))
               .intercept(new CreateInstruction(fields, clazz));
 
-
       return builder
           .make()
           .load(ReflectHelpers.findClassLoader(), ClassLoadingStrategy.Default.INJECTION)


### PR DESCRIPTION
Previously we were subclassing user POJO objects in order to create them from a Beam Row. This can cause unexpected behavior: e.g. many equals() implementations check that the class is the same, and and will fail if the rhs is a subclass. In this PR we stop doing this, and instead simply generate the code to create the POJO directly.

As a bonus, this should be a small performance boost, as we no longer use reflection to creat e the object.