### PR TITLE
[BEAM-4725] Use unsafe to avoid small allocations to the heap.

### DIFF
--- a/sdks/go/pkg/beam/core/graph/coder/int.go
+++ b/sdks/go/pkg/beam/core/graph/coder/int.go
@@ -24,36 +24,36 @@ import (
 
 // EncodeUint64 encodes an uint64 in big endian format.
 func EncodeUint64(value uint64, w io.Writer) error {
-	ret := make([]byte, 8)
-	binary.BigEndian.PutUint64(ret, value)
-	_, err := w.Write(ret)
+	var data [8]byte
+	binary.BigEndian.PutUint64(data[:], value)
+	_, err := ioutilx.WriteUnsafe(w, data[:])
 	return err
 }
 
 // DecodeUint64 decodes an uint64 in big endian format.
 func DecodeUint64(r io.Reader) (uint64, error) {
-	data, err := ioutilx.ReadN(r, 8)
-	if err != nil {
+	var data [8]byte
+	if err := ioutilx.ReadNBufUnsafe(r, data[:]); err != nil {
 		return 0, err
 	}
-	return binary.BigEndian.Uint64(data), nil
+	return binary.BigEndian.Uint64(data[:]), nil
 }
 
 // EncodeUint32 encodes an uint32 in big endian format.
 func EncodeUint32(value uint32, w io.Writer) error {
-	ret := make([]byte, 4)
-	binary.BigEndian.PutUint32(ret, value)
-	_, err := w.Write(ret)
+	var data [4]byte
+	binary.BigEndian.PutUint32(data[:], value)
+	_, err := ioutilx.WriteUnsafe(w, data[:])
 	return err
 }
 
 // DecodeUint32 decodes an uint32 in big endian format.
 func DecodeUint32(r io.Reader) (uint32, error) {
-	data, err := ioutilx.ReadN(r, 4)
-	if err != nil {
+	var data [4]byte
+	if err := ioutilx.ReadNBufUnsafe(r, data[:]); err != nil {
 		return 0, err
 	}
-	return binary.BigEndian.Uint32(data), nil
+	return binary.BigEndian.Uint32(data[:]), nil
 }
 
 // EncodeInt32 encodes an int32 in big endian format.

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -384,7 +384,8 @@ func DecodeWindowedValueHeader(dec WindowDecoder, r io.Reader) ([]typex.Window, 
 	if err != nil {
 		return nil, mtime.ZeroTimestamp, err
 	}
-	if _, err := ioutilx.ReadN(r, 1); err != nil { // NO_FIRING pane
+	var data [1]byte
+	if err := ioutilx.ReadNBufUnsafe(r, data[:]); err != nil { // NO_FIRING pane
 		return nil, mtime.ZeroTimestamp, err
 	}
 	return ws, t, nil

--- a/sdks/go/pkg/beam/core/util/ioutilx/read.go
+++ b/sdks/go/pkg/beam/core/util/ioutilx/read.go
@@ -19,6 +19,7 @@ package ioutilx
 import (
 	"errors"
 	"io"
+	"unsafe"
 )
 
 // ReadN reads exactly N bytes from the reader. Fails otherwise.
@@ -40,4 +41,45 @@ func ReadN(r io.Reader, n int) ([]byte, error) {
 
 		index += i
 	}
+}
+
+// ReadNBufUnsafe reads exactly cap(buf) bytes from the reader. Fails otherwise.
+// Uses the unsafe package unsafely to convince escape analysis that the passed
+// in []byte doesn't escape this function through the io.Reader.
+// Intended for use with small, fixed sized, stack allocated buffers that have
+// no business being allocated to the heap.
+// If the io.Reader somehow retains the passed in []byte, then this should not
+// be used, and ReadN prefered.
+func ReadNBufUnsafe(r io.Reader, b []byte) error {
+	// Use with unsafe readers at your own peril.
+	p := uintptr(unsafe.Pointer(&b))
+	ret := *(*[]byte)(unsafe.Pointer(p))
+	index := 0
+	n := len(ret)
+	for {
+		i, err := r.Read(ret[index:])
+		if i+index == n {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if i == 0 {
+			return errors.New("No data")
+		}
+
+		index += i
+	}
+}
+
+// ReadUnsafe is an unsafe version of read that breaks escape analysis
+// to allow the passed in []byte to be allocated to the stack.
+// Intended for use with small, fixed sized, stack allocated buffers that have
+// no business being allocated to the heap.
+// If the io.Reader somehow retains the passed in []byte, then this should not
+// be used, and ReadN prefered.
+func ReadUnsafe(r io.Reader, b []byte) (int, error) {
+	p := uintptr(unsafe.Pointer(&b))
+	ret := *(*[]byte)(unsafe.Pointer(p))
+	return r.Read(ret)
 }

--- a/sdks/go/pkg/beam/core/util/ioutilx/write.go
+++ b/sdks/go/pkg/beam/core/util/ioutilx/write.go
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ioutilx
+
+import (
+	"io"
+	"unsafe"
+)
+
+// WriteUnsafe writes the buffer to the given writer, but breaks
+// escape analysis so that the passed in []byte can be allocated
+// to the stack. Use with caution, and only when you're certain
+// the writer doesn't retain the passed in byte buffer.
+func WriteUnsafe(w io.Writer, b []byte) (int, error) {
+	p := uintptr(unsafe.Pointer(&b))
+	ret := *(*[]byte)(unsafe.Pointer(p))
+	return w.Write(ret)
+}


### PR DESCRIPTION
This avoids tiny allocations on encode and decode of all the ints,varints, and window headers necessary for Beam Go to function over the FnAPI.

Go's escape analysis is pretty good, except when it comes to indirect function calls and interfaces. If an argument is passed through to one of those, the compiler has no choice but to allocate it to the heap, as the lifetime can't be known without additional analysis.

Using the unsafe package, it's possible to wrap invocations of interfaces like io.Reader and io.Writer, and encourage the compiler to allocate the small buffers to the stack instead. This reduces garbage generation, which saves CPU time in the garbage collector.

Go's tooling permits reading the escape analysis results and justification for why something was moved to the heap or not. For example, before I changed the coder/int.go this was the analysis output for the file:

```
~/code/src/github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder
 % go build -gcflags '-m -m -l' 2>&1 | grep /int.go
./int.go:27:13: make([]byte, 8) escapes to heap
./int.go:27:13:         from ret (assigned) at ./int.go:27:6
./int.go:27:13:         from w.Write(ret) (parameter to indirect call) at ./int.go:29:19
./int.go:26:33: leaking param: w
./int.go:26:33:         from w.Write(ret) (receiver in indirect call) at ./int.go:29:19
./int.go:34:19: leaking param: r
./int.go:34:19:         from r (passed to call[argument escapes]) at ./int.go:35:28
./int.go:44:13: make([]byte, 4) escapes to heap
./int.go:44:13:         from ret (assigned) at ./int.go:44:6
./int.go:44:13:         from w.Write(ret) (parameter to indirect call) at ./int.go:46:19
./int.go:43:33: leaking param: w
./int.go:43:33:         from w.Write(ret) (receiver in indirect call) at ./int.go:46:19
./int.go:51:19: leaking param: r
./int.go:51:19:         from r (passed to call[argument escapes]) at ./int.go:52:28
./int.go:60:31: leaking param: w
./int.go:60:31:         from w (passed to call[argument escapes]) at ./int.go:61:21
./int.go:65:18: leaking param: r
./int.go:65:18:         from r (passed to call[argument escapes]) at ./int.go:66:26
```

Note that  all the make []bytes are escaping.

```
~/code/src/github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder
 % go build -gcflags '-m -m -l' 2>&1 | grep /int.go
./int.go:26:33: leaking param: w
./int.go:26:33:         from w (passed to call[argument escapes]) at ./int.go:29:31
./int.go:28:33: EncodeUint64 data does not escape
./int.go:29:39: EncodeUint64 data does not escape
./int.go:34:19: leaking param: r
./int.go:34:19:         from r (passed to call[argument escapes]) at ./int.go:36:34
./int.go:36:42: DecodeUint64 data does not escape
./int.go:39:37: DecodeUint64 data does not escape
./int.go:43:33: leaking param: w
./int.go:43:33:         from w (passed to call[argument escapes]) at ./int.go:46:31
./int.go:45:33: EncodeUint32 data does not escape
./int.go:46:39: EncodeUint32 data does not escape
./int.go:51:19: leaking param: r
./int.go:51:19:         from r (passed to call[argument escapes]) at ./int.go:53:34
./int.go:53:42: DecodeUint32 data does not escape
./int.go:56:37: DecodeUint32 data does not escape
./int.go:60:31: leaking param: w
./int.go:60:31:         from w (passed to call[argument escapes]) at ./int.go:61:21
./int.go:65:18: leaking param: r
./int.go:65:18:         from r (passed to call[argument escapes]) at ./int.go:66:26
```

Afterwards, they are not escaping. 

An alternative of this would be to pass around concrete reader and writers, so escape analysis would function properly, however, this would tie the code too in-depth to the implementation.


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




