### PR TITLE
[BEAM-5315] [BEAM-5627] [BEAM-5623] Python 3 port io.filesystem module

### DIFF
--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -209,7 +209,7 @@ class CompressedFile(object):
         # objects for the unused compressed data.
         if (self._compression_type == CompressionTypes.BZIP2 or
             self._compression_type == CompressionTypes.GZIP):
-          if self._decompressor.unused_data != '':
+          if self._decompressor.unused_data != b'':
             buf = self._decompressor.unused_data
             self._decompressor = (
                 bz2.BZ2Decompressor()
@@ -259,7 +259,7 @@ class CompressedFile(object):
       line = self._read_from_internal_buffer(
           lambda: self._read_buffer.readline())
       bytes_io.write(line)
-      if line.endswith('\n') or not line:
+      if line.endswith(b'\n') or not line:
         break  # Newline or EOF reached.
 
     return bytes_io.getvalue()

--- a/sdks/python/apache_beam/io/filesystem_test.py
+++ b/sdks/python/apache_beam/io/filesystem_test.py
@@ -265,7 +265,7 @@ class TestCompressedFile(unittest.TestCase):
   which will be deleted at the end of the tests (when tearDown() is called).
   """
 
-  content = """- the BEAM -
+  content = b"""- the BEAM -
 How things really are we would like to know.
 Does
      Time
@@ -291,10 +291,6 @@ atomized in instants hammered around the
     self._tempfiles.append(path)
     return path
 
-  @unittest.skipIf(sys.version_info[0] == 3 and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3'
-                   'TODO: BEAM-5627')
   def _create_compressed_file(self, compression_type, content):
     file_name = self._create_temp_file()
 
@@ -395,7 +391,7 @@ atomized in instants hammered around the
         seek_position = 0
         compressed_fd.seek(seek_position, os.SEEK_END)
 
-        expected_data = ''
+        expected_data = b''
         uncompressed_data = compressed_fd.read(10)
 
         self.assertEqual(uncompressed_data, expected_data)
@@ -435,14 +431,10 @@ atomized in instants hammered around the
 
         self.assertEqual(first_pass, second_pass)
 
-  @unittest.skipIf(sys.version_info[0] == 3 and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3'
-                   'TODO: BEAM-5627')
   def test_tell(self):
-    lines = ['line%d\n' % i for i in range(10)]
+    lines = [b'line%d\n' % i for i in range(10)]
     tmpfile = self._create_temp_file()
-    with open(tmpfile, 'w') as f:
+    with open(tmpfile, 'wb') as f:
       writeable = CompressedFile(f)
       current_offset = 0
       for line in lines:
@@ -450,7 +442,7 @@ atomized in instants hammered around the
         current_offset += len(line)
         self.assertEqual(current_offset, writeable.tell())
 
-    with open(tmpfile) as f:
+    with open(tmpfile, 'rb') as f:
       readable = CompressedFile(f)
       current_offset = 0
       while True:


### PR DESCRIPTION
This is is part of a series of PRs with goal to make Apache Beam PY3 compatible. The proposal with the outlined approach has been documented here: https://s.apache.org/beam-python-3.

Since the io package is quite big, with a large amount of open issues, I've decided to split up the porting of this package into multiple PRs.

This PR ports the io.filesystem module and fixes the hanging tests related to gzip (BEAM-5623), which were blocking further porting of the io package.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




