### PR TITLE
[BEAM-5918] Fix CastTest

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastTest.java
@@ -71,6 +71,22 @@ public class CastTest {
     pipeline.run();
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  @Category(NeedsRunner.class)
+  public void testTypeWidenFail() {
+    Schema inputSchema =
+        Schema.of(
+            Schema.Field.of("f0", Schema.FieldType.INT32),
+            Schema.Field.of("f1", Schema.FieldType.INT64));
+
+    Schema outputSchema =
+        Schema.of(
+            Schema.Field.of("f0", Schema.FieldType.INT16),
+            Schema.Field.of("f1", Schema.FieldType.INT32));
+
+    Cast.widening(outputSchema).verifyCompatibility(inputSchema);
+  }
+
   @Test
   @Category(NeedsRunner.class)
   public void testTypeNarrow() throws Exception {
@@ -87,19 +103,9 @@ public class CastTest {
     pipeline.run();
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  @Category(NeedsRunner.class)
-  public void testTypeNarrowFail() throws Exception {
-    // narrowing is the opposite of widening
-    Schema inputSchema = pipeline.getSchemaRegistry().getSchema(TypeWiden2.class);
-    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(TypeWiden1.class);
-
-    Cast.narrowing(outputSchema).verifyCompatibility(inputSchema);
-  }
-
   @Test
   @Category(NeedsRunner.class)
-  public void testWeakedNullable() throws Exception {
+  public void testWeakenNullable() throws Exception {
     Schema outputSchema = pipeline.getSchemaRegistry().getSchema(Nullable2.class);
 
     PCollection<Nullable2> pojos =
@@ -110,15 +116,6 @@ public class CastTest {
 
     PAssert.that(pojos).containsInAnyOrder(new Nullable2());
     pipeline.run();
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  @Category(NeedsRunner.class)
-  public void testWeakedNullableFail() throws Exception {
-    Schema inputSchema = pipeline.getSchemaRegistry().getSchema(Nullable1.class);
-    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(Nullable2.class);
-
-    Cast.widening(outputSchema).verifyCompatibility(inputSchema);
   }
 
   @Test


### PR DESCRIPTION
Right now `CastTest` is failing, the build is green because runner tests aren't part of Java Run PreCommit. If we want to enable runner tests, it would be better to fix failing tests first.

I have PR with a bigger refactor, however, I want to start small, and fix failing tests first.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




