### PR TITLE
[BEAM-6239] Add SQL sessionize then side input join as a benchmark

### DIFF
--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkConfiguration.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
+import org.joda.time.Duration;
 
 /**
  * Configuration controlling how a query is run. May be supplied by command line or
@@ -70,6 +71,9 @@ public class NexmarkConfiguration implements Serializable {
    * stream to static enrichment data.
    */
   @JsonProperty public String sideInputUrl = null;
+
+  /** Gap for the session in {@link org.apache.beam.sdk.nexmark.queries.SessionSideInputJoin}. */
+  @JsonProperty public Duration sessionGap = Duration.standardMinutes(10);
 
   /**
    * Number of events to generate. If zero, generate as many as possible without overflowing

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
@@ -78,6 +78,8 @@ import org.apache.beam.sdk.nexmark.queries.Query8;
 import org.apache.beam.sdk.nexmark.queries.Query8Model;
 import org.apache.beam.sdk.nexmark.queries.Query9;
 import org.apache.beam.sdk.nexmark.queries.Query9Model;
+import org.apache.beam.sdk.nexmark.queries.SessionSideInputJoin;
+import org.apache.beam.sdk.nexmark.queries.SessionSideInputJoinModel;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlBoundedSideInputJoin;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlQuery0;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlQuery1;
@@ -1218,6 +1220,7 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
         .put(NexmarkQueryName.MONITOR_NEW_USERS, new Query8Model(configuration))
         .put(NexmarkQueryName.WINNING_BIDS, new Query9Model(configuration))
         .put(NexmarkQueryName.BOUNDED_SIDE_INPUT_JOIN, new BoundedSideInputJoinModel(configuration))
+        .put(NexmarkQueryName.SESSION_SIDE_INPUT_JOIN, new SessionSideInputJoinModel(configuration))
         .build();
   }
 
@@ -1285,6 +1288,9 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
         .put(
             NexmarkQueryName.BOUNDED_SIDE_INPUT_JOIN,
             new NexmarkQuery(configuration, new BoundedSideInputJoin(configuration)))
+        .put(
+            NexmarkQueryName.SESSION_SIDE_INPUT_JOIN,
+            new NexmarkQuery(configuration, new SessionSideInputJoin(configuration)))
         .build();
   }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
@@ -87,6 +87,7 @@ import org.apache.beam.sdk.nexmark.queries.sql.SqlQuery2;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlQuery3;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlQuery5;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlQuery7;
+import org.apache.beam.sdk.nexmark.queries.sql.SqlSessionSideInputJoin;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testutils.metrics.MetricsReader;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -1247,6 +1248,9 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
         .put(
             NexmarkQueryName.BOUNDED_SIDE_INPUT_JOIN,
             new NexmarkQuery(configuration, new SqlBoundedSideInputJoin(configuration)))
+        .put(
+            NexmarkQueryName.SESSION_SIDE_INPUT_JOIN,
+            new NexmarkQuery(configuration, new SqlSessionSideInputJoin(configuration)))
         .build();
   }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkQueryName.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkQueryName.java
@@ -42,7 +42,8 @@ public enum NexmarkQueryName {
   PROCESSING_TIME_WINDOWS(12), // Query "12"
 
   // Other non-numbered queries
-  BOUNDED_SIDE_INPUT_JOIN;
+  BOUNDED_SIDE_INPUT_JOIN,
+  SESSION_SIDE_INPUT_JOIN;
 
   private @Nullable Integer number;
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoin.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoin.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.queries;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.Map;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.model.Bid;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.WithKeys;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Sessions;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * Query that joins a stream to a bounded side input, modeling basic stream enrichment.
+ *
+ * <pre>
+ * SELECT bid.*, sideInput.*
+ * FROM bid, sideInput
+ * GROUP BY SESSION(etime => bid.bidtime, key => bid.auctionid)
+ * WHERE bid.id = sideInput.id
+ * </pre>
+ */
+public class SessionSideInputJoin extends NexmarkQueryTransform<Bid> {
+  private final NexmarkConfiguration configuration;
+
+  public SessionSideInputJoin(NexmarkConfiguration configuration) {
+    super("BoundedSideInputJoin");
+    this.configuration = configuration;
+  }
+
+  @Override
+  public boolean needsSideInput() {
+    return true;
+  }
+
+  @Override
+  public PCollection<Bid> expand(PCollection<Event> events) {
+
+    checkState(getSideInput() != null, "Configuration error: side input is null");
+
+    final PCollectionView<Map<Long, String>> sideInputMap = getSideInput().apply(View.asMap());
+
+    return events
+        // Only want the bid events; easier to fake some side input data
+        .apply(NexmarkQueryUtil.JUST_BIDS)
+
+        // Sessionize on bidtime keyed by bidder id (they might bid on multiple auctions)
+        .apply(WithKeys.of(new SimpleFunction<Bid, Long>(bid -> bid.bidder) {}))
+        .apply(Window.into(Sessions.withGapDuration(configuration.sessionGap)))
+        .apply(GroupByKey.create())
+
+        // Enrich each bid in the session with the joined data
+        // concatenated with the session bounds
+        .apply(
+            name + ".JoinToFiles",
+            ParDo.of(
+                    new DoFn<KV<Long, Iterable<Bid>>, Bid>() {
+                      @ProcessElement
+                      public void processElement(ProcessContext c, BoundedWindow untypedWindow) {
+                        IntervalWindow window = (IntervalWindow) untypedWindow;
+
+                        String extra =
+                            c.sideInput(sideInputMap)
+                                .get(c.element().getKey() % configuration.sideInputRowCount);
+
+                        for (Bid bid : c.element().getValue()) {
+                          c.output(
+                              new Bid(
+                                  bid.auction,
+                                  bid.bidder,
+                                  bid.price,
+                                  bid.dateTime,
+                                  extra + ":" + window.start() + ":" + window.end()));
+                        }
+                      }
+                    })
+                .withSideInputs(sideInputMap));
+  }
+}

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoinModel.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoinModel.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.queries;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Ordering;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.NexmarkUtils;
+import org.apache.beam.sdk.nexmark.model.Bid;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.Instant;
+
+/** A direct implementation of {@link SessionSideInputJoin}. */
+public class SessionSideInputJoinModel extends NexmarkQueryModel<Bid> {
+
+  /** Simulator for SESSION_SIDE_INPUT_JOIN query. */
+  private static class Simulator extends AbstractSimulator<Event, Bid> {
+    private final NexmarkConfiguration configuration;
+
+    /**
+     * Active session for each bidder. Data is generated in-order so one suffices. Flushed when the
+     * simulator terminates.
+     */
+    private final Map<Long, List<TimestampedValue<Event>>> activeSessions;
+
+    public Simulator(NexmarkConfiguration configuration) {
+      super(NexmarkUtils.standardEventIterator(configuration));
+      this.configuration = configuration;
+      this.activeSessions = new HashMap<>();
+    }
+
+    @Override
+    protected void run() {
+      TimestampedValue<Event> timestampedEvent = nextInput();
+      if (timestampedEvent == null) {
+        for (Long bidder : ImmutableSet.copyOf(activeSessions.keySet())) {
+          flushSession(bidder);
+        }
+        allDone();
+        return;
+      }
+      Event event = timestampedEvent.getValue();
+      if (event.bid == null) {
+        // Ignore non-bid events.
+        return;
+      }
+
+      List<TimestampedValue<Event>> activeSession = activeSessions.get(event.bid.bidder);
+      if (activeSession == null) {
+        beginSession(timestampedEvent);
+      } else if (timestampedEvent
+          .getTimestamp()
+          .isAfter(
+              activeSession
+                  .get(activeSession.size() - 1)
+                  .getTimestamp()
+                  .plus(configuration.sessionGap))) {
+        flushSession(event.bid.bidder);
+        beginSession(timestampedEvent);
+      } else {
+        activeSession.add(timestampedEvent);
+      }
+    }
+
+    private void beginSession(TimestampedValue<Event> timestampedEvent) {
+      checkState(activeSessions.get(timestampedEvent.getValue().bid.bidder) == null);
+      List<TimestampedValue<Event>> session = new ArrayList<>();
+      session.add(timestampedEvent);
+      activeSessions.put(timestampedEvent.getValue().bid.bidder, session);
+    }
+
+    private void flushSession(long bidder) {
+      List<TimestampedValue<Event>> session = activeSessions.get(bidder);
+      checkState(session != null);
+
+      Instant sessionStart =
+          Ordering.<Instant>natural()
+              .min(
+                  session
+                      .stream()
+                      .<Instant>map(tsv -> tsv.getTimestamp())
+                      .collect(Collectors.toList()));
+
+      Instant sessionEnd =
+          Ordering.<Instant>natural()
+              .max(
+                  session
+                      .stream()
+                      .<Instant>map(tsv -> tsv.getTimestamp())
+                      .collect(Collectors.toList()))
+              .plus(configuration.sessionGap);
+
+      for (TimestampedValue<Event> timestampedEvent : session) {
+        // Join to the side input is always a string representation of the id being looked up
+        Bid bid = timestampedEvent.getValue().bid;
+        Bid resultBid =
+            new Bid(
+                bid.auction,
+                bid.bidder,
+                bid.price,
+                bid.dateTime,
+                String.format(
+                    "%d:%s:%s",
+                    bid.bidder % configuration.sideInputRowCount, sessionStart, sessionEnd));
+        TimestampedValue<Bid> result =
+            TimestampedValue.of(resultBid, timestampedEvent.getTimestamp());
+        addResult(result);
+      }
+      activeSessions.remove(bidder);
+    }
+  }
+
+  public SessionSideInputJoinModel(NexmarkConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public AbstractSimulator<?, Bid> simulator() {
+    return new Simulator(configuration);
+  }
+
+  @Override
+  protected Collection<String> toCollection(Iterator<TimestampedValue<Bid>> itr) {
+    return toValue(itr);
+  }
+}

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/sql/SqlSessionSideInputJoin.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/sql/SqlSessionSideInputJoin.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.queries.sql;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import org.apache.beam.sdk.extensions.sql.SqlTransform;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.model.Bid;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.nexmark.model.sql.SelectEvent;
+import org.apache.beam.sdk.nexmark.queries.NexmarkQueryTransform;
+import org.apache.beam.sdk.nexmark.queries.NexmarkQueryUtil;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.transforms.Convert;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TupleTag;
+
+/** Advanced stream enrichment: join a sessionized stream to a bounded side input. */
+public class SqlSessionSideInputJoin extends NexmarkQueryTransform<Bid> {
+  private final String query;
+
+  public SqlSessionSideInputJoin(NexmarkConfiguration configuration) {
+    super("SqlSessionSideInputJoin");
+
+    // Notes on the sensitivities of our parsing and planning:
+    //  - cannot directly join MOD(bidder, x) = side.id because only equijoins on col refs allowed,
+    //    so we need a WITH clause or subquery
+    //  - must have the CAST inside the WITH clause for the same reason, otherwise the cast
+    //    occurs in the join condition CAST(side_id AS BIGINT) = side.id
+    query =
+        String.format(
+            "WITH sessions (bidder, bids, starttime, endtime) AS (%n"
+                + "  SELECT %n"
+                + "    bidder %n"
+                + "    ARRAY_AGG(ROW(auction, bidder, price, dateTime)),%n"
+                + "    SESSION_START(bid.bidtime, INTERVAL '%d' MINUTES))%n"
+                + "    SESSION_START(bid.bidtime, INTERVAL '%d' MINUTES))%n"
+                + "  FROM bid_with_side %n"
+                + "  GROUP BY bidder, SESSION(bid.bidtime, INTERVAL '%d' MINUTES))"
+                + "WITH session_with_side (bidder, bids, starttime, endtime, side_id) AS (%n"
+                + "  SELECT *, CAST(MOD(bidder, %d) AS BIGINT) side_id FROM sessions%n"
+                + ")%n"
+                + "SELECT %n"
+                + "  session_bid.auction, %n"
+                + "  session_with_side.bidder, %n"
+                + "  session_bid.price, %n"
+                + "  session_bid.dateTime, %n"
+                + "  CONCAT(side.extra, ':', starttime, ':', endtime) %n"
+                + "FROM session_with_side, side, %n"
+                + "JOIN UNNEST(session_with_side.bids) session_bid %n"
+                + "WHERE bid_with_side.side_id = side.id",
+            configuration.sessionGap.getStandardMinutes(),
+            configuration.sessionGap.getStandardMinutes(),
+            configuration.sessionGap.getStandardMinutes(),
+            configuration.sideInputRowCount);
+  }
+
+  @Override
+  public boolean needsSideInput() {
+    return true;
+  }
+
+  @Override
+  public PCollection<Bid> expand(PCollection<Event> events) {
+    PCollection<Row> bids =
+        events
+            .apply(Filter.by(NexmarkQueryUtil.IS_BID))
+            .apply(getName() + ".SelectEvent", new SelectEvent(Event.Type.BID));
+
+    checkState(getSideInput() != null, "Configuration error: side input is null");
+
+    TupleTag<Row> sideTag = new TupleTag<Row>("side") {};
+    TupleTag<Row> bidTag = new TupleTag<Row>("bid") {};
+
+    Schema schema =
+        Schema.of(
+            Schema.Field.of("id", Schema.FieldType.INT64),
+            Schema.Field.of("extra", Schema.FieldType.STRING));
+
+    PCollection<Row> sideRows =
+        getSideInput()
+            .setSchema(
+                schema,
+                kv -> Row.withSchema(schema).addValues(kv.getKey(), kv.getValue()).build(),
+                row -> KV.of(row.getInt64("id"), row.getString("extra")))
+            .apply("SideToRows", Convert.toRows());
+
+    return PCollectionTuple.of(bidTag, bids)
+        .and(sideTag, sideRows)
+        .apply(SqlTransform.query(query))
+        .apply("ResultToBid", Convert.fromRows(Bid.class));
+  }
+}

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoinTest.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoinTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.queries;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Iterables;
+import java.util.Random;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.NexmarkUtils;
+import org.apache.beam.sdk.nexmark.model.Bid;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.nexmark.model.KnownSize;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test the various NEXMark queries yield results coherent with their models. */
+@RunWith(JUnit4.class)
+public class SessionSideInputJoinTest {
+
+  @Rule public TestPipeline p = TestPipeline.create();
+
+  @Before
+  public void setupPipeline() {
+    NexmarkUtils.setupPipeline(NexmarkUtils.CoderStrategy.HAND, p);
+  }
+
+  /** Test {@code query} matches {@code model}. */
+  private <T extends KnownSize> void queryMatchesModel(
+      String name,
+      NexmarkConfiguration config,
+      NexmarkQueryTransform<T> query,
+      NexmarkQueryModel<T> model,
+      boolean streamingMode)
+      throws Exception {
+
+    ResourceId sideInputResourceId =
+        FileSystems.matchNewResource(
+            String.format(
+                "%s/SessionSideInputJoin-%s",
+                p.getOptions().getTempLocation(), new Random().nextInt()),
+            false);
+    config.sideInputUrl = sideInputResourceId.toString();
+
+    try {
+      PCollection<KV<Long, String>> sideInput = NexmarkUtils.prepareSideInput(p, config);
+      query.setSideInput(sideInput);
+
+      PCollection<Event> events =
+          p.apply(
+              name + ".Read",
+              streamingMode
+                  ? NexmarkUtils.streamEventsSource(config)
+                  : NexmarkUtils.batchEventsSource(config));
+
+      PCollection<TimestampedValue<T>> results =
+          (PCollection<TimestampedValue<T>>) events.apply(new NexmarkQuery<>(config, query));
+      PAssert.that(results).satisfies(model.assertionFor());
+      PipelineResult result = p.run();
+      result.waitUntilFinish();
+    } finally {
+      NexmarkUtils.cleanUpSideInput(config);
+    }
+  }
+
+  /**
+   * A smoke test that the count of input bids and outputs are the same, to help diagnose flakiness
+   * in more complex tests.
+   */
+  @Test
+  @Category(NeedsRunner.class)
+  public void inputOutputSameEvents() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    PCollection<KV<Long, String>> sideInput = NexmarkUtils.prepareSideInput(p, config);
+
+    try {
+      PCollection<Event> input = p.apply(NexmarkUtils.batchEventsSource(config));
+      PCollection<Bid> justBids = input.apply(NexmarkQueryUtil.JUST_BIDS);
+      PCollection<Long> bidCount = justBids.apply("Count Bids", Count.globally());
+
+      NexmarkQueryTransform<Bid> query = new SessionSideInputJoin(config);
+      query.setSideInput(sideInput);
+
+      PCollection<TimestampedValue<Bid>> output =
+          (PCollection<TimestampedValue<Bid>>) input.apply(new NexmarkQuery(config, query));
+      PCollection<Long> outputCount =
+          output.apply(Window.into(new GlobalWindows())).apply("Count outputs", Count.globally());
+
+      PAssert.that(PCollectionList.of(bidCount).and(outputCount).apply(Flatten.pCollections()))
+          .satisfies(
+              counts -> {
+                assertThat(Iterables.size(counts), equalTo(2));
+                assertThat(Iterables.get(counts, 0), greaterThan(0L));
+                assertThat(Iterables.get(counts, 0), equalTo(Iterables.get(counts, 1)));
+                return null;
+              });
+      p.run();
+    } finally {
+      NexmarkUtils.cleanUpSideInput(config);
+    }
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelBatchDirect() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+
+    queryMatchesModel(
+        "SessionSideInputJoinTestBatch",
+        config,
+        new SessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        false);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelStreamingDirect() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    queryMatchesModel(
+        "SessionSideInputJoinTestStreaming",
+        config,
+        new SessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        true);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelBatchCsv() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.CSV;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+
+    queryMatchesModel(
+        "SessionSideInputJoinTestBatch",
+        config,
+        new SessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        false);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelStreamingCsv() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.CSV;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    queryMatchesModel(
+        "SessionSideInputJoinTestStreaming",
+        config,
+        new SessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        true);
+  }
+}

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/sql/SqlSessionSideInputJoinTest.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/sql/SqlSessionSideInputJoinTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.queries.sql;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Iterables;
+import java.util.Random;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.NexmarkUtils;
+import org.apache.beam.sdk.nexmark.model.Bid;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.nexmark.model.KnownSize;
+import org.apache.beam.sdk.nexmark.queries.NexmarkQuery;
+import org.apache.beam.sdk.nexmark.queries.NexmarkQueryModel;
+import org.apache.beam.sdk.nexmark.queries.NexmarkQueryTransform;
+import org.apache.beam.sdk.nexmark.queries.NexmarkQueryUtil;
+import org.apache.beam.sdk.nexmark.queries.SessionSideInputJoinModel;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test the various NEXMark queries yield results coherent with their models. */
+@RunWith(JUnit4.class)
+public class SqlSessionSideInputJoinTest {
+
+  @Rule public TestPipeline p = TestPipeline.create();
+
+  @Before
+  public void setupPipeline() {
+    NexmarkUtils.setupPipeline(NexmarkUtils.CoderStrategy.HAND, p);
+  }
+
+  /** Test {@code query} matches {@code model}. */
+  private <T extends KnownSize> void queryMatchesModel(
+      String name,
+      NexmarkConfiguration config,
+      NexmarkQueryTransform<T> query,
+      NexmarkQueryModel<T> model,
+      boolean streamingMode)
+      throws Exception {
+
+    ResourceId sideInputResourceId =
+        FileSystems.matchNewResource(
+            String.format(
+                "%s/JoinToFiles-%s", p.getOptions().getTempLocation(), new Random().nextInt()),
+            false);
+    config.sideInputUrl = sideInputResourceId.toString();
+
+    try {
+      PCollection<KV<Long, String>> sideInput = NexmarkUtils.prepareSideInput(p, config);
+      query.setSideInput(sideInput);
+
+      PCollection<Event> events =
+          p.apply(
+              name + ".Read",
+              streamingMode
+                  ? NexmarkUtils.streamEventsSource(config)
+                  : NexmarkUtils.batchEventsSource(config));
+
+      PCollection<TimestampedValue<T>> results =
+          (PCollection<TimestampedValue<T>>) events.apply(new NexmarkQuery<>(config, query));
+      PAssert.that(results).satisfies(model.assertionFor());
+      PipelineResult result = p.run();
+      result.waitUntilFinish();
+    } finally {
+      NexmarkUtils.cleanUpSideInput(config);
+    }
+  }
+
+  /**
+   * A smoke test that the count of input bids and outputs are the same, to help diagnose flakiness
+   * in more complex tests.
+   */
+  @Test
+  @Category(NeedsRunner.class)
+  public void inputOutputSameEvents() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    PCollection<KV<Long, String>> sideInput = NexmarkUtils.prepareSideInput(p, config);
+
+    try {
+      PCollection<Event> input = p.apply(NexmarkUtils.batchEventsSource(config));
+      PCollection<Bid> justBids = input.apply(NexmarkQueryUtil.JUST_BIDS);
+      PCollection<Long> bidCount = justBids.apply("Count Bids", Count.globally());
+
+      NexmarkQueryTransform<Bid> query = new SqlSessionSideInputJoin(config);
+      query.setSideInput(sideInput);
+
+      PCollection<TimestampedValue<Bid>> output =
+          (PCollection<TimestampedValue<Bid>>) input.apply(new NexmarkQuery(config, query));
+      PCollection<Long> outputCount = output.apply("Count outputs", Count.globally());
+
+      PAssert.that(PCollectionList.of(bidCount).and(outputCount).apply(Flatten.pCollections()))
+          .satisfies(
+              counts -> {
+                assertThat(Iterables.size(counts), equalTo(2));
+                assertThat(Iterables.get(counts, 0), greaterThan(0L));
+                assertThat(Iterables.get(counts, 0), equalTo(Iterables.get(counts, 1)));
+                return null;
+              });
+      p.run();
+    } finally {
+      NexmarkUtils.cleanUpSideInput(config);
+    }
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelBatchDirect() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+
+    queryMatchesModel(
+        "SqlSessionSideInputJoinTestBatch",
+        config,
+        new SqlSessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        false);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelStreamingDirect() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    queryMatchesModel(
+        "SqlSessionSideInputJoinTestStreaming",
+        config,
+        new SqlSessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        true);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelBatchCsv() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.CSV;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+
+    queryMatchesModel(
+        "SqlSessionSideInputJoinTestBatch",
+        config,
+        new SqlSessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        false);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelStreamingCsv() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.CSV;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    queryMatchesModel(
+        "SqlSessionSideInputJoinTestStreaming",
+        config,
+        new SqlSessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        true);
+  }
+}


### PR DESCRIPTION
This is my attempt at #7287 in SQL. I believe these features may not be supported by Calcite, and have reached out to their mailing list.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




