### PR TITLE
Fixing publishing problem introduced in #7197

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -902,7 +902,7 @@ artifactId=${project.name}
         project.artifacts.archives project.javadocJar
 
         project.publishing {
-          repositories = project.ext.repositories
+          repositories project.ext.repositories
 
           publications {
             mavenJava(MavenPublication) {


### PR DESCRIPTION
Verified that the following command fails before this fix, succeeds after:

```
./gradlew -Ppublishing --no-parallel -PdistMgmtSnapshotsUrl=file:///Users/garrettjones/.m2/repository/ -p sdks/java/io/kafka/ publish
```
