### PR TITLE
Remove Gradle from Jenkins job names

### DIFF
--- a/.test-infra/jenkins/job_PostCommit_Go.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Go.groovy
@@ -21,9 +21,10 @@ import PostcommitJobBuilder
 
 // This is the Go postcommit which runs a gradle build, and the current set
 // of postcommit tests.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Go_GradleBuild', 'Run Go PostCommit',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Go', 'Run Go PostCommit',
   './gradlew :goPostCommit', this) {
   description('Runs Go PostCommit tests against master.')
+  previousNames(/beam_PostCommit_Go_GradleBuild/)
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(

--- a/.test-infra/jenkins/job_PostCommit_Java.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java.groovy
@@ -22,10 +22,11 @@ import PostcommitJobBuilder
 
 // This job runs the Java postcommit tests, including the suite of integration
 // tests.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_GradleBuild', 'Run Java PostCommit',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java', 'Run Java PostCommit',
   'Java SDK Post Commit Tests', this) {
 
   description('Runs PostCommit tests on the Java SDK.')
+  previousNames(/beam_PostCommit_Java_GradleBuild/)
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)

--- a/.test-infra/jenkins/job_PostCommit_Java_PortabilityApi.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_PortabilityApi.groovy
@@ -22,10 +22,11 @@ import PostcommitJobBuilder
 
 // This job runs the Java postcommit tests, including the suite of integration
 // tests.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_PortabilityApi_GradleBuild', 'Run Java PortabilityApi PostCommit',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_PortabilityApi', 'Run Java PortabilityApi PostCommit',
   'Java SDK PortabilityApi Post Commit Tests', this) {
 
   description('Runs PostCommit tests on the Java SDK using Portability APIs.')
+  previousNames(/beam_PostCommit_Java_PortabilityApi_GradleBuild/)
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)

--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Apex.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Apex.groovy
@@ -20,7 +20,7 @@ import CommonJobProperties as commonJobProperties
 import PostcommitJobBuilder
 
 // This job runs the suite of ValidatesRunner tests against the Apex runner.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Apex_Gradle',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Apex',
   'Run Apex ValidatesRunner', 'Apache Apex Runner ValidatesRunner Tests', this) {
   description('Runs the ValidatesRunner suite on the Apex runner.')
   previousNames('beam_PostCommit_Java_ValidatesRunner_Apex')
@@ -28,6 +28,7 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Apex_Gr
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate)
+  previousNames(/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/)
 
   // Publish all test results to Jenkins
   publishers {

--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Dataflow.groovy
@@ -22,15 +22,14 @@ import PostcommitJobBuilder
 
 // This job runs the suite of ValidatesRunner tests against the Dataflow
 // runner.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Dataflow',
   'Run Dataflow ValidatesRunner', 'Google Cloud Dataflow Runner ValidatesRunner Tests', this) {
 
   description('Runs the ValidatesRunner suite on the Dataflow runner.')
-  previousNames('beam_PostCommit_Java_ValidatesRunner_Dataflow')
-  previousNames('beam_PostCommit_Java_RunnableOnService_Dataflow')
 
   // Set common parameters. Sets a 3 hour timeout.
   commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 300)
+  previousNames(/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/)
 
   // Publish all test results to Jenkins
   publishers {

--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Flink.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Flink.groovy
@@ -20,12 +20,13 @@ import CommonJobProperties as commonJobProperties
 import PostcommitJobBuilder
 
 // This job runs the suite of ValidatesRunner tests against the Flink runner.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Flink_Gradle',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Flink',
   'Run Flink ValidatesRunner', 'Apache Flink Runner ValidatesRunner Tests', this) {
   description('Runs the ValidatesRunner suite on the Flink runner.')
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate)
+  previousNames(/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/)
 
   // Publish all test results to Jenkins
   publishers {

--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Gearpump.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Gearpump.groovy
@@ -21,12 +21,11 @@ import PostcommitJobBuilder
 
 // This job runs the suite of ValidatesRunner tests against the Gearpump
 // runner.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Gearpump',
   'Run Gearpump ValidatesRunner', 'Apache Gearpump Runner ValidatesRunner Tests',
   this) {
   description('Runs the ValidatesRunner suite on the Gearpump runner.')
-  previousNames('beam_PostCommit_Java_ValidatesRunner_Gearpump')
-  previousNames('beam_PostCommit_Java_RunnableOnService_Gearpump')
+  previousNames(/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/)
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(

--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_PortabilityApi_Dataflow.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_PortabilityApi_Dataflow.groovy
@@ -22,10 +22,11 @@ import PostcommitJobBuilder
 
 // This job runs the suite of ValidatesRunner tests against the Dataflow
 // runner.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_PortabilityApi_Dataflow_Gradle',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_PortabilityApi_Dataflow',
   'Run Dataflow PortabilityApi ValidatesRunner', 'Google Cloud Dataflow Runner PortabilityApi ValidatesRunner Tests', this) {
 
   description('Runs the ValidatesRunner suite on the Dataflow PortabilityApi runner.')
+  previousNames(/beam_PostCommit_Java_ValidatesRunner_PortabilityApi_Dataflow_Gradle/)
 
   // Set common parameters. Sets a 3 hour timeout.
   commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 400)

--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Samza.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Samza.groovy
@@ -20,9 +20,10 @@ import CommonJobProperties as commonJobProperties
 import PostcommitJobBuilder
 
 // This job runs the suite of ValidatesRunner tests against the Samza runner.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Samza_Gradle',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Samza',
   'Run Samza ValidatesRunner', 'Apache Samza Runner ValidatesRunner Tests', this) {
   description('Runs the ValidatesRunner suite on the Samza runner.')
+  previousNames(/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/)
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate)

--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Spark.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Spark.groovy
@@ -20,11 +20,10 @@ import CommonJobProperties as commonJobProperties
 import PostcommitJobBuilder
 
 // This job runs the suite of ValidatesRunner tests against the Spark runner.
-PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Spark_Gradle',
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Spark',
   'Run Spark ValidatesRunner', 'Apache Spark Runner ValidatesRunner Tests', this) {
   description('Runs the ValidatesRunner suite on the Spark runner.')
-  previousNames('beam_PostCommit_Java_ValidatesRunner_Spark')
-  previousNames('beam_PostCommit_Java_RunnableOnService_Spark')
+  previousNames(/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/)
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 120)

--- a/.test-infra/jenkins/job_Release_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_Release_NightlySnapshot.groovy
@@ -20,8 +20,9 @@ import CommonJobProperties as commonJobProperties
 
 // This creates the nightly snapshot build.
 // Into https://repository.apache.org/content/groups/snapshots/org/apache/beam.
-job('beam_Release_Gradle_NightlySnapshot') {
+job('beam_Release_NightlySnapshot') {
   description('Publish a nightly snapshot.')
+  previousNames(/beam_Release_Gradle_NightlySnapshot/)
 
   // Execute concurrent builds if necessary.
   concurrentBuild()


### PR DESCRIPTION
This is an artifact from the build migration from Maven to Gradle.
During migration we were maintaining both build systems, and had Jenkins
jobs for both variants. Now that Maven is gone, there is no need to
specify 'Gradle' in the job name. This makes all the job names a bit
shorter.

**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




