### PR TITLE
[BEAM-6294] Use Flink rebalance for shuffle.

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
@@ -23,6 +23,7 @@ import static org.apache.beam.runners.flink.translation.utils.FlinkPipelineTrans
 import static org.apache.beam.runners.flink.translation.utils.FlinkPipelineTranslatorUtils.getWindowingStrategy;
 import static org.apache.beam.runners.flink.translation.utils.FlinkPipelineTranslatorUtils.instantiateCoder;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -43,6 +44,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.ExecutableStagePayload.SideInputId;
+import org.apache.beam.runners.core.construction.NativeTransforms;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.WindowingStrategyTranslation;
@@ -81,6 +83,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.grpc.v1p13p1.com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -119,7 +122,8 @@ public class FlinkBatchPortablePipelineTranslator
    * Creates a batch translation context. The resulting Flink execution dag will live in a new
    * {@link ExecutionEnvironment}.
    */
-  public static BatchTranslationContext createTranslationContext(
+  @Override
+  public BatchTranslationContext createTranslationContext(
       JobInfo jobInfo,
       FlinkPipelineOptions pipelineOptions,
       @Nullable String confDir,
@@ -158,7 +162,8 @@ public class FlinkBatchPortablePipelineTranslator
    * flink {@link ExecutionEnvironment} that the execution plan will be applied to.
    */
   public static class BatchTranslationContext
-      implements FlinkPortablePipelineTranslator.TranslationContext {
+      implements FlinkPortablePipelineTranslator.TranslationContext,
+          FlinkPortablePipelineTranslator.Executor {
 
     private final JobInfo jobInfo;
     private final FlinkPipelineOptions options;
@@ -183,6 +188,11 @@ public class FlinkBatchPortablePipelineTranslator
     @Override
     public FlinkPipelineOptions getPipelineOptions() {
       return options;
+    }
+
+    @Override
+    public JobExecutionResult execute(String jobName) throws Exception {
+      return getExecutionEnvironment().execute(jobName);
     }
 
     public ExecutionEnvironment getExecutionEnvironment() {
@@ -229,7 +239,23 @@ public class FlinkBatchPortablePipelineTranslator
   }
 
   @Override
-  public void translate(BatchTranslationContext context, RunnerApi.Pipeline pipeline) {
+  public Set<String> knownUrns() {
+    return urnToTransformTranslator.keySet();
+  }
+
+  /** Predicate to determine whether a URN is a Flink native transform. */
+  @AutoService(NativeTransforms.IsNativeTransform.class)
+  public static class IsFlinkNativeTransform implements NativeTransforms.IsNativeTransform {
+    @Override
+    public boolean test(RunnerApi.PTransform pTransform) {
+      return PTransformTranslation.RESHUFFLE_URN.equals(
+          PTransformTranslation.urnForTransformOrNull(pTransform));
+    }
+  }
+
+  @Override
+  public FlinkPortablePipelineTranslator.Executor translate(
+      BatchTranslationContext context, RunnerApi.Pipeline pipeline) {
     // Use a QueryablePipeline to traverse transforms topologically.
     QueryablePipeline p =
         QueryablePipeline.forTransforms(
@@ -246,6 +272,8 @@ public class FlinkBatchPortablePipelineTranslator
     for (DataSet<?> dataSet : context.getDanglingDataSets()) {
       dataSet.output(new DiscardingOutputFormat<>()).name("DiscardingOutput");
     }
+
+    return context;
   }
 
   private static <K, V> void translateReshuffle(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvocation.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvocation.java
@@ -21,6 +21,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -29,12 +31,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.beam.model.jobmanagement.v1.JobApi.JobMessage;
 import org.apache.beam.model.jobmanagement.v1.JobApi.JobState;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Pipeline;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
 import org.apache.beam.runners.core.construction.graph.GreedyPipelineFuser;
 import org.apache.beam.runners.fnexecution.jobsubmission.JobInvocation;
@@ -98,39 +102,73 @@ public class FlinkJobInvocation implements JobInvocation {
   private PipelineResult runPipeline() throws Exception {
     MetricsEnvironment.setMetricsSupported(false);
 
+    FlinkPortablePipelineTranslator<?> translator;
+    if (!pipelineOptions.isStreaming() && !hasUnboundedPCollections(pipeline)) {
+      // TODO: Do we need to inspect for unbounded sources before fusing?
+      translator = FlinkBatchPortablePipelineTranslator.createTranslator();
+    } else {
+      translator = new FlinkStreamingPortablePipelineTranslator();
+    }
+    return runPipelineWithTranslator(translator);
+  }
+
+  private <T extends FlinkPortablePipelineTranslator.TranslationContext>
+      PipelineResult runPipelineWithTranslator(FlinkPortablePipelineTranslator<T> translator)
+          throws Exception {
     LOG.info("Translating pipeline to Flink program.");
+
+    // Don't let the fuser fuse any subcomponents of native transforms.
+    // TODO(BEAM-6327): Remove the need for this.
+    RunnerApi.Pipeline trimmedPipeline =
+        makeKnownUrnsPrimitives(
+            pipeline,
+            Sets.difference(
+                translator.knownUrns(),
+                ImmutableSet.of(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)));
+
     // Fused pipeline proto.
-    RunnerApi.Pipeline fusedPipeline = GreedyPipelineFuser.fuse(pipeline).toPipeline();
+    RunnerApi.Pipeline fusedPipeline = GreedyPipelineFuser.fuse(trimmedPipeline).toPipeline();
     JobInfo jobInfo =
         JobInfo.create(
             id,
             pipelineOptions.getJobName(),
             retrievalToken,
             PipelineOptionsTranslation.toProto(pipelineOptions));
-    final JobExecutionResult result;
 
-    if (!pipelineOptions.isStreaming() && !hasUnboundedPCollections(fusedPipeline)) {
-      // TODO: Do we need to inspect for unbounded sources before fusing?
-      // batch translation
-      FlinkBatchPortablePipelineTranslator translator =
-          FlinkBatchPortablePipelineTranslator.createTranslator();
-      FlinkBatchPortablePipelineTranslator.BatchTranslationContext context =
-          FlinkBatchPortablePipelineTranslator.createTranslationContext(
-              jobInfo, pipelineOptions, confDir, filesToStage);
-      translator.translate(context, fusedPipeline);
-      result = context.getExecutionEnvironment().execute(pipelineOptions.getJobName());
-    } else {
-      // streaming translation
-      FlinkStreamingPortablePipelineTranslator translator =
-          new FlinkStreamingPortablePipelineTranslator();
-      FlinkStreamingPortablePipelineTranslator.StreamingTranslationContext context =
-          FlinkStreamingPortablePipelineTranslator.createTranslationContext(
-              jobInfo, pipelineOptions, confDir, filesToStage);
-      translator.translate(context, fusedPipeline);
-      result = context.getExecutionEnvironment().execute(pipelineOptions.getJobName());
-    }
+    FlinkPortablePipelineTranslator.Executor executor =
+        translator.translate(
+            translator.createTranslationContext(jobInfo, pipelineOptions, confDir, filesToStage),
+            fusedPipeline);
+    final JobExecutionResult result = executor.execute(pipelineOptions.getJobName());
 
     return FlinkRunner.createPipelineResult(result, pipelineOptions);
+  }
+
+  private RunnerApi.Pipeline makeKnownUrnsPrimitives(
+      RunnerApi.Pipeline pipeline, Set<String> knownUrns) {
+    RunnerApi.Pipeline.Builder trimmedPipeline = pipeline.toBuilder();
+    for (String ptransformId : pipeline.getComponents().getTransformsMap().keySet()) {
+      if (knownUrns.contains(
+          pipeline.getComponents().getTransformsOrThrow(ptransformId).getSpec().getUrn())) {
+        LOG.debug("Removing descendants of known PTransform {}" + ptransformId);
+        removeDescendants(trimmedPipeline, ptransformId);
+      }
+    }
+    return trimmedPipeline.build();
+  }
+
+  private void removeDescendants(RunnerApi.Pipeline.Builder pipeline, String parentId) {
+    RunnerApi.PTransform parentProto =
+        pipeline.getComponents().getTransformsOrDefault(parentId, null);
+    if (parentProto != null) {
+      for (String childId : parentProto.getSubtransformsList()) {
+        removeDescendants(pipeline, childId);
+        pipeline.getComponentsBuilder().removeTransforms(childId);
+      }
+      pipeline
+          .getComponentsBuilder()
+          .putTransforms(parentId, parentProto.toBuilder().clearSubtransforms().build());
+    }
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPortablePipelineTranslator.java
@@ -17,8 +17,12 @@
  */
 package org.apache.beam.runners.flink;
 
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.flink.api.common.JobExecutionResult;
 
 /**
  * Interface for portable Flink translators. This allows for a uniform invocation pattern for
@@ -38,6 +42,19 @@ public interface FlinkPortablePipelineTranslator<
     FlinkPipelineOptions getPipelineOptions();
   }
 
+  /** A handle used to execute a translated pipeline. */
+  interface Executor {
+    JobExecutionResult execute(String jobName) throws Exception;
+  }
+
+  T createTranslationContext(
+      JobInfo jobInfo,
+      FlinkPipelineOptions pipelineOptions,
+      @Nullable String confDir,
+      List<String> filesToStage);
+
+  Set<String> knownUrns();
+
   /** Translates the given pipeline. */
-  void translate(T context, RunnerApi.Pipeline pipeline);
+  Executor translate(T context, RunnerApi.Pipeline pipeline);
 }

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -33,6 +33,7 @@ from future.utils import itervalues
 
 from apache_beam import typehints
 from apache_beam.metrics import Metrics
+from apache_beam.portability import common_urns
 from apache_beam.transforms import window
 from apache_beam.transforms.core import CombinePerKey
 from apache_beam.transforms.core import DoFn
@@ -636,3 +637,10 @@ class Reshuffle(PTransform):
             | 'AddRandomKeys' >> Map(lambda t: (random.getrandbits(32), t))
             | ReshufflePerKey()
             | 'RemoveRandomKeys' >> Map(lambda t: t[1]))
+
+  def to_runner_api_parameter(self, unused_context):
+    return common_urns.composites.RESHUFFLE.urn, None
+
+  @PTransform.register_urn(common_urns.composites.RESHUFFLE.urn, None)
+  def from_runner_api_parameter(unused_parameter, unused_context):
+    return Reshuffle()


### PR DESCRIPTION

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




