### PR TITLE
[BEAM-6292] PasswordDecrypter: Delay decryption / Avoid serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ sdks/python/NOTICE
 sdks/python/README.md
 sdks/python/apache_beam/portability/api/*pb2*.*
 sdks/python/nosetests.xml
+sdks/python/postcommit_requirements.txt
 
 # Ignore IntelliJ files.
 **/.idea/**/*

--- a/.test-infra/jenkins/job_PostCommit_SQL.groovy
+++ b/.test-infra/jenkins/job_PostCommit_SQL.groovy
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonJobProperties as commonJobProperties
+import PostcommitJobBuilder
+
+// This job runs the Java postcommit tests, including the suite of integration
+// tests.
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_SQL', 'Run SQL PostCommit',
+  'SQL Post Commit Tests', this) {
+
+  description('Runs PostCommit tests for Beam SQL.')
+
+  // Set common parameters.
+  commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
+
+  // Publish all test results to Jenkins
+  publishers {
+    archiveJunit('**/build/test-results/**/*.xml')
+  }
+
+  // Gradle goals for this job.
+  steps {
+    gradle {
+      rootBuildScriptDir(commonJobProperties.checkoutDir)
+      tasks(':sqlPostCommit')
+      commonJobProperties.setGradleSwitches(delegate)
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,9 @@ task javaPreCommitPortabilityApi() {
 task javaPostCommit() {
   dependsOn ":beam-runners-google-cloud-dataflow-java:postCommit"
   dependsOn ":beam-sdks-java-io-google-cloud-platform:postCommit"
+}
+
+task sqlPostCommit() {
   dependsOn ":beam-sdks-java-extensions-sql:postCommit"
   dependsOn ":beam-sdks-java-extensions-sql-jdbc:postCommit"
 }

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -420,7 +420,7 @@ class BeamModulePlugin implements Plugin<Project> {
         jackson_module_scala                        : "com.fasterxml.jackson.module:jackson-module-scala_2.11:$jackson_version",
         jaxb_api                                    : "javax.xml.bind:jaxb-api:$jaxb_api_version",
         joda_time                                   : "joda-time:joda-time:2.4",
-        junit                                       : "junit:junit:4.12",
+        junit                                       : "junit:junit:4.13-beta-1",
         kafka_2_11                                  : "org.apache.kafka:kafka_2.11:$kafka_version",
         kafka_clients                               : "org.apache.kafka:kafka-clients:$kafka_version",
         malhar_library                              : "org.apache.apex:malhar-library:$apex_malhar_version",

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableExecutionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableExecutionTest.java
@@ -17,19 +17,16 @@
  */
 package org.apache.beam.runners.flink;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.Executors;
 import org.apache.beam.model.jobmanagement.v1.JobApi.JobState.Enum;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.Environments;
+import org.apache.beam.runners.core.construction.JavaReadViaImpulse;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.BigEndianLongCoder;
@@ -39,12 +36,14 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.sdk.testing.CrashingRunner;
+import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.Impulse;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +60,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class PortableExecutionTest implements Serializable {
 
-  @Parameters
+  @Parameters(name = "streaming: {0}")
   public static Object[] data() {
     return new Object[] {true, false};
   }
@@ -80,9 +79,7 @@ public class PortableExecutionTest implements Serializable {
     flinkJobExecutor.shutdown();
   }
 
-  private static ArrayList<KV<String, Iterable<Long>>> outputValues = new ArrayList<>();
-
-  @Test
+  @Test(timeout = 120_000)
   public void testExecution() throws Exception {
     PipelineOptions options = PipelineOptionsFactory.create();
     options.setRunner(CrashingRunner.class);
@@ -92,45 +89,42 @@ public class PortableExecutionTest implements Serializable {
         .as(PortablePipelineOptions.class)
         .setDefaultEnvironmentType(Environments.ENVIRONMENT_EMBEDDED);
     Pipeline p = Pipeline.create(options);
-    p.apply("impulse", Impulse.create())
-        .apply(
-            "create",
-            ParDo.of(
-                new DoFn<byte[], String>() {
-                  @ProcessElement
-                  public void process(ProcessContext ctxt) {
-                    ctxt.output("zero");
-                    ctxt.output("one");
-                    ctxt.output("two");
-                  }
-                }))
-        .apply(
-            "len",
-            ParDo.of(
-                new DoFn<String, Long>() {
-                  @ProcessElement
-                  public void process(ProcessContext ctxt) {
-                    ctxt.output((long) ctxt.element().length());
-                  }
-                }))
-        .apply("addKeys", WithKeys.of("foo"))
-        // Use some unknown coders
-        .setCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianLongCoder.of()))
-        // Force the output to be materialized
-        .apply("gbk", GroupByKey.create())
-        .apply(
-            "collect",
-            ParDo.of(
-                new DoFn<KV<String, Iterable<Long>>, Void>() {
-                  @ProcessElement
-                  public void process(ProcessContext ctx) {
-                    outputValues.add(ctx.element());
-                  }
-                }));
+    PCollection<KV<String, Iterable<Long>>> result =
+        p.apply("impulse", Impulse.create())
+            .apply(
+                "create",
+                ParDo.of(
+                    new DoFn<byte[], String>() {
+                      @ProcessElement
+                      public void process(ProcessContext ctxt) {
+                        ctxt.output("zero");
+                        ctxt.output("one");
+                        ctxt.output("two");
+                      }
+                    }))
+            .apply(
+                "len",
+                ParDo.of(
+                    new DoFn<String, Long>() {
+                      @ProcessElement
+                      public void process(ProcessContext ctxt) {
+                        ctxt.output((long) ctxt.element().length());
+                      }
+                    }))
+            .apply("addKeys", WithKeys.of("foo"))
+            // Use some unknown coders
+            .setCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianLongCoder.of()))
+            // Force the output to be materialized
+            .apply("gbk", GroupByKey.create());
+
+    PAssert.that(result).containsInAnyOrder(KV.of("foo", ImmutableList.of(4L, 3L, 3L)));
+
+    // This is line below required to convert the PAssert's read to an impulse, which is expected
+    // by the GreedyPipelineFuser.
+    p.replaceAll(Collections.singletonList(JavaReadViaImpulse.boundedOverride()));
 
     RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(p);
 
-    outputValues.clear();
     // execute the pipeline
     FlinkJobInvocation jobInvocation =
         FlinkJobInvocation.create(
@@ -140,16 +134,10 @@ public class PortableExecutionTest implements Serializable {
             pipelineProto,
             options.as(FlinkPipelineOptions.class),
             null,
-            Collections.EMPTY_LIST);
+            Collections.emptyList());
     jobInvocation.start();
-    long timeout = System.currentTimeMillis() + 60 * 1000;
-    while (jobInvocation.getState() != Enum.DONE && System.currentTimeMillis() < timeout) {
+    while (jobInvocation.getState() != Enum.DONE) {
       Thread.sleep(1000);
     }
-    assertEquals("job state", Enum.DONE, jobInvocation.getState());
-
-    assertEquals(1, outputValues.size());
-    assertEquals("foo", outputValues.get(0).getKey());
-    assertThat(outputValues.get(0).getValue(), containsInAnyOrder(4L, 3L, 3L));
   }
 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableStateExecutionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableStateExecutionTest.java
@@ -17,20 +17,15 @@
  */
 package org.apache.beam.runners.flink;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import org.apache.beam.model.jobmanagement.v1.JobApi.JobState.Enum;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.Environments;
+import org.apache.beam.runners.core.construction.JavaReadViaImpulse;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.VarIntCoder;
@@ -41,10 +36,12 @@ import org.apache.beam.sdk.state.StateSpec;
 import org.apache.beam.sdk.state.StateSpecs;
 import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.testing.CrashingRunner;
+import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Impulse;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +57,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class PortableStateExecutionTest implements Serializable {
 
-  @Parameters
+  @Parameters(name = "streaming: {0}")
   public static Object[] data() {
     return new Object[] {true, false};
   }
@@ -79,21 +76,11 @@ public class PortableStateExecutionTest implements Serializable {
     flinkJobExecutor.shutdown();
   }
 
-  // State -> Key -> Value
-  private static final Map<String, Map<String, Integer>> stateValuesMap = new HashMap<>();
-
-  @Before
-  public void before() {
-    stateValuesMap.clear();
-    stateValuesMap.put("valueState", new HashMap<>());
-    stateValuesMap.put("valueState2", new HashMap<>());
-  }
-
   // Special values which clear / write out state
   private static final int CLEAR_STATE = -1;
-  private static final int WRITE_STATE_TO_MAP = -2;
+  private static final int WRITE_STATE = -2;
 
-  @Test
+  @Test(timeout = 120_000)
   public void testExecution() throws Exception {
     PipelineOptions options = PipelineOptionsFactory.create();
     options.setRunner(CrashingRunner.class);
@@ -103,74 +90,93 @@ public class PortableStateExecutionTest implements Serializable {
         .as(PortablePipelineOptions.class)
         .setDefaultEnvironmentType(Environments.ENVIRONMENT_EMBEDDED);
     Pipeline p = Pipeline.create(options);
-    p.apply(Impulse.create())
-        .apply(
-            ParDo.of(
-                new DoFn<byte[], KV<String, Integer>>() {
-                  @ProcessElement
-                  public void process(ProcessContext ctx) {
-                    // Values == -1 will clear the state
-                    ctx.output(KV.of("clearedState", 1));
-                    ctx.output(KV.of("clearedState", CLEAR_STATE));
-                    // values >= 1 will be added on top of each other
-                    ctx.output(KV.of("bla1", 42));
-                    ctx.output(KV.of("bla", 23));
-                    ctx.output(KV.of("bla2", 64));
-                    ctx.output(KV.of("bla", 1));
-                    ctx.output(KV.of("bla", 1));
-                    // values == -2 will write the state to a map
-                    ctx.output(KV.of("bla", WRITE_STATE_TO_MAP));
-                    ctx.output(KV.of("bla1", WRITE_STATE_TO_MAP));
-                    ctx.output(KV.of("bla2", WRITE_STATE_TO_MAP));
-                    ctx.output(KV.of("clearedState", -2));
-                  }
-                }))
-        .apply(
-            "statefulDoFn",
-            ParDo.of(
-                new DoFn<KV<String, Integer>, String>() {
-                  @StateId("valueState")
-                  private final StateSpec<ValueState<Integer>> valueStateSpec =
-                      StateSpecs.value(VarIntCoder.of());
+    PCollection<KV<String, String>> output =
+        p.apply(Impulse.create())
+            .apply(
+                ParDo.of(
+                    new DoFn<byte[], KV<String, Integer>>() {
+                      @ProcessElement
+                      public void process(ProcessContext ctx) {
+                        // Values == -1 will clear the state
+                        ctx.output(KV.of("clearedState", 1));
+                        ctx.output(KV.of("clearedState", CLEAR_STATE));
+                        // values >= 1 will be added on top of each other
+                        ctx.output(KV.of("bla1", 42));
+                        ctx.output(KV.of("bla", 23));
+                        ctx.output(KV.of("bla2", 64));
+                        ctx.output(KV.of("bla", 1));
+                        ctx.output(KV.of("bla", 1));
+                        // values == -2 will write the current state to the output
+                        ctx.output(KV.of("bla", WRITE_STATE));
+                        ctx.output(KV.of("bla1", WRITE_STATE));
+                        ctx.output(KV.of("bla2", WRITE_STATE));
+                        ctx.output(KV.of("clearedState", WRITE_STATE));
+                      }
+                    }))
+            .apply(
+                "statefulDoFn",
+                ParDo.of(
+                    new DoFn<KV<String, Integer>, KV<String, String>>() {
+                      @StateId("valueState")
+                      private final StateSpec<ValueState<Integer>> valueStateSpec =
+                          StateSpecs.value(VarIntCoder.of());
 
-                  @StateId("valueState2")
-                  private final StateSpec<ValueState<Integer>> valueStateSpec2 =
-                      StateSpecs.value(VarIntCoder.of());
+                      @StateId("valueState2")
+                      private final StateSpec<ValueState<Integer>> valueStateSpec2 =
+                          StateSpecs.value(VarIntCoder.of());
 
-                  @ProcessElement
-                  public void process(
-                      ProcessContext ctx,
-                      @StateId("valueState") ValueState<Integer> valueState,
-                      @StateId("valueState2") ValueState<Integer> valueState2) {
-                    performStateUpdates("valueState", ctx, valueState);
-                    performStateUpdates("valueState2", ctx, valueState2);
-                  }
+                      @ProcessElement
+                      public void process(
+                          ProcessContext ctx,
+                          @StateId("valueState") ValueState<Integer> valueState,
+                          @StateId("valueState2") ValueState<Integer> valueState2) {
+                        performStateUpdates(ctx, valueState);
+                        performStateUpdates(ctx, valueState2);
+                      }
 
-                  private void performStateUpdates(
-                      String stateId, ProcessContext ctx, ValueState<Integer> valueState) {
-                    Map<String, Integer> stateValues = stateValuesMap.get(stateId);
-                    Integer value = ctx.element().getValue();
-                    if (value == null) {
-                      throw new IllegalStateException();
-                    }
-                    switch (value) {
-                      case CLEAR_STATE:
-                        valueState.clear();
-                        break;
-                      case WRITE_STATE_TO_MAP:
-                        stateValues.put(ctx.element().getKey(), valueState.read());
-                        break;
-                      default:
-                        Integer currentState = valueState.read();
-                        if (currentState == null) {
-                          currentState = value;
-                        } else {
-                          currentState += value;
+                      private void performStateUpdates(
+                          ProcessContext ctx, ValueState<Integer> valueState) {
+                        Integer value = ctx.element().getValue();
+                        if (value == null) {
+                          throw new IllegalStateException();
                         }
-                        valueState.write(currentState);
-                    }
-                  }
-                }));
+                        switch (value) {
+                          case CLEAR_STATE:
+                            valueState.clear();
+                            break;
+                          case WRITE_STATE:
+                            Integer read = valueState.read();
+                            ctx.output(
+                                KV.of(
+                                    ctx.element().getKey(),
+                                    read == null ? "null" : read.toString()));
+                            break;
+                          default:
+                            Integer currentState = valueState.read();
+                            if (currentState == null) {
+                              currentState = value;
+                            } else {
+                              currentState += value;
+                            }
+                            valueState.write(currentState);
+                        }
+                      }
+                    }));
+
+    PAssert.that(output)
+        .containsInAnyOrder(
+            KV.of("bla", "25"),
+            KV.of("bla1", "42"),
+            KV.of("bla2", "64"),
+            KV.of("clearedState", "null"),
+            KV.of("bla", "25"),
+            KV.of("bla1", "42"),
+            KV.of("bla2", "64"),
+            KV.of("clearedState", "null"));
+
+    // This is line below required to convert the PAssert's read to an impulse, which is expected
+    // by the GreedyPipelineFuser.
+    p.replaceAll(Collections.singletonList(JavaReadViaImpulse.boundedOverride()));
 
     RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(p);
 
@@ -185,20 +191,9 @@ public class PortableStateExecutionTest implements Serializable {
             Collections.emptyList());
 
     jobInvocation.start();
-    long timeout = System.currentTimeMillis() + 60 * 1000;
-    while (jobInvocation.getState() != Enum.DONE && System.currentTimeMillis() < timeout) {
+
+    while (jobInvocation.getState() != Enum.DONE) {
       Thread.sleep(1000);
-    }
-    assertThat(jobInvocation.getState(), is(Enum.DONE));
-
-    Map<String, Integer> expected = new HashMap<>();
-    expected.put("bla", 25);
-    expected.put("bla1", 42);
-    expected.put("bla2", 64);
-    expected.put("clearedState", null);
-
-    for (Map<String, Integer> statesValues : stateValuesMap.values()) {
-      assertThat(statesValues, equalTo(expected));
     }
   }
 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableTimersExecutionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableTimersExecutionTest.java
@@ -67,7 +67,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class PortableTimersExecutionTest implements Serializable {
 
-  @Parameters
+  @Parameters(name = "streaming: {0}")
   public static Object[] testModes() {
     return new Object[] {true, false};
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -278,6 +278,7 @@ public class AvroIO {
         .setMatchConfiguration(MatchConfiguration.create(EmptyMatchTreatment.DISALLOW))
         .setRecordClass(recordClass)
         .setSchema(ReflectData.get().getSchema(recordClass))
+        .setInferBeamSchema(false)
         .setHintMatchesManyFiles(false)
         .build();
   }
@@ -288,6 +289,7 @@ public class AvroIO {
         .setMatchConfiguration(MatchConfiguration.create(EmptyMatchTreatment.ALLOW_IF_WILDCARD))
         .setRecordClass(recordClass)
         .setSchema(ReflectData.get().getSchema(recordClass))
+        .setInferBeamSchema(false)
         // 64MB is a reasonable value that allows to amortize the cost of opening files,
         // but is not so large as to exhaust a typical runner's maximum amount of output per
         // ProcessElement call.
@@ -301,6 +303,7 @@ public class AvroIO {
         .setMatchConfiguration(MatchConfiguration.create(EmptyMatchTreatment.DISALLOW))
         .setRecordClass(GenericRecord.class)
         .setSchema(schema)
+        .setInferBeamSchema(false)
         .setHintMatchesManyFiles(false)
         .build();
   }
@@ -314,6 +317,7 @@ public class AvroIO {
         .setMatchConfiguration(MatchConfiguration.create(EmptyMatchTreatment.ALLOW_IF_WILDCARD))
         .setRecordClass(GenericRecord.class)
         .setSchema(schema)
+        .setInferBeamSchema(false)
         .setDesiredBundleSizeBytes(64 * 1024 * 1024L)
         .build();
   }
@@ -430,6 +434,19 @@ public class AvroIO {
         .setWindowedWrites(false);
   }
 
+  private static <T> PCollection<T> setBeamSchema(
+      PCollection<T> pc, Class<T> clazz, @Nullable Schema schema) {
+    org.apache.beam.sdk.schemas.Schema beamSchema =
+        org.apache.beam.sdk.schemas.utils.AvroUtils.getSchema(clazz, schema);
+    if (beamSchema != null) {
+      pc.setSchema(
+          beamSchema,
+          org.apache.beam.sdk.schemas.utils.AvroUtils.getToRowFunction(clazz, schema),
+          org.apache.beam.sdk.schemas.utils.AvroUtils.getFromRowFunction(clazz));
+    }
+    return pc;
+  }
+
   /** Implementation of {@link #read} and {@link #readGenericRecords}. */
   @AutoValue
   public abstract static class Read<T> extends PTransform<PBegin, PCollection<T>> {
@@ -444,6 +461,8 @@ public class AvroIO {
     @Nullable
     abstract Schema getSchema();
 
+    abstract boolean getInferBeamSchema();
+
     abstract boolean getHintMatchesManyFiles();
 
     abstract Builder<T> toBuilder();
@@ -457,6 +476,8 @@ public class AvroIO {
       abstract Builder<T> setRecordClass(Class<T> recordClass);
 
       abstract Builder<T> setSchema(Schema schema);
+
+      abstract Builder<T> setInferBeamSchema(boolean infer);
 
       abstract Builder<T> setHintMatchesManyFiles(boolean hintManyFiles);
 
@@ -488,6 +509,11 @@ public class AvroIO {
       return withMatchConfiguration(getMatchConfiguration().withEmptyMatchTreatment(treatment));
     }
 
+    @Experimental(Kind.SCHEMAS)
+    public Read<T> withBeamSchemas(boolean withBeamSchemas) {
+      return toBuilder().setInferBeamSchema(withBeamSchemas).build();
+    }
+
     /**
      * Continuously watches for new files matching the filepattern, polling it at the given
      * interval, until the given termination condition is reached. The returned {@link PCollection}
@@ -516,19 +542,22 @@ public class AvroIO {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public PCollection<T> expand(PBegin input) {
       checkNotNull(getFilepattern(), "filepattern");
       checkNotNull(getSchema(), "schema");
 
       if (getMatchConfiguration().getWatchInterval() == null && !getHintMatchesManyFiles()) {
-        return input.apply(
-            "Read",
-            org.apache.beam.sdk.io.Read.from(
-                createSource(
-                    getFilepattern(),
-                    getMatchConfiguration().getEmptyMatchTreatment(),
-                    getRecordClass(),
-                    getSchema())));
+        PCollection<T> read =
+            input.apply(
+                "Read",
+                org.apache.beam.sdk.io.Read.from(
+                    createSource(
+                        getFilepattern(),
+                        getMatchConfiguration().getEmptyMatchTreatment(),
+                        getRecordClass(),
+                        getSchema())));
+        return getInferBeamSchema() ? setBeamSchema(read, getRecordClass(), getSchema()) : read;
       }
       // All other cases go through ReadAll.
 
@@ -580,6 +609,8 @@ public class AvroIO {
 
     abstract long getDesiredBundleSizeBytes();
 
+    abstract boolean getInferBeamSchema();
+
     abstract Builder<T> toBuilder();
 
     @AutoValue.Builder
@@ -591,6 +622,8 @@ public class AvroIO {
       abstract Builder<T> setSchema(Schema schema);
 
       abstract Builder<T> setDesiredBundleSizeBytes(long desiredBundleSizeBytes);
+
+      abstract Builder<T> setInferBeamSchema(boolean infer);
 
       abstract ReadAll<T> build();
     }
@@ -618,18 +651,29 @@ public class AvroIO {
       return toBuilder().setDesiredBundleSizeBytes(desiredBundleSizeBytes).build();
     }
 
+    /**
+     * If set to true, a Beam schema will be inferred from the AVRO schema. This allows the output
+     * to be used by SQL and by the schema-transform library.
+     */
+    @Experimental(Kind.SCHEMAS)
+    public ReadAll<T> withBeamSchemas(boolean withBeamSchemas) {
+      return toBuilder().setInferBeamSchema(withBeamSchemas).build();
+    }
+
     @Override
     public PCollection<T> expand(PCollection<String> input) {
       checkNotNull(getSchema(), "schema");
-      return input
-          .apply(FileIO.matchAll().withConfiguration(getMatchConfiguration()))
-          .apply(FileIO.readMatches().withDirectoryTreatment(DirectoryTreatment.PROHIBIT))
-          .apply(
-              "Read all via FileBasedSource",
-              new ReadAllViaFileBasedSource<>(
-                  getDesiredBundleSizeBytes(),
-                  new CreateSourceFn<>(getRecordClass(), getSchema().toString()),
-                  AvroCoder.of(getRecordClass(), getSchema())));
+      PCollection<T> read =
+          input
+              .apply(FileIO.matchAll().withConfiguration(getMatchConfiguration()))
+              .apply(FileIO.readMatches().withDirectoryTreatment(DirectoryTreatment.PROHIBIT))
+              .apply(
+                  "Read all via FileBasedSource",
+                  new ReadAllViaFileBasedSource<>(
+                      getDesiredBundleSizeBytes(),
+                      new CreateSourceFn<>(getRecordClass(), getSchema().toString()),
+                      AvroCoder.of(getRecordClass(), getSchema())));
+      return getInferBeamSchema() ? setBeamSchema(read, getRecordClass(), getSchema()) : read;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroRecordSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroRecordSchema.java
@@ -17,6 +17,9 @@
  */
 package org.apache.beam.sdk.schemas;
 
+import static org.apache.beam.sdk.schemas.utils.AvroUtils.toBeamSchema;
+
+import org.apache.avro.reflect.ReflectData;
 import org.apache.beam.sdk.schemas.utils.AvroUtils;
 import org.apache.beam.sdk.values.TypeDescriptor;
 
@@ -30,7 +33,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 public class AvroRecordSchema extends GetterBasedSchemaProvider {
   @Override
   public <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
-    return AvroUtils.getSchema(typeDescriptor.getRawType());
+    return toBeamSchema(ReflectData.get().getSchema(typeDescriptor.getRawType()));
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroByteBuddyUtils.java
@@ -36,6 +36,7 @@ import org.apache.avro.specific.SpecificRecord;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertType;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.InjectPackageStrategy;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils.ClassWithSchema;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -76,6 +77,7 @@ class AvroByteBuddyUtils {
     try {
       DynamicType.Builder<SchemaUserTypeCreator> builder =
           BYTE_BUDDY
+              .with(new InjectPackageStrategy(clazz))
               .subclass(SchemaUserTypeCreator.class)
               .method(ElementMatchers.named("create"))
               .intercept(construct);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -65,11 +65,9 @@ class ByteBuddyUtils {
   /**
    * A naming strategy for ByteBuddy classes.
    *
-   * <p>We always inject the generatter classes in the same same package as the user's target class.
-   *
-   * @kanterov kanterov 20 hours ago Contributor nit: s/generatter/generated/
-   * @reuvenlax Reply… This way, if the class fields or methods are package private, our generated
-   *     class can still access them.
+   * <p>We always inject the generator classes in the same same package as the user's target class.
+   * This way, if the class fields or methods are package private, our generated class can still
+   * access them.
    */
   static class InjectPackageStrategy extends NamingStrategy.AbstractBase {
     /** A resolver for the base name for naming the unnamed type. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -55,6 +55,7 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertType;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertValueForGetter;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.InjectPackageStrategy;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils.ClassWithSchema;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -129,6 +130,7 @@ public class POJOUtils {
     try {
       DynamicType.Builder<SchemaUserTypeCreator> builder =
           BYTE_BUDDY
+              .with(new InjectPackageStrategy(clazz))
               .subclass(SchemaUserTypeCreator.class)
               .method(ElementMatchers.named("create"))
               .intercept(new CreateInstruction(fields, clazz));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ReflectUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ReflectUtils.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.Schema;
 
 /** A set of reflection helper methods. */
@@ -71,7 +70,8 @@ public class ReflectUtils {
         clazz,
         c -> {
           return Arrays.stream(c.getDeclaredMethods())
-              .filter(m -> Modifier.isPublic(m.getModifiers()))
+              .filter(m -> !Modifier.isPrivate(m.getModifiers()))
+              .filter(m -> !Modifier.isProtected(m.getModifiers()))
               .filter(m -> !Modifier.isStatic(m.getModifiers()))
               .collect(Collectors.toList());
         });
@@ -89,8 +89,7 @@ public class ReflectUtils {
             }
             for (java.lang.reflect.Field field : c.getDeclaredFields()) {
               if ((field.getModifiers() & (Modifier.TRANSIENT | Modifier.STATIC)) == 0) {
-                if ((field.getModifiers() & Modifier.PUBLIC) != 0) {
-                  boolean nullable = field.getAnnotation(Nullable.class) != null;
+                if ((field.getModifiers() & (Modifier.PRIVATE | Modifier.PROTECTED)) == 0) {
                   checkArgument(
                       types.put(field.getName(), field) == null,
                       c.getSimpleName() + " contains two fields named: " + field);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -48,6 +48,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -105,1138 +106,1187 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 
 /** Tests for AvroIO Read and Write transforms. */
-@RunWith(JUnit4.class)
 public class AvroIOTest implements Serializable {
+  /** Unit tests. */
+  @RunWith(JUnit4.class)
+  public static class SimpleTests implements Serializable {
+    @Test
+    public void testAvroIOGetName() {
+      assertEquals("AvroIO.Read", AvroIO.read(String.class).from("/tmp/foo*/baz").getName());
+      assertEquals("AvroIO.Write", AvroIO.write(String.class).to("/tmp/foo/baz").getName());
+    }
 
-  @Rule public transient TestPipeline writePipeline = TestPipeline.create();
+    @Test
+    public void testWriteWithDefaultCodec() throws Exception {
+      AvroIO.Write<String> write = AvroIO.write(String.class).to("/tmp/foo/baz");
+      assertEquals(CodecFactory.snappyCodec().toString(), write.inner.getCodec().toString());
+    }
 
-  @Rule public transient TestPipeline readPipeline = TestPipeline.create();
+    @Test
+    public void testWriteWithCustomCodec() throws Exception {
+      AvroIO.Write<String> write =
+          AvroIO.write(String.class).to("/tmp/foo/baz").withCodec(CodecFactory.snappyCodec());
+      assertEquals(SNAPPY_CODEC, write.inner.getCodec().toString());
+    }
 
-  @Rule public transient TestPipeline windowedAvroWritePipeline = TestPipeline.create();
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWriteWithSerDeCustomDeflateCodec() throws Exception {
+      AvroIO.Write<String> write =
+          AvroIO.write(String.class).to("/tmp/foo/baz").withCodec(CodecFactory.deflateCodec(9));
 
-  @Rule public transient TemporaryFolder tmpFolder = new TemporaryFolder();
+      assertEquals(
+          CodecFactory.deflateCodec(9).toString(),
+          SerializableUtils.clone(write.inner.getCodec()).getCodec().toString());
+    }
 
-  @Rule public transient ExpectedException expectedException = ExpectedException.none();
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testWriteWithSerDeCustomXZCodec() throws Exception {
+      AvroIO.Write<String> write =
+          AvroIO.write(String.class).to("/tmp/foo/baz").withCodec(CodecFactory.xzCodec(9));
 
-  @Test
-  public void testAvroIOGetName() {
-    assertEquals("AvroIO.Read", AvroIO.read(String.class).from("/tmp/foo*/baz").getName());
-    assertEquals("AvroIO.Write", AvroIO.write(String.class).to("/tmp/foo/baz").getName());
+      assertEquals(
+          CodecFactory.xzCodec(9).toString(),
+          SerializableUtils.clone(write.inner.getCodec()).getCodec().toString());
+    }
+
+    @Test
+    public void testReadDisplayData() {
+      AvroIO.Read<String> read = AvroIO.read(String.class).from("/foo.*");
+
+      DisplayData displayData = DisplayData.from(read);
+      assertThat(displayData, hasDisplayItem("filePattern", "/foo.*"));
+    }
   }
 
-  @DefaultCoder(AvroCoder.class)
-  static class GenericClass {
-    int intField;
-    String stringField;
+  /** NeedsRunner tests. */
+  @RunWith(Parameterized.class)
+  @Category(NeedsRunner.class)
+  public static class NeedsRunnerTests implements Serializable {
+    @Rule public transient TestPipeline writePipeline = TestPipeline.create();
 
-    public GenericClass() {}
+    @Rule public transient TestPipeline readPipeline = TestPipeline.create();
 
-    public GenericClass(int intField, String stringField) {
-      this.intField = intField;
-      this.stringField = stringField;
+    @Rule public transient TestPipeline windowedAvroWritePipeline = TestPipeline.create();
+
+    @Rule public transient TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Rule public transient ExpectedException expectedException = ExpectedException.none();
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> params() {
+      return Arrays.asList(new Object[][] {{true}, {false}});
     }
 
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(getClass())
-          .add("intField", intField)
-          .add("stringField", stringField)
-          .toString();
-    }
+    @Parameterized.Parameter public boolean withBeamSchemas;
 
-    @Override
-    public int hashCode() {
-      return Objects.hash(intField, stringField);
-    }
+    @DefaultCoder(AvroCoder.class)
+    static class GenericClass {
+      int intField;
+      String stringField;
 
-    @Override
-    public boolean equals(Object other) {
-      if (other == null || !(other instanceof GenericClass)) {
-        return false;
+      public GenericClass() {}
+
+      public GenericClass(int intField, String stringField) {
+        this.intField = intField;
+        this.stringField = stringField;
       }
-      GenericClass o = (GenericClass) other;
-      return Objects.equals(intField, o.intField) && Objects.equals(stringField, o.stringField);
-    }
-  }
 
-  private static class ParseGenericClass
-      implements SerializableFunction<GenericRecord, GenericClass> {
-    @Override
-    public GenericClass apply(GenericRecord input) {
-      return new GenericClass((int) input.get("intField"), input.get("stringField").toString());
-    }
-  }
-
-  private enum Sharding {
-    RUNNER_DETERMINED,
-    WITHOUT_SHARDING,
-    FIXED_3_SHARDS
-  }
-
-  private enum WriteMethod {
-    AVROIO_WRITE,
-    AVROIO_SINK
-  }
-
-  private static final String SCHEMA_STRING =
-      "{\"namespace\": \"example.avro\",\n"
-          + " \"type\": \"record\",\n"
-          + " \"name\": \"AvroGeneratedUser\",\n"
-          + " \"fields\": [\n"
-          + "     {\"name\": \"name\", \"type\": \"string\"},\n"
-          + "     {\"name\": \"favorite_number\", \"type\": [\"int\", \"null\"]},\n"
-          + "     {\"name\": \"favorite_color\", \"type\": [\"string\", \"null\"]}\n"
-          + " ]\n"
-          + "}";
-
-  private static final Schema SCHEMA = new Schema.Parser().parse(SCHEMA_STRING);
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWriteThenReadJavaClass() throws Throwable {
-    List<GenericClass> values =
-        ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
-    File outputFile = tmpFolder.newFile("output.avro");
-
-    writePipeline
-        .apply(Create.of(values))
-        .apply(
-            AvroIO.write(GenericClass.class)
-                .to(writePipeline.newProvider(outputFile.getAbsolutePath()))
-                .withoutSharding());
-    writePipeline.run();
-
-    PAssert.that(
-            readPipeline.apply(
-                "Read",
-                AvroIO.read(GenericClass.class)
-                    .from(readPipeline.newProvider(outputFile.getAbsolutePath()))))
-        .containsInAnyOrder(values);
-
-    readPipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWriteThenReadCustomType() throws Throwable {
-    List<Long> values = Arrays.asList(0L, 1L, 2L);
-    File outputFile = tmpFolder.newFile("output.avro");
-
-    writePipeline
-        .apply(Create.of(values))
-        .apply(
-            AvroIO.<Long, GenericClass>writeCustomType()
-                .to(writePipeline.newProvider(outputFile.getAbsolutePath()))
-                .withFormatFunction(new CreateGenericClass())
-                .withSchema(ReflectData.get().getSchema(GenericClass.class))
-                .withoutSharding());
-    writePipeline.run();
-
-    PAssert.that(
-            readPipeline
-                .apply(
-                    "Read",
-                    AvroIO.read(GenericClass.class)
-                        .from(readPipeline.newProvider(outputFile.getAbsolutePath())))
-                .apply(
-                    MapElements.via(
-                        new SimpleFunction<GenericClass, Long>() {
-                          @Override
-                          public Long apply(GenericClass input) {
-                            return (long) input.intField;
-                          }
-                        })))
-        .containsInAnyOrder(values);
-
-    readPipeline.run();
-  }
-
-  private <T extends GenericRecord> void testWriteThenReadGeneratedClass(
-      AvroIO.Write<T> writeTransform, AvroIO.Read<T> readTransform) throws Exception {
-    File outputFile = tmpFolder.newFile("output.avro");
-
-    List<T> values =
-        ImmutableList.of(
-            (T) new AvroGeneratedUser("Bob", 256, null),
-            (T) new AvroGeneratedUser("Alice", 128, null),
-            (T) new AvroGeneratedUser("Ted", null, "white"));
-
-    writePipeline
-        .apply(Create.of(values))
-        .apply(
-            writeTransform
-                .to(writePipeline.newProvider(outputFile.getAbsolutePath()))
-                .withoutSharding());
-    writePipeline.run();
-
-    PAssert.that(
-            readPipeline.apply(
-                "Read", readTransform.from(readPipeline.newProvider(outputFile.getAbsolutePath()))))
-        .containsInAnyOrder(values);
-
-    readPipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWriteThenReadGeneratedClassWithClass() throws Throwable {
-    testWriteThenReadGeneratedClass(
-        AvroIO.write(AvroGeneratedUser.class), AvroIO.read(AvroGeneratedUser.class));
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWriteThenReadGeneratedClassWithSchema() throws Throwable {
-    testWriteThenReadGeneratedClass(
-        AvroIO.writeGenericRecords(SCHEMA), AvroIO.readGenericRecords(SCHEMA));
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWriteThenReadGeneratedClassWithSchemaString() throws Throwable {
-    testWriteThenReadGeneratedClass(
-        AvroIO.writeGenericRecords(SCHEMA.toString()),
-        AvroIO.readGenericRecords(SCHEMA.toString()));
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWriteSingleFileThenReadUsingAllMethods() throws Throwable {
-    List<GenericClass> values =
-        ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
-    File outputFile = tmpFolder.newFile("output.avro");
-
-    writePipeline
-        .apply(Create.of(values))
-        .apply(AvroIO.write(GenericClass.class).to(outputFile.getAbsolutePath()).withoutSharding());
-    writePipeline.run();
-
-    // Test the same data using all versions of read().
-    PCollection<String> path =
-        readPipeline.apply("Create path", Create.of(outputFile.getAbsolutePath()));
-    PAssert.that(
-            readPipeline.apply(
-                "Read", AvroIO.read(GenericClass.class).from(outputFile.getAbsolutePath())))
-        .containsInAnyOrder(values);
-    PAssert.that(
-            readPipeline.apply(
-                "Read withHintMatchesManyFiles",
-                AvroIO.read(GenericClass.class)
-                    .from(outputFile.getAbsolutePath())
-                    .withHintMatchesManyFiles()))
-        .containsInAnyOrder(values);
-    PAssert.that(
-            path.apply(
-                "ReadAll", AvroIO.readAll(GenericClass.class).withDesiredBundleSizeBytes(10)))
-        .containsInAnyOrder(values);
-    PAssert.that(
-            readPipeline.apply(
-                "Parse",
-                AvroIO.parseGenericRecords(new ParseGenericClass())
-                    .from(outputFile.getAbsolutePath())
-                    .withCoder(AvroCoder.of(GenericClass.class))))
-        .containsInAnyOrder(values);
-    PAssert.that(
-            readPipeline.apply(
-                "Parse withHintMatchesManyFiles",
-                AvroIO.parseGenericRecords(new ParseGenericClass())
-                    .from(outputFile.getAbsolutePath())
-                    .withCoder(AvroCoder.of(GenericClass.class))
-                    .withHintMatchesManyFiles()))
-        .containsInAnyOrder(values);
-    PAssert.that(
-            path.apply(
-                "ParseAll",
-                AvroIO.parseAllGenericRecords(new ParseGenericClass())
-                    .withCoder(AvroCoder.of(GenericClass.class))
-                    .withDesiredBundleSizeBytes(10)))
-        .containsInAnyOrder(values);
-
-    readPipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWriteThenReadMultipleFilepatterns() throws Throwable {
-    List<GenericClass> firstValues = Lists.newArrayList();
-    List<GenericClass> secondValues = Lists.newArrayList();
-    for (int i = 0; i < 10; ++i) {
-      firstValues.add(new GenericClass(i, "a" + i));
-      secondValues.add(new GenericClass(i, "b" + i));
-    }
-    writePipeline
-        .apply("Create first", Create.of(firstValues))
-        .apply(
-            "Write first",
-            AvroIO.write(GenericClass.class)
-                .to(tmpFolder.getRoot().getAbsolutePath() + "/first")
-                .withNumShards(2));
-    writePipeline
-        .apply("Create second", Create.of(secondValues))
-        .apply(
-            "Write second",
-            AvroIO.write(GenericClass.class)
-                .to(tmpFolder.getRoot().getAbsolutePath() + "/second")
-                .withNumShards(3));
-    writePipeline.run();
-
-    // Test readAll() and parseAllGenericRecords().
-    PCollection<String> paths =
-        readPipeline.apply(
-            "Create paths",
-            Create.of(
-                tmpFolder.getRoot().getAbsolutePath() + "/first*",
-                tmpFolder.getRoot().getAbsolutePath() + "/second*"));
-    PAssert.that(
-            paths.apply(
-                "Read all", AvroIO.readAll(GenericClass.class).withDesiredBundleSizeBytes(10)))
-        .containsInAnyOrder(Iterables.concat(firstValues, secondValues));
-    PAssert.that(
-            paths.apply(
-                "Parse all",
-                AvroIO.parseAllGenericRecords(new ParseGenericClass())
-                    .withCoder(AvroCoder.of(GenericClass.class))
-                    .withDesiredBundleSizeBytes(10)))
-        .containsInAnyOrder(Iterables.concat(firstValues, secondValues));
-
-    readPipeline.run();
-  }
-
-  private static class CreateGenericClass extends SimpleFunction<Long, GenericClass> {
-    @Override
-    public GenericClass apply(Long i) {
-      return new GenericClass(i.intValue(), "value" + i);
-    }
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testContinuouslyWriteAndReadMultipleFilepatterns() throws Throwable {
-    SimpleFunction<Long, GenericClass> mapFn = new CreateGenericClass();
-    List<GenericClass> firstValues = Lists.newArrayList();
-    List<GenericClass> secondValues = Lists.newArrayList();
-    for (int i = 0; i < 7; ++i) {
-      (i < 3 ? firstValues : secondValues).add(mapFn.apply((long) i));
-    }
-    // Configure windowing of the input so that it fires every time a new element is generated,
-    // so that files are written continuously.
-    Window<Long> window =
-        Window.<Long>into(FixedWindows.of(Duration.millis(100)))
-            .withAllowedLateness(Duration.ZERO)
-            .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
-            .discardingFiredPanes();
-    readPipeline
-        .apply("Sequence first", GenerateSequence.from(0).to(3).withRate(1, Duration.millis(300)))
-        .apply("Window first", window)
-        .apply("Map first", MapElements.via(mapFn))
-        .apply(
-            "Write first",
-            AvroIO.write(GenericClass.class)
-                .to(tmpFolder.getRoot().getAbsolutePath() + "/first")
-                .withNumShards(2)
-                .withWindowedWrites());
-    readPipeline
-        .apply("Sequence second", GenerateSequence.from(3).to(7).withRate(1, Duration.millis(300)))
-        .apply("Window second", window)
-        .apply("Map second", MapElements.via(mapFn))
-        .apply(
-            "Write second",
-            AvroIO.write(GenericClass.class)
-                .to(tmpFolder.getRoot().getAbsolutePath() + "/second")
-                .withNumShards(3)
-                .withWindowedWrites());
-
-    // Test read(), readAll(), parse(), and parseAllGenericRecords() with watchForNewFiles().
-    PAssert.that(
-            readPipeline.apply(
-                "Read",
-                AvroIO.read(GenericClass.class)
-                    .from(tmpFolder.getRoot().getAbsolutePath() + "/first*")
-                    .watchForNewFiles(
-                        Duration.millis(100),
-                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)))))
-        .containsInAnyOrder(firstValues);
-    PAssert.that(
-            readPipeline.apply(
-                "Parse",
-                AvroIO.parseGenericRecords(new ParseGenericClass())
-                    .from(tmpFolder.getRoot().getAbsolutePath() + "/first*")
-                    .watchForNewFiles(
-                        Duration.millis(100),
-                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)))))
-        .containsInAnyOrder(firstValues);
-
-    PCollection<String> paths =
-        readPipeline.apply(
-            "Create paths",
-            Create.of(
-                tmpFolder.getRoot().getAbsolutePath() + "/first*",
-                tmpFolder.getRoot().getAbsolutePath() + "/second*"));
-    PAssert.that(
-            paths.apply(
-                "Read all",
-                AvroIO.readAll(GenericClass.class)
-                    .watchForNewFiles(
-                        Duration.millis(100),
-                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)))
-                    .withDesiredBundleSizeBytes(10)))
-        .containsInAnyOrder(Iterables.concat(firstValues, secondValues));
-    PAssert.that(
-            paths.apply(
-                "Parse all",
-                AvroIO.parseAllGenericRecords(new ParseGenericClass())
-                    .withCoder(AvroCoder.of(GenericClass.class))
-                    .watchForNewFiles(
-                        Duration.millis(100),
-                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)))
-                    .withDesiredBundleSizeBytes(10)))
-        .containsInAnyOrder(Iterables.concat(firstValues, secondValues));
-    readPipeline.run();
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  @Category(NeedsRunner.class)
-  public void testCompressedWriteAndReadASingleFile() throws Throwable {
-    List<GenericClass> values =
-        ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
-    File outputFile = tmpFolder.newFile("output.avro");
-
-    writePipeline
-        .apply(Create.of(values))
-        .apply(
-            AvroIO.write(GenericClass.class)
-                .to(outputFile.getAbsolutePath())
-                .withoutSharding()
-                .withCodec(CodecFactory.deflateCodec(9)));
-    writePipeline.run();
-
-    PAssert.that(
-            readPipeline.apply(AvroIO.read(GenericClass.class).from(outputFile.getAbsolutePath())))
-        .containsInAnyOrder(values);
-    readPipeline.run();
-
-    try (DataFileStream dataFileStream =
-        new DataFileStream(new FileInputStream(outputFile), new GenericDatumReader())) {
-      assertEquals("deflate", dataFileStream.getMetaString("avro.codec"));
-    }
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  @Category(NeedsRunner.class)
-  public void testWriteThenReadASingleFileWithNullCodec() throws Throwable {
-    List<GenericClass> values =
-        ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
-    File outputFile = tmpFolder.newFile("output.avro");
-
-    writePipeline
-        .apply(Create.of(values))
-        .apply(
-            AvroIO.write(GenericClass.class)
-                .to(outputFile.getAbsolutePath())
-                .withoutSharding()
-                .withCodec(CodecFactory.nullCodec()));
-    writePipeline.run();
-
-    PAssert.that(
-            readPipeline.apply(AvroIO.read(GenericClass.class).from(outputFile.getAbsolutePath())))
-        .containsInAnyOrder(values);
-    readPipeline.run();
-
-    try (DataFileStream dataFileStream =
-        new DataFileStream(new FileInputStream(outputFile), new GenericDatumReader())) {
-      assertEquals("null", dataFileStream.getMetaString("avro.codec"));
-    }
-  }
-
-  @DefaultCoder(AvroCoder.class)
-  static class GenericClassV2 {
-    int intField;
-    String stringField;
-    @Nullable String nullableField;
-
-    public GenericClassV2() {}
-
-    public GenericClassV2(int intValue, String stringValue, String nullableValue) {
-      this.intField = intValue;
-      this.stringField = stringValue;
-      this.nullableField = nullableValue;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(getClass())
-          .add("intField", intField)
-          .add("stringField", stringField)
-          .add("nullableField", nullableField)
-          .toString();
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(intField, stringField, nullableField);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (other == null || !(other instanceof GenericClassV2)) {
-        return false;
+      @Override
+      public String toString() {
+        return MoreObjects.toStringHelper(getClass())
+            .add("intField", intField)
+            .add("stringField", stringField)
+            .toString();
       }
-      GenericClassV2 o = (GenericClassV2) other;
-      return Objects.equals(intField, o.intField)
-          && Objects.equals(stringField, o.stringField)
-          && Objects.equals(nullableField, o.nullableField);
-    }
-  }
 
-  /**
-   * Tests that {@code AvroIO} can read an upgraded version of an old class, as long as the schema
-   * resolution process succeeds. This test covers the case when a new, {@code @Nullable} field has
-   * been added.
-   *
-   * <p>For more information, see http://avro.apache.org/docs/1.7.7/spec.html#Schema+Resolution
-   */
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWriteThenReadSchemaUpgrade() throws Throwable {
-    List<GenericClass> values =
-        ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
-    File outputFile = tmpFolder.newFile("output.avro");
+      @Override
+      public int hashCode() {
+        return Objects.hash(intField, stringField);
+      }
 
-    writePipeline
-        .apply(Create.of(values))
-        .apply(AvroIO.write(GenericClass.class).to(outputFile.getAbsolutePath()).withoutSharding());
-    writePipeline.run();
-
-    List<GenericClassV2> expected =
-        ImmutableList.of(new GenericClassV2(3, "hi", null), new GenericClassV2(5, "bar", null));
-
-    PAssert.that(
-            readPipeline.apply(
-                AvroIO.read(GenericClassV2.class).from(outputFile.getAbsolutePath())))
-        .containsInAnyOrder(expected);
-    readPipeline.run();
-  }
-
-  private static class WindowedFilenamePolicy extends FilenamePolicy {
-    final ResourceId outputFilePrefix;
-
-    WindowedFilenamePolicy(ResourceId outputFilePrefix) {
-      this.outputFilePrefix = outputFilePrefix;
+      @Override
+      public boolean equals(Object other) {
+        if (other == null || !(other instanceof GenericClass)) {
+          return false;
+        }
+        GenericClass o = (GenericClass) other;
+        return Objects.equals(intField, o.intField) && Objects.equals(stringField, o.stringField);
+      }
     }
 
-    @Override
-    public ResourceId windowedFilename(
-        int shardNumber,
-        int numShards,
-        BoundedWindow window,
-        PaneInfo paneInfo,
-        OutputFileHints outputFileHints) {
-      String filenamePrefix =
-          outputFilePrefix.isDirectory() ? "" : firstNonNull(outputFilePrefix.getFilename(), "");
+    private static class ParseGenericClass
+        implements SerializableFunction<GenericRecord, GenericClass> {
+      @Override
+      public GenericClass apply(GenericRecord input) {
+        return new GenericClass((int) input.get("intField"), input.get("stringField").toString());
+      }
 
-      IntervalWindow interval = (IntervalWindow) window;
-      String windowStr =
-          String.format("%s-%s", interval.start().toString(), interval.end().toString());
-      String filename =
-          String.format(
-              "%s-%s-%s-of-%s-pane-%s%s%s.avro",
-              filenamePrefix,
-              windowStr,
-              shardNumber,
-              numShards,
-              paneInfo.getIndex(),
-              paneInfo.isLast() ? "-last" : "",
-              outputFileHints.getSuggestedFilenameSuffix());
-      return outputFilePrefix.getCurrentDirectory().resolve(filename, RESOLVE_FILE);
+      @Test
+      public void testWriteDisplayData() {
+        AvroIO.Write<GenericClass> write =
+            AvroIO.write(GenericClass.class)
+                .to("/foo")
+                .withShardNameTemplate("-SS-of-NN-")
+                .withSuffix("bar")
+                .withNumShards(100)
+                .withCodec(CodecFactory.deflateCodec(6));
+
+        DisplayData displayData = DisplayData.from(write);
+
+        assertThat(displayData, hasDisplayItem("filePrefix", "/foo"));
+        assertThat(displayData, hasDisplayItem("shardNameTemplate", "-SS-of-NN-"));
+        assertThat(displayData, hasDisplayItem("fileSuffix", "bar"));
+        assertThat(
+            displayData,
+            hasDisplayItem(
+                "schema",
+                "{\"type\":\"record\",\"name\":\"GenericClass\",\"namespace\":\"org.apache.beam.sdk.io"
+                    + ".AvroIOTest$\",\"fields\":[{\"name\":\"intField\",\"type\":\"int\"},"
+                    + "{\"name\":\"stringField\",\"type\":\"string\"}]}"));
+        assertThat(displayData, hasDisplayItem("numShards", 100));
+        assertThat(displayData, hasDisplayItem("codec", CodecFactory.deflateCodec(6).toString()));
+      }
     }
 
-    @Override
-    public ResourceId unwindowedFilename(
-        int shardNumber, int numShards, OutputFileHints outputFileHints) {
-      throw new UnsupportedOperationException("Expecting windowed outputs only");
+    private enum Sharding {
+      RUNNER_DETERMINED,
+      WITHOUT_SHARDING,
+      FIXED_3_SHARDS
     }
 
-    @Override
-    public void populateDisplayData(DisplayData.Builder builder) {
-      builder.add(
-          DisplayData.item("fileNamePrefix", outputFilePrefix.toString())
-              .withLabel("File Name Prefix"));
-    }
-  }
-
-  @Test
-  @Category({NeedsRunner.class, UsesTestStream.class})
-  public void testWriteWindowed() throws Throwable {
-    testWindowedAvroIOWriteUsingMethod(WriteMethod.AVROIO_WRITE);
-  }
-
-  @Test
-  @Category({NeedsRunner.class, UsesTestStream.class})
-  public void testWindowedAvroIOWriteViaSink() throws Throwable {
-    testWindowedAvroIOWriteUsingMethod(WriteMethod.AVROIO_SINK);
-  }
-
-  void testWindowedAvroIOWriteUsingMethod(WriteMethod method) throws IOException {
-    Path baseDir = Files.createTempDirectory(tmpFolder.getRoot().toPath(), "testwrite");
-    final String baseFilename = baseDir.resolve("prefix").toString();
-
-    Instant base = new Instant(0);
-    ArrayList<GenericClass> allElements = new ArrayList<>();
-    ArrayList<TimestampedValue<GenericClass>> firstWindowElements = new ArrayList<>();
-    ArrayList<Instant> firstWindowTimestamps =
-        Lists.newArrayList(
-            base.plus(Duration.ZERO), base.plus(Duration.standardSeconds(10)),
-            base.plus(Duration.standardSeconds(20)), base.plus(Duration.standardSeconds(30)));
-
-    Random random = new Random();
-    for (int i = 0; i < 100; ++i) {
-      GenericClass item = new GenericClass(i, String.valueOf(i));
-      allElements.add(item);
-      firstWindowElements.add(
-          TimestampedValue.of(
-              item, firstWindowTimestamps.get(random.nextInt(firstWindowTimestamps.size()))));
+    private enum WriteMethod {
+      AVROIO_WRITE,
+      AVROIO_SINK
     }
 
-    ArrayList<TimestampedValue<GenericClass>> secondWindowElements = new ArrayList<>();
-    ArrayList<Instant> secondWindowTimestamps =
-        Lists.newArrayList(
-            base.plus(Duration.standardSeconds(60)), base.plus(Duration.standardSeconds(70)),
-            base.plus(Duration.standardSeconds(80)), base.plus(Duration.standardSeconds(90)));
-    for (int i = 100; i < 200; ++i) {
-      GenericClass item = new GenericClass(i, String.valueOf(i));
-      allElements.add(new GenericClass(i, String.valueOf(i)));
-      secondWindowElements.add(
-          TimestampedValue.of(
-              item, secondWindowTimestamps.get(random.nextInt(secondWindowTimestamps.size()))));
-    }
+    private static final String SCHEMA_STRING =
+        "{\"namespace\": \"example.avro\",\n"
+            + " \"type\": \"record\",\n"
+            + " \"name\": \"AvroGeneratedUser\",\n"
+            + " \"fields\": [\n"
+            + "     {\"name\": \"name\", \"type\": \"string\"},\n"
+            + "     {\"name\": \"favorite_number\", \"type\": [\"int\", \"null\"]},\n"
+            + "     {\"name\": \"favorite_color\", \"type\": [\"string\", \"null\"]}\n"
+            + " ]\n"
+            + "}";
 
-    TimestampedValue<GenericClass>[] firstWindowArray =
-        firstWindowElements.toArray(new TimestampedValue[100]);
-    TimestampedValue<GenericClass>[] secondWindowArray =
-        secondWindowElements.toArray(new TimestampedValue[100]);
+    private static final Schema SCHEMA = new Schema.Parser().parse(SCHEMA_STRING);
 
-    TestStream<GenericClass> values =
-        TestStream.create(AvroCoder.of(GenericClass.class))
-            .advanceWatermarkTo(new Instant(0))
-            .addElements(
-                firstWindowArray[0],
-                Arrays.copyOfRange(firstWindowArray, 1, firstWindowArray.length))
-            .advanceWatermarkTo(new Instant(0).plus(Duration.standardMinutes(1)))
-            .addElements(
-                secondWindowArray[0],
-                Arrays.copyOfRange(secondWindowArray, 1, secondWindowArray.length))
-            .advanceWatermarkToInfinity();
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWriteThenReadJavaClass() throws Throwable {
+      List<GenericClass> values =
+          ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
+      File outputFile = tmpFolder.newFile("output.avro");
 
-    final PTransform<PCollection<GenericClass>, WriteFilesResult<Void>> write;
-    switch (method) {
-      case AVROIO_WRITE:
-        {
-          FilenamePolicy policy =
-              new WindowedFilenamePolicy(
-                  FileBasedSink.convertToFileResourceIfPossible(baseFilename));
-          write =
+      writePipeline
+          .apply(Create.of(values))
+          .apply(
               AvroIO.write(GenericClass.class)
-                  .to(policy)
-                  .withTempDirectory(
-                      StaticValueProvider.of(
-                          FileSystems.matchNewResource(baseDir.toString(), true)))
-                  .withWindowedWrites()
-                  .withNumShards(2)
-                  .withOutputFilenames();
-          break;
-        }
+                  .to(writePipeline.newProvider(outputFile.getAbsolutePath()))
+                  .withoutSharding());
+      writePipeline.run();
 
-      case AVROIO_SINK:
-        {
-          write =
-              FileIO.<GenericClass>write()
-                  .via(AvroIO.sink(GenericClass.class))
-                  .to(baseDir.toString())
-                  .withPrefix("prefix")
-                  .withSuffix(".avro")
-                  .withTempDirectory(baseDir.toString())
-                  .withNumShards(2);
-          break;
-        }
+      PAssert.that(
+              readPipeline.apply(
+                  "Read",
+                  AvroIO.read(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .from(readPipeline.newProvider(outputFile.getAbsolutePath()))))
+          .containsInAnyOrder(values);
 
-      default:
-        throw new UnsupportedOperationException();
+      readPipeline.run();
     }
-    windowedAvroWritePipeline
-        .apply(values)
-        .apply(Window.into(FixedWindows.of(Duration.standardMinutes(1))))
-        .apply(write);
-    windowedAvroWritePipeline.run();
 
-    // Validate that the data written matches the expected elements in the expected order
-    List<File> expectedFiles = new ArrayList<>();
-    for (int shard = 0; shard < 2; shard++) {
-      for (int window = 0; window < 2; window++) {
-        Instant windowStart = new Instant(0).plus(Duration.standardMinutes(window));
-        IntervalWindow iw = new IntervalWindow(windowStart, Duration.standardMinutes(1));
-        String baseAndWindow = baseFilename + "-" + iw.start() + "-" + iw.end();
-        switch (method) {
-          case AVROIO_WRITE:
-            expectedFiles.add(new File(baseAndWindow + "-" + shard + "-of-2-pane-0-last.avro"));
-            break;
-          case AVROIO_SINK:
-            expectedFiles.add(new File(baseAndWindow + "-0000" + shard + "-of-00002.avro"));
-            break;
-        }
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWriteThenReadCustomType() throws Throwable {
+      List<Long> values = Arrays.asList(0L, 1L, 2L);
+      File outputFile = tmpFolder.newFile("output.avro");
+
+      writePipeline
+          .apply(Create.of(values))
+          .apply(
+              AvroIO.<Long, GenericClass>writeCustomType()
+                  .to(writePipeline.newProvider(outputFile.getAbsolutePath()))
+                  .withFormatFunction(new CreateGenericClass())
+                  .withSchema(ReflectData.get().getSchema(GenericClass.class))
+                  .withoutSharding());
+      writePipeline.run();
+
+      PAssert.that(
+              readPipeline
+                  .apply(
+                      "Read",
+                      AvroIO.read(GenericClass.class)
+                          .withBeamSchemas(withBeamSchemas)
+                          .from(readPipeline.newProvider(outputFile.getAbsolutePath())))
+                  .apply(
+                      MapElements.via(
+                          new SimpleFunction<GenericClass, Long>() {
+                            @Override
+                            public Long apply(GenericClass input) {
+                              return (long) input.intField;
+                            }
+                          })))
+          .containsInAnyOrder(values);
+
+      readPipeline.run();
+    }
+
+    private <T extends GenericRecord> void testWriteThenReadGeneratedClass(
+        AvroIO.Write<T> writeTransform, AvroIO.Read<T> readTransform) throws Exception {
+      File outputFile = tmpFolder.newFile("output.avro");
+
+      List<T> values =
+          ImmutableList.of(
+              (T) new AvroGeneratedUser("Bob", 256, null),
+              (T) new AvroGeneratedUser("Alice", 128, null),
+              (T) new AvroGeneratedUser("Ted", null, "white"));
+
+      writePipeline
+          .apply(Create.of(values))
+          .apply(
+              writeTransform
+                  .to(writePipeline.newProvider(outputFile.getAbsolutePath()))
+                  .withoutSharding());
+      writePipeline.run();
+
+      PAssert.that(
+              readPipeline.apply(
+                  "Read",
+                  readTransform.from(readPipeline.newProvider(outputFile.getAbsolutePath()))))
+          .containsInAnyOrder(values);
+
+      readPipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWriteThenReadGeneratedClassWithClass() throws Throwable {
+      testWriteThenReadGeneratedClass(
+          AvroIO.write(AvroGeneratedUser.class),
+          AvroIO.read(AvroGeneratedUser.class).withBeamSchemas(withBeamSchemas));
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWriteThenReadGeneratedClassWithSchema() throws Throwable {
+      testWriteThenReadGeneratedClass(
+          AvroIO.writeGenericRecords(SCHEMA),
+          AvroIO.readGenericRecords(SCHEMA).withBeamSchemas(withBeamSchemas));
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWriteThenReadGeneratedClassWithSchemaString() throws Throwable {
+      testWriteThenReadGeneratedClass(
+          AvroIO.writeGenericRecords(SCHEMA.toString()),
+          AvroIO.readGenericRecords(SCHEMA.toString()).withBeamSchemas(withBeamSchemas));
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWriteSingleFileThenReadUsingAllMethods() throws Throwable {
+      List<GenericClass> values =
+          ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
+      File outputFile = tmpFolder.newFile("output.avro");
+
+      writePipeline
+          .apply(Create.of(values))
+          .apply(
+              AvroIO.write(GenericClass.class).to(outputFile.getAbsolutePath()).withoutSharding());
+      writePipeline.run();
+
+      // Test the same data using all versions of read().
+      PCollection<String> path =
+          readPipeline.apply("Create path", Create.of(outputFile.getAbsolutePath()));
+      PAssert.that(
+              readPipeline.apply(
+                  "Read",
+                  AvroIO.read(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .from(outputFile.getAbsolutePath())))
+          .containsInAnyOrder(values);
+      PAssert.that(
+              readPipeline.apply(
+                  "Read withHintMatchesManyFiles",
+                  AvroIO.read(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .from(outputFile.getAbsolutePath())
+                      .withHintMatchesManyFiles()))
+          .containsInAnyOrder(values);
+      PAssert.that(
+              path.apply(
+                  "ReadAll",
+                  AvroIO.readAll(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .withDesiredBundleSizeBytes(10)))
+          .containsInAnyOrder(values);
+      PAssert.that(
+              readPipeline.apply(
+                  "Parse",
+                  AvroIO.parseGenericRecords(new ParseGenericClass())
+                      .from(outputFile.getAbsolutePath())
+                      .withCoder(AvroCoder.of(GenericClass.class))))
+          .containsInAnyOrder(values);
+      PAssert.that(
+              readPipeline.apply(
+                  "Parse withHintMatchesManyFiles",
+                  AvroIO.parseGenericRecords(new ParseGenericClass())
+                      .from(outputFile.getAbsolutePath())
+                      .withCoder(AvroCoder.of(GenericClass.class))
+                      .withHintMatchesManyFiles()))
+          .containsInAnyOrder(values);
+      PAssert.that(
+              path.apply(
+                  "ParseAll",
+                  AvroIO.parseAllGenericRecords(new ParseGenericClass())
+                      .withCoder(AvroCoder.of(GenericClass.class))
+                      .withDesiredBundleSizeBytes(10)))
+          .containsInAnyOrder(values);
+
+      readPipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWriteThenReadMultipleFilepatterns() throws Throwable {
+      List<GenericClass> firstValues = Lists.newArrayList();
+      List<GenericClass> secondValues = Lists.newArrayList();
+      for (int i = 0; i < 10; ++i) {
+        firstValues.add(new GenericClass(i, "a" + i));
+        secondValues.add(new GenericClass(i, "b" + i));
       }
-    }
+      writePipeline
+          .apply("Create first", Create.of(firstValues))
+          .apply(
+              "Write first",
+              AvroIO.write(GenericClass.class)
+                  .to(tmpFolder.getRoot().getAbsolutePath() + "/first")
+                  .withNumShards(2));
+      writePipeline
+          .apply("Create second", Create.of(secondValues))
+          .apply(
+              "Write second",
+              AvroIO.write(GenericClass.class)
+                  .to(tmpFolder.getRoot().getAbsolutePath() + "/second")
+                  .withNumShards(3));
+      writePipeline.run();
 
-    List<GenericClass> actualElements = new ArrayList<>();
-    for (File outputFile : expectedFiles) {
-      assertTrue("Expected output file " + outputFile.getAbsolutePath(), outputFile.exists());
-      try (DataFileReader<GenericClass> reader =
-          new DataFileReader<>(
-              outputFile,
-              new ReflectDatumReader<GenericClass>(
-                  ReflectData.get().getSchema(GenericClass.class)))) {
-        Iterators.addAll(actualElements, reader);
-      }
-      outputFile.delete();
-    }
-    assertThat(actualElements, containsInAnyOrder(allElements.toArray()));
-  }
-
-  private static final String SCHEMA_TEMPLATE_STRING =
-      "{\"namespace\": \"example.avro\",\n"
-          + " \"type\": \"record\",\n"
-          + " \"name\": \"TestTemplateSchema$$\",\n"
-          + " \"fields\": [\n"
-          + "     {\"name\": \"$$full\", \"type\": \"string\"},\n"
-          + "     {\"name\": \"$$suffix\", \"type\": [\"string\", \"null\"]}\n"
-          + " ]\n"
-          + "}";
-
-  private static String schemaFromPrefix(String prefix) {
-    return SCHEMA_TEMPLATE_STRING.replace("$$", prefix);
-  }
-
-  private static GenericRecord createRecord(String record, String prefix, Schema schema) {
-    GenericRecord genericRecord = new GenericData.Record(schema);
-    genericRecord.put(prefix + "full", record);
-    genericRecord.put(prefix + "suffix", record.substring(1));
-    return genericRecord;
-  }
-
-  private static class TestDynamicDestinations
-      extends DynamicAvroDestinations<String, String, GenericRecord> {
-    ResourceId baseDir;
-    PCollectionView<Map<String, String>> schemaView;
-
-    TestDynamicDestinations(ResourceId baseDir, PCollectionView<Map<String, String>> schemaView) {
-      this.baseDir = baseDir;
-      this.schemaView = schemaView;
-    }
-
-    @Override
-    public Schema getSchema(String destination) {
-      // Return a per-destination schema.
-      String schema = sideInput(schemaView).get(destination);
-      return new Schema.Parser().parse(schema);
-    }
-
-    @Override
-    public List<PCollectionView<?>> getSideInputs() {
-      return ImmutableList.of(schemaView);
-    }
-
-    @Override
-    public GenericRecord formatRecord(String record) {
-      String prefix = record.substring(0, 1);
-      return createRecord(record, prefix, getSchema(prefix));
-    }
-
-    @Override
-    public String getDestination(String element) {
-      // Destination is based on first character of string.
-      return element.substring(0, 1);
-    }
-
-    @Override
-    public String getDefaultDestination() {
-      return "";
-    }
-
-    @Override
-    public FilenamePolicy getFilenamePolicy(String destination) {
-      return DefaultFilenamePolicy.fromStandardParameters(
-          StaticValueProvider.of(baseDir.resolve("file_" + destination, RESOLVE_FILE)),
-          "-SSSSS-of-NNNNN",
-          ".avro",
-          false);
-    }
-  }
-
-  private void testDynamicDestinationsUnwindowedWithSharding(
-      WriteMethod writeMethod, Sharding sharding) throws Exception {
-    final ResourceId baseDir =
-        FileSystems.matchNewResource(
-            Files.createTempDirectory(tmpFolder.getRoot().toPath(), "testDynamicDestinations")
-                .toString(),
-            true);
-
-    List<String> elements = Lists.newArrayList("aaaa", "aaab", "baaa", "baab", "caaa", "caab");
-    Multimap<String, GenericRecord> expectedElements = ArrayListMultimap.create();
-    Map<String, String> schemaMap = Maps.newHashMap();
-    for (String element : elements) {
-      String prefix = element.substring(0, 1);
-      String jsonSchema = schemaFromPrefix(prefix);
-      schemaMap.put(prefix, jsonSchema);
-      expectedElements.put(
-          prefix, createRecord(element, prefix, new Schema.Parser().parse(jsonSchema)));
-    }
-    final PCollectionView<Map<String, String>> schemaView =
-        writePipeline.apply("createSchemaView", Create.of(schemaMap)).apply(View.asMap());
-
-    PCollection<String> input =
-        writePipeline.apply("createInput", Create.of(elements).withCoder(StringUtf8Coder.of()));
-
-    switch (writeMethod) {
-      case AVROIO_WRITE:
-        {
-          AvroIO.TypedWrite<String, String, GenericRecord> write =
-              AvroIO.<String>writeCustomTypeToGenericRecords()
-                  .to(new TestDynamicDestinations(baseDir, schemaView))
-                  .withTempDirectory(baseDir);
-
-          switch (sharding) {
-            case RUNNER_DETERMINED:
-              break;
-            case WITHOUT_SHARDING:
-              write = write.withoutSharding();
-              break;
-            case FIXED_3_SHARDS:
-              write = write.withNumShards(3);
-              break;
-            default:
-              throw new IllegalArgumentException("Unknown sharding " + sharding);
-          }
-
-          input.apply(write);
-          break;
-        }
-
-      case AVROIO_SINK:
-        {
-          final AvroIO.RecordFormatter<String> formatter =
-              (element, schema) -> {
-                String prefix = element.substring(0, 1);
-                GenericRecord record = new GenericData.Record(schema);
-                record.put(prefix + "full", element);
-                record.put(prefix + "suffix", element.substring(1));
-                return record;
-              };
-          FileIO.Write<String, String> write =
-              FileIO.<String, String>writeDynamic()
-                  .by(
-                      fn(
-                          (element, c) -> {
-                            c.sideInput(schemaView); // Ignore result
-                            return element.substring(0, 1);
-                          },
-                          requiresSideInputs(schemaView)))
-                  .via(
-                      fn(
-                          (dest, c) -> {
-                            Schema schema =
-                                new Schema.Parser().parse(c.sideInput(schemaView).get(dest));
-                            return AvroIO.sinkViaGenericRecords(schema, formatter);
-                          },
-                          requiresSideInputs(schemaView)))
-                  .to(baseDir.toString())
-                  .withNaming(
-                      fn(
-                          (dest, c) -> {
-                            c.sideInput(schemaView); // Ignore result
-                            return FileIO.Write.defaultNaming("file_" + dest, ".avro");
-                          },
-                          requiresSideInputs(schemaView)))
-                  .withTempDirectory(baseDir.toString())
-                  .withDestinationCoder(StringUtf8Coder.of())
-                  .withIgnoreWindowing();
-          switch (sharding) {
-            case RUNNER_DETERMINED:
-              break;
-            case WITHOUT_SHARDING:
-              write = write.withNumShards(1);
-              break;
-            case FIXED_3_SHARDS:
-              write = write.withNumShards(3);
-              break;
-            default:
-              throw new IllegalArgumentException("Unknown sharding " + sharding);
-          }
-
-          input.apply(write);
-          break;
-        }
-    }
-
-    writePipeline.run();
-
-    // Validate that the data written matches the expected elements in the expected order.
-
-    for (String prefix : expectedElements.keySet()) {
-      String shardPattern;
-      switch (sharding) {
-        case RUNNER_DETERMINED:
-          shardPattern = "-*";
-          break;
-        case WITHOUT_SHARDING:
-          shardPattern = "-00000-of-00001";
-          break;
-        case FIXED_3_SHARDS:
-          shardPattern = "-*-of-00003";
-          break;
-        default:
-          throw new IllegalArgumentException("Unknown sharding " + sharding);
-      }
-      String expectedFilepattern =
-          baseDir.resolve("file_" + prefix + shardPattern + ".avro", RESOLVE_FILE).toString();
-
-      PCollection<GenericRecord> records =
+      // Test readAll() and parseAllGenericRecords().
+      PCollection<String> paths =
           readPipeline.apply(
-              "read_" + prefix,
-              AvroIO.readGenericRecords(schemaFromPrefix(prefix)).from(expectedFilepattern));
-      PAssert.that(records).containsInAnyOrder(expectedElements.get(prefix));
-    }
-    readPipeline.run();
-  }
+              "Create paths",
+              Create.of(
+                  tmpFolder.getRoot().getAbsolutePath() + "/first*",
+                  tmpFolder.getRoot().getAbsolutePath() + "/second*"));
+      PAssert.that(
+              paths.apply(
+                  "Read all",
+                  AvroIO.readAll(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .withDesiredBundleSizeBytes(10)))
+          .containsInAnyOrder(Iterables.concat(firstValues, secondValues));
+      PAssert.that(
+              paths.apply(
+                  "Parse all",
+                  AvroIO.parseAllGenericRecords(new ParseGenericClass())
+                      .withCoder(AvroCoder.of(GenericClass.class))
+                      .withDesiredBundleSizeBytes(10)))
+          .containsInAnyOrder(Iterables.concat(firstValues, secondValues));
 
-  @Test
-  @Category(NeedsRunner.class)
-  public void testDynamicDestinationsRunnerDeterminedSharding() throws Exception {
-    testDynamicDestinationsUnwindowedWithSharding(
-        WriteMethod.AVROIO_WRITE, Sharding.RUNNER_DETERMINED);
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testDynamicDestinationsWithoutSharding() throws Exception {
-    testDynamicDestinationsUnwindowedWithSharding(
-        WriteMethod.AVROIO_WRITE, Sharding.WITHOUT_SHARDING);
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testDynamicDestinationsWithNumShards() throws Exception {
-    testDynamicDestinationsUnwindowedWithSharding(
-        WriteMethod.AVROIO_WRITE, Sharding.FIXED_3_SHARDS);
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testDynamicDestinationsViaSinkRunnerDeterminedSharding() throws Exception {
-    testDynamicDestinationsUnwindowedWithSharding(
-        WriteMethod.AVROIO_SINK, Sharding.RUNNER_DETERMINED);
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testDynamicDestinationsViaSinkWithoutSharding() throws Exception {
-    testDynamicDestinationsUnwindowedWithSharding(
-        WriteMethod.AVROIO_SINK, Sharding.WITHOUT_SHARDING);
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testDynamicDestinationsViaSinkWithNumShards() throws Exception {
-    testDynamicDestinationsUnwindowedWithSharding(WriteMethod.AVROIO_SINK, Sharding.FIXED_3_SHARDS);
-  }
-
-  @Test
-  public void testWriteWithDefaultCodec() throws Exception {
-    AvroIO.Write<String> write = AvroIO.write(String.class).to("/tmp/foo/baz");
-    assertEquals(CodecFactory.snappyCodec().toString(), write.inner.getCodec().toString());
-  }
-
-  @Test
-  public void testWriteWithCustomCodec() throws Exception {
-    AvroIO.Write<String> write =
-        AvroIO.write(String.class).to("/tmp/foo/baz").withCodec(CodecFactory.snappyCodec());
-    assertEquals(SNAPPY_CODEC, write.inner.getCodec().toString());
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testWriteWithSerDeCustomDeflateCodec() throws Exception {
-    AvroIO.Write<String> write =
-        AvroIO.write(String.class).to("/tmp/foo/baz").withCodec(CodecFactory.deflateCodec(9));
-
-    assertEquals(
-        CodecFactory.deflateCodec(9).toString(),
-        SerializableUtils.clone(write.inner.getCodec()).getCodec().toString());
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testWriteWithSerDeCustomXZCodec() throws Exception {
-    AvroIO.Write<String> write =
-        AvroIO.write(String.class).to("/tmp/foo/baz").withCodec(CodecFactory.xzCodec(9));
-
-    assertEquals(
-        CodecFactory.xzCodec(9).toString(),
-        SerializableUtils.clone(write.inner.getCodec()).getCodec().toString());
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  @Category(NeedsRunner.class)
-  public void testMetadata() throws Exception {
-    List<GenericClass> values =
-        ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
-    File outputFile = tmpFolder.newFile("output.avro");
-
-    writePipeline
-        .apply(Create.of(values))
-        .apply(
-            AvroIO.write(GenericClass.class)
-                .to(outputFile.getAbsolutePath())
-                .withoutSharding()
-                .withMetadata(
-                    ImmutableMap.of(
-                        "stringKey",
-                        "stringValue",
-                        "longKey",
-                        100L,
-                        "bytesKey",
-                        "bytesValue".getBytes(Charsets.UTF_8))));
-    writePipeline.run();
-
-    try (DataFileStream dataFileStream =
-        new DataFileStream(new FileInputStream(outputFile), new GenericDatumReader())) {
-      assertEquals("stringValue", dataFileStream.getMetaString("stringKey"));
-      assertEquals(100L, dataFileStream.getMetaLong("longKey"));
-      assertArrayEquals("bytesValue".getBytes(Charsets.UTF_8), dataFileStream.getMeta("bytesKey"));
-    }
-  }
-
-  @SuppressWarnings("deprecation") // using AvroCoder#createDatumReader for tests.
-  private void runTestWrite(String[] expectedElements, int numShards) throws IOException {
-    File baseOutputFile = new File(tmpFolder.getRoot(), "prefix");
-    String outputFilePrefix = baseOutputFile.getAbsolutePath();
-
-    AvroIO.Write<String> write =
-        AvroIO.write(String.class).to(outputFilePrefix).withSuffix(".avro");
-    if (numShards > 1) {
-      write = write.withNumShards(numShards);
-    } else {
-      write = write.withoutSharding();
-    }
-    writePipeline.apply(Create.of(ImmutableList.copyOf(expectedElements))).apply(write);
-    writePipeline.run();
-
-    String shardNameTemplate =
-        firstNonNull(
-            write.inner.getShardTemplate(),
-            DefaultFilenamePolicy.DEFAULT_UNWINDOWED_SHARD_TEMPLATE);
-
-    assertTestOutputs(expectedElements, numShards, outputFilePrefix, shardNameTemplate);
-  }
-
-  public static void assertTestOutputs(
-      String[] expectedElements, int numShards, String outputFilePrefix, String shardNameTemplate)
-      throws IOException {
-    // Validate that the data written matches the expected elements in the expected order
-    List<File> expectedFiles = new ArrayList<>();
-    for (int i = 0; i < numShards; i++) {
-      expectedFiles.add(
-          new File(
-              DefaultFilenamePolicy.constructName(
-                      FileBasedSink.convertToFileResourceIfPossible(outputFilePrefix),
-                      shardNameTemplate,
-                      ".avro",
-                      i,
-                      numShards,
-                      null,
-                      null)
-                  .toString()));
+      readPipeline.run();
     }
 
-    List<String> actualElements = new ArrayList<>();
-    for (File outputFile : expectedFiles) {
-      assertTrue("Expected output file " + outputFile.getName(), outputFile.exists());
-      try (DataFileReader<String> reader =
-          new DataFileReader<>(
-              outputFile, new ReflectDatumReader(ReflectData.get().getSchema(String.class)))) {
-        Iterators.addAll(actualElements, reader);
+    private static class CreateGenericClass extends SimpleFunction<Long, GenericClass> {
+      @Override
+      public GenericClass apply(Long i) {
+        return new GenericClass(i.intValue(), "value" + i);
       }
     }
-    assertThat(actualElements, containsInAnyOrder(expectedElements));
-  }
 
-  @Test
-  @Category(NeedsRunner.class)
-  public void testAvroSinkWrite() throws Exception {
-    String[] expectedElements = new String[] {"first", "second", "third"};
+    @Test
+    @Category(NeedsRunner.class)
+    public void testContinuouslyWriteAndReadMultipleFilepatterns() throws Throwable {
+      SimpleFunction<Long, GenericClass> mapFn = new CreateGenericClass();
+      List<GenericClass> firstValues = Lists.newArrayList();
+      List<GenericClass> secondValues = Lists.newArrayList();
+      for (int i = 0; i < 7; ++i) {
+        (i < 3 ? firstValues : secondValues).add(mapFn.apply((long) i));
+      }
+      // Configure windowing of the input so that it fires every time a new element is generated,
+      // so that files are written continuously.
+      Window<Long> window =
+          Window.<Long>into(FixedWindows.of(Duration.millis(100)))
+              .withAllowedLateness(Duration.ZERO)
+              .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
+              .discardingFiredPanes();
+      readPipeline
+          .apply("Sequence first", GenerateSequence.from(0).to(3).withRate(1, Duration.millis(300)))
+          .apply("Window first", window)
+          .apply("Map first", MapElements.via(mapFn))
+          .apply(
+              "Write first",
+              AvroIO.write(GenericClass.class)
+                  .to(tmpFolder.getRoot().getAbsolutePath() + "/first")
+                  .withNumShards(2)
+                  .withWindowedWrites());
+      readPipeline
+          .apply(
+              "Sequence second", GenerateSequence.from(3).to(7).withRate(1, Duration.millis(300)))
+          .apply("Window second", window)
+          .apply("Map second", MapElements.via(mapFn))
+          .apply(
+              "Write second",
+              AvroIO.write(GenericClass.class)
+                  .to(tmpFolder.getRoot().getAbsolutePath() + "/second")
+                  .withNumShards(3)
+                  .withWindowedWrites());
 
-    runTestWrite(expectedElements, 1);
-  }
+      // Test read(), readAll(), parse(), and parseAllGenericRecords() with watchForNewFiles().
+      PAssert.that(
+              readPipeline.apply(
+                  "Read",
+                  AvroIO.read(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .from(tmpFolder.getRoot().getAbsolutePath() + "/first*")
+                      .watchForNewFiles(
+                          Duration.millis(100),
+                          Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)))))
+          .containsInAnyOrder(firstValues);
+      PAssert.that(
+              readPipeline.apply(
+                  "Parse",
+                  AvroIO.parseGenericRecords(new ParseGenericClass())
+                      .from(tmpFolder.getRoot().getAbsolutePath() + "/first*")
+                      .watchForNewFiles(
+                          Duration.millis(100),
+                          Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)))))
+          .containsInAnyOrder(firstValues);
 
-  @Test
-  @Category(NeedsRunner.class)
-  public void testAvroSinkShardedWrite() throws Exception {
-    String[] expectedElements = new String[] {"first", "second", "third", "fourth", "fifth"};
+      PCollection<String> paths =
+          readPipeline.apply(
+              "Create paths",
+              Create.of(
+                  tmpFolder.getRoot().getAbsolutePath() + "/first*",
+                  tmpFolder.getRoot().getAbsolutePath() + "/second*"));
+      PAssert.that(
+              paths.apply(
+                  "Read all",
+                  AvroIO.readAll(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .watchForNewFiles(
+                          Duration.millis(100),
+                          Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)))
+                      .withDesiredBundleSizeBytes(10)))
+          .containsInAnyOrder(Iterables.concat(firstValues, secondValues));
+      PAssert.that(
+              paths.apply(
+                  "Parse all",
+                  AvroIO.parseAllGenericRecords(new ParseGenericClass())
+                      .withCoder(AvroCoder.of(GenericClass.class))
+                      .watchForNewFiles(
+                          Duration.millis(100),
+                          Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)))
+                      .withDesiredBundleSizeBytes(10)))
+          .containsInAnyOrder(Iterables.concat(firstValues, secondValues));
+      readPipeline.run();
+    }
 
-    runTestWrite(expectedElements, 4);
-  }
-  // TODO: for Write only, test withSuffix,
-  // withShardNameTemplate and withoutSharding.
+    @Test
+    @SuppressWarnings("unchecked")
+    @Category(NeedsRunner.class)
+    public void testCompressedWriteAndReadASingleFile() throws Throwable {
+      List<GenericClass> values =
+          ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
+      File outputFile = tmpFolder.newFile("output.avro");
 
-  @Test
-  public void testReadDisplayData() {
-    AvroIO.Read<String> read = AvroIO.read(String.class).from("/foo.*");
+      writePipeline
+          .apply(Create.of(values))
+          .apply(
+              AvroIO.write(GenericClass.class)
+                  .to(outputFile.getAbsolutePath())
+                  .withoutSharding()
+                  .withCodec(CodecFactory.deflateCodec(9)));
+      writePipeline.run();
 
-    DisplayData displayData = DisplayData.from(read);
-    assertThat(displayData, hasDisplayItem("filePattern", "/foo.*"));
-  }
+      PAssert.that(
+              readPipeline.apply(
+                  AvroIO.read(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .from(outputFile.getAbsolutePath())))
+          .containsInAnyOrder(values);
+      readPipeline.run();
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testPrimitiveReadDisplayData() {
-    DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
+      try (DataFileStream dataFileStream =
+          new DataFileStream(new FileInputStream(outputFile), new GenericDatumReader())) {
+        assertEquals("deflate", dataFileStream.getMetaString("avro.codec"));
+      }
+    }
 
-    AvroIO.Read<GenericRecord> read =
-        AvroIO.readGenericRecords(Schema.create(Schema.Type.STRING)).from("/foo.*");
+    @Test
+    @SuppressWarnings("unchecked")
+    @Category(NeedsRunner.class)
+    public void testWriteThenReadASingleFileWithNullCodec() throws Throwable {
+      List<GenericClass> values =
+          ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
+      File outputFile = tmpFolder.newFile("output.avro");
 
-    Set<DisplayData> displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
-    assertThat(
-        "AvroIO.Read should include the file pattern in its primitive transform",
-        displayData,
-        hasItem(hasDisplayItem("filePattern")));
-  }
+      writePipeline
+          .apply(Create.of(values))
+          .apply(
+              AvroIO.write(GenericClass.class)
+                  .to(outputFile.getAbsolutePath())
+                  .withoutSharding()
+                  .withCodec(CodecFactory.nullCodec()));
+      writePipeline.run();
 
-  @Test
-  public void testWriteDisplayData() {
-    AvroIO.Write<GenericClass> write =
-        AvroIO.write(GenericClass.class)
-            .to("/foo")
-            .withShardNameTemplate("-SS-of-NN-")
-            .withSuffix("bar")
-            .withNumShards(100)
-            .withCodec(CodecFactory.deflateCodec(6));
+      PAssert.that(
+              readPipeline.apply(
+                  AvroIO.read(GenericClass.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .from(outputFile.getAbsolutePath())))
+          .containsInAnyOrder(values);
+      readPipeline.run();
 
-    DisplayData displayData = DisplayData.from(write);
+      try (DataFileStream dataFileStream =
+          new DataFileStream(new FileInputStream(outputFile), new GenericDatumReader())) {
+        assertEquals("null", dataFileStream.getMetaString("avro.codec"));
+      }
+    }
 
-    assertThat(displayData, hasDisplayItem("filePrefix", "/foo"));
-    assertThat(displayData, hasDisplayItem("shardNameTemplate", "-SS-of-NN-"));
-    assertThat(displayData, hasDisplayItem("fileSuffix", "bar"));
-    assertThat(
-        displayData,
-        hasDisplayItem(
-            "schema",
-            "{\"type\":\"record\",\"name\":\"GenericClass\",\"namespace\":\"org.apache.beam.sdk.io"
-                + ".AvroIOTest$\",\"fields\":[{\"name\":\"intField\",\"type\":\"int\"},"
-                + "{\"name\":\"stringField\",\"type\":\"string\"}]}"));
-    assertThat(displayData, hasDisplayItem("numShards", 100));
-    assertThat(displayData, hasDisplayItem("codec", CodecFactory.deflateCodec(6).toString()));
+    @DefaultCoder(AvroCoder.class)
+    static class GenericClassV2 {
+      int intField;
+      String stringField;
+      @Nullable String nullableField;
+
+      public GenericClassV2() {}
+
+      public GenericClassV2(int intValue, String stringValue, String nullableValue) {
+        this.intField = intValue;
+        this.stringField = stringValue;
+        this.nullableField = nullableValue;
+      }
+
+      @Override
+      public String toString() {
+        return MoreObjects.toStringHelper(getClass())
+            .add("intField", intField)
+            .add("stringField", stringField)
+            .add("nullableField", nullableField)
+            .toString();
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(intField, stringField, nullableField);
+      }
+
+      @Override
+      public boolean equals(Object other) {
+        if (other == null || !(other instanceof GenericClassV2)) {
+          return false;
+        }
+        GenericClassV2 o = (GenericClassV2) other;
+        return Objects.equals(intField, o.intField)
+            && Objects.equals(stringField, o.stringField)
+            && Objects.equals(nullableField, o.nullableField);
+      }
+    }
+
+    /**
+     * Tests that {@code AvroIO} can read an upgraded version of an old class, as long as the schema
+     * resolution process succeeds. This test covers the case when a new, {@code @Nullable} field
+     * has been added.
+     *
+     * <p>For more information, see http://avro.apache.org/docs/1.7.7/spec.html#Schema+Resolution
+     */
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWriteThenReadSchemaUpgrade() throws Throwable {
+      List<GenericClass> values =
+          ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
+      File outputFile = tmpFolder.newFile("output.avro");
+
+      writePipeline
+          .apply(Create.of(values))
+          .apply(
+              AvroIO.write(GenericClass.class).to(outputFile.getAbsolutePath()).withoutSharding());
+      writePipeline.run();
+
+      List<GenericClassV2> expected =
+          ImmutableList.of(new GenericClassV2(3, "hi", null), new GenericClassV2(5, "bar", null));
+
+      PAssert.that(
+              readPipeline.apply(
+                  AvroIO.read(GenericClassV2.class)
+                      .withBeamSchemas(withBeamSchemas)
+                      .from(outputFile.getAbsolutePath())))
+          .containsInAnyOrder(expected);
+      readPipeline.run();
+    }
+
+    private static class WindowedFilenamePolicy extends FilenamePolicy {
+      final ResourceId outputFilePrefix;
+
+      WindowedFilenamePolicy(ResourceId outputFilePrefix) {
+        this.outputFilePrefix = outputFilePrefix;
+      }
+
+      @Override
+      public ResourceId windowedFilename(
+          int shardNumber,
+          int numShards,
+          BoundedWindow window,
+          PaneInfo paneInfo,
+          OutputFileHints outputFileHints) {
+        String filenamePrefix =
+            outputFilePrefix.isDirectory() ? "" : firstNonNull(outputFilePrefix.getFilename(), "");
+
+        IntervalWindow interval = (IntervalWindow) window;
+        String windowStr =
+            String.format("%s-%s", interval.start().toString(), interval.end().toString());
+        String filename =
+            String.format(
+                "%s-%s-%s-of-%s-pane-%s%s%s.avro",
+                filenamePrefix,
+                windowStr,
+                shardNumber,
+                numShards,
+                paneInfo.getIndex(),
+                paneInfo.isLast() ? "-last" : "",
+                outputFileHints.getSuggestedFilenameSuffix());
+        return outputFilePrefix.getCurrentDirectory().resolve(filename, RESOLVE_FILE);
+      }
+
+      @Override
+      public ResourceId unwindowedFilename(
+          int shardNumber, int numShards, OutputFileHints outputFileHints) {
+        throw new UnsupportedOperationException("Expecting windowed outputs only");
+      }
+
+      @Override
+      public void populateDisplayData(DisplayData.Builder builder) {
+        builder.add(
+            DisplayData.item("fileNamePrefix", outputFilePrefix.toString())
+                .withLabel("File Name Prefix"));
+      }
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesTestStream.class})
+    public void testWriteWindowed() throws Throwable {
+      testWindowedAvroIOWriteUsingMethod(WriteMethod.AVROIO_WRITE);
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesTestStream.class})
+    public void testWindowedAvroIOWriteViaSink() throws Throwable {
+      testWindowedAvroIOWriteUsingMethod(WriteMethod.AVROIO_SINK);
+    }
+
+    void testWindowedAvroIOWriteUsingMethod(WriteMethod method) throws IOException {
+      Path baseDir = Files.createTempDirectory(tmpFolder.getRoot().toPath(), "testwrite");
+      final String baseFilename = baseDir.resolve("prefix").toString();
+
+      Instant base = new Instant(0);
+      ArrayList<GenericClass> allElements = new ArrayList<>();
+      ArrayList<TimestampedValue<GenericClass>> firstWindowElements = new ArrayList<>();
+      ArrayList<Instant> firstWindowTimestamps =
+          Lists.newArrayList(
+              base.plus(Duration.ZERO), base.plus(Duration.standardSeconds(10)),
+              base.plus(Duration.standardSeconds(20)), base.plus(Duration.standardSeconds(30)));
+
+      Random random = new Random();
+      for (int i = 0; i < 100; ++i) {
+        GenericClass item = new GenericClass(i, String.valueOf(i));
+        allElements.add(item);
+        firstWindowElements.add(
+            TimestampedValue.of(
+                item, firstWindowTimestamps.get(random.nextInt(firstWindowTimestamps.size()))));
+      }
+
+      ArrayList<TimestampedValue<GenericClass>> secondWindowElements = new ArrayList<>();
+      ArrayList<Instant> secondWindowTimestamps =
+          Lists.newArrayList(
+              base.plus(Duration.standardSeconds(60)), base.plus(Duration.standardSeconds(70)),
+              base.plus(Duration.standardSeconds(80)), base.plus(Duration.standardSeconds(90)));
+      for (int i = 100; i < 200; ++i) {
+        GenericClass item = new GenericClass(i, String.valueOf(i));
+        allElements.add(new GenericClass(i, String.valueOf(i)));
+        secondWindowElements.add(
+            TimestampedValue.of(
+                item, secondWindowTimestamps.get(random.nextInt(secondWindowTimestamps.size()))));
+      }
+
+      TimestampedValue<GenericClass>[] firstWindowArray =
+          firstWindowElements.toArray(new TimestampedValue[100]);
+      TimestampedValue<GenericClass>[] secondWindowArray =
+          secondWindowElements.toArray(new TimestampedValue[100]);
+
+      TestStream<GenericClass> values =
+          TestStream.create(AvroCoder.of(GenericClass.class))
+              .advanceWatermarkTo(new Instant(0))
+              .addElements(
+                  firstWindowArray[0],
+                  Arrays.copyOfRange(firstWindowArray, 1, firstWindowArray.length))
+              .advanceWatermarkTo(new Instant(0).plus(Duration.standardMinutes(1)))
+              .addElements(
+                  secondWindowArray[0],
+                  Arrays.copyOfRange(secondWindowArray, 1, secondWindowArray.length))
+              .advanceWatermarkToInfinity();
+
+      final PTransform<PCollection<GenericClass>, WriteFilesResult<Void>> write;
+      switch (method) {
+        case AVROIO_WRITE:
+          {
+            FilenamePolicy policy =
+                new WindowedFilenamePolicy(
+                    FileBasedSink.convertToFileResourceIfPossible(baseFilename));
+            write =
+                AvroIO.write(GenericClass.class)
+                    .to(policy)
+                    .withTempDirectory(
+                        StaticValueProvider.of(
+                            FileSystems.matchNewResource(baseDir.toString(), true)))
+                    .withWindowedWrites()
+                    .withNumShards(2)
+                    .withOutputFilenames();
+            break;
+          }
+
+        case AVROIO_SINK:
+          {
+            write =
+                FileIO.<GenericClass>write()
+                    .via(AvroIO.sink(GenericClass.class))
+                    .to(baseDir.toString())
+                    .withPrefix("prefix")
+                    .withSuffix(".avro")
+                    .withTempDirectory(baseDir.toString())
+                    .withNumShards(2);
+            break;
+          }
+
+        default:
+          throw new UnsupportedOperationException();
+      }
+      windowedAvroWritePipeline
+          .apply(values)
+          .apply(Window.into(FixedWindows.of(Duration.standardMinutes(1))))
+          .apply(write);
+      windowedAvroWritePipeline.run();
+
+      // Validate that the data written matches the expected elements in the expected order
+      List<File> expectedFiles = new ArrayList<>();
+      for (int shard = 0; shard < 2; shard++) {
+        for (int window = 0; window < 2; window++) {
+          Instant windowStart = new Instant(0).plus(Duration.standardMinutes(window));
+          IntervalWindow iw = new IntervalWindow(windowStart, Duration.standardMinutes(1));
+          String baseAndWindow = baseFilename + "-" + iw.start() + "-" + iw.end();
+          switch (method) {
+            case AVROIO_WRITE:
+              expectedFiles.add(new File(baseAndWindow + "-" + shard + "-of-2-pane-0-last.avro"));
+              break;
+            case AVROIO_SINK:
+              expectedFiles.add(new File(baseAndWindow + "-0000" + shard + "-of-00002.avro"));
+              break;
+          }
+        }
+      }
+
+      List<GenericClass> actualElements = new ArrayList<>();
+      for (File outputFile : expectedFiles) {
+        assertTrue("Expected output file " + outputFile.getAbsolutePath(), outputFile.exists());
+        try (DataFileReader<GenericClass> reader =
+            new DataFileReader<>(
+                outputFile,
+                new ReflectDatumReader<GenericClass>(
+                    ReflectData.get().getSchema(GenericClass.class)))) {
+          Iterators.addAll(actualElements, reader);
+        }
+        outputFile.delete();
+      }
+      assertThat(actualElements, containsInAnyOrder(allElements.toArray()));
+    }
+
+    private static final String SCHEMA_TEMPLATE_STRING =
+        "{\"namespace\": \"example.avro\",\n"
+            + " \"type\": \"record\",\n"
+            + " \"name\": \"TestTemplateSchema$$\",\n"
+            + " \"fields\": [\n"
+            + "     {\"name\": \"$$full\", \"type\": \"string\"},\n"
+            + "     {\"name\": \"$$suffix\", \"type\": [\"string\", \"null\"]}\n"
+            + " ]\n"
+            + "}";
+
+    private static String schemaFromPrefix(String prefix) {
+      return SCHEMA_TEMPLATE_STRING.replace("$$", prefix);
+    }
+
+    private static GenericRecord createRecord(String record, String prefix, Schema schema) {
+      GenericRecord genericRecord = new GenericData.Record(schema);
+      genericRecord.put(prefix + "full", record);
+      genericRecord.put(prefix + "suffix", record.substring(1));
+      return genericRecord;
+    }
+
+    private static class TestDynamicDestinations
+        extends DynamicAvroDestinations<String, String, GenericRecord> {
+      ResourceId baseDir;
+      PCollectionView<Map<String, String>> schemaView;
+
+      TestDynamicDestinations(ResourceId baseDir, PCollectionView<Map<String, String>> schemaView) {
+        this.baseDir = baseDir;
+        this.schemaView = schemaView;
+      }
+
+      @Override
+      public Schema getSchema(String destination) {
+        // Return a per-destination schema.
+        String schema = sideInput(schemaView).get(destination);
+        return new Schema.Parser().parse(schema);
+      }
+
+      @Override
+      public List<PCollectionView<?>> getSideInputs() {
+        return ImmutableList.of(schemaView);
+      }
+
+      @Override
+      public GenericRecord formatRecord(String record) {
+        String prefix = record.substring(0, 1);
+        return createRecord(record, prefix, getSchema(prefix));
+      }
+
+      @Override
+      public String getDestination(String element) {
+        // Destination is based on first character of string.
+        return element.substring(0, 1);
+      }
+
+      @Override
+      public String getDefaultDestination() {
+        return "";
+      }
+
+      @Override
+      public FilenamePolicy getFilenamePolicy(String destination) {
+        return DefaultFilenamePolicy.fromStandardParameters(
+            StaticValueProvider.of(baseDir.resolve("file_" + destination, RESOLVE_FILE)),
+            "-SSSSS-of-NNNNN",
+            ".avro",
+            false);
+      }
+    }
+
+    private void testDynamicDestinationsUnwindowedWithSharding(
+        WriteMethod writeMethod, Sharding sharding) throws Exception {
+      final ResourceId baseDir =
+          FileSystems.matchNewResource(
+              Files.createTempDirectory(tmpFolder.getRoot().toPath(), "testDynamicDestinations")
+                  .toString(),
+              true);
+
+      List<String> elements = Lists.newArrayList("aaaa", "aaab", "baaa", "baab", "caaa", "caab");
+      Multimap<String, GenericRecord> expectedElements = ArrayListMultimap.create();
+      Map<String, String> schemaMap = Maps.newHashMap();
+      for (String element : elements) {
+        String prefix = element.substring(0, 1);
+        String jsonSchema = schemaFromPrefix(prefix);
+        schemaMap.put(prefix, jsonSchema);
+        expectedElements.put(
+            prefix, createRecord(element, prefix, new Schema.Parser().parse(jsonSchema)));
+      }
+      final PCollectionView<Map<String, String>> schemaView =
+          writePipeline.apply("createSchemaView", Create.of(schemaMap)).apply(View.asMap());
+
+      PCollection<String> input =
+          writePipeline.apply("createInput", Create.of(elements).withCoder(StringUtf8Coder.of()));
+
+      switch (writeMethod) {
+        case AVROIO_WRITE:
+          {
+            AvroIO.TypedWrite<String, String, GenericRecord> write =
+                AvroIO.<String>writeCustomTypeToGenericRecords()
+                    .to(new TestDynamicDestinations(baseDir, schemaView))
+                    .withTempDirectory(baseDir);
+
+            switch (sharding) {
+              case RUNNER_DETERMINED:
+                break;
+              case WITHOUT_SHARDING:
+                write = write.withoutSharding();
+                break;
+              case FIXED_3_SHARDS:
+                write = write.withNumShards(3);
+                break;
+              default:
+                throw new IllegalArgumentException("Unknown sharding " + sharding);
+            }
+
+            input.apply(write);
+            break;
+          }
+
+        case AVROIO_SINK:
+          {
+            final AvroIO.RecordFormatter<String> formatter =
+                (element, schema) -> {
+                  String prefix = element.substring(0, 1);
+                  GenericRecord record = new GenericData.Record(schema);
+                  record.put(prefix + "full", element);
+                  record.put(prefix + "suffix", element.substring(1));
+                  return record;
+                };
+            FileIO.Write<String, String> write =
+                FileIO.<String, String>writeDynamic()
+                    .by(
+                        fn(
+                            (element, c) -> {
+                              c.sideInput(schemaView); // Ignore result
+                              return element.substring(0, 1);
+                            },
+                            requiresSideInputs(schemaView)))
+                    .via(
+                        fn(
+                            (dest, c) -> {
+                              Schema schema =
+                                  new Schema.Parser().parse(c.sideInput(schemaView).get(dest));
+                              return AvroIO.sinkViaGenericRecords(schema, formatter);
+                            },
+                            requiresSideInputs(schemaView)))
+                    .to(baseDir.toString())
+                    .withNaming(
+                        fn(
+                            (dest, c) -> {
+                              c.sideInput(schemaView); // Ignore result
+                              return FileIO.Write.defaultNaming("file_" + dest, ".avro");
+                            },
+                            requiresSideInputs(schemaView)))
+                    .withTempDirectory(baseDir.toString())
+                    .withDestinationCoder(StringUtf8Coder.of())
+                    .withIgnoreWindowing();
+            switch (sharding) {
+              case RUNNER_DETERMINED:
+                break;
+              case WITHOUT_SHARDING:
+                write = write.withNumShards(1);
+                break;
+              case FIXED_3_SHARDS:
+                write = write.withNumShards(3);
+                break;
+              default:
+                throw new IllegalArgumentException("Unknown sharding " + sharding);
+            }
+
+            input.apply(write);
+            break;
+          }
+      }
+
+      writePipeline.run();
+
+      // Validate that the data written matches the expected elements in the expected order.
+
+      for (String prefix : expectedElements.keySet()) {
+        String shardPattern;
+        switch (sharding) {
+          case RUNNER_DETERMINED:
+            shardPattern = "-*";
+            break;
+          case WITHOUT_SHARDING:
+            shardPattern = "-00000-of-00001";
+            break;
+          case FIXED_3_SHARDS:
+            shardPattern = "-*-of-00003";
+            break;
+          default:
+            throw new IllegalArgumentException("Unknown sharding " + sharding);
+        }
+        String expectedFilepattern =
+            baseDir.resolve("file_" + prefix + shardPattern + ".avro", RESOLVE_FILE).toString();
+
+        PCollection<GenericRecord> records =
+            readPipeline.apply(
+                "read_" + prefix,
+                AvroIO.readGenericRecords(schemaFromPrefix(prefix))
+                    .withBeamSchemas(withBeamSchemas)
+                    .from(expectedFilepattern));
+        PAssert.that(records).containsInAnyOrder(expectedElements.get(prefix));
+      }
+      readPipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testDynamicDestinationsRunnerDeterminedSharding() throws Exception {
+      testDynamicDestinationsUnwindowedWithSharding(
+          WriteMethod.AVROIO_WRITE, Sharding.RUNNER_DETERMINED);
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testDynamicDestinationsWithoutSharding() throws Exception {
+      testDynamicDestinationsUnwindowedWithSharding(
+          WriteMethod.AVROIO_WRITE, Sharding.WITHOUT_SHARDING);
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testDynamicDestinationsWithNumShards() throws Exception {
+      testDynamicDestinationsUnwindowedWithSharding(
+          WriteMethod.AVROIO_WRITE, Sharding.FIXED_3_SHARDS);
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testDynamicDestinationsViaSinkRunnerDeterminedSharding() throws Exception {
+      testDynamicDestinationsUnwindowedWithSharding(
+          WriteMethod.AVROIO_SINK, Sharding.RUNNER_DETERMINED);
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testDynamicDestinationsViaSinkWithoutSharding() throws Exception {
+      testDynamicDestinationsUnwindowedWithSharding(
+          WriteMethod.AVROIO_SINK, Sharding.WITHOUT_SHARDING);
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testDynamicDestinationsViaSinkWithNumShards() throws Exception {
+      testDynamicDestinationsUnwindowedWithSharding(
+          WriteMethod.AVROIO_SINK, Sharding.FIXED_3_SHARDS);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    @Category(NeedsRunner.class)
+    public void testMetadata() throws Exception {
+      List<GenericClass> values =
+          ImmutableList.of(new GenericClass(3, "hi"), new GenericClass(5, "bar"));
+      File outputFile = tmpFolder.newFile("output.avro");
+
+      writePipeline
+          .apply(Create.of(values))
+          .apply(
+              AvroIO.write(GenericClass.class)
+                  .to(outputFile.getAbsolutePath())
+                  .withoutSharding()
+                  .withMetadata(
+                      ImmutableMap.of(
+                          "stringKey",
+                          "stringValue",
+                          "longKey",
+                          100L,
+                          "bytesKey",
+                          "bytesValue".getBytes(Charsets.UTF_8))));
+      writePipeline.run();
+
+      try (DataFileStream dataFileStream =
+          new DataFileStream(new FileInputStream(outputFile), new GenericDatumReader())) {
+        assertEquals("stringValue", dataFileStream.getMetaString("stringKey"));
+        assertEquals(100L, dataFileStream.getMetaLong("longKey"));
+        assertArrayEquals(
+            "bytesValue".getBytes(Charsets.UTF_8), dataFileStream.getMeta("bytesKey"));
+      }
+    }
+
+    @SuppressWarnings("deprecation") // using AvroCoder#createDatumReader for tests.
+    private void runTestWrite(String[] expectedElements, int numShards) throws IOException {
+      File baseOutputFile = new File(tmpFolder.getRoot(), "prefix");
+      String outputFilePrefix = baseOutputFile.getAbsolutePath();
+
+      AvroIO.Write<String> write =
+          AvroIO.write(String.class).to(outputFilePrefix).withSuffix(".avro");
+      if (numShards > 1) {
+        write = write.withNumShards(numShards);
+      } else {
+        write = write.withoutSharding();
+      }
+      writePipeline.apply(Create.of(ImmutableList.copyOf(expectedElements))).apply(write);
+      writePipeline.run();
+
+      String shardNameTemplate =
+          firstNonNull(
+              write.inner.getShardTemplate(),
+              DefaultFilenamePolicy.DEFAULT_UNWINDOWED_SHARD_TEMPLATE);
+
+      assertTestOutputs(expectedElements, numShards, outputFilePrefix, shardNameTemplate);
+    }
+
+    public static void assertTestOutputs(
+        String[] expectedElements, int numShards, String outputFilePrefix, String shardNameTemplate)
+        throws IOException {
+      // Validate that the data written matches the expected elements in the expected order
+      List<File> expectedFiles = new ArrayList<>();
+      for (int i = 0; i < numShards; i++) {
+        expectedFiles.add(
+            new File(
+                DefaultFilenamePolicy.constructName(
+                        FileBasedSink.convertToFileResourceIfPossible(outputFilePrefix),
+                        shardNameTemplate,
+                        ".avro",
+                        i,
+                        numShards,
+                        null,
+                        null)
+                    .toString()));
+      }
+
+      List<String> actualElements = new ArrayList<>();
+      for (File outputFile : expectedFiles) {
+        assertTrue("Expected output file " + outputFile.getName(), outputFile.exists());
+        try (DataFileReader<String> reader =
+            new DataFileReader<>(
+                outputFile, new ReflectDatumReader(ReflectData.get().getSchema(String.class)))) {
+          Iterators.addAll(actualElements, reader);
+        }
+      }
+      assertThat(actualElements, containsInAnyOrder(expectedElements));
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testAvroSinkWrite() throws Exception {
+      String[] expectedElements = new String[] {"first", "second", "third"};
+
+      runTestWrite(expectedElements, 1);
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testAvroSinkShardedWrite() throws Exception {
+      String[] expectedElements = new String[] {"first", "second", "third", "fourth", "fifth"};
+
+      runTestWrite(expectedElements, 4);
+    }
+    // TODO: for Write only, test withSuffix,
+    // withShardNameTemplate and withoutSharding.
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testPrimitiveReadDisplayData() {
+      DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
+
+      AvroIO.Read<GenericRecord> read =
+          AvroIO.readGenericRecords(Schema.create(Schema.Type.STRING))
+              .withBeamSchemas(withBeamSchemas)
+              .from("/foo.*");
+
+      Set<DisplayData> displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
+      assertThat(
+          "AvroIO.Read should include the file pattern in its primitive transform",
+          displayData,
+          hasItem(hasDisplayItem("filePattern")));
+    }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
@@ -290,7 +290,7 @@ public class AvroSchemaTest {
 
   @Test
   public void testPojoSchema() {
-    assertEquals(POJO_SCHEMA, AvroUtils.getSchema(AvroPojo.class));
+    assertEquals(POJO_SCHEMA, new AvroRecordSchema().schemaFor(TypeDescriptor.of(AvroPojo.class)));
   }
 
   @Test

--- a/sdks/java/extensions/euphoria/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/translate/BeamMetricsTranslationTest.java
+++ b/sdks/java/extensions/euphoria/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/translate/BeamMetricsTranslationTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.extensions.euphoria.core.translate;
 
 import static org.apache.beam.sdk.metrics.MetricResultsMatchers.metricsResult;
-import static org.junit.Assert.assertThat;
 
 import java.util.stream.Stream;
 import org.apache.beam.sdk.PipelineResult;
@@ -36,6 +35,7 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -134,11 +134,11 @@ public class BeamMetricsTranslationTest {
   }
 
   private void testStep1Metrics(MetricQueryResults metrics, String counterName1, String stepName1) {
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getCounters(),
         Matchers.hasItem(metricsResult(stepName1, counterName1, stepName1, 5L, true)));
 
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getDistributions(),
         Matchers.hasItem(
             metricsResult(
@@ -146,11 +146,11 @@ public class BeamMetricsTranslationTest {
   }
 
   private void testStep2Metrics(MetricQueryResults metrics, String counterName2, String stepName2) {
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getCounters(),
         Matchers.hasItem(metricsResult(stepName2, counterName2, stepName2, 2L, true)));
 
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getDistributions(),
         Matchers.hasItem(
             metricsResult(
@@ -159,11 +159,11 @@ public class BeamMetricsTranslationTest {
 
   private void testStep3WithDefaultOperatorName(
       MetricQueryResults metrics, String counterName2, String stepName3) {
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getCounters(),
         Matchers.hasItem(metricsResult(stepName3, counterName2, stepName3, 6L, true)));
 
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getDistributions(),
         Matchers.hasItem(
             metricsResult(

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
@@ -133,6 +133,9 @@ public class CassandraIO {
     abstract String password();
 
     @Nullable
+    abstract PasswordDecrypter passwordDecrypter();
+
+    @Nullable
     abstract String localDc();
 
     @Nullable
@@ -198,6 +201,16 @@ public class CassandraIO {
       return builder().setPassword(password).build();
     }
 
+    /**
+     * Specify the password decrypter used to retrieve the raw password. It delayed the decryption
+     * of the password when connecting to the cluster, which ensures that the raw password is never
+     * serialized in the pipeline.
+     */
+    public Read<T> withPasswordDecrypter(PasswordDecrypter passwordDecrypter) {
+      checkArgument(passwordDecrypter != null, "passwordDecrypter can not be null");
+      return builder().setPasswordDecrypter(passwordDecrypter).build();
+    }
+
     /** Specify the local DC used for the load balancing. */
     public Read<T> withLocalDc(String localDc) {
       checkArgument(localDc != null, "localDc can not be null");
@@ -259,6 +272,8 @@ public class CassandraIO {
       abstract Builder<T> setUsername(String username);
 
       abstract Builder<T> setPassword(String password);
+
+      abstract Builder<T> setPasswordDecrypter(PasswordDecrypter passwordDecrypter);
 
       abstract Builder<T> setLocalDc(String localDc);
 
@@ -351,6 +366,9 @@ public class CassandraIO {
     abstract String password();
 
     @Nullable
+    abstract PasswordDecrypter passwordDecrypter();
+
+    @Nullable
     abstract String localDc();
 
     @Nullable
@@ -438,6 +456,16 @@ public class CassandraIO {
               + "().withPassword(password) called with "
               + "null password");
       return builder().setPassword(password).build();
+    }
+
+    /**
+     * Specify the password decrypter used to retrieve the raw password. It delayed the decryption
+     * of the password when connecting to the cluster, which ensures that the raw password is never
+     * serialized in the pipeline.
+     */
+    public Write<T> withPasswordDecrypter(PasswordDecrypter passwordDecrypter) {
+      checkArgument(passwordDecrypter != null, "passwordDecrypter can not be null");
+      return builder().setPasswordDecrypter(passwordDecrypter).build();
     }
 
     /** Specify the local DC used by the load balancing policy. */
@@ -532,6 +560,8 @@ public class CassandraIO {
       abstract Builder<T> setUsername(String username);
 
       abstract Builder<T> setPassword(String password);
+
+      abstract Builder<T> setPasswordDecrypter(PasswordDecrypter passwordDecrypter);
 
       abstract Builder<T> setLocalDc(String localDc);
 

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
@@ -463,7 +463,7 @@ public class CassandraIO {
      * of the password when connecting to the cluster, which ensures that the raw password is never
      * serialized in the pipeline.
      */
-    public Write<T> withPasswordDecrypter(PasswordDecrypter passwordDecrypter) {
+    public Mutate<T> withPasswordDecrypter(PasswordDecrypter passwordDecrypter) {
       checkArgument(passwordDecrypter != null, "passwordDecrypter can not be null");
       return builder().setPasswordDecrypter(passwordDecrypter).build();
     }

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImpl.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImpl.java
@@ -74,6 +74,7 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
               source.spec.port(),
               source.spec.username(),
               source.spec.password(),
+              source.spec.passwordDecrypter(),
               source.spec.localDc(),
               source.spec.consistencyLevel());
       session = cluster.connect(source.spec.keyspace());
@@ -145,6 +146,7 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
             spec.port(),
             spec.username(),
             spec.password(),
+            spec.passwordDecrypter(),
             spec.localDc(),
             spec.consistencyLevel())) {
       if (isMurmur3Partitioner(cluster)) {
@@ -183,6 +185,7 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
             spec.port(),
             spec.username(),
             spec.password(),
+            spec.passwordDecrypter(),
             spec.localDc(),
             spec.consistencyLevel())) {
       if (isMurmur3Partitioner(cluster)) {
@@ -284,12 +287,16 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
       int port,
       String username,
       String password,
+      PasswordDecrypter passwordDecrypter,
       String localDc,
       String consistencyLevel) {
     Cluster.Builder builder =
         Cluster.builder().addContactPoints(hosts.toArray(new String[0])).withPort(port);
 
     if (username != null) {
+      if (passwordDecrypter != null) {
+        password = passwordDecrypter.decrypt(password);
+      }
       builder.withAuthProvider(new PlainTextAuthProvider(username, password));
     }
 
@@ -435,6 +442,7 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
               spec.port(),
               spec.username(),
               spec.password(),
+              spec.passwordDecrypter(),
               spec.localDc(),
               spec.consistencyLevel());
       this.session = cluster.connect(spec.keyspace());

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/PasswordDecrypter.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/PasswordDecrypter.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import java.io.Serializable;
+
+/** An interface used to decrypt the Cassandra password. */
+public interface PasswordDecrypter extends Serializable {
+
+  String decrypt(String encryptedPassword);
+}

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOIT.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOIT.java
@@ -168,7 +168,7 @@ public class CassandraIOIT implements Serializable {
     Assert.assertTrue(1L <= TestPasswordDecrypter.getNbCallsBySession(sessionReadUID));
   }
 
-  private void runWrite(CassandraIO.Write<Scientist> write) {
+  private void runWrite(CassandraIO.Mutate<Scientist> write) {
     pipelineWrite
         .apply("GenSequence", GenerateSequence.from(0).to((long) options.getNumberOfRecords()))
         .apply("PrepareTestRows", ParDo.of(new TestRow.DeterministicallyConstructTestRowFn()))

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/TestPasswordDecrypter.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/TestPasswordDecrypter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Class used to decrypt the Cassandra password. */
+public class TestPasswordDecrypter implements PasswordDecrypter {
+
+  /**
+   * Can't use the Mockito.verify() method to inspect the passwordDecrypter.decrypt() method
+   * invocation in integration tests because the PasswordDecrypter instance is directly deserialized
+   * on workers. Example => verify(passwordDecrypter, atLeast(1)).decrypt(ENCRYPTED_PASSWORD);
+   */
+  private static final Map<String, Long> nbCallsBySession = new HashMap<>();
+
+  private final String sessionUID;
+
+  public TestPasswordDecrypter(String sessionUID) {
+    this.sessionUID = sessionUID;
+  }
+
+  @Override
+  public String decrypt(String encryptedPassword) {
+    nbCallsBySession.put(sessionUID, nbCallsBySession.getOrDefault(sessionUID, 0L) + 1L);
+
+    return new String(Base64.getDecoder().decode(encryptedPassword), StandardCharsets.UTF_8);
+  }
+
+  public static long getNbCallsBySession(String sessionUID) {
+    return nbCallsBySession.get(sessionUID);
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -28,22 +28,49 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
+import com.google.api.client.util.Clock;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.io.AvroGeneratedUser;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO.Read;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubTestClient.PubsubTestClientFactory;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesUnboundedPCollections;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayDataEvaluator;
+import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.runners.model.Statement;
+import org.testng.collections.Lists;
 
 /** Tests for PubsubIO Read and Write transforms. */
 @RunWith(JUnit4.class)
@@ -247,5 +274,171 @@ public class PubsubIOTest {
         "PubsubIO.Write should include the topic in its primitive display data",
         displayData,
         hasItem(hasDisplayItem("topic")));
+  }
+
+  static class GenericClass {
+    int intField;
+    String stringField;
+
+    public GenericClass() {}
+
+    public GenericClass(int intField, String stringField) {
+      this.intField = intField;
+      this.stringField = stringField;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(getClass())
+          .add("intField", intField)
+          .add("stringField", stringField)
+          .toString();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(intField, stringField);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == null || !(other instanceof GenericClass)) {
+        return false;
+      }
+      GenericClass o = (GenericClass) other;
+      return Objects.equals(intField, o.intField) && Objects.equals(stringField, o.stringField);
+    }
+  }
+
+  private transient PipelineOptions options;
+  private static final SubscriptionPath SUBSCRIPTION =
+      PubsubClient.subscriptionPathFromName("test-project", "testSubscription");
+  private static final Clock CLOCK = (Clock & Serializable) () -> 673L;
+  transient TestPipeline readPipeline;
+
+  private static final String SCHEMA_STRING =
+      "{\"namespace\": \"example.avro\",\n"
+          + " \"type\": \"record\",\n"
+          + " \"name\": \"AvroGeneratedUser\",\n"
+          + " \"fields\": [\n"
+          + "     {\"name\": \"name\", \"type\": \"string\"},\n"
+          + "     {\"name\": \"favorite_number\", \"type\": [\"int\", \"null\"]},\n"
+          + "     {\"name\": \"favorite_color\", \"type\": [\"string\", \"null\"]}\n"
+          + " ]\n"
+          + "}";
+
+  private static final Schema SCHEMA = new Schema.Parser().parse(SCHEMA_STRING);
+
+  @Rule
+  public final transient TestRule setupPipeline =
+      new TestRule() {
+        @Override
+        public Statement apply(final Statement base, final Description description) {
+          // We need to set up the temporary folder, and then set up the TestPipeline based on the
+          // chosen folder. Unfortunately, since rule evaluation order is unspecified and unrelated
+          // to field order, and is separate from construction, that requires manually creating this
+          // TestRule.
+          Statement withPipeline =
+              new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                  options = TestPipeline.testingPipelineOptions();
+                  options.as(PubsubOptions.class).setProject("test-project");
+                  readPipeline = TestPipeline.fromOptions(options);
+                  readPipeline.apply(base, description).evaluate();
+                }
+              };
+          return withPipeline;
+        }
+      };
+
+  private <T> void setupTestClient(List<T> inputs, Coder<T> coder) {
+    List<IncomingMessage> messages =
+        inputs
+            .stream()
+            .map(
+                t -> {
+                  try {
+                    return CoderUtils.encodeToByteArray(coder, t);
+                  } catch (CoderException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .map(
+                ba ->
+                    new IncomingMessage(
+                        ba,
+                        null,
+                        1234L,
+                        0,
+                        UUID.randomUUID().toString(),
+                        UUID.randomUUID().toString()))
+            .collect(Collectors.toList());
+
+    clientFactory = PubsubTestClient.createFactoryForPull(CLOCK, SUBSCRIPTION, 60, messages);
+  }
+
+  private PubsubTestClientFactory clientFactory;
+
+  @After
+  public void after() throws IOException {
+    if (clientFactory != null) {
+      clientFactory.close();
+      clientFactory = null;
+    }
+  }
+
+  @Test
+  public void testAvroGenericRecords() {
+    AvroCoder<GenericRecord> coder = AvroCoder.of(GenericRecord.class, SCHEMA);
+    List<GenericRecord> inputs =
+        ImmutableList.of(
+            new AvroGeneratedUser("Bob", 256, null),
+            new AvroGeneratedUser("Alice", 128, null),
+            new AvroGeneratedUser("Ted", null, "white"));
+    setupTestClient(inputs, coder);
+    PCollection<GenericRecord> read =
+        readPipeline.apply(
+            PubsubIO.readAvroGenericRecords(SCHEMA)
+                .fromSubscription(SUBSCRIPTION.getPath())
+                .withClock(CLOCK)
+                .withClientFactory(clientFactory));
+    PAssert.that(read).containsInAnyOrder(inputs);
+    readPipeline.run();
+  }
+
+  @Test
+  public void testAvroPojo() {
+    AvroCoder<GenericClass> coder = AvroCoder.of(GenericClass.class);
+    List<GenericClass> inputs =
+        Lists.newArrayList(new GenericClass(1, "foo"), new GenericClass(2, "bar"));
+    setupTestClient(inputs, coder);
+    PCollection<GenericClass> read =
+        readPipeline.apply(
+            PubsubIO.readAvrosWithBeamSchema(GenericClass.class)
+                .fromSubscription(SUBSCRIPTION.getPath())
+                .withClock(CLOCK)
+                .withClientFactory(clientFactory));
+    PAssert.that(read).containsInAnyOrder(inputs);
+    readPipeline.run();
+  }
+
+  @Test
+  public void testAvroSpecificRecord() {
+    AvroCoder<AvroGeneratedUser> coder = AvroCoder.of(AvroGeneratedUser.class);
+    List<AvroGeneratedUser> inputs =
+        ImmutableList.of(
+            new AvroGeneratedUser("Bob", 256, null),
+            new AvroGeneratedUser("Alice", 128, null),
+            new AvroGeneratedUser("Ted", null, "white"));
+    setupTestClient(inputs, coder);
+    PCollection<AvroGeneratedUser> read =
+        readPipeline.apply(
+            PubsubIO.readAvrosWithBeamSchema(AvroGeneratedUser.class)
+                .fromSubscription(SUBSCRIPTION.getPath())
+                .withClock(CLOCK)
+                .withClientFactory(clientFactory));
+    PAssert.that(read).containsInAnyOrder(inputs);
+    readPipeline.run();
   }
 }

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -23,12 +23,14 @@ import static com.mongodb.client.model.Projections.include;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.BasicDBObject;
+import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.InsertManyOptions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -119,6 +121,7 @@ public class MongoDbIO {
         .setSslEnabled(false)
         .setIgnoreSSLCertificate(false)
         .setSslInvalidHostNameAllowed(false)
+        .setOrdered(true)
         .build();
   }
 
@@ -612,6 +615,8 @@ public class MongoDbIO {
 
     abstract boolean ignoreSSLCertificate();
 
+    abstract boolean ordered();
+
     @Nullable
     abstract String database();
 
@@ -635,6 +640,8 @@ public class MongoDbIO {
       abstract Builder setSslInvalidHostNameAllowed(boolean value);
 
       abstract Builder setIgnoreSSLCertificate(boolean value);
+
+      abstract Builder setOrdered(boolean value);
 
       abstract Builder setDatabase(String database);
 
@@ -705,6 +712,17 @@ public class MongoDbIO {
       return builder().setSslInvalidHostNameAllowed(invalidHostNameAllowed).build();
     }
 
+    /**
+     * Enables ordered bulk insertion (default: true).
+     *
+     * @see <a href=
+     *     "https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#basic">
+     *     specification of MongoDb CRUD operations</a>
+     */
+    public Write withOrdered(boolean ordered) {
+      return builder().setOrdered(ordered).build();
+    }
+
     /** Enable ignoreSSLCertificate for ssl for connection (allow for self signed ceritificates). */
     public Write withIgnoreSSLCertificate(boolean ignoreSSLCertificate) {
       return builder().setIgnoreSSLCertificate(ignoreSSLCertificate).build();
@@ -746,6 +764,7 @@ public class MongoDbIO {
       builder.add(DisplayData.item("sslEnable", sslEnabled()));
       builder.add(DisplayData.item("sslInvalidHostNameAllowed", sslInvalidHostNameAllowed()));
       builder.add(DisplayData.item("ignoreSSLCertificate", ignoreSSLCertificate()));
+      builder.add(DisplayData.item("ordered", ordered()));
       builder.add(DisplayData.item("database", database()));
       builder.add(DisplayData.item("collection", collection()));
       builder.add(DisplayData.item("batchSize", batchSize()));
@@ -799,7 +818,14 @@ public class MongoDbIO {
         }
         MongoDatabase mongoDatabase = client.getDatabase(spec.database());
         MongoCollection<Document> mongoCollection = mongoDatabase.getCollection(spec.collection());
-        mongoCollection.insertMany(batch);
+        try {
+          mongoCollection.insertMany(batch, new InsertManyOptions().ordered(spec.ordered()));
+        } catch (MongoBulkWriteException e) {
+          if (spec.ordered()) {
+            throw e;
+          }
+        }
+
         batch.clear();
       }
 

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDbIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDbIOTest.java
@@ -368,4 +368,34 @@ public class MongoDbIOTest implements Serializable {
 
     Assert.assertEquals(0, collection.count());
   }
+
+  @Test
+  public void testWriteUnordered() throws Exception {
+    Document doc =
+        Document.parse("{\"_id\":\"521df3a4300466f1f2b5ae82\",\"scientist\":\"Test %s\"}");
+
+    pipeline
+        .apply(Create.of(doc, doc))
+        .apply(
+            MongoDbIO.write()
+                .withUri("mongodb://localhost:" + port)
+                .withDatabase("test")
+                .withOrdered(false)
+                .withCollection("test"));
+    pipeline.run();
+
+    MongoClient client = new MongoClient("localhost", port);
+    MongoDatabase database = client.getDatabase("test");
+    MongoCollection collection = database.getCollection("test");
+
+    MongoCursor cursor = collection.find().iterator();
+
+    int count = 0;
+    while (cursor.hasNext()) {
+      count = count + 1;
+      cursor.next();
+    }
+
+    assertEquals(1, count);
+  }
 }

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkConfiguration.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
+import org.joda.time.Duration;
 
 /**
  * Configuration controlling how a query is run. May be supplied by command line or
@@ -70,6 +71,9 @@ public class NexmarkConfiguration implements Serializable {
    * stream to static enrichment data.
    */
   @JsonProperty public String sideInputUrl = null;
+
+  /** Gap for the session in {@link org.apache.beam.sdk.nexmark.queries.SessionSideInputJoin}. */
+  @JsonProperty public Duration sessionGap = Duration.standardMinutes(10);
 
   /**
    * Number of events to generate. If zero, generate as many as possible without overflowing

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
@@ -78,6 +78,8 @@ import org.apache.beam.sdk.nexmark.queries.Query8;
 import org.apache.beam.sdk.nexmark.queries.Query8Model;
 import org.apache.beam.sdk.nexmark.queries.Query9;
 import org.apache.beam.sdk.nexmark.queries.Query9Model;
+import org.apache.beam.sdk.nexmark.queries.SessionSideInputJoin;
+import org.apache.beam.sdk.nexmark.queries.SessionSideInputJoinModel;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlBoundedSideInputJoin;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlQuery0;
 import org.apache.beam.sdk.nexmark.queries.sql.SqlQuery1;
@@ -1221,6 +1223,7 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
         .put(NexmarkQueryName.MONITOR_NEW_USERS, new Query8Model(configuration))
         .put(NexmarkQueryName.WINNING_BIDS, new Query9Model(configuration))
         .put(NexmarkQueryName.BOUNDED_SIDE_INPUT_JOIN, new BoundedSideInputJoinModel(configuration))
+        .put(NexmarkQueryName.SESSION_SIDE_INPUT_JOIN, new SessionSideInputJoinModel(configuration))
         .build();
   }
 
@@ -1288,6 +1291,9 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
         .put(
             NexmarkQueryName.BOUNDED_SIDE_INPUT_JOIN,
             new NexmarkQuery(configuration, new BoundedSideInputJoin(configuration)))
+        .put(
+            NexmarkQueryName.SESSION_SIDE_INPUT_JOIN,
+            new NexmarkQuery(configuration, new SessionSideInputJoin(configuration)))
         .build();
   }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkQueryName.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkQueryName.java
@@ -42,7 +42,8 @@ public enum NexmarkQueryName {
   PROCESSING_TIME_WINDOWS(12), // Query "12"
 
   // Other non-numbered queries
-  BOUNDED_SIDE_INPUT_JOIN;
+  BOUNDED_SIDE_INPUT_JOIN,
+  SESSION_SIDE_INPUT_JOIN;
 
   private @Nullable Integer number;
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoin.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoin.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.queries;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.Map;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.model.Bid;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.WithKeys;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Sessions;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * Query that joins a stream to a bounded side input, modeling basic stream enrichment.
+ *
+ * <pre>
+ * SELECT bid.*, sideInput.*
+ * FROM bid, sideInput
+ * GROUP BY SESSION(bid.bidtime, bid.auctionid, config.sessionGap)
+ * WHERE bid.id = sideInput.id
+ * </pre>
+ */
+public class SessionSideInputJoin extends NexmarkQueryTransform<Bid> {
+  private final NexmarkConfiguration configuration;
+
+  public SessionSideInputJoin(NexmarkConfiguration configuration) {
+    super("BoundedSideInputJoin");
+    this.configuration = configuration;
+  }
+
+  @Override
+  public boolean needsSideInput() {
+    return true;
+  }
+
+  @Override
+  public PCollection<Bid> expand(PCollection<Event> events) {
+
+    checkState(getSideInput() != null, "Configuration error: side input is null");
+
+    final PCollectionView<Map<Long, String>> sideInputMap = getSideInput().apply(View.asMap());
+
+    return events
+        // Only want the bid events; easier to fake some side input data
+        .apply(NexmarkQueryUtil.JUST_BIDS)
+
+        // Sessionize on bidtime keyed by bidder id (they might bid on multiple auctions)
+        .apply(WithKeys.of(new SimpleFunction<Bid, Long>(bid -> bid.bidder) {}))
+        .apply(Window.into(Sessions.withGapDuration(configuration.sessionGap)))
+        .apply(GroupByKey.create())
+
+        // Enrich each bid in the session with the joined data
+        // concatenated with the session bounds
+        .apply(
+            name + ".JoinToFiles",
+            ParDo.of(
+                    new DoFn<KV<Long, Iterable<Bid>>, Bid>() {
+                      @ProcessElement
+                      public void processElement(ProcessContext c, BoundedWindow untypedWindow) {
+                        IntervalWindow window = (IntervalWindow) untypedWindow;
+
+                        String extra =
+                            c.sideInput(sideInputMap)
+                                .get(c.element().getKey() % configuration.sideInputRowCount);
+
+                        for (Bid bid : c.element().getValue()) {
+                          c.output(
+                              new Bid(
+                                  bid.auction,
+                                  bid.bidder,
+                                  bid.price,
+                                  bid.dateTime,
+                                  extra + ":" + window.start() + ":" + window.end()));
+                        }
+                      }
+                    })
+                .withSideInputs(sideInputMap));
+  }
+}

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoinModel.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoinModel.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.queries;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Ordering;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.NexmarkUtils;
+import org.apache.beam.sdk.nexmark.model.Bid;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.Instant;
+
+/** A direct implementation of {@link SessionSideInputJoin}. */
+public class SessionSideInputJoinModel extends NexmarkQueryModel<Bid> {
+
+  /** Simulator for SESSION_SIDE_INPUT_JOIN query. */
+  private static class Simulator extends AbstractSimulator<Event, Bid> {
+    private final NexmarkConfiguration configuration;
+
+    /**
+     * Active session for each bidder. Data is generated in-order so one suffices. Flushed when the
+     * simulator terminates.
+     */
+    private final Map<Long, List<TimestampedValue<Event>>> activeSessions;
+
+    public Simulator(NexmarkConfiguration configuration) {
+      super(NexmarkUtils.standardEventIterator(configuration));
+      this.configuration = configuration;
+      this.activeSessions = new HashMap<>();
+    }
+
+    @Override
+    protected void run() {
+      TimestampedValue<Event> timestampedEvent = nextInput();
+      if (timestampedEvent == null) {
+        for (Long bidder : ImmutableSet.copyOf(activeSessions.keySet())) {
+          flushSession(bidder);
+        }
+        allDone();
+        return;
+      }
+      Event event = timestampedEvent.getValue();
+      if (event.bid == null) {
+        // Ignore non-bid events.
+        return;
+      }
+
+      List<TimestampedValue<Event>> activeSession = activeSessions.get(event.bid.bidder);
+      if (activeSession == null) {
+        beginSession(timestampedEvent);
+      } else if (timestampedEvent
+          .getTimestamp()
+          .isAfter(
+              activeSession
+                  .get(activeSession.size() - 1)
+                  .getTimestamp()
+                  .plus(configuration.sessionGap))) {
+        flushSession(event.bid.bidder);
+        beginSession(timestampedEvent);
+      } else {
+        activeSession.add(timestampedEvent);
+      }
+    }
+
+    private void beginSession(TimestampedValue<Event> timestampedEvent) {
+      checkState(activeSessions.get(timestampedEvent.getValue().bid.bidder) == null);
+      List<TimestampedValue<Event>> session = new ArrayList<>();
+      session.add(timestampedEvent);
+      activeSessions.put(timestampedEvent.getValue().bid.bidder, session);
+    }
+
+    private void flushSession(long bidder) {
+      List<TimestampedValue<Event>> session = activeSessions.get(bidder);
+      checkState(session != null);
+
+      Instant sessionStart =
+          Ordering.<Instant>natural()
+              .min(
+                  session
+                      .stream()
+                      .<Instant>map(tsv -> tsv.getTimestamp())
+                      .collect(Collectors.toList()));
+
+      Instant sessionEnd =
+          Ordering.<Instant>natural()
+              .max(
+                  session
+                      .stream()
+                      .<Instant>map(tsv -> tsv.getTimestamp())
+                      .collect(Collectors.toList()))
+              .plus(configuration.sessionGap);
+
+      for (TimestampedValue<Event> timestampedEvent : session) {
+        // Join to the side input is always a string representation of the id being looked up
+        Bid bid = timestampedEvent.getValue().bid;
+        Bid resultBid =
+            new Bid(
+                bid.auction,
+                bid.bidder,
+                bid.price,
+                bid.dateTime,
+                String.format(
+                    "%d:%s:%s",
+                    bid.bidder % configuration.sideInputRowCount, sessionStart, sessionEnd));
+        TimestampedValue<Bid> result =
+            TimestampedValue.of(resultBid, timestampedEvent.getTimestamp());
+        addResult(result);
+      }
+      activeSessions.remove(bidder);
+    }
+  }
+
+  public SessionSideInputJoinModel(NexmarkConfiguration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  public AbstractSimulator<?, Bid> simulator() {
+    return new Simulator(configuration);
+  }
+
+  @Override
+  protected Collection<String> toCollection(Iterator<TimestampedValue<Bid>> itr) {
+    return toValue(itr);
+  }
+}

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoinTest.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/SessionSideInputJoinTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.queries;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Iterables;
+import java.util.Random;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.NexmarkUtils;
+import org.apache.beam.sdk.nexmark.model.Bid;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.nexmark.model.KnownSize;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test the various NEXMark queries yield results coherent with their models. */
+@RunWith(JUnit4.class)
+public class SessionSideInputJoinTest {
+
+  @Rule public TestPipeline p = TestPipeline.create();
+
+  @Before
+  public void setupPipeline() {
+    NexmarkUtils.setupPipeline(NexmarkUtils.CoderStrategy.HAND, p);
+  }
+
+  /** Test {@code query} matches {@code model}. */
+  private <T extends KnownSize> void queryMatchesModel(
+      String name,
+      NexmarkConfiguration config,
+      NexmarkQueryTransform<T> query,
+      NexmarkQueryModel<T> model,
+      boolean streamingMode)
+      throws Exception {
+
+    ResourceId sideInputResourceId =
+        FileSystems.matchNewResource(
+            String.format(
+                "%s/SessionSideInputJoin-%s",
+                p.getOptions().getTempLocation(), new Random().nextInt()),
+            false);
+    config.sideInputUrl = sideInputResourceId.toString();
+
+    try {
+      PCollection<KV<Long, String>> sideInput = NexmarkUtils.prepareSideInput(p, config);
+      query.setSideInput(sideInput);
+
+      PCollection<Event> events =
+          p.apply(
+              name + ".Read",
+              streamingMode
+                  ? NexmarkUtils.streamEventsSource(config)
+                  : NexmarkUtils.batchEventsSource(config));
+
+      PCollection<TimestampedValue<T>> results =
+          (PCollection<TimestampedValue<T>>) events.apply(new NexmarkQuery<>(config, query));
+      PAssert.that(results).satisfies(model.assertionFor());
+      PipelineResult result = p.run();
+      result.waitUntilFinish();
+    } finally {
+      NexmarkUtils.cleanUpSideInput(config);
+    }
+  }
+
+  /**
+   * A smoke test that the count of input bids and outputs are the same, to help diagnose flakiness
+   * in more complex tests.
+   */
+  @Test
+  @Category(NeedsRunner.class)
+  public void inputOutputSameEvents() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    PCollection<KV<Long, String>> sideInput = NexmarkUtils.prepareSideInput(p, config);
+
+    try {
+      PCollection<Event> input = p.apply(NexmarkUtils.batchEventsSource(config));
+      PCollection<Bid> justBids = input.apply(NexmarkQueryUtil.JUST_BIDS);
+      PCollection<Long> bidCount = justBids.apply("Count Bids", Count.globally());
+
+      NexmarkQueryTransform<Bid> query = new SessionSideInputJoin(config);
+      query.setSideInput(sideInput);
+
+      PCollection<TimestampedValue<Bid>> output =
+          (PCollection<TimestampedValue<Bid>>) input.apply(new NexmarkQuery(config, query));
+      PCollection<Long> outputCount =
+          output.apply(Window.into(new GlobalWindows())).apply("Count outputs", Count.globally());
+
+      PAssert.that(PCollectionList.of(bidCount).and(outputCount).apply(Flatten.pCollections()))
+          .satisfies(
+              counts -> {
+                assertThat(Iterables.size(counts), equalTo(2));
+                assertThat(Iterables.get(counts, 0), greaterThan(0L));
+                assertThat(Iterables.get(counts, 0), equalTo(Iterables.get(counts, 1)));
+                return null;
+              });
+      p.run();
+    } finally {
+      NexmarkUtils.cleanUpSideInput(config);
+    }
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelBatchDirect() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+
+    queryMatchesModel(
+        "SessionSideInputJoinTestBatch",
+        config,
+        new SessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        false);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelStreamingDirect() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.DIRECT;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    queryMatchesModel(
+        "SessionSideInputJoinTestStreaming",
+        config,
+        new SessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        true);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelBatchCsv() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.CSV;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+
+    queryMatchesModel(
+        "SessionSideInputJoinTestBatch",
+        config,
+        new SessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        false);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void queryMatchesModelStreamingCsv() throws Exception {
+    NexmarkConfiguration config = NexmarkConfiguration.DEFAULT.copy();
+    config.sideInputType = NexmarkUtils.SideInputType.CSV;
+    config.numEventGenerators = 1;
+    config.numEvents = 5000;
+    config.sideInputRowCount = 10;
+    config.sideInputNumShards = 3;
+    queryMatchesModel(
+        "SessionSideInputJoinTestStreaming",
+        config,
+        new SessionSideInputJoin(config),
+        new SessionSideInputJoinModel(config),
+        true);
+  }
+}

--- a/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
@@ -1,0 +1,183 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration tests for gcsio module.
+
+Runs tests against Google Cloud Storage service.
+Instantiates a TestPipeline to get options such as GCP project name, but
+doesn't actually start a Beam pipeline or test any specific runner.
+
+Options:
+  --kms_key_name=projects/<project-name>/locations/<region>/keyRings/\
+      <key-ring-name>/cryptoKeys/<key-name>/cryptoKeyVersions/<version>
+    Pass a Cloud KMS key name to test GCS operations using customer managed
+    encryption keys (CMEK).
+
+Cloud KMS permissions:
+The project's Cloud Storage service account requires Encrypter/Decrypter
+permissions for the key specified in --kms_key_name.
+
+To run these tests manually:
+  ./gradlew beam-sdks-python:integrationTest \
+    -Ptests=apache_beam.io.gcp.gcsio_integration_test:GcsIOIntegrationTest \
+    -PkmsKeyName=KMS_KEY_NAME
+"""
+
+from __future__ import absolute_import
+
+import logging
+import unittest
+import uuid
+
+from nose.plugins.attrib import attr
+
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.testing.test_pipeline import TestPipeline
+
+try:
+  from apache_beam.io.gcp import gcsio
+except ImportError:
+  gcsio = None
+
+
+@unittest.skipIf(gcsio is None, 'GCP dependencies are not installed')
+class GcsIOIntegrationTest(unittest.TestCase):
+
+  INPUT_FILE = 'gs://dataflow-samples/shakespeare/kinglear.txt'
+  # Larger than 1MB to test maxBytesRewrittenPerCall.
+  INPUT_FILE_LARGE = (
+      'gs://dataflow-samples/wikipedia_edits/wiki_data-000000000000.json')
+
+  def setUp(self):
+    self.test_pipeline = TestPipeline(is_integration_test=True)
+    self.runner_name = type(self.test_pipeline.runner).__name__
+    if self.runner_name != 'TestDataflowRunner':
+      # This test doesn't run a pipeline, so it doesn't make sense to try it on
+      # different runners. Running with TestDataflowRunner makes sense since
+      # it uses GoogleCloudOptions such as 'project'.
+      raise unittest.SkipTest(
+          'This test only runs with TestDataflowRunner.')
+    self.project = self.test_pipeline.get_option('project')
+    self.gcs_tempdir = (self.test_pipeline.get_option('temp_location') +
+                        '/gcs_it-' + str(uuid.uuid4()))
+    self.kms_key_name = self.test_pipeline.get_option('kms_key_name')
+    self.gcsio = gcsio.GcsIO()
+
+  def tearDown(self):
+    FileSystems.delete([self.gcs_tempdir + '/'])
+
+  def _verify_copy(self, src, dst, dst_kms_key_name=None):
+    self.assertTrue(FileSystems.exists(src), 'src does not exist: %s' % src)
+    self.assertTrue(FileSystems.exists(dst), 'dst does not exist: %s' % dst)
+    src_checksum = self.gcsio.checksum(src)
+    dst_checksum = self.gcsio.checksum(dst)
+    self.assertEqual(src_checksum, dst_checksum)
+    self.assertEqual(self.gcsio.kms_key(dst), dst_kms_key_name)
+
+  def _test_copy(self, name, kms_key_name=None,
+                 max_bytes_rewritten_per_call=None, src=None):
+    src = src or self.INPUT_FILE
+    dst = self.gcs_tempdir + '/%s' % name
+    extra_kwargs = {}
+    if max_bytes_rewritten_per_call is not None:
+      extra_kwargs['max_bytes_rewritten_per_call'] = (
+          max_bytes_rewritten_per_call)
+
+    self.gcsio.copy(src, dst, kms_key_name, **extra_kwargs)
+    self._verify_copy(src, dst, kms_key_name)
+
+  @attr('IT')
+  def test_copy(self):
+    self._test_copy("test_copy")
+
+  @attr('IT')
+  def test_copy_kms(self):
+    if self.kms_key_name is None:
+      raise unittest.SkipTest('--kms_key_name not specified')
+    self._test_copy("test_copy_kms", self.kms_key_name)
+
+  @attr('IT')
+  def test_copy_rewrite_token(self):
+    # Tests a multi-part copy (rewrite) operation. This is triggered by a
+    # combination of 3 conditions:
+    #  - a large enough src
+    #  - setting max_bytes_rewritten_per_call
+    #  - setting kms_key_name
+    if self.kms_key_name is None:
+      raise unittest.SkipTest('--kms_key_name not specified')
+
+    rewrite_responses = []
+    self.gcsio._set_rewrite_response_callback(
+        lambda response: rewrite_responses.append(response))
+    self._test_copy("test_copy_rewrite_token", kms_key_name=self.kms_key_name,
+                    max_bytes_rewritten_per_call=50 * 1024 * 1024,
+                    src=self.INPUT_FILE_LARGE)
+    # Verify that there was a multi-part rewrite.
+    self.assertTrue(any([not r.done for r in rewrite_responses]))
+
+  def _test_copy_batch(self, name, kms_key_name=None,
+                       max_bytes_rewritten_per_call=None, src=None):
+    num_copies = 10
+    srcs = [src or self.INPUT_FILE] * num_copies
+    dsts = [self.gcs_tempdir + '/%s_%d' % (name, i)
+            for i in range(num_copies)]
+    src_dst_pairs = list(zip(srcs, dsts))
+    extra_kwargs = {}
+    if max_bytes_rewritten_per_call is not None:
+      extra_kwargs['max_bytes_rewritten_per_call'] = (
+          max_bytes_rewritten_per_call)
+
+    result_statuses = self.gcsio.copy_batch(
+        src_dst_pairs, kms_key_name, **extra_kwargs)
+    for status in result_statuses:
+      self.assertIsNone(status[2], status)
+    for _src, _dst in src_dst_pairs:
+      self._verify_copy(_src, _dst, kms_key_name)
+
+  @attr('IT')
+  def test_copy_batch(self):
+    self._test_copy_batch("test_copy_batch")
+
+  @attr('IT')
+  def test_copy_batch_kms(self):
+    if self.kms_key_name is None:
+      raise unittest.SkipTest('--kms_key_name not specified')
+    self._test_copy_batch("test_copy_batch_kms", self.kms_key_name)
+
+  @attr('IT')
+  def test_copy_batch_rewrite_token(self):
+    # Tests a multi-part copy (rewrite) operation. This is triggered by a
+    # combination of 3 conditions:
+    #  - a large enough src
+    #  - setting max_bytes_rewritten_per_call
+    #  - setting kms_key_name
+    if self.kms_key_name is None:
+      raise unittest.SkipTest('--kms_key_name not specified')
+
+    rewrite_responses = []
+    self.gcsio._set_rewrite_response_callback(
+        lambda response: rewrite_responses.append(response))
+    self._test_copy_batch(
+        "test_copy_batch_rewrite_token", kms_key_name=self.kms_key_name,
+        max_bytes_rewritten_per_call=50 * 1024 * 1024,
+        src=self.INPUT_FILE_LARGE)
+    # Verify that there was a multi-part rewrite.
+    self.assertTrue(any([not r.done for r in rewrite_responses]))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -257,6 +257,8 @@ task integrationTest(dependsOn: ['installGcpTest', 'sdist']) {
     // Build pipeline options that configures pipeline job
     if (project.hasProperty('pipelineOptions'))
       argMap["pipeline_opts"] = project.property('pipelineOptions')
+    if (project.hasProperty('kmsKeyName'))
+      argMap["kms_key_name"] = project.property('kmsKeyName')
 
     def cmdArgs = mapToArgString(argMap)
     exec {

--- a/sdks/python/scripts/run_integration_test.sh
+++ b/sdks/python/scripts/run_integration_test.sh
@@ -27,17 +27,18 @@
 #
 # Pipeline related flags:
 #     runner        -> Runner that execute pipeline job.
-#                      e.g. TestDataflowRunner, DirectRunner
+#                      e.g. TestDataflowRunner, TestDirectRunner
 #     project       -> Project name of the cloud service.
 #     gcs_location  -> Base location on GCS. Some pipeline options are
-#                      dirived from it including output, staging_location
+#                      derived from it including output, staging_location
 #                      and temp_location.
 #     sdk_location  -> Python tar ball location. Glob is accepted.
 #     num_workers   -> Number of workers.
 #     sleep_secs    -> Number of seconds to wait before verification.
 #     streaming     -> True if a streaming job.
 #     worker_jar    -> Customized worker jar for dataflow runner.
-#     pipeline_opts -> List of space separateed pipeline options. If this
+#     kms_key_name  -> Name of Cloud KMS encryption key to use in some tests.
+#     pipeline_opts -> List of space separated pipeline options. If this
 #                      flag is specified, all above flag will be ignored.
 #                      Please include all required pipeline options when
 #                      using this flag.
@@ -70,6 +71,9 @@ NUM_WORKERS=1
 SLEEP_SECS=20
 STREAMING=false
 WORKER_JAR=""
+# Specify "/cryptoKeyVersions/1" suffix for testing simplicity. For this to work
+# in the long term, this key has rotation disabled.
+KMS_KEY_NAME="projects/apache-beam-testing/locations/global/keyRings/beam-it/cryptoKeys/test/cryptoKeyVersions/1"
 
 # Default test (nose) options.
 # Default test sets are full integration tests.
@@ -116,6 +120,11 @@ case $key in
         ;;
     --worker_jar)
         WORKER_JAR="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    --kms_key_name)
+        KMS_KEY_NAME="$2"
         shift # past argument
         shift # past value
         ;;
@@ -192,10 +201,13 @@ if [[ -z $PIPELINE_OPTS ]]; then
     opts+=("--dataflow_worker_jar=$WORKER_JAR")
   fi
 
+  if [[ ! -z "$KMS_KEY_NAME" ]]; then
+    opts+=("--kms_key_name=$KMS_KEY_NAME")
+  fi
+
   PIPELINE_OPTS=$(IFS=" " ; echo "${opts[*]}")
 
 fi
-
 
 ###########################################################################
 # Run tests and validate that jobs finish successfully.

--- a/website/src/community/contact-us.md
+++ b/website/src/community/contact-us.md
@@ -35,7 +35,7 @@ whichever one seems best!
 | [builds@](https://lists.apache.org/list.html?builds@beam.apache.org) mailing list | Firehose of build notifications from Jenkins ([Subscribe](mailto:builds-subscribe@beam.apache.org)[^1], [Unsubscribe](mailto:builds-unsubscribe@beam.apache.org)[^1], [Archives](https://lists.apache.org/list.html?builds@beam.apache.org)) |
 | [JIRA bug tracker](https://issues.apache.org/jira/browse/BEAM) | Report bugs / discover known issues |
 | [StackOverflow](http://stackoverflow.com/questions/tagged/apache-beam) | Ask and answer user support questions |
-| [Slack](https://s.apache.org/beam-slack-channel) | Chat with users and developers in the ASF slack. Please do not ask for questions in the #general channel. Do it in the specific Beam channels #beam ([Join](https://s.apache.org/slack-invite)) |
+| [Slack](https://s.apache.org/beam-slack-channel) | Chat with users and developers in the ASF Slack. Note: Please [join the #beam channel](https://s.apache.org/beam-slack-channel) after you [created an account](https://s.apache.org/slack-invite). Please do not ask Beam questions in #general. |
 {:.table}
 
 [^1]: To subscribe or unsubscribe, a blank email is fine.

--- a/website/src/community/contact-us.md
+++ b/website/src/community/contact-us.md
@@ -35,7 +35,7 @@ whichever one seems best!
 | [builds@](https://lists.apache.org/list.html?builds@beam.apache.org) mailing list | Firehose of build notifications from Jenkins ([Subscribe](mailto:builds-subscribe@beam.apache.org)[^1], [Unsubscribe](mailto:builds-unsubscribe@beam.apache.org)[^1], [Archives](https://lists.apache.org/list.html?builds@beam.apache.org)) |
 | [JIRA bug tracker](https://issues.apache.org/jira/browse/BEAM) | Report bugs / discover known issues |
 | [StackOverflow](http://stackoverflow.com/questions/tagged/apache-beam) | Ask and answer user support questions |
-| [Slack](https://s.apache.org/beam-slack-channel) | Chat with users and developers on channel #beam ([Join](https://s.apache.org/slack-invite)) |
+| [Slack](https://s.apache.org/beam-slack-channel) | Chat with users and developers in the ASF slack. Please do not ask for questions in the #general channel. Do it in the specific Beam channels #beam ([Join](https://s.apache.org/slack-invite)) |
 {:.table}
 
 [^1]: To subscribe or unsubscribe, a blank email is fine.

--- a/website/src/documentation/sdks/java-dependencies.md
+++ b/website/src/documentation/sdks/java-dependencies.md
@@ -163,27 +163,27 @@ Beam SDK for Java 2.9.0 has the following compile and runtime dependencies.
   <tr><td>com.google.errorprone</td><td>error_prone_annotations</td><td>2.0.15</td></tr>
   <tr><td>com.google.api</td><td>gax-grpc</td><td>1.29.0</td></tr>
   <tr><td>com.google.cloud.bigdataoss</td><td>gcsio</td><td>1.9.0</td></tr>
-  <tr><td>com.google.api-client</td><td>google-api-client-jackson2</td><td>1.23.0</td></tr>
-  <tr><td>com.google.api-client</td><td>google-api-client-java6</td><td>1.23.0</td></tr>
-  <tr><td>com.google.api-client</td><td>google-api-client</td><td>1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-bigquery</td><td>v2-rev402-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-clouddebugger</td><td>v2-rev253-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-cloudresourcemanager</td><td>v1-rev502-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-dataflow</td><td>v1b3-rev257-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-pubsub</td><td>v1-rev399-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-storage</td><td>v1-rev136-1.23.0</td></tr>
+  <tr><td>com.google.api-client</td><td>google-api-client-jackson2</td><td>1.24.1</td></tr>
+  <tr><td>com.google.api-client</td><td>google-api-client-java6</td><td>1.24.1</td></tr>
+  <tr><td>com.google.api-client</td><td>google-api-client</td><td>1.24.1</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-bigquery</td><td>v2-rev402-1.24.1</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-clouddebugger</td><td>v2-rev253-1.24.1</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-cloudresourcemanager</td><td>v1-rev502-1.24.1</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-dataflow</td><td>v1b3-rev257-1.24.1</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-pubsub</td><td>v1-rev399-1.24.1</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-storage</td><td>v1-rev136-1.24.1</td></tr>
   <tr><td>com.google.auth</td><td>google-auth-library-credentials</td><td>0.10.0</td></tr>
   <tr><td>com.google.auth</td><td>google-auth-library-oauth2-http</td><td>0.10.0</td></tr>
   <tr><td>com.google.cloud</td><td>google-cloud-core-grpc</td><td>1.36.0</td></tr>
   <tr><td>com.google.cloud</td><td>google-cloud-core</td><td>1.36.0</td></tr>
   <tr><td>com.google.cloud.dataflow</td><td>google-cloud-dataflow-java-proto-library-all</td><td>0.5.160304</td></tr>
   <tr><td>com.google.cloud</td><td>google-cloud-spanner</td><td>0.54.0-beta</td></tr>
-  <tr><td>com.google.http-client</td><td>google-http-client-jackson2</td><td>1.23.0</td></tr>
-  <tr><td>com.google.http-client</td><td>google-http-client-jackson</td><td>1.23.0</td></tr>
-  <tr><td>com.google.http-client</td><td>google-http-client-protobuf</td><td>1.23.0</td></tr>
-  <tr><td>com.google.http-client</td><td>google-http-client</td><td>1.23.0</td></tr>
-  <tr><td>com.google.oauth-client</td><td>google-oauth-client-java6</td><td>1.23.0</td></tr>
-  <tr><td>com.google.oauth-client</td><td>google-oauth-client</td><td>1.23.0</td></tr>
+  <tr><td>com.google.http-client</td><td>google-http-client-jackson2</td><td>1.24.1</td></tr>
+  <tr><td>com.google.http-client</td><td>google-http-client-jackson</td><td>1.24.1</td></tr>
+  <tr><td>com.google.http-client</td><td>google-http-client-protobuf</td><td>1.24.1</td></tr>
+  <tr><td>com.google.http-client</td><td>google-http-client</td><td>1.24.1</td></tr>
+  <tr><td>com.google.oauth-client</td><td>google-oauth-client-java6</td><td>1.24.1</td></tr>
+  <tr><td>com.google.oauth-client</td><td>google-oauth-client</td><td>1.24.1</td></tr>
   <tr><td>io.grpc</td><td>grpc-all</td><td>1.13.1</td></tr>
   <tr><td>io.grpc</td><td>grpc-auth</td><td>1.13.1</td></tr>
   <tr><td>io.grpc</td><td>grpc-core</td><td>1.13.1</td></tr>

--- a/website/src/documentation/sdks/java-dependencies.md
+++ b/website/src/documentation/sdks/java-dependencies.md
@@ -276,12 +276,12 @@ Beam SDK for Java 2.9.0 has the following compile and runtime dependencies.
   <tr><td>com.google.api-client</td><td>google-api-client-jackson2</td><td>1.23.0</td></tr>
   <tr><td>com.google.api-client</td><td>google-api-client-java6</td><td>1.23.0</td></tr>
   <tr><td>com.google.api-client</td><td>google-api-client</td><td>1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-bigquery</td><td>v2-rev402-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-clouddebugger</td><td>v2-rev253-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-cloudresourcemanager</td><td>v1-rev502-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-dataflow</td><td>v1b3-rev257-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-pubsub</td><td>v1-rev399-1.23.0</td></tr>
-  <tr><td>com.google.apis</td><td>google-api-services-storage</td><td>v1-rev136-1.23.0</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-bigquery</td><td>v2-rev374-1.23.0</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-clouddebugger</td><td>v2-rev233-1.23.0</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-cloudresourcemanager</td><td>v1-rev477-1.23.0</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-dataflow</td><td>v1b3-rev221-1.23.0</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-pubsub</td><td>v1-rev382-1.23.0</td></tr>
+  <tr><td>com.google.apis</td><td>google-api-services-storage</td><td>v1-rev124-1.23.0</td></tr>
   <tr><td>com.google.auth</td><td>google-auth-library-credentials</td><td>0.10.0</td></tr>
   <tr><td>com.google.auth</td><td>google-auth-library-oauth2-http</td><td>0.10.0</td></tr>
   <tr><td>com.google.cloud</td><td>google-cloud-core-grpc</td><td>1.36.0</td></tr>


### PR DESCRIPTION
Currently, the password is decrypted before the serialization of the pipeline and this causes the raw version to be visible to everyone on the staging location.

To avoid this, we delayed the decryption of the password when connecting to the cluster, which ensures that the raw password is never serialized in the pipeline.

n.b. In our case, we use Google KMS to decrypt Cassandra's password

------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




