### PR TITLE
[BEAM-6155] Plumb the contexts though the gcsx library.

### DIFF
--- a/sdks/go/pkg/beam/artifact/gcsproxy/retrieval.go
+++ b/sdks/go/pkg/beam/artifact/gcsproxy/retrieval.go
@@ -45,7 +45,7 @@ func ReadProxyManifest(ctx context.Context, object string) (*pb.ProxyManifest, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GCS client: %v", err)
 	}
-	content, err := gcsx.ReadObject(cl, bucket, obj)
+	content, err := gcsx.ReadObject(ctx, cl, bucket, obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read manifest %v: %v", object, err)
 	}
@@ -88,13 +88,13 @@ func (s *RetrievalServer) GetArtifact(req *pb.GetArtifactRequest, stream pb.Arti
 
 	bucket, object := parseObject(blob)
 
-	client, err := gcsx.NewClient(stream.Context(), storage.ScopeReadOnly)
+	ctx := stream.Context()
+	client, err := gcsx.NewClient(ctx, storage.ScopeReadOnly)
 	if err != nil {
 		return fmt.Errorf("Failed to create client for %v: %v", key, err)
 	}
 
 	// Stream artifact in up to 1MB chunks.
-	ctx := context.TODO()
 	r, err := client.Bucket(bucket).Object(object).NewReader(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to read object for %v: %v", key, err)

--- a/sdks/go/pkg/beam/runners/dataflow/dataflow.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow.go
@@ -182,7 +182,7 @@ func gcsRecorderHook(opts []string) perf.CaptureHook {
 		if err != nil {
 			return fmt.Errorf("couldn't establish GCS client: %v", err)
 		}
-		return gcsx.WriteObject(client, bucket, path.Join(prefix, spec), r)
+		return gcsx.WriteObject(ctx, client, bucket, path.Join(prefix, spec), r)
 	}
 }
 

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/stage.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/stage.go
@@ -51,6 +51,6 @@ func upload(ctx context.Context, project, object string, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	_, err = gcsx.Upload(client, project, bucket, obj, r)
+	_, err = gcsx.Upload(ctx, client, project, bucket, obj, r)
 	return err
 }

--- a/sdks/go/pkg/beam/util/gcsx/gcs.go
+++ b/sdks/go/pkg/beam/util/gcsx/gcs.go
@@ -41,18 +41,18 @@ func NewUnauthenticatedClient(ctx context.Context) (*storage.Client, error) {
 
 // Upload writes the given content to GCS. If the specified bucket does not
 // exist, it is created first. Returns the full path of the object.
-func Upload(client *storage.Client, project, bucket, object string, r io.Reader) (string, error) {
-	exists, err := BucketExists(client, bucket)
+func Upload(ctx context.Context, client *storage.Client, project, bucket, object string, r io.Reader) (string, error) {
+	exists, err := BucketExists(ctx, client, bucket)
 	if err != nil {
 		return "", err
 	}
 	if !exists {
-		if err = CreateBucket(client, project, bucket); err != nil {
+		if err = CreateBucket(ctx, client, project, bucket); err != nil {
 			return "", err
 		}
 	}
 
-	if err := WriteObject(client, bucket, object, r); err != nil {
+	if err := WriteObject(ctx, client, bucket, object, r); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("gs://%s/%s", bucket, object), nil
@@ -60,14 +60,12 @@ func Upload(client *storage.Client, project, bucket, object string, r io.Reader)
 }
 
 // CreateBucket creates a bucket in GCS.
-func CreateBucket(client *storage.Client, project, bucket string) error {
-	ctx := context.TODO()
+func CreateBucket(ctx context.Context, client *storage.Client, project, bucket string) error {
 	return client.Bucket(bucket).Create(ctx, project, nil)
 }
 
 // BucketExists returns true iff the given bucket exists.
-func BucketExists(client *storage.Client, bucket string) (bool, error) {
-	ctx := context.TODO()
+func BucketExists(ctx context.Context, client *storage.Client, bucket string) (bool, error) {
 	_, err := client.Bucket(bucket).Attrs(ctx)
 	if err == storage.ErrBucketNotExist {
 		return false, nil
@@ -77,8 +75,7 @@ func BucketExists(client *storage.Client, bucket string) (bool, error) {
 
 // WriteObject writes the given content to the specified object. If the object
 // already exist, it is overwritten.
-func WriteObject(client *storage.Client, bucket, object string, r io.Reader) error {
-	ctx := context.TODO()
+func WriteObject(ctx context.Context, client *storage.Client, bucket, object string, r io.Reader) error {
 	w := client.Bucket(bucket).Object(object).NewWriter(ctx)
 	_, err := io.Copy(w, r)
 	if err != nil {
@@ -88,8 +85,7 @@ func WriteObject(client *storage.Client, bucket, object string, r io.Reader) err
 }
 
 // ReadObject reads the content of the given object in full.
-func ReadObject(client *storage.Client, bucket, object string) ([]byte, error) {
-	ctx := context.TODO()
+func ReadObject(ctx context.Context, client *storage.Client, bucket, object string) ([]byte, error) {
 	r, err := client.Bucket(bucket).Object(object).NewReader(ctx)
 	if err != nil {
 		return nil, err

--- a/sdks/go/pkg/beam/util/gcsx/gcs_test.go
+++ b/sdks/go/pkg/beam/util/gcsx/gcs_test.go
@@ -17,6 +17,7 @@ package gcsx_test
 
 import (
 	"context"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/gcsx"
@@ -34,7 +35,10 @@ func Example() {
 		// do something
 	}
 
-	bytes, err := gcsx.ReadObject(c, buckets, object)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	bytes, err := gcsx.ReadObject(ctx, c, buckets, object)
 	if err != nil {
 		// do something
 	}


### PR DESCRIPTION
Plumb the context through the gcsx library. This is a continuation from https://github.com/apache/beam/pull/7182

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




