### PR TITLE
[BEAM-4461] Support inner and outer style joins in CoGroup.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/CoGroup.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/CoGroup.java
@@ -117,8 +117,8 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
  * cross-product of two tables. This transform also supports the same functionality using the {@link
  * Inner#crossProductJoin()} method.
  *
- * <p>For example, consider the SQL join:
- *   SELECT * FROM input1 INNER JOIN input2 ON input1.user = input2.user
+ * <p>For example, consider the SQL join: SELECT * FROM input1 INNER JOIN input2 ON input1.user =
+ * input2.user
  *
  * <p>You could express this with:
  *
@@ -127,31 +127,30 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
  *   .apply(CoGroup.join(By.fieldNames("user")).crossProductJoin();
  * }</pre>
  *
- * <pr>The schema of the output PCollection contains a nested message for each of input1 and
- * input2. Like above, you could use the {@link Convert} transform to convert it to the following
- * POJO:
+ * <p>The schema of the output PCollection contains a nested message for each of input1 and input2.
+ * Like above, you could use the {@link Convert} transform to convert it to the following POJO:
  *
- *  <pre>{@code
- *  {@literal @}DefaultSchema(JavaFieldSchema.class)
- *  public class JoinedValue {
- *   public Input1Type input1;
- *   public Input2Type input2;
- *  }
+ * <pre>{@code
+ * {@literal @}DefaultSchema(JavaFieldSchema.class)
+ * public class JoinedValue {
+ *  public Input1Type input1;
+ *  public Input2Type input2;
+ * }
  * }</pre>
  *
- * <pre>The {@link Unnest} transform can then be used to flatten all the subfields into one
- * single top-level row containing all the fields in both Input1 and Input2; this will often be
- * combined with a {@link Select} transform to select out the fields of interest, as the key
- * fields will be identical between input1 and input2.
+ * <p>The {@link Unnest} transform can then be used to flatten all the subfields into one single
+ * top-level row containing all the fields in both Input1 and Input2; this will often be combined
+ * with a {@link Select} transform to select out the fields of interest, as the key fields will be
+ * identical between input1 and input2.
  *
  * <p>This transform also supports outer-join semantics. By default, all input PCollections must
  * participate fully in the join, providing inner-join semantics. This means that if if all input
- * save one have values for a given user "Bob" the join will produce no values for "Bob."
- * However, you can mark that input as having outer-join participation; this means that even
- * though one input has no value for "Bob" an output Row will still be produced with a null in
- * place for that input. To continue the SQL example:
+ * save one have values for a given user "Bob" the join will produce no values for "Bob." However,
+ * you can mark that input as having outer-join participation; this means that even though one input
+ * has no value for "Bob" an output Row will still be produced with a null in place for that input.
+ * To continue the SQL example:
  *
- * <p>  SELECT * FROM input1 LEFT OUTER JOIN input2 ON input1.user = input2.user
+ * <p>SELECT * FROM input1 LEFT OUTER JOIN input2 ON input1.user = input2.user
  *
  * <p>Is equivalent to:
  *
@@ -162,7 +161,7 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
  *                 .crossProductJoin();
  * }</pre>
  *
- * <p>  SELECT * FROM input1 RIGHT OUTER JOIN input2 ON input1.user = input2.user
+ * <p>SELECT * FROM input1 RIGHT OUTER JOIN input2 ON input1.user = input2.user
  *
  * <p>Is equivalent to:
  *
@@ -173,7 +172,7 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
  *                 .crossProductJoin();
  * }</pre>
  *
- * <p>  and SELECT * FROM input1 FULL OUTER JOIN input2 ON input1.user = input2.user
+ * <p>and SELECT * FROM input1 FULL OUTER JOIN input2 ON input1.user = input2.user
  *
  * <p>Is equivalent to:
  *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/CoGroup.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/CoGroup.java
@@ -62,7 +62,7 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
  *     .of("input1", input1)
  *     .and("input2, input2)
  *     .and("input3", input3)
- *   .apply(CoGroup.byFieldNames("user", "country"));
+ *   .apply(CoGroup.join(By.fieldNames("user", "country")));
  * }</pre>
  *
  * <p>In the above case, the key schema will contain the two string fields "user" and "country"; in
@@ -109,8 +109,8 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
  *     .of("input1Tag", input1)
  *     .and("input2Tag", input2)
  *   .apply(CoGroup
- *     .byFieldNamesForInput("input1Tag", "referringUser"))
- *     .byFieldNamesForInput("input2Tag", "user"));
+ *     .join("input1Tag", By.fieldNames("referringUser")))
+ *     .join("input2Tag", By.fieldNames("user")));
  * }</pre>
  */
 public class CoGroup {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/CoGroup.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/CoGroup.java
@@ -321,10 +321,7 @@ public class CoGroup {
           KeyedPCollectionTuple.empty(input.getPipeline());
 
       List<String> sortedTags =
-          input
-              .getAll()
-              .keySet()
-              .stream()
+          input.getAll().keySet().stream()
               .map(TupleTag::getId)
               .sorted()
               .collect(Collectors.toList());
@@ -590,7 +587,8 @@ public class CoGroup {
           crossProductHelper(tagIndex, accumulatedRows, null, gbkResult, o);
         }
         for (Object item : items) {
-          // For every item that joined for the current input, and recurse down to calculate the list
+          // For every item that joined for the current input, and recurse down to calculate the
+          // list
           // of expanded records.
           Row row = toRow.apply(item);
           crossProductHelper(tagIndex, accumulatedRows, row, gbkResult, o);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
@@ -146,6 +146,19 @@ public class Create<T> {
   }
 
   /**
+   * Returns a new {@code Create.Values} transform that produces an empty {@link PCollection} of
+   * rows.
+   */
+  public static Values<Row> empty(Schema schema) {
+    return new Values<Row>(
+        new ArrayList<>(),
+        Optional.of(
+            SchemaCoder.of(
+                schema, SerializableFunctions.identity(), SerializableFunctions.identity())),
+        Optional.absent());
+  }
+
+  /**
    * Returns a new {@code Create.Values} transform that produces an empty {@link PCollection}.
    *
    * <p>The elements will have a timestamp of negative infinity, see {@link Create#timestamped} for

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
@@ -167,6 +167,7 @@ public class CoGbkResult {
     return unions;
   }
 
+  /** Like {@link #getAll(TupleTag)} but using a String instead of a {@link TupleTag}. */
   public <V> Iterable<V> getAll(String tag) {
     return getAll(new TupleTag<>(tag));
   }
@@ -182,6 +183,7 @@ public class CoGbkResult {
     return innerGetOnly(tag, null, false);
   }
 
+  /** Like {@link #getOnly(TupleTag)}  but using a String instead of a TupleTag. */
   @SuppressWarnings("TypeParameterUnusedInFormals")
   public <V> V getOnly(String tag) {
     return getOnly(new TupleTag<>(tag));
@@ -199,6 +201,7 @@ public class CoGbkResult {
     return innerGetOnly(tag, defaultValue, true);
   }
 
+  /** Like {@link #getOnly(TupleTag, Object)} but uisng a String instead of a TupleTag. */
   @Nullable
   public <V> V getOnly(String tag, @Nullable V defaultValue) {
     return getOnly(new TupleTag<>(tag), defaultValue);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
@@ -183,7 +183,7 @@ public class CoGbkResult {
     return innerGetOnly(tag, null, false);
   }
 
-  /** Like {@link #getOnly(TupleTag)}  but using a String instead of a TupleTag. */
+  /** Like {@link #getOnly(TupleTag)} but using a String instead of a TupleTag. */
   @SuppressWarnings("TypeParameterUnusedInFormals")
   public <V> V getOnly(String tag) {
     return getOnly(new TupleTag<>(tag));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
@@ -201,7 +201,7 @@ public class CoGbkResult {
     return innerGetOnly(tag, defaultValue, true);
   }
 
-  /** Like {@link #getOnly(TupleTag, Object)} but uisng a String instead of a TupleTag. */
+  /** Like {@link #getOnly(TupleTag, Object)} but using a String instead of a TupleTag. */
   @Nullable
   public <V> V getOnly(String tag, @Nullable V defaultValue) {
     return getOnly(new TupleTag<>(tag), defaultValue);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
@@ -167,6 +167,10 @@ public class CoGbkResult {
     return unions;
   }
 
+  public <V> Iterable<V> getAll(String tag) {
+    return getAll(new TupleTag<>(tag));
+  }
+
   /**
    * If there is a singleton value for the given tag, returns it. Otherwise, throws an
    * IllegalArgumentException.
@@ -176,6 +180,11 @@ public class CoGbkResult {
    */
   public <V> V getOnly(TupleTag<V> tag) {
     return innerGetOnly(tag, null, false);
+  }
+
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  public <V> V getOnly(String tag) {
+    return getOnly(new TupleTag<>(tag));
   }
 
   /**
@@ -188,6 +197,11 @@ public class CoGbkResult {
   @Nullable
   public <V> V getOnly(TupleTag<V> tag, @Nullable V defaultValue) {
     return innerGetOnly(tag, defaultValue, true);
+  }
+
+  @Nullable
+  public <V> V getOnly(String tag, @Nullable V defaultValue) {
+    return getOnly(new TupleTag<>(tag), defaultValue);
   }
 
   /** A {@link Coder} for {@link CoGbkResult}s. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/KeyedPCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/KeyedPCollectionTuple.java
@@ -52,7 +52,12 @@ public class KeyedPCollectionTuple<K> implements PInput {
     return new KeyedPCollectionTuple<K>(pc.getPipeline()).and(tag, pc);
   }
 
-  /** A version that takes in a string instead of a TupleTag. */
+  /**
+   * A version of {@link #of(TupleTag, PCollection)} that takes in a string instead of a TupleTag.
+   *
+   * <p>This method is simpler for cases when a typed tuple-tag is not needed to extract a
+   * PCollection, for example when using schema transforms.
+   */
   public static <K, InputT> KeyedPCollectionTuple<K> of(String tag, PCollection<KV<K, InputT>> pc) {
     return of(new TupleTag<>(tag), pc);
   }
@@ -72,7 +77,12 @@ public class KeyedPCollectionTuple<K> implements PInput {
         getPipeline(), newKeyedCollections, schema.getTupleTagList().and(tag), myKeyCoder);
   }
 
-  /** A version that takes in a string instead of a TupleTag. */
+  /**
+   * A version of {@link #and(String, PCollection)} that takes in a string instead of a TupleTag.
+   *
+   * <p>This method is simpler for cases when a typed tuple-tag is not needed to extract a
+   * PCollection, for example when using schema transforms.
+   */
   public <V> KeyedPCollectionTuple<K> and(String tag, PCollection<KV<K, V>> pc) {
     return and(new TupleTag<>(tag), pc);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/KeyedPCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/KeyedPCollectionTuple.java
@@ -52,6 +52,11 @@ public class KeyedPCollectionTuple<K> implements PInput {
     return new KeyedPCollectionTuple<K>(pc.getPipeline()).and(tag, pc);
   }
 
+  /** A version that takes in a string instead of a TupleTag. */
+  public static <K, InputT> KeyedPCollectionTuple<K> of(String tag, PCollection<KV<K, InputT>> pc) {
+    return of(new TupleTag<>(tag), pc);
+  }
+
   /**
    * Returns a new {@code KeyedPCollectionTuple<K>} that is the same as this, appended with the
    * given PCollection.
@@ -65,6 +70,11 @@ public class KeyedPCollectionTuple<K> implements PInput {
     List<TaggedKeyedPCollection<K, ?>> newKeyedCollections = copyAddLast(keyedCollections, wrapper);
     return new KeyedPCollectionTuple<>(
         getPipeline(), newKeyedCollections, schema.getTupleTagList().and(tag), myKeyCoder);
+  }
+
+  /** A version that takes in a string instead of a TupleTag. */
+  public <V> KeyedPCollectionTuple<K> and(String tag, PCollection<KV<K, V>> pc) {
+    return and(new TupleTag<>(tag), pc);
   }
 
   public boolean isEmpty() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
@@ -140,7 +140,7 @@ public class PCollectionTuple implements PInput, POutput {
   }
 
   /**
-   * A version of {@link #of(String, PCollection)} that takes in five PCollections of the same type
+   * A version of {@link #of(String, PCollection)} that takes in five PCollections of the same type.
    */
   public static <T> PCollectionTuple of(
       String tag1,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
@@ -91,9 +91,73 @@ public class PCollectionTuple implements PInput, POutput {
     return empty(pc.getPipeline()).and(tag, pc);
   }
 
+  /**
+   * A version of {@link #of(TupleTag, PCollection)} that takes in a String instead of a {@link
+   * TupleTag}.
+   *
+   * <p>This method is simpler for cases when a typed tuple-tag is not needed to extract a
+   * PCollection, for example when using schema transforms.
+   */
   public static <T> PCollectionTuple of(String tag, PCollection<T> pc) {
     return of(new TupleTag<>(tag), pc);
   }
+
+  /**
+   * A version of {@link #of(String, PCollection)} that takes in two PCollections of the same type.
+   */
+  public static <T> PCollectionTuple of(
+      String tag1, PCollection<T> pc1, String tag2, PCollection<T> pc2) {
+    return of(tag1, pc1).and(tag2, pc2);
+  }
+
+  /**
+   * A version of {@link #of(String, PCollection)} that takes in three PCollections of the same
+   * type.
+   */
+  public static <T> PCollectionTuple of(
+      String tag1,
+      PCollection<T> pc1,
+      String tag2,
+      PCollection<T> pc2,
+      String tag3,
+      PCollection<T> pc3) {
+    return of(tag1, pc1, tag2, pc2).and(tag3, pc3);
+  }
+
+  /**
+   * A version of {@link #of(String, PCollection)} that takes in four PCollections of the same type.
+   */
+  public static <T> PCollectionTuple of(
+      String tag1,
+      PCollection<T> pc1,
+      String tag2,
+      PCollection<T> pc2,
+      String tag3,
+      PCollection<T> pc3,
+      String tag4,
+      PCollection<T> pc4) {
+    return of(tag1, pc1, tag2, pc2, tag3, pc3).and(tag4, pc4);
+  }
+
+  /**
+   * A version of {@link #of(String, PCollection)} that takes in five PCollections of the same type
+   */
+  public static <T> PCollectionTuple of(
+      String tag1,
+      PCollection<T> pc1,
+      String tag2,
+      PCollection<T> pc2,
+      String tag3,
+      PCollection<T> pc3,
+      String tag4,
+      PCollection<T> pc4,
+      String tag5,
+      PCollection<T> pc5) {
+    return of(tag1, pc1, tag2, pc2, tag3, pc3, tag4, pc4).and(tag5, pc5);
+  }
+
+  // To create a PCollectionTuple with more than five inputs, use the and() builder method.
+
   /**
    * Returns a new {@link PCollectionTuple} that has each {@link PCollection} and {@link TupleTag}
    * of this {@link PCollectionTuple} plus the given {@link PCollection} associated with the given
@@ -118,6 +182,12 @@ public class PCollectionTuple implements PInput, POutput {
             .build());
   }
 
+  /**
+   * A version of {@link #and(TupleTag, PCollection)} that takes in a String instead of a TupleTag.
+   *
+   * <p>This method is simpler for cases when a typed tuple-tag is not needed to extract a
+   * PCollection, for example when using schema transforms.
+   */
   public <T> PCollectionTuple and(String tag, PCollection<T> pc) {
     return and(new TupleTag<>(tag), pc);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
@@ -200,6 +200,10 @@ public class PCollectionTuple implements PInput, POutput {
     return pcollectionMap.containsKey(tag);
   }
 
+  /**
+   * Returns whether this {@link PCollectionTuple} contains a {@link PCollection} with the given
+   * tag.
+   */
   public <T> boolean has(String tag) {
     return has(new TupleTag<>(tag));
   }
@@ -218,6 +222,11 @@ public class PCollectionTuple implements PInput, POutput {
     return pcollection;
   }
 
+  /**
+   * Returns the {@link PCollection} associated with the given tag in this {@link PCollectionTuple}.
+   * Throws {@link IllegalArgumentException} if there is no such {@link PCollection}, i.e., {@code
+   * !has(tag)}.
+   */
   public <T> PCollection<T> get(String tag) {
     return get(new TupleTag<>(tag));
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
@@ -91,6 +91,9 @@ public class PCollectionTuple implements PInput, POutput {
     return empty(pc.getPipeline()).and(tag, pc);
   }
 
+  public static <T> PCollectionTuple of(String tag, PCollection<T> pc) {
+    return of(new TupleTag<>(tag), pc);
+  }
   /**
    * Returns a new {@link PCollectionTuple} that has each {@link PCollection} and {@link TupleTag}
    * of this {@link PCollectionTuple} plus the given {@link PCollection} associated with the given
@@ -115,12 +118,20 @@ public class PCollectionTuple implements PInput, POutput {
             .build());
   }
 
+  public <T> PCollectionTuple and(String tag, PCollection<T> pc) {
+    return and(new TupleTag<>(tag), pc);
+  }
+
   /**
    * Returns whether this {@link PCollectionTuple} contains a {@link PCollection} with the given
    * tag.
    */
   public <T> boolean has(TupleTag<T> tag) {
     return pcollectionMap.containsKey(tag);
+  }
+
+  public <T> boolean has(String tag) {
+    return has(new TupleTag<>(tag));
   }
 
   /**
@@ -135,6 +146,10 @@ public class PCollectionTuple implements PInput, POutput {
       throw new IllegalArgumentException("TupleTag not found in this PCollectionTuple tuple");
     }
     return pcollection;
+  }
+
+  public <T> PCollection<T> get(String tag) {
+    return get(new TupleTag<>(tag));
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -544,8 +544,8 @@ public abstract class Row implements Serializable {
       if (schema.getFieldCount() != values.size()) {
         throw new IllegalArgumentException(
             String.format(
-                "Field count in Schema (%s) and values (%s) must match",
-                schema.getFieldNames(), values));
+                "Field count in Schema (%s) (%d) and values (%s) (%d)  must match",
+                schema.getFieldNames(), schema.getFieldCount(), values, values.size()));
       }
       for (int i = 0; i < values.size(); ++i) {
         Object value = values.get(i);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.beam.sdk.TestUtils.KvMatcher;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -183,9 +184,7 @@ public class CoGroupTest {
             .build();
 
     PCollection<KV<Row, Row>> joined =
-        PCollectionTuple.of("pc1", pc1)
-            .and("pc2", pc2)
-            .and("pc3", pc3)
+        PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
             .apply("CoGroup", CoGroup.join(By.fieldNames("user", "country")));
     List<KV<Row, Row>> expected =
         ImmutableList.of(
@@ -326,9 +325,7 @@ public class CoGroupTest {
             .build();
 
     PCollection<KV<Row, Row>> joined =
-        PCollectionTuple.of("pc1", pc1)
-            .and("pc2", pc2)
-            .and("pc3", pc3)
+        PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
             .apply(
                 "CoGroup",
                 CoGroup.join("pc1", By.fieldNames("user", "country"))
@@ -366,9 +363,7 @@ public class CoGroupTest {
 
     thrown.expect(IllegalStateException.class);
     PCollection<KV<Row, Row>> joined =
-        PCollectionTuple.of("pc1", pc1)
-            .and("pc2", pc2)
-            .and("pc3", pc3)
+        PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
             .apply(
                 "CoGroup",
                 CoGroup.join("pc1", By.fieldNames("user", "country"))
@@ -394,11 +389,305 @@ public class CoGroupTest {
 
     thrown.expect(IllegalStateException.class);
     PCollection<KV<Row, Row>> joined =
-        PCollectionTuple.of("pc1", pc1)
-            .and("pc2", pc2)
+        PCollectionTuple.of("pc1", pc1, "pc2", pc2)
             .apply(
                 "CoGroup",
                 CoGroup.join("pc1", By.fieldNames("user")).join("pc2", By.fieldNames("count")));
+    pipeline.run();
+  }
+
+  private List<Row> innerJoin(
+      List<Row> inputs1,
+      List<Row> inputs2,
+      List<Row> inputs3,
+      String[] keys1,
+      String[] keys2,
+      String[] keys3,
+      Schema expectedSchema) {
+    List<Row> joined = Lists.newArrayList();
+    for (Row row1 : inputs1) {
+      for (Row row2 : inputs2) {
+        for (Row row3 : inputs3) {
+          boolean shouldJoin = true;
+          for (int i = 0; i < keys1.length && shouldJoin; ++i) {
+            shouldJoin =
+                Stream.of(row1.getValue(keys1[i]), row2.getValue(keys2[i]), row3.getValue(keys3[i]))
+                        .distinct()
+                        .count()
+                    == 1;
+          }
+          if (shouldJoin) {
+            joined.add(Row.withSchema(expectedSchema).addValues(row1, row2, row3).build());
+          }
+        }
+      }
+    }
+    return joined;
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testInnerJoin() {
+    List<Row> pc1Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 1, "us").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 2, "us").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 3, "il").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 4, "il").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 5, "fr").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 6, "fr").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 7, "ar").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 8, "ar").build());
+    List<Row> pc2Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 9, "us").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 10, "us").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 11, "il").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 12, "il").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 13, "fr").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 14, "fr").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 15, "ar").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 16, "ar").build());
+    List<Row> pc3Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 17, "us").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 18, "us").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 19, "il").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 20, "il").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 21, "fr").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 22, "fr").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 23, "ar").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 24, "ar").build());
+
+    PCollection<Row> pc1 = pipeline.apply("Create1", Create.of(pc1Rows)).setRowSchema(CG_SCHEMA_1);
+    PCollection<Row> pc2 = pipeline.apply("Create2", Create.of(pc2Rows)).setRowSchema(CG_SCHEMA_2);
+    PCollection<Row> pc3 = pipeline.apply("Create3", Create.of(pc3Rows)).setRowSchema(CG_SCHEMA_3);
+
+    Schema expectedSchema =
+        Schema.builder()
+            .addRowField("pc1", CG_SCHEMA_1)
+            .addRowField("pc2", CG_SCHEMA_2)
+            .addRowField("pc3", CG_SCHEMA_3)
+            .build();
+
+    PCollection<Row> joined =
+        PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
+            .apply(
+                "CoGroup",
+                CoGroup.join("pc1", By.fieldNames("user", "country"))
+                    .join("pc2", By.fieldNames("user2", "country2"))
+                    .join("pc3", By.fieldNames("user3", "country3"))
+                    .crossProductJoin());
+    assertEquals(expectedSchema, joined.getSchema());
+
+    List<Row> expectedJoinedRows =
+        innerJoin(
+            pc1Rows,
+            pc2Rows,
+            pc3Rows,
+            new String[] {"user", "country"},
+            new String[] {"user2", "country2"},
+            new String[] {"user3", "country3"},
+            expectedSchema);
+
+    PAssert.that(joined).containsInAnyOrder(expectedJoinedRows);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testFullOuterJoin() {
+    List<Row> pc1Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 1, "us").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 2, "us").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 3, "il").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 4, "il").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 5, "fr").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 6, "fr").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 7, "ar").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 8, "ar").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user3", 7, "ar").build());
+
+    List<Row> pc2Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 9, "us").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 10, "us").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 11, "il").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 12, "il").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 13, "fr").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 14, "fr").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 15, "ar").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 16, "ar").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 16, "es").build());
+
+    List<Row> pc3Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 17, "us").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 18, "us").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 19, "il").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 20, "il").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 21, "fr").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 22, "fr").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 23, "ar").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 24, "ar").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user27", 24, "se").build());
+
+    PCollection<Row> pc1 = pipeline.apply("Create1", Create.of(pc1Rows)).setRowSchema(CG_SCHEMA_1);
+    PCollection<Row> pc2 = pipeline.apply("Create2", Create.of(pc2Rows)).setRowSchema(CG_SCHEMA_2);
+    PCollection<Row> pc3 = pipeline.apply("Create3", Create.of(pc3Rows)).setRowSchema(CG_SCHEMA_3);
+
+    // Full outer join, so any field might be null.
+    Schema expectedSchema =
+        Schema.builder()
+            .addNullableField("pc1", FieldType.row(CG_SCHEMA_1))
+            .addNullableField("pc2", FieldType.row(CG_SCHEMA_2))
+            .addNullableField("pc3", FieldType.row(CG_SCHEMA_3))
+            .build();
+
+    PCollection<Row> joined =
+        PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
+            .apply(
+                "CoGroup",
+                CoGroup.join("pc1", By.fieldNames("user", "country").withOuterJoinParticipation())
+                    .join("pc2", By.fieldNames("user2", "country2").withOuterJoinParticipation())
+                    .join("pc3", By.fieldNames("user3", "country3").withOuterJoinParticipation())
+                    .crossProductJoin());
+    assertEquals(expectedSchema, joined.getSchema());
+
+    List<Row> expectedJoinedRows =
+        innerJoin(
+            pc1Rows,
+            pc2Rows,
+            pc3Rows,
+            new String[] {"user", "country"},
+            new String[] {"user2", "country2"},
+            new String[] {"user3", "country3"},
+            expectedSchema);
+    // Manually add the outer-join rows to the list of expected results.
+    expectedJoinedRows.add(
+        Row.withSchema(expectedSchema)
+            .addValues(Row.withSchema(CG_SCHEMA_1).addValues("user3", 7, "ar").build(), null, null)
+            .build());
+    expectedJoinedRows.add(
+        Row.withSchema(expectedSchema)
+            .addValues(null, Row.withSchema(CG_SCHEMA_2).addValues("user2", 16, "es").build(), null)
+            .build());
+    expectedJoinedRows.add(
+        Row.withSchema(expectedSchema)
+            .addValues(
+                null, null, Row.withSchema(CG_SCHEMA_3).addValues("user27", 24, "se").build())
+            .build());
+
+    PAssert.that(joined).containsInAnyOrder(expectedJoinedRows);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testPartialOuterJoin() {
+    List<Row> pc1Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 1, "us").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 2, "us").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 3, "il").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user1", 4, "il").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 5, "fr").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 6, "fr").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 7, "ar").build(),
+            Row.withSchema(CG_SCHEMA_1).addValues("user2", 8, "ar").build());
+
+    List<Row> pc2Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 9, "us").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 10, "us").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 11, "il").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user1", 12, "il").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 13, "fr").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user2", 14, "fr").build(),
+            Row.withSchema(CG_SCHEMA_2).addValues("user3", 7, "ar").build());
+
+    List<Row> pc3Rows =
+        Lists.newArrayList(
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 17, "us").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 18, "us").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 19, "il").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user1", 20, "il").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 21, "fr").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 22, "fr").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 23, "ar").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user2", 24, "ar").build(),
+            Row.withSchema(CG_SCHEMA_3).addValues("user3", 25, "ar").build());
+
+    PCollection<Row> pc1 = pipeline.apply("Create1", Create.of(pc1Rows)).setRowSchema(CG_SCHEMA_1);
+    PCollection<Row> pc2 = pipeline.apply("Create2", Create.of(pc2Rows)).setRowSchema(CG_SCHEMA_2);
+    PCollection<Row> pc3 = pipeline.apply("Create3", Create.of(pc3Rows)).setRowSchema(CG_SCHEMA_3);
+
+    // Partial outer join. Missing entries in the "pc2" PCollection will be filled in with nulls,
+    // but not others.
+    Schema expectedSchema =
+        Schema.builder()
+            .addField("pc1", FieldType.row(CG_SCHEMA_1))
+            .addNullableField("pc2", FieldType.row(CG_SCHEMA_2))
+            .addField("pc3", FieldType.row(CG_SCHEMA_3))
+            .build();
+
+    PCollection<Row> joined =
+        PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
+            .apply(
+                "CoGroup",
+                CoGroup.join("pc1", By.fieldNames("user", "country"))
+                    .join("pc2", By.fieldNames("user2", "country2").withOuterJoinParticipation())
+                    .join("pc3", By.fieldNames("user3", "country3"))
+                    .crossProductJoin());
+    assertEquals(expectedSchema, joined.getSchema());
+
+    List<Row> expectedJoinedRows =
+        innerJoin(
+            pc1Rows,
+            pc2Rows,
+            pc3Rows,
+            new String[] {"user", "country"},
+            new String[] {"user2", "country2"},
+            new String[] {"user3", "country3"},
+            expectedSchema);
+
+    // Manually add the outer-join rows to the list of expected results. Missing results from the
+    // middle (pc2) PCollection are filled in with nulls. Missing events from other PCollections
+    // are not. Events with key ("user2", "ar) show up in pc1 and pc3 but not in pc2, so we expect
+    // the outer join to still produce those rows, with nulls for pc2. Events with key
+    // ("user3", "ar) however show up in in p2 and pc3, but not in pc1; since pc1 is marked for
+    // full participation (no outer join), these events should not be included in the join.
+    expectedJoinedRows.add(
+        Row.withSchema(expectedSchema)
+            .addValues(
+                Row.withSchema(CG_SCHEMA_1).addValues("user2", 7, "ar").build(),
+                null,
+                Row.withSchema(CG_SCHEMA_3).addValues("user2", 23, "ar").build())
+            .build());
+    expectedJoinedRows.add(
+        Row.withSchema(expectedSchema)
+            .addValues(
+                Row.withSchema(CG_SCHEMA_1).addValues("user2", 7, "ar").build(),
+                null,
+                Row.withSchema(CG_SCHEMA_3).addValues("user2", 24, "ar").build())
+            .build());
+    expectedJoinedRows.add(
+        Row.withSchema(expectedSchema)
+            .addValues(
+                Row.withSchema(CG_SCHEMA_1).addValues("user2", 8, "ar").build(),
+                null,
+                Row.withSchema(CG_SCHEMA_3).addValues("user2", 23, "ar").build())
+            .build());
+    expectedJoinedRows.add(
+        Row.withSchema(expectedSchema)
+            .addValues(
+                Row.withSchema(CG_SCHEMA_1).addValues("user2", 8, "ar").build(),
+                null,
+                Row.withSchema(CG_SCHEMA_3).addValues("user2", 24, "ar").build())
+            .build());
+
+    PAssert.that(joined).containsInAnyOrder(expectedJoinedRows);
     pipeline.run();
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.TestUtils.KvMatcher;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.schemas.transforms.CoGroup.By;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -185,7 +186,7 @@ public class CoGroupTest {
         PCollectionTuple.of("pc1", pc1)
             .and("pc2", pc2)
             .and("pc3", pc3)
-            .apply("CoGroup", CoGroup.byFieldNames("user", "country"));
+            .apply("CoGroup", CoGroup.join(By.fieldNames("user", "country")));
     List<KV<Row, Row>> expected =
         ImmutableList.of(
             KV.of(key1, key1Joined),
@@ -330,9 +331,9 @@ public class CoGroupTest {
             .and("pc3", pc3)
             .apply(
                 "CoGroup",
-                CoGroup.byFieldNamesForInput("pc1", "user", "country")
-                    .byFieldNamesForInput("pc2", "user2", "country2")
-                    .byFieldNamesForInput("pc3", "user3", "country3"));
+                CoGroup.join("pc1", By.fieldNames("user", "country"))
+                    .join("pc2", By.fieldNames("user2", "country2"))
+                    .join("pc3", By.fieldNames("user3", "country3")));
 
     List<KV<Row, Row>> expected =
         ImmutableList.of(
@@ -370,8 +371,8 @@ public class CoGroupTest {
             .and("pc3", pc3)
             .apply(
                 "CoGroup",
-                CoGroup.byFieldNamesForInput("pc1", "user", "country")
-                    .byFieldNamesForInput("pc2", "user2", "country2"));
+                CoGroup.join("pc1", By.fieldNames("user", "country"))
+                    .join("pc2", By.fieldNames("user2", "country2")));
     pipeline.run();
   }
 
@@ -397,7 +398,7 @@ public class CoGroupTest {
             .and("pc2", pc2)
             .apply(
                 "CoGroup",
-                CoGroup.byFieldNamesForInput("pc1", "user").byFieldNamesForInput("pc2", "count"));
+                CoGroup.join("pc1", By.fieldNames("user")).join("pc2", By.fieldNames("count")));
     pipeline.run();
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
@@ -36,7 +36,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
-import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
 import org.hamcrest.BaseMatcher;
@@ -183,9 +182,9 @@ public class CoGroupTest {
             .build();
 
     PCollection<KV<Row, Row>> joined =
-        PCollectionTuple.of(new TupleTag<>("pc1"), pc1)
-            .and(new TupleTag<>("pc2"), pc2)
-            .and(new TupleTag<>("pc3"), pc3)
+        PCollectionTuple.of("pc1", pc1)
+            .and("pc2", pc2)
+            .and("pc3", pc3)
             .apply("CoGroup", CoGroup.byFieldNames("user", "country"));
     List<KV<Row, Row>> expected =
         ImmutableList.of(
@@ -325,19 +324,15 @@ public class CoGroupTest {
                     Row.withSchema(CG_SCHEMA_3).addValues("user2", 24, "ar").build()))
             .build();
 
-    TupleTag<Row> pc1Tag = new TupleTag<>("pc1");
-    TupleTag<Row> pc2Tag = new TupleTag<>("pc2");
-    TupleTag<Row> pc3Tag = new TupleTag<>("pc3");
-
     PCollection<KV<Row, Row>> joined =
-        PCollectionTuple.of(pc1Tag, pc1)
-            .and(pc2Tag, pc2)
-            .and(pc3Tag, pc3)
+        PCollectionTuple.of("pc1", pc1)
+            .and("pc2", pc2)
+            .and("pc3", pc3)
             .apply(
                 "CoGroup",
-                CoGroup.byFieldNames(pc1Tag, "user", "country")
-                    .byFieldNames(pc2Tag, "user2", "country2")
-                    .byFieldNames(pc3Tag, "user3", "country3"));
+                CoGroup.byFieldNamesForInput("pc1", "user", "country")
+                    .byFieldNamesForInput("pc2", "user2", "country2")
+                    .byFieldNamesForInput("pc3", "user3", "country3"));
 
     List<KV<Row, Row>> expected =
         ImmutableList.of(
@@ -367,19 +362,16 @@ public class CoGroupTest {
     PCollection<Row> pc3 =
         pipeline.apply(
             "Create3", Create.of(Row.withSchema(CG_SCHEMA_3).addValues("user1", 17, "us").build()));
-    TupleTag<Row> pc1Tag = new TupleTag<>("pc1");
-    TupleTag<Row> pc2Tag = new TupleTag<>("pc2");
-    TupleTag<Row> pc3Tag = new TupleTag<>("pc3");
 
     thrown.expect(IllegalStateException.class);
     PCollection<KV<Row, Row>> joined =
-        PCollectionTuple.of(pc1Tag, pc1)
-            .and(pc2Tag, pc2)
-            .and(pc3Tag, pc3)
+        PCollectionTuple.of("pc1", pc1)
+            .and("pc2", pc2)
+            .and("pc3", pc3)
             .apply(
                 "CoGroup",
-                CoGroup.byFieldNames(pc1Tag, "user", "country")
-                    .byFieldNames(pc2Tag, "user2", "country2"));
+                CoGroup.byFieldNamesForInput("pc1", "user", "country")
+                    .byFieldNamesForInput("pc2", "user2", "country2"));
     pipeline.run();
   }
 
@@ -399,13 +391,13 @@ public class CoGroupTest {
                 Create.of(Row.withSchema(CG_SCHEMA_1).addValues("user1", 9, "us").build()))
             .setRowSchema(CG_SCHEMA_1);
 
-    TupleTag<Row> pc1Tag = new TupleTag<>("pc1");
-    TupleTag<Row> pc2Tag = new TupleTag<>("pc2");
     thrown.expect(IllegalStateException.class);
     PCollection<KV<Row, Row>> joined =
-        PCollectionTuple.of(pc1Tag, pc1)
-            .and(pc2Tag, pc2)
-            .apply("CoGroup", CoGroup.byFieldNames(pc1Tag, "user").byFieldNames(pc2Tag, "count"));
+        PCollectionTuple.of("pc1", pc1)
+            .and("pc2", pc2)
+            .apply(
+                "CoGroup",
+                CoGroup.byFieldNamesForInput("pc1", "user").byFieldNamesForInput("pc2", "count"));
     pipeline.run();
   }
 


### PR DESCRIPTION
Multiple improvements to the schema CoGroup transform:
  * Allow the user to use strings instead of TupleTags. TupleTags existed to make Java type inference work, and this is not needed with the schema-based join as the types are in the schema. This also allows a simpler builder for PCollectionTuple.

  * Instead of multiple CoGroup.byFieldNames, byFieldIds, etc. the new syntax is CoGroup.join(By.fieldNames), CoGroup.join(By.fieldIds), etc. This shrinks the API surface area, and also provides a place to provide per-input options (used for outer joins).

* Add a .crossProductJoin. This expands the iterables into an inner-product. For example:
    PCollection<Row> innerJoined = inputs.apply(
        CoGroup.join("input1", By.fieldNames("user"))
                       .join("input2", By.fieldNames("user"))
                       .crossProductJoin();

* Each input can be marked for "outer-join" participation semantics. This means that if no records for that input are present for a join key, an output is still generated from the cross product with the value for that input replaced by a null. This generalizes normal left/right/full outer joins to N inputs. For example with two inputs:
    PCollection<Row> leftOuterJoined = inputs.apply(
        CoGroup.join("input1", By.fieldNames("user").withOuterJoinParticipation())
                       .join("input2", By.fieldNames("user"))
                       .crossProductJoin();
R: @dpmills 
R: @akedin 