### PR TITLE
[BEAM-6287] pyarrow is not supported on Windows Python 2

### DIFF
--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -29,10 +29,9 @@ Parquet file.
 """
 from __future__ import absolute_import
 
+import platform
+import sys
 from functools import partial
-
-import pyarrow as pa
-import pyarrow.parquet as pq
 
 from apache_beam.io import filebasedsink
 from apache_beam.io import filebasedsource
@@ -41,6 +40,10 @@ from apache_beam.io.iobase import RangeTracker
 from apache_beam.io.iobase import Read
 from apache_beam.io.iobase import Write
 from apache_beam.transforms import PTransform
+
+if not (platform.system() == 'Windows' and sys.version_info[0] == 2):
+  import pyarrow as pa
+  import pyarrow.parquet as pq
 
 __all__ = ['ReadFromParquet', 'ReadAllFromParquet', 'WriteToParquet']
 

--- a/sdks/python/apache_beam/io/parquetio_it_test.py
+++ b/sdks/python/apache_beam/io/parquetio_it_test.py
@@ -18,12 +18,12 @@ from __future__ import absolute_import
 from __future__ import division
 
 import logging
+import platform
 import string
 import sys
 import unittest
 from collections import Counter
 
-import pyarrow as pa
 from nose.plugins.attrib import attr
 
 from apache_beam import Create
@@ -41,7 +41,14 @@ from apache_beam.testing.util import BeamAssertException
 from apache_beam.transforms import CombineGlobally
 from apache_beam.transforms.combiners import Count
 
+if not (platform.system() == 'Windows' and sys.version_info[0] == 2):
+  import pyarrow as pa
 
+
+@unittest.skipIf(
+    platform.system() == 'Windows' and sys.version_info[0] == 2,
+    "pyarrow doesn't support Windows Python 2."
+)
 class TestParquetIT(unittest.TestCase):
 
   @classmethod
@@ -55,12 +62,6 @@ class TestParquetIT(unittest.TestCase):
 
   def tearDown(self):
     pass
-
-  SCHEMA = pa.schema([
-      ('name', pa.binary()),
-      ('favorite_number', pa.int64()),
-      ('favorite_color', pa.binary())
-  ])
 
   @attr('IT')
   def test_parquetio_it(self):

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -159,6 +159,12 @@ elif sys.version_info[0] >= 3:
                       '@7a73fbe3d6aa445f93f58f266687b7315d14a3ac'
                       '#egg=dill-0.2.9.dev0']
 
+# pyarrow is not supported on Windows Python 2 [BEAM-6287]
+if platform.system() == 'Windows' and sys.version_info[0] == 2:
+  REQUIRED_PACKAGES = [
+      x for x in REQUIRED_PACKAGES if not x.startswith("pyarrow")
+  ]
+
 
 # We must generate protos after setup_requires are installed.
 def generate_protos_first(original_cmd):


### PR DESCRIPTION
Filtering out pyarrow dependency when the platform is Windows and Python version is 2. There's no pyarrow package for the given platform and version.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




