### PR TITLE
[BEAM-6299] Update JUnit to fix bug with parameterized tests

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -420,7 +420,7 @@ class BeamModulePlugin implements Plugin<Project> {
         jackson_module_scala                        : "com.fasterxml.jackson.module:jackson-module-scala_2.11:$jackson_version",
         jaxb_api                                    : "javax.xml.bind:jaxb-api:$jaxb_api_version",
         joda_time                                   : "joda-time:joda-time:2.4",
-        junit                                       : "junit:junit:4.12",
+        junit                                       : "junit:junit:4.13-beta-1",
         kafka_2_11                                  : "org.apache.kafka:kafka_2.11:$kafka_version",
         kafka_clients                               : "org.apache.kafka:kafka-clients:$kafka_version",
         malhar_library                              : "org.apache.apex:malhar-library:$apex_malhar_version",

--- a/sdks/java/extensions/euphoria/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/translate/BeamMetricsTranslationTest.java
+++ b/sdks/java/extensions/euphoria/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/translate/BeamMetricsTranslationTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.extensions.euphoria.core.translate;
 
 import static org.apache.beam.sdk.metrics.MetricResultsMatchers.metricsResult;
-import static org.junit.Assert.assertThat;
 
 import java.util.stream.Stream;
 import org.apache.beam.sdk.PipelineResult;
@@ -36,6 +35,7 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -134,11 +134,11 @@ public class BeamMetricsTranslationTest {
   }
 
   private void testStep1Metrics(MetricQueryResults metrics, String counterName1, String stepName1) {
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getCounters(),
         Matchers.hasItem(metricsResult(stepName1, counterName1, stepName1, 5L, true)));
 
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getDistributions(),
         Matchers.hasItem(
             metricsResult(
@@ -146,11 +146,11 @@ public class BeamMetricsTranslationTest {
   }
 
   private void testStep2Metrics(MetricQueryResults metrics, String counterName2, String stepName2) {
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getCounters(),
         Matchers.hasItem(metricsResult(stepName2, counterName2, stepName2, 2L, true)));
 
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getDistributions(),
         Matchers.hasItem(
             metricsResult(
@@ -159,11 +159,11 @@ public class BeamMetricsTranslationTest {
 
   private void testStep3WithDefaultOperatorName(
       MetricQueryResults metrics, String counterName2, String stepName3) {
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getCounters(),
         Matchers.hasItem(metricsResult(stepName3, counterName2, stepName3, 6L, true)));
 
-    assertThat(
+    MatcherAssert.assertThat(
         metrics.getDistributions(),
         Matchers.hasItem(
             metricsResult(


### PR DESCRIPTION
Many of our NeedsRunner tests were simply not being run due to a bug in JUnit 4.12. Updating to the 4.13 RC to fix these tests. All other tests are fine on the RC, and will update to the final 4.13 once it's out.

R: @kanterov 

This has already been reviewed. Splitting this off into a separate PR to ease bisection/rollback if anything goes wrong.