### PR TITLE
[BEAM-5386] Prevent CheckpointMarks from not getting acknowledged

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -79,6 +79,12 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
    */
   private final List<? extends UnboundedSource<OutputT, CheckpointMarkT>> splitSources;
 
+  /**
+   * Shuts down the source if the final watermark is read. Note: This prevents further checkpoints
+   * of the streaming application.
+   */
+  private final boolean shutdownOnFinalWatermark;
+
   /** The local split sources. Assigned at runtime when the wrapper is executed in parallel. */
   private transient List<UnboundedSource<OutputT, CheckpointMarkT>> localSplitSources;
 
@@ -148,6 +154,8 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
     // this is necessary so that the mapping of state to source is correct
     // when restoring
     splitSources = source.split(parallelism, pipelineOptions);
+    shutdownOnFinalWatermark =
+        pipelineOptions.as(FlinkPipelineOptions.class).isShutdownSourcesOnFinalWatermark();
   }
 
   /** Initialize and restore state before starting execution of the source. */
@@ -282,8 +290,7 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
   }
 
   private void finalizeSource() {
-    FlinkPipelineOptions options = serializedOptions.get().as(FlinkPipelineOptions.class);
-    if (!options.isShutdownSourcesOnFinalWatermark()) {
+    if (!shutdownOnFinalWatermark) {
       // do nothing, but still look busy ...
       // we can't return here since Flink requires that all operators stay up,
       // otherwise checkpointing would not work correctly anymore
@@ -429,7 +436,8 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
         }
         context.emitWatermark(new Watermark(watermarkMillis));
 
-        if (watermarkMillis >= BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
+        if (shutdownOnFinalWatermark
+            && watermarkMillis >= BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
           this.isRunning = false;
         }
       }
@@ -464,14 +472,30 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
 
   /** Visible so that we can check this in tests. Must not be used for anything else. */
   @VisibleForTesting
-  public List<? extends UnboundedSource<OutputT, CheckpointMarkT>> getLocalSplitSources() {
+  List<? extends UnboundedSource<OutputT, CheckpointMarkT>> getLocalSplitSources() {
     return localSplitSources;
   }
 
   /** Visible so that we can check this in tests. Must not be used for anything else. */
   @VisibleForTesting
-  public List<UnboundedSource.UnboundedReader<OutputT>> getLocalReaders() {
+  List<UnboundedSource.UnboundedReader<OutputT>> getLocalReaders() {
     return localReaders;
+  }
+
+  /** Visible so that we can check this in tests. Must not be used for anything else. */
+  @VisibleForTesting
+  boolean isRunning() {
+    return isRunning;
+  }
+
+  /**
+   * Visible so that we can set this in tests. This is only set in the run method which is
+   * inconvenient for the tests where the context is assumed to be set when run is called. Must not
+   * be used for anything else.
+   */
+  @VisibleForTesting
+  public void setSourceContext(SourceContext<WindowedValue<ValueWithRecordId<OutputT>>> ctx) {
+    context = ctx;
   }
 
   @Override

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/BoundedSourceRestoreTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/BoundedSourceRestoreTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.beam.runners.core.construction.UnboundedReadFromBoundedSource.BoundedToUnboundedSourceAdapter;
 import org.apache.beam.runners.core.construction.UnboundedReadFromBoundedSource.BoundedToUnboundedSourceAdapter.Checkpoint;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.io.TestCountingSource;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.UnboundedSourceWrapper;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.CountingSource;

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/TestCountingSource.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/TestCountingSource.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.flink.streaming;
+package org.apache.beam.runners.flink.translation.wrappers.streaming.io;
 
 import static org.apache.beam.sdk.util.CoderUtils.encodeToByteArray;
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapperTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapperTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.flink.streaming;
+package org.apache.beam.runners.flink.translation.wrappers.streaming.io;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -28,20 +28,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
-import org.apache.beam.runners.flink.translation.wrappers.streaming.io.UnboundedSourceWrapper;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.ValueWithRecordId;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -54,6 +52,7 @@ import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.OutputTag;
@@ -594,9 +593,17 @@ public class UnboundedSourceWrapperTest {
 
     @Test(timeout = 10_000)
     public void testSourceWithNoReaderDoesNotShutdown() throws Exception {
+      testSourceDoesNotShutdown(false);
+    }
+
+    @Test(timeout = 10_000)
+    public void testSourceWithReadersDoesNotShutdown() throws Exception {
+      testSourceDoesNotShutdown(true);
+    }
+
+    private static void testSourceDoesNotShutdown(boolean shouldHaveReaders) throws Exception {
       final int parallelism = 2;
       FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
-      options.setShutdownSourcesOnFinalWatermark(true);
 
       TestCountingSource source = new TestCountingSource(20).withoutSplitting();
 
@@ -604,15 +611,32 @@ public class UnboundedSourceWrapperTest {
           new UnboundedSourceWrapper<>("noReader", options, source, parallelism);
 
       StreamingRuntimeContext mock = Mockito.mock(StreamingRuntimeContext.class);
-      // Set up the RuntimeContext such that this instance won't receive any readers
-      Mockito.when(mock.getIndexOfThisSubtask()).thenReturn(parallelism - 1);
+      if (shouldHaveReaders) {
+        // Since the source can't be split, the first subtask index will read everything
+        Mockito.when(mock.getIndexOfThisSubtask()).thenReturn(0);
+      } else {
+        // Set up the RuntimeContext such that this instance won't receive any readers
+        Mockito.when(mock.getIndexOfThisSubtask()).thenReturn(parallelism - 1);
+      }
+
       Mockito.when(mock.getNumberOfParallelSubtasks()).thenReturn(parallelism);
+      Mockito.when(mock.getExecutionConfig()).thenReturn(new ExecutionConfig());
+      ProcessingTimeService timerService = Mockito.mock(ProcessingTimeService.class);
+      Mockito.when(timerService.getCurrentProcessingTime()).thenReturn(Long.MAX_VALUE);
+      Mockito.when(mock.getProcessingTimeService()).thenReturn(timerService);
+
       sourceWrapper.setRuntimeContext(mock);
       sourceWrapper.open(new Configuration());
 
       SourceFunction.SourceContext sourceContext = Mockito.mock(SourceFunction.SourceContext.class);
       Object checkpointLock = new Object();
       Mockito.when(sourceContext.getCheckpointLock()).thenReturn(checkpointLock);
+      // Initialize source context early to avoid concurrency issues with its initialization in the run
+      // method and the onProcessingTime call on the wrapper.
+      sourceWrapper.setSourceContext(sourceContext);
+
+      sourceWrapper.open(new Configuration());
+      assertThat(sourceWrapper.getLocalReaders().isEmpty(), is(!shouldHaveReaders));
 
       Thread thread =
           new Thread(
@@ -626,13 +650,20 @@ public class UnboundedSourceWrapperTest {
 
       try {
         thread.start();
-        List<UnboundedSource.UnboundedReader<KV<Integer, Integer>>> localReaders =
-            sourceWrapper.getLocalReaders();
-        while (localReaders != null && !localReaders.isEmpty()) {
+        // Wait to see if the wrapper shuts down immediately in case it doesn't have readers
+        if (!shouldHaveReaders) {
           Thread.sleep(200);
-          // should stay alive
-          assertThat(thread.isAlive(), is(true));
         }
+        // Source should still be running even if there are no readers
+        assertThat(sourceWrapper.isRunning(), is(true));
+        synchronized (checkpointLock) {
+          // Trigger emission of the watermark by updating processing time.
+          // The actual processing time value does not matter.
+          sourceWrapper.onProcessingTime(42);
+        }
+        // Source should still be running even when watermark is at max
+        assertThat(sourceWrapper.isRunning(), is(true));
+        assertThat(thread.isAlive(), is(true));
         sourceWrapper.cancel();
       } finally {
         thread.interrupt();


### PR DESCRIPTION
The UnboundedSourceWrapper would still shutdown when the final watermarks of all
readers are equal to the maximum timestamp. This could then lead to the remaining
CheckpointMarks to never get acknowledged. Acknowledgement is performed as part
of the checkpoint completion which is only possible when the source and its task
are running.

A user had previously reported that the last remaining messages were not getting
acknowledged in a PubSub scenario. It looks like this is the cause.

CC @tweise 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




