### PR TITLE
[BEAM-6228] Ensure the website can build without a git repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ buildscript {
     classpath "gradle.plugin.io.pry.gradle.offline_dependencies:gradle-offline-dependencies-plugin:0.3" // Enable creating an offline repository
     classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"                                         // Enable errorprone Java static analysis
     classpath "com.github.ben-manes:gradle-versions-plugin:0.17.0"                                      // Enable dependency checks
-    classpath "org.ajoberstar.grgit:grgit-gradle:3.0.0-beta.1"                                          // Enable website git publish to asf-site branch
+    classpath "org.ajoberstar.grgit:grgit-gradle:3.0.0"                                                 // Enable website git publish to asf-site branch
     classpath "com.avast.gradle:gradle-docker-compose-plugin:0.8.8"                                     // Enable docker compose tasks
 
     // Plugins which require online access should not be enabled when running in offline mode.

--- a/website/build.gradle
+++ b/website/build.gradle
@@ -138,10 +138,21 @@ build.dependsOn buildWebsite
 createBuildTask( name:'Gcs', useTestConfig: true, baseUrl: getBaseUrl(), dockerWorkDir: dockerWorkDir)
 createBuildTask( name:'Apache', dockerWorkDir: dockerWorkDir)
 
+/**
+ * Use the pull request ID in the URL path, or the git branch when building locally.
+ * This allows staging multiple work trees without clobbering eachother, i.e.
+ * for shared GCS staging, or for locally comparing the differences between
+ * branches.
+ */
 def getBaseUrl() {
-  System.getenv('ghprbPullId')?.trim() ?:
-    "${System.getProperty('user.name')}-${grgit.branch.current().getName()}"
+  def pullRequestId = System.getenv('ghprbPullId')?.trim()
+  if (pullRequestId) { return pullRequestId }
+
+  // grgit is null if building outside of git (i.e. from source archive)
+  def buildContext = grgit ? grgit.branch.current().getName() : 'archive'
+  return "${System.getProperty('user.name')}-${buildContext}"
 }
+
 def buildContentDir(name) {
   "${project.rootDir}/build/website/generated-${name.toLowerCase()}-content"
 }
@@ -186,6 +197,7 @@ task preCommit {
 // Creates a new commit on asf-site branch
 task commitWebsite {
   doLast {
+    assert grgit : "Cannot commit website outside of git repository"
     assert file("${buildContentDir('apache')}/index.html").exists()
     // Generated javadoc and pydoc content is not built or stored in this repo.
     assert !file("${buildContentDir('apache')}/documentation/sdks/javadoc").exists()
@@ -242,6 +254,8 @@ task commitWebsite {
  */
 task publishWebsite {
   doLast {
+    assert grgit : "Cannot publish website outside of git repository"
+
     def git = grgit.open()
     git.checkout(branch: 'asf-site')
     if (!commitedChanges) {


### PR DESCRIPTION
During the 2.9.0 release, we [realized](https://lists.apache.org/thread.html/dc816a5f8c82dd4d19e82666209305ec67d46440fe8edba4534f9b63@%3Cdev.beam.apache.org%3E) that the website could not be built from the source archive because the build assumes a git environment. This change explicitly handles the case of building outside of git.

I validated this using the following steps:

1. Download a zip archive of this branch and unzip in a new directory: https://github.com/swegner/beam/archive/website_git.zip
  a. Copy gradle wrapper files which are [excluded from export](https://github.com/apache/beam/blob/d3fbf8059c1282fc12251538121830381dfaff6f/.gitattributes#L32).
1. From the unzipped directory, build and test the website: `./gradlew -p website check stageWebsite --scan`

The build [now succeeds](https://gradle.com/s/qjon5mqdxh4n4) and staged website was uploaded to http://apache-beam-website-pull-requests.storage.googleapis.com/swegner-archive/index.html

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




