### PR TITLE
[BEAM-6292] PasswordDecrypter: Delay decryption / Avoid serialization

### DIFF
--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
@@ -219,20 +219,23 @@ public class CassandraIO {
       return builder().setUsername(username).build();
     }
 
-    /** Specify the password for authentication. */
+    /** Specify the clear password used for authentication. */
     public Read<T> withPassword(String password) {
       checkArgument(password != null, "password can not be null");
       return builder().setPassword(password).build();
     }
 
-    /** Specify the encrypted password used for authentication. */
+    /**
+     * Specify the encrypted password used for authentication, the password decrypter provided in
+     * {@link #withPasswordDecrypter(PasswordDecrypter)} will be used to decrypt it.
+     */
     public Read<T> withEncryptedPassword(String encryptedPassword) {
       checkArgument(encryptedPassword != null, "encryptedPassword can not be null");
       return builder().setEncryptedPassword(encryptedPassword).build();
     }
 
     /**
-     * Specify the password decrypter used to decrypt the encrypted password. It delayed the
+     * Specify the password decrypter used to decrypt the encrypted password. It delays the
      * decryption of the password when connecting to the cluster, which ensures that the raw
      * password is never serialized in the pipeline.
      */
@@ -764,7 +767,7 @@ public class CassandraIO {
       return builder().setUsername(username).build();
     }
 
-    /** Specify the password used for authentication. */
+    /** Specify the clear password used for authentication. */
     public Write<T> withPassword(String password) {
       checkArgument(
           password != null,
@@ -775,14 +778,17 @@ public class CassandraIO {
       return builder().setPassword(password).build();
     }
 
-    /** Specify the encrypted password used for authentication. */
+    /**
+     * Specify the encrypted password used for authentication, the password decrypter provided in
+     * {@link #withPasswordDecrypter(PasswordDecrypter)} will be used to decrypt it.
+     */
     public Write<T> withEncryptedPassword(String encryptedPassword) {
       checkArgument(encryptedPassword != null, "encryptedPassword can not be null");
       return builder().setEncryptedPassword(encryptedPassword).build();
     }
 
     /**
-     * Specify the password decrypter used to decrypt the encrypted password. It delayed the
+     * Specify the password decrypter used to decrypt the encrypted password. It delays the
      * decryption of the password when connecting to the cluster, which ensures that the raw
      * password is never serialized in the pipeline.
      */

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/PasswordDecrypter.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/PasswordDecrypter.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import java.io.Serializable;
+
+/** An interface used to decrypt the Cassandra password. */
+public interface PasswordDecrypter extends Serializable {
+
+  String decrypt(String encryptedPassword);
+}

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import javax.management.JMX;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -70,6 +71,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,6 +82,9 @@ public class CassandraIOTest implements Serializable {
   private static final String CASSANDRA_KEYSPACE = "beam_ks";
   private static final String CASSANDRA_HOST = "127.0.0.1";
   private static final int CASSANDRA_PORT = 9142;
+  private static final String CASSANDRA_USERNAME = "cassandra";
+  private static final String CASSANDRA_ENCRYPTED_PASSWORD =
+      "Y2Fzc2FuZHJh"; // Base64 encoded version of "cassandra"
   private static final String CASSANDRA_TABLE = "scientist";
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraIOTest.class);
   private static final String STORAGE_SERVICE_MBEAN = "org.apache.cassandra.db:type=StorageService";
@@ -242,16 +247,10 @@ public class CassandraIOTest implements Serializable {
 
   @Test
   public void testWrite() {
-    ArrayList<Scientist> data = new ArrayList<>();
-    for (int i = 0; i < NUM_ROWS; i++) {
-      Scientist scientist = new Scientist();
-      scientist.id = i;
-      scientist.name = "Name " + i;
-      data.add(scientist);
-    }
+    ArrayList<Scientist> scientists = buildScientists(NUM_ROWS);
 
     pipeline
-        .apply(Create.of(data))
+        .apply(Create.of(scientists))
         .apply(
             CassandraIO.<Scientist>write()
                 .withHosts(Arrays.asList(CASSANDRA_HOST))
@@ -266,6 +265,36 @@ public class CassandraIOTest implements Serializable {
     for (Row row : results) {
       assertTrue(row.getString("person_name").matches("Name (\\d*)"));
     }
+  }
+
+  @Test
+  public void testWriteWithPasswordDecryption() {
+    ArrayList<Scientist> scientists = buildScientists(NUM_ROWS);
+
+    String sessionWriteUID = "session-write-" + UUID.randomUUID();
+    PasswordDecrypter writePwdDecrypter = Mockito.spy(new TestPasswordDecrypter(sessionWriteUID));
+
+    pipeline
+        .apply(Create.of(scientists))
+        .apply(
+            CassandraIO.<Scientist>write()
+                .withHosts(Arrays.asList(CASSANDRA_HOST))
+                .withPort(CASSANDRA_PORT)
+                .withUsername(CASSANDRA_USERNAME)
+                .withEncryptedPassword(CASSANDRA_ENCRYPTED_PASSWORD)
+                .withPasswordDecrypter(writePwdDecrypter)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withEntity(Scientist.class));
+
+    pipeline.run();
+
+    List<Row> results = getRows();
+    assertEquals(NUM_ROWS, results.size());
+    for (Row row : results) {
+      assertTrue(row.getString("person_name").matches("Name (\\d*)"));
+    }
+
+    assertTrue(1L <= TestPasswordDecrypter.getNbCallsBySession(sessionWriteUID));
   }
 
   @Test
@@ -300,6 +329,17 @@ public class CassandraIOTest implements Serializable {
       }
     }
     assertEquals("Wrong number of empty splits", expectedNumSplits, nonEmptySplits);
+  }
+
+  private ArrayList<Scientist> buildScientists(long nbRows) {
+    ArrayList<Scientist> scientists = new ArrayList<>();
+    for (int i = 0; i < nbRows; i++) {
+      Scientist scientist = new Scientist();
+      scientist.id = i;
+      scientist.name = "Name " + i;
+      scientists.add(scientist);
+    }
+    return scientists;
   }
 
   private List<Row> getRows() {

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -71,7 +71,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -268,11 +267,56 @@ public class CassandraIOTest implements Serializable {
   }
 
   @Test
+  public void testReadWithPasswordDecryption() throws Exception {
+    insertRecords();
+
+    String sessionReadUID = "session-read-" + UUID.randomUUID();
+    PasswordDecrypter readPwdDecrypter = new TestPasswordDecrypter(sessionReadUID);
+
+    PCollection<Scientist> output =
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(Arrays.asList(CASSANDRA_HOST))
+                .withPort(CASSANDRA_PORT)
+                .withUsername(CASSANDRA_USERNAME)
+                .withEncryptedPassword(CASSANDRA_ENCRYPTED_PASSWORD)
+                .withPasswordDecrypter(readPwdDecrypter)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withTable(CASSANDRA_TABLE)
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class));
+
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(NUM_ROWS);
+
+    PCollection<KV<String, Integer>> mapped =
+        output.apply(
+            MapElements.via(
+                new SimpleFunction<Scientist, KV<String, Integer>>() {
+                  @Override
+                  public KV<String, Integer> apply(Scientist scientist) {
+                    return KV.of(scientist.name, scientist.id);
+                  }
+                }));
+    PAssert.that(mapped.apply("Count occurrences per scientist", Count.perKey()))
+        .satisfies(
+            input -> {
+              for (KV<String, Long> element : input) {
+                assertEquals(element.getKey(), NUM_ROWS / 10, element.getValue().longValue());
+              }
+              return null;
+            });
+
+    pipeline.run();
+
+    assertTrue(1L <= TestPasswordDecrypter.getNbCallsBySession(sessionReadUID));
+  }
+
+  @Test
   public void testWriteWithPasswordDecryption() {
     ArrayList<Scientist> scientists = buildScientists(NUM_ROWS);
 
     String sessionWriteUID = "session-write-" + UUID.randomUUID();
-    PasswordDecrypter writePwdDecrypter = Mockito.spy(new TestPasswordDecrypter(sessionWriteUID));
+    PasswordDecrypter writePwdDecrypter = new TestPasswordDecrypter(sessionWriteUID);
 
     pipeline
         .apply(Create.of(scientists))

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/TestPasswordDecrypter.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/TestPasswordDecrypter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Class used in the tests to decrypt the Cassandra password. */
+public class TestPasswordDecrypter implements PasswordDecrypter {
+
+  /**
+   * Can't use the Mockito.verify() method to inspect the passwordDecrypter.decrypt() method
+   * invocation in integration tests because the PasswordDecrypter instance is directly deserialized
+   * on workers. Example => verify(passwordDecrypter, atLeast(1)).decrypt(ENCRYPTED_PASSWORD);
+   */
+  private static final Map<String, Long> nbCallsBySession = new HashMap<>();
+
+  private final String sessionUID;
+
+  public TestPasswordDecrypter(String sessionUID) {
+    this.sessionUID = sessionUID;
+  }
+
+  @Override
+  public String decrypt(String encryptedPassword) {
+    nbCallsBySession.put(sessionUID, nbCallsBySession.getOrDefault(sessionUID, 0L) + 1L);
+
+    return new String(Base64.getDecoder().decode(encryptedPassword), StandardCharsets.UTF_8);
+  }
+
+  public static long getNbCallsBySession(String sessionUID) {
+    return nbCallsBySession.get(sessionUID);
+  }
+}


### PR DESCRIPTION
Currently, the password is decrypted before the serialization of the pipeline and this causes the raw version to be visible to everyone on the staging location.

To avoid this, we delayed the decryption of the password when connecting to the cluster, which ensures that the raw password is never serialized in the pipeline.

n.b. In our case, we use Google KMS to decrypt Cassandra's password

------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




