### PR TITLE
[BEAM-5723] Changed shadow plugin configuration to avoid relocating g…

### DIFF
--- a/sdks/java/io/cassandra/build.gradle
+++ b/sdks/java/io/cassandra/build.gradle
@@ -17,10 +17,7 @@
  */
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(shadowClosure: {
-    dependencies {
-        include(dependency(project.library.java.guava))
-    }
+applyJavaNature(shadowClosure: DEFAULT_SHADOW_CLOSURE >> {
     // guava uses the com.google.common and com.google.thirdparty package namespaces
     relocate("com.google.common", project.getJavaRelocatedPath("com.google.common")) {
         // com.google.common is too generic, need to exclude guava-testlib
@@ -33,7 +30,6 @@ applyJavaNature(shadowClosure: {
     }
     // we haven't relocated this so we shouldn't shadow it either
     exclude "com/google/common/util/concurrent/ListenableFuture.class"
-    relocate "com.google.thirdparty", project.getJavaRelocatedPath("com.google.thirdparty")
 })
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
@@ -44,11 +40,11 @@ ext.summary = "IO to read and write with Apache Cassandra database"
 def cassandra_version = "3.5.0"
 
 dependencies {
-  compile library.java.guava
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.slf4j_api
   shadow "com.datastax.cassandra:cassandra-driver-core:$cassandra_version"
   shadow "com.datastax.cassandra:cassandra-driver-mapping:$cassandra_version"
+  shadow library.java.vendored_guava_20_0
   testCompile project(path: ":beam-runners-direct-java", configuration: "shadow")
   testCompile project(path: ":beam-sdks-java-io-common", configuration: "shadowTest")
   testCompile library.java.junit

--- a/sdks/java/io/cassandra/build.gradle
+++ b/sdks/java/io/cassandra/build.gradle
@@ -17,19 +17,11 @@
  */
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(shadowClosure: DEFAULT_SHADOW_CLOSURE >> {
-    // guava uses the com.google.common and com.google.thirdparty package namespaces
-    relocate("com.google.common", project.getJavaRelocatedPath("com.google.common")) {
-        // com.google.common is too generic, need to exclude guava-testlib
-        exclude "com.google.common.collect.testing.**"
-        exclude "com.google.common.escape.testing.**"
-        exclude "com.google.common.testing.**"
-        exclude "com.google.common.util.concurrent.testing.**"
-        // don't relocate because the cassandra driver's public API uses it
-        exclude "com.google.common.util.concurrent.ListenableFuture"
-    }
-    // we haven't relocated this so we shouldn't shadow it either
-    exclude "com/google/common/util/concurrent/ListenableFuture.class"
+// exclude everything because we don't need to repackage any dependencies
+applyJavaNature(shadowClosure: {
+  dependencies {
+    exclude { true }
+  }
 })
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()

--- a/sdks/java/io/cassandra/build.gradle
+++ b/sdks/java/io/cassandra/build.gradle
@@ -17,7 +17,24 @@
  */
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature()
+applyJavaNature(shadowClosure: {
+    dependencies {
+        include(dependency(project.library.java.guava))
+    }
+    // guava uses the com.google.common and com.google.thirdparty package namespaces
+    relocate("com.google.common", project.getJavaRelocatedPath("com.google.common")) {
+        // com.google.common is too generic, need to exclude guava-testlib
+        exclude "com.google.common.collect.testing.**"
+        exclude "com.google.common.escape.testing.**"
+        exclude "com.google.common.testing.**"
+        exclude "com.google.common.util.concurrent.testing.**"
+        // don't relocate because the cassandra driver's public API uses it
+        exclude "com.google.common.util.concurrent.ListenableFuture"
+    }
+    // we haven't relocated this so we shouldn't shadow it either
+    exclude "com/google/common/util/concurrent/ListenableFuture.class"
+    relocate "com.google.thirdparty", project.getJavaRelocatedPath("com.google.thirdparty")
+})
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
 

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
@@ -79,6 +79,7 @@ import org.apache.beam.sdk.values.PDone;
  */
 @Experimental(Experimental.Kind.SOURCE_SINK)
 public class CassandraIO {
+
   private CassandraIO() {}
 
   /** Provide a {@link Read} {@link PTransform} to read data from a Cassandra database. */

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImpl.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImpl.java
@@ -32,8 +32,6 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -45,6 +43,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterators;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
…uava's ListenableFuture

This seems to be required because the Cassandra driver uses `ListenableFuture` in it's public API, causing relocation to break `CassandraServiceImpl` since its bytecode expects the relocated class but the driver always returns the original one.

My change was simply to exclude `ListenableFuture` from relocation *and* shadowing.

@jbonofre

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




