### PR TITLE
[BEAM-6311] [BEAM-6312] [BEAM-6319] Improve BigQueryClient and BigQueryToTableIT

### DIFF
--- a/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficMaxLaneFlowIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficMaxLaneFlowIT.java
@@ -43,7 +43,7 @@ public class TrafficMaxLaneFlowIT {
   private BigqueryClient bqClient;
 
   @Before
-  public void setupTestEnvironment() {
+  public void setupTestEnvironment() throws Exception {
     PipelineOptionsFactory.register(TrafficMaxLaneFlowOptions.class);
     this.options = TestPipeline.testingPipelineOptions().as(TrafficMaxLaneFlowOptions.class);
     this.projectId = TestPipeline.testingPipelineOptions().as(GcpOptions.class).getProject();

--- a/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficRoutesIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficRoutesIT.java
@@ -43,7 +43,7 @@ public class TrafficRoutesIT {
   private BigqueryClient bqClient;
 
   @Before
-  public void setupTestEnvironment() {
+  public void setupTestEnvironment() throws Exception {
     PipelineOptionsFactory.register(TrafficRoutesOptions.class);
     this.options = TestPipeline.testingPipelineOptions().as(TrafficRoutesOptions.class);
     this.projectId = TestPipeline.testingPipelineOptions().as(GcpOptions.class).getProject();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/BigqueryClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/BigqueryClient.java
@@ -473,12 +473,20 @@ public class BigqueryClient {
                     tableName,
                     new TableDataInsertAllRequest().setRows(dataRows))
                 .execute();
-        if (response != null || response.getInsertErrors().isEmpty()) {
+        if (response != null
+            && (response.getInsertErrors() == null || response.getInsertErrors().isEmpty())) {
           LOG.info("Successfully inserted data into table : " + tableName);
           return;
         } else {
-          lastException =
-              new IOException("Expected valid response from insert data job, but received null.");
+          if (response == null || response.getInsertErrors() == null) {
+            lastException =
+                new IOException("Expected valid response from insert data job, but received null.");
+          } else {
+            lastException =
+                new IOException(
+                    String.format(
+                        "Got insertion error (%s)", response.getInsertErrors().toString()));
+          }
         }
       } catch (IOException e) {
         // ignore and retry

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -49,8 +48,8 @@ import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.Values;
 import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.values.PCollection;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -62,14 +61,13 @@ import org.slf4j.LoggerFactory;
 @RunWith(JUnit4.class)
 public class BigQueryToTableIT {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryToTableIT.class);
-  private BigQueryToTableOptions options;
-  private String project;
+  private static final String project =
+      TestPipeline.testingPipelineOptions().as(GcpOptions.class).getProject();
 
-  private String bigQueryDatasetId;
-  private static final String OUTPUT_TABLE_NAME = "output_table";
-  private BigQueryOptions bqOption;
-  private String outputTable;
-  private BigqueryClient bqClient;
+  private static BigqueryClient bqClient = new BigqueryClient("BigQueryToTableIT");
+
+  private static final String bigQueryDatasetId = "bq_query_to_table_" + System.currentTimeMillis();
+
   private static final TableSchema LEGACY_QUERY_TABLE_SCHEMA =
       new TableSchema()
           .setFields(ImmutableList.of(new TableFieldSchema().setName("fruit").setType("STRING")));
@@ -87,10 +85,9 @@ public class BigQueryToTableIT {
           ImmutableMap.of("bytes", "dec=", "date", "3000-12-31", "time", "23:59:59.990000"),
           ImmutableMap.of("bytes", "xyw=", "date", "2011-01-01", "time", "23:59:59.999999"));
 
-  private void runBigQueryToTablePipeline() {
+  private void runBigQueryToTablePipeline(BigQueryToTableOptions options) {
     Pipeline p = Pipeline.create(options);
-    BigQueryIO.Read bigQueryRead =
-        BigQueryIO.read().withoutValidation().fromQuery(options.getQuery());
+    BigQueryIO.Read bigQueryRead = BigQueryIO.read().fromQuery(options.getQuery());
     if (options.getUsingStandardSql()) {
       bigQueryRead = bigQueryRead.usingStandardSql();
     }
@@ -107,55 +104,49 @@ public class BigQueryToTableIT {
         BigQueryIO.writeTableRows()
             .to(options.getOutput())
             .withSchema(options.getOutputSchema())
-            .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
-            .withoutValidation());
+            .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED));
 
     p.run().waitUntilFinish();
   }
 
-  private void setupLegacyQueryTest() {
+  private BigQueryToTableOptions setupLegacyQueryTest(String outputTable) {
+    BigQueryToTableOptions options =
+        TestPipeline.testingPipelineOptions().as(BigQueryToTableOptions.class);
+    options.setTempLocation(options.getTempRoot() + "/bq_it_temp");
     options.setQuery("SELECT * FROM (SELECT \"apple\" as fruit), (SELECT \"orange\" as fruit),");
     options.setOutput(outputTable);
     options.setOutputSchema(BigQueryToTableIT.LEGACY_QUERY_TABLE_SCHEMA);
+    return options;
   }
 
-  private void setupNewTypesQueryTest() {
-    this.bqClient.createNewTable(
-        this.project,
-        this.bigQueryDatasetId,
-        new Table()
-            .setSchema(BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_SCHEMA)
-            .setTableReference(
-                new TableReference()
-                    .setTableId(BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_NAME)
-                    .setDatasetId(this.bigQueryDatasetId)
-                    .setProjectId(this.project)));
-    this.bqClient.insertDataToTable(
-        this.project,
-        this.bigQueryDatasetId,
-        BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_NAME,
-        BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_DATA);
-    this.options.setQuery(
+  private BigQueryToTableOptions setupNewTypesQueryTest(String outputTable) {
+    BigQueryToTableOptions options =
+        TestPipeline.testingPipelineOptions().as(BigQueryToTableOptions.class);
+    options.setTempLocation(options.getTempRoot() + "/bq_it_temp");
+    options.setQuery(
         String.format(
             "SELECT bytes, date, time FROM [%s:%s.%s]",
-            project, this.bigQueryDatasetId, BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_NAME));
-    this.options.setOutput(outputTable);
-    this.options.setOutputSchema(BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_SCHEMA);
+            project, bigQueryDatasetId, BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_NAME));
+    options.setOutput(outputTable);
+    options.setOutputSchema(BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_SCHEMA);
+    return options;
   }
 
-  private void setupStandardQueryTest() {
-    this.setupLegacyQueryTest();
-    this.options.setQuery(
+  private BigQueryToTableOptions setupStandardQueryTest(String outputTable) {
+    BigQueryToTableOptions options = this.setupLegacyQueryTest(outputTable);
+    options.setTempLocation(options.getTempRoot() + "/bq_it_temp");
+    options.setQuery(
         "SELECT * FROM (SELECT \"apple\" as fruit) UNION ALL (SELECT \"orange\" as fruit)");
-    this.options.setUsingStandardSql(true);
+    options.setUsingStandardSql(true);
+    return options;
   }
 
-  private void verifyLegacyQueryRes() throws Exception {
+  private void verifyLegacyQueryRes(String outputTable) throws Exception {
     LOG.info("Starting verifyLegacyQueryRes in outputTable {}", outputTable);
     List<String> legacyQueryExpectedRes = ImmutableList.of("apple", "orange");
     QueryResponse response =
         bqClient.queryWithRetries(String.format("SELECT fruit from [%s];", outputTable), project);
-    LOG.info("Finished to query result table {}", this.outputTable);
+    LOG.info("Finished to query result table {}", outputTable);
     List<String> tableResult =
         response
             .getRows()
@@ -167,7 +158,7 @@ public class BigQueryToTableIT {
     assertEquals(legacyQueryExpectedRes, tableResult);
   }
 
-  private void verifyNewTypesQueryRes() throws Exception {
+  private void verifyNewTypesQueryRes(String outputTable) throws Exception {
     LOG.info("Starting verifyNewTypesQueryRes with outputTable {}", outputTable);
     List<String> newTypeQueryExpectedRes =
         ImmutableList.of(
@@ -176,8 +167,8 @@ public class BigQueryToTableIT {
             "xyw=,2011-01-01,23:59:59.999999");
     QueryResponse response =
         bqClient.queryWithRetries(
-            String.format("SELECT bytes, date, time FROM [%s];", this.outputTable), this.project);
-    LOG.info("Finished to query result table {}", this.outputTable);
+            String.format("SELECT bytes, date, time FROM [%s];", outputTable), project);
+    LOG.info("Finished to query result table {}", outputTable);
     List<String> tableResult =
         response
             .getRows()
@@ -199,8 +190,8 @@ public class BigQueryToTableIT {
     assertEquals(newTypeQueryExpectedRes, tableResult);
   }
 
-  private void verifyStandardQueryRes() throws Exception {
-    this.verifyLegacyQueryRes();
+  private void verifyStandardQueryRes(String outputTable) throws Exception {
+    this.verifyLegacyQueryRes(outputTable);
   }
 
   /** Customized PipelineOption for BigQueryToTable Pipeline. */
@@ -239,99 +230,118 @@ public class BigQueryToTableIT {
     void setUsingStandardSql(boolean usingStandardSql);
   }
 
-  @Before
-  public void setupBqEnvironment() {
-    Long timeSeed = System.currentTimeMillis();
-    Integer random = new Random(timeSeed).nextInt(900) + 100;
-    this.bigQueryDatasetId = "bq_query_to_table_" + timeSeed.toString() + "_" + random.toString();
+  @BeforeClass
+  public static void setupTestEnvironment() throws Exception {
     PipelineOptionsFactory.register(BigQueryToTableOptions.class);
-    options = TestPipeline.testingPipelineOptions().as(BigQueryToTableOptions.class);
-    options.setTempLocation(options.getTempRoot() + "/bq_it_temp");
-    project = TestPipeline.testingPipelineOptions().as(GcpOptions.class).getProject();
 
-    bqOption = options.as(BigQueryOptions.class);
-    bqClient = new BigqueryClient(bqOption.getAppName());
-    bqClient.createNewDataset(project, this.bigQueryDatasetId);
-    outputTable =
-        project + ":" + this.bigQueryDatasetId + "." + BigQueryToTableIT.OUTPUT_TABLE_NAME;
+    // Create one BQ dataset for all test cases.
+    bqClient.createNewDataset(project, bigQueryDatasetId);
+
+    // Create table and insert data for new type query test cases.
+    bqClient.createNewTable(
+        project,
+        bigQueryDatasetId,
+        new Table()
+            .setSchema(BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_SCHEMA)
+            .setTableReference(
+                new TableReference()
+                    .setTableId(BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_NAME)
+                    .setDatasetId(bigQueryDatasetId)
+                    .setProjectId(project)));
+    bqClient.insertDataToTable(
+        project,
+        bigQueryDatasetId,
+        BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_NAME,
+        BigQueryToTableIT.NEW_TYPES_QUERY_TABLE_DATA);
   }
 
-  @After
-  public void cleanBqEnvironment() {
+  @AfterClass
+  public static void cleanup() {
     LOG.info("Start to clean up tables and datasets.");
-    bqClient.deleteDataset(project, this.bigQueryDatasetId);
+    bqClient.deleteDataset(project, bigQueryDatasetId);
   }
 
   @Test
   public void testLegacyQueryWithoutReshuffle() throws Exception {
-    this.setupLegacyQueryTest();
+    final String outputTable =
+        project + ":" + bigQueryDatasetId + "." + "testLegacyQueryWithoutReshuffle";
 
-    this.runBigQueryToTablePipeline();
+    this.runBigQueryToTablePipeline(setupLegacyQueryTest(outputTable));
 
-    this.verifyLegacyQueryRes();
+    this.verifyLegacyQueryRes(outputTable);
   }
 
   @Test
   public void testNewTypesQueryWithoutReshuffle() throws Exception {
-    this.setupNewTypesQueryTest();
+    final String outputTable =
+        project + ":" + bigQueryDatasetId + "." + "testNewTypesQueryWithoutReshuffle";
 
-    this.runBigQueryToTablePipeline();
+    this.runBigQueryToTablePipeline(setupNewTypesQueryTest(outputTable));
 
-    this.verifyNewTypesQueryRes();
+    this.verifyNewTypesQueryRes(outputTable);
   }
 
   @Test
   public void testNewTypesQueryWithReshuffle() throws Exception {
-    this.setupNewTypesQueryTest();
-    this.options.setReshuffle(true);
+    final String outputTable =
+        project + ":" + bigQueryDatasetId + "." + "testNewTypesQueryWithReshuffle";
+    BigQueryToTableOptions options = setupNewTypesQueryTest(outputTable);
+    options.setReshuffle(true);
 
-    this.runBigQueryToTablePipeline();
+    this.runBigQueryToTablePipeline(options);
 
-    this.verifyNewTypesQueryRes();
+    this.verifyNewTypesQueryRes(outputTable);
   }
 
   @Test
   public void testStandardQueryWithoutCustom() throws Exception {
-    this.setupStandardQueryTest();
+    final String outputTable =
+        project + ":" + bigQueryDatasetId + "." + "testStandardQueryWithoutCustom";
 
-    this.runBigQueryToTablePipeline();
+    this.runBigQueryToTablePipeline(setupStandardQueryTest(outputTable));
 
-    this.verifyStandardQueryRes();
+    this.verifyStandardQueryRes(outputTable);
   }
 
   @Test
   @Category(DataflowPortabilityApiUnsupported.class)
   public void testNewTypesQueryWithoutReshuffleWithCustom() throws Exception {
-    this.setupNewTypesQueryTest();
-    this.options.setExperiments(
+    final String outputTable =
+        project + ":" + bigQueryDatasetId + "." + "testNewTypesQueryWithoutReshuffleWithCustom";
+    BigQueryToTableOptions options = this.setupNewTypesQueryTest(outputTable);
+    options.setExperiments(
         ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
 
-    this.runBigQueryToTablePipeline();
+    this.runBigQueryToTablePipeline(options);
 
-    this.verifyNewTypesQueryRes();
+    this.verifyNewTypesQueryRes(outputTable);
   }
 
   @Test
   @Category(DataflowPortabilityApiUnsupported.class)
   public void testLegacyQueryWithoutReshuffleWithCustom() throws Exception {
-    this.setupLegacyQueryTest();
-    this.options.setExperiments(
+    final String outputTable =
+        project + ":" + bigQueryDatasetId + "." + "testLegacyQueryWithoutReshuffleWithCustom";
+    BigQueryToTableOptions options = this.setupLegacyQueryTest(outputTable);
+    options.setExperiments(
         ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
 
-    this.runBigQueryToTablePipeline();
+    this.runBigQueryToTablePipeline(options);
 
-    this.verifyLegacyQueryRes();
+    this.verifyLegacyQueryRes(outputTable);
   }
 
   @Test
   @Category(DataflowPortabilityApiUnsupported.class)
   public void testStandardQueryWithoutReshuffleWithCustom() throws Exception {
-    this.setupStandardQueryTest();
-    this.options.setExperiments(
+    final String outputTable =
+        project + ":" + bigQueryDatasetId + "." + "testStandardQueryWithoutReshuffleWithCustom";
+    BigQueryToTableOptions options = this.setupStandardQueryTest(outputTable);
+    options.setExperiments(
         ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
 
-    this.runBigQueryToTablePipeline();
+    this.runBigQueryToTablePipeline(options);
 
-    this.verifyStandardQueryRes();
+    this.verifyStandardQueryRes(outputTable);
   }
 }


### PR DESCRIPTION
This PR is aimed to reduce the flakiness of BigQueryToTableIT.

Changes in BigQueryClient enable retry strategies in
1. Create dataset.
2. Create table.
3. Insert data into the table.

Changes in BigQueryToTableIT focus on
1. Make all test cases use one pre-created dataset, instead of a dataset per test case.
2. Each test outputs to its own table, instead of one output table for all tests.
3. Make creating dataset and the input table before all tests start(\@BeforeClass).
4. Delete tables and dataset after all tests finishing(\@AfterClass).

R: @apilloud 