### PR TITLE
[BEAM-5449] Tagging failing ULR ValidatesRunner tests.

### DIFF
--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -160,24 +160,32 @@ createJavaExamplesArchetypeValidationTask(type: 'MobileGaming',
 createPortableValidatesRunnerTask(
         jobServerDriver: "org.apache.beam.runners.direct.portable.job.ReferenceRunnerJobServer",
         testClasspathConfiguration: configurations.validatesPortableRunner,
+        jobServerConfig: "--port=0",
         testCategories: {
           includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
           excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
           excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
-          excludeCategories 'org.apache.beam.sdk.testing.UsesAttemptedMetrics'
-          excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
-          excludeCategories 'org.apache.beam.sdk.testing.UsesCounterMetrics'
           excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
           excludeCategories 'org.apache.beam.sdk.testing.UsesDistributionMetrics'
           excludeCategories 'org.apache.beam.sdk.testing.UsesFailureMessage'
-          excludeCategories 'org.apache.beam.sdk.testing.UsesGaugeMetrics'
           excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
-          excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
-          excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
           excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
-          //SplitableDoFnTests
+          // TODO(BEAM-5452): Support metrics.
+          excludeCategories 'org.apache.beam.sdk.testing.UsesGaugeMetrics'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesAttemptedMetrics'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesCounterMetrics'
+          // TODO(BEAM-3743): Support SplittableDoFn
           excludeCategories 'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo'
           excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs'
           excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+          // TODO(BEAM-2928): Support sideinput.
+          excludeCategories 'org.apache.beam.sdk.testing.UsesSideInputs'
+          // TODO(BEAM-2917): Support user state.
+          excludeCategories 'org.apache.beam.sdk.testing.UsesStatefulParDo'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
+          // TODO(BEAM-4680): Support user timers.
+          excludeCategories 'org.apache.beam.sdk.testing.UsesTimersInParDo'
         },
 )

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.testing.DataflowPortabilityApiUnsupported;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesStatefulParDo;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Distinct;
@@ -92,7 +93,11 @@ public class CountingSourceTest {
   }
 
   @Test
-  @Category({ValidatesRunner.class, DataflowPortabilityApiUnsupported.class})
+  @Category({
+    ValidatesRunner.class,
+    UsesStatefulParDo.class, // This test fails if State is unsupported despite no direct usage.
+    DataflowPortabilityApiUnsupported.class
+  })
   public void testBoundedSourceSplits() throws Exception {
     long numElements = 1000;
     long numSplits = 10;
@@ -214,7 +219,11 @@ public class CountingSourceTest {
   }
 
   @Test
-  @Category({ValidatesRunner.class, DataflowPortabilityApiUnsupported.class})
+  @Category({
+    ValidatesRunner.class,
+    UsesStatefulParDo.class, // This test fails if State is unsupported despite no direct usage.
+    DataflowPortabilityApiUnsupported.class
+  })
   public void testUnboundedSourceSplits() throws Exception {
     long numElements = 1000;
     int numSplits = 10;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
@@ -306,7 +306,11 @@ public class PAssertTest implements Serializable {
 
   /** Basic test for {@code isEqualTo}. */
   @Test
-  @Category({ValidatesRunner.class, DataflowPortabilityExecutableStageUnsupported.class})
+  @Category({
+    ValidatesRunner.class,
+    UsesStatefulParDo.class, // This test fails if State is unsupported despite no direct usage.
+    DataflowPortabilityExecutableStageUnsupported.class
+  })
   public void testWindowedIsEqualTo() throws Exception {
     PCollection<Integer> pcollection =
         pipeline

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineFnsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineFnsTest.java
@@ -40,6 +40,7 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.DataflowPortabilityApiUnsupported;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSideInputs;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Combine.BinaryCombineFn;
 import org.apache.beam.sdk.transforms.CombineFns.CoCombineResult;
@@ -97,7 +98,7 @@ public class CombineFnsTest {
   }
 
   @Test
-  @Category({ValidatesRunner.class, DataflowPortabilityApiUnsupported.class})
+  @Category({ValidatesRunner.class, UsesSideInputs.class, DataflowPortabilityApiUnsupported.class})
   public void testComposedCombine() {
     p.getCoderRegistry().registerCoderForClass(UserString.class, UserStringCoder.of());
 
@@ -147,7 +148,7 @@ public class CombineFnsTest {
   }
 
   @Test
-  @Category({ValidatesRunner.class, DataflowPortabilityApiUnsupported.class})
+  @Category({ValidatesRunner.class, UsesSideInputs.class, DataflowPortabilityApiUnsupported.class})
   public void testComposedCombineWithContext() {
     p.getCoderRegistry().registerCoderForClass(UserString.class, UserStringCoder.of());
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -648,7 +648,11 @@ public class CombineTest implements Serializable {
   @RunWith(JUnit4.class)
   public static class BasicTests extends SharedTestBase {
     @Test
-    @Category({ValidatesRunner.class, DataflowPortabilityApiUnsupported.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesSideInputs.class,
+      DataflowPortabilityApiUnsupported.class
+    })
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void testSimpleCombine() {
       runTestSimpleCombine(
@@ -658,7 +662,11 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, DataflowPortabilityApiUnsupported.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesSideInputs.class,
+      DataflowPortabilityApiUnsupported.class
+    })
     public void testSimpleCombineEmpty() {
       runTestSimpleCombine(EMPTY_TABLE, 0, Collections.emptyList());
     }
@@ -1024,7 +1032,11 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, DataflowPortabilityExecutableStageUnsupported.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesSideInputs.class,
+      DataflowPortabilityExecutableStageUnsupported.class
+    })
     public void testFixedWindowsCombineWithContext() {
       PCollection<KV<String, Integer>> perKeyInput =
           pipeline
@@ -1125,7 +1137,11 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, DataflowPortabilityExecutableStageUnsupported.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesSideInputs.class,
+      DataflowPortabilityExecutableStageUnsupported.class
+    })
     public void testSlidingWindowsCombineWithContext() {
       // [a: 1, 1], [a: 4; b: 1], [b: 13]
       PCollection<KV<String, Integer>> perKeyInput =
@@ -1229,7 +1245,11 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, DataflowPortabilityExecutableStageUnsupported.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesSideInputs.class,
+      DataflowPortabilityExecutableStageUnsupported.class
+    })
     public void testSessionsCombineWithContext() {
       PCollection<KV<String, Integer>> perKeyInput =
           pipeline.apply(
@@ -1320,7 +1340,11 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, DataflowPortabilityExecutableStageUnsupported.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesSideInputs.class,
+      DataflowPortabilityExecutableStageUnsupported.class
+    })
     public void testWindowedCombineGloballyAsSingletonView() {
       FixedWindows windowFn = FixedWindows.of(Duration.standardMinutes(1));
       final PCollectionView<Integer> view =
@@ -1401,7 +1425,11 @@ public class CombineTest implements Serializable {
   @RunWith(JUnit4.class)
   public static class AccumulationTests extends SharedTestBase {
     @Test
-    @Category({ValidatesRunner.class, DataflowPortabilityApiUnsupported.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesSideInputs.class,
+      DataflowPortabilityApiUnsupported.class
+    })
     public void testAccumulatingCombine() {
       runTestAccumulatingCombine(
           Arrays.asList(KV.of("a", 1), KV.of("a", 1), KV.of("a", 4), KV.of("b", 1), KV.of("b", 13)),
@@ -1410,7 +1438,11 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, DataflowPortabilityApiUnsupported.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesSideInputs.class,
+      DataflowPortabilityApiUnsupported.class
+    })
     public void testAccumulatingCombineEmpty() {
       runTestAccumulatingCombine(EMPTY_TABLE, 0.0, Collections.emptyList());
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
@@ -50,6 +50,7 @@ import org.apache.beam.sdk.testing.DataflowPortabilityApiUnsupported;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSideInputs;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
@@ -77,6 +78,7 @@ import org.junit.runners.JUnit4;
  * views can only be observed via {@link ParDo}.
  */
 @RunWith(JUnit4.class)
+@Category(UsesSideInputs.class)
 public class ViewTest implements Serializable {
   // This test is Serializable, just so that it's easy to have
   // anonymous inner classes inside the non-static test methods.


### PR DESCRIPTION
Adding new tags to ValidatesRunner tests so that Junit can skip them when running ULR ValidatesRunner tests. Also adding some TODOs with relevant bugs for getting the tests working.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




