### PR TITLE
Fix go PostCommit break

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/fn_arity.tmpl
+++ b/sdks/go/pkg/beam/core/runtime/exec/fn_arity.tmpl
@@ -5,7 +5,7 @@
 // (the "License"); you may not use this file except in compliance with
 // the License.  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,53 +18,52 @@
 package exec
 
 import (
-    "github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
-    "github.com/apache/beam/sdks/go/pkg/beam/core/typex"
+	"fmt"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 )
 
 // initCall initializes the caller for the invoker, avoiding slice allocation for the 
 // return values, and uses a cached return processor to handle the different possible
 // return cases.
 func (n *invoker) initCall() {
-    switch fn := n.fn.Fn.(type) {
+	switch fn := n.fn.Fn.(type) {
 {{range $out := upto 4}}
 {{range $in := upto 8}}
-    case reflectx.Func{{$in}}x{{$out}}:
-        n.call = func(ws []typex.Window, ts typex.EventTime) (*FullValue, error) {
+	case reflectx.Func{{$in}}x{{$out}}:
+		n.call = func(ws []typex.Window, ts typex.EventTime) (*FullValue, error) {
 			{{if $out}}{{mktuplef $out "r%v"}} := {{end}}fn.Call{{$in}}x{{$out}}({{mktuplef $in "n.args[%v]"}})
-            {{- if $out}}
-            return n.ret{{$out}}(ws, ts, {{mktuplef $out "r%v"}})
-            {{- else}}
+			{{- if $out}}
+			return n.ret{{$out}}(ws, ts, {{mktuplef $out "r%v"}})
+			{{- else}}
 			return nil, nil
-            {{- end}}
+			{{- end}}
 		}
 {{end}}
 {{end}}
-    default:
-        n.call = func(ws []typex.Window, ts typex.EventTime) (*FullValue, error) {
-            ret := n.fn.Fn.Call(n.args)
-            if n.errIdx >= 0 && ret[n.errIdx] != nil {
-                return nil, ret[n.errIdx].(error)
-            }
+	default:
+		n.call = func(ws []typex.Window, ts typex.EventTime) (*FullValue, error) {
+			ret := n.fn.Fn.Call(n.args)
+			if n.outErrIdx >= 0 && ret[n.outErrIdx] != nil {
+				return nil, ret[n.outErrIdx].(error)
+			}
 
-            // (5) Return direct output, if any. Input timestamp and windows are implicitly
-            // propagated.
-
-            out := n.out
-            if len(out) > 0 {
-                n.ret = FullValue{Windows: ws, Timestamp: ts}
-                if n.outEtIdx >= 0 {
-                    n.ret.Timestamp = ret[n.outEtIdx].(typex.EventTime)
-                }
-                // TODO(herohde) 4/16/2018: apply windowing function to elements with explicit timestamp?
-
-                n.ret.Elm = ret[out[0]]
-                if len(out) > 1 {
-                    n.ret.Elm2 = ret[out[1]]
-                }
-                return &n.ret, nil
-            }
-            return nil, nil
-        } 
-    }
+			// (5) Return direct output, if any. Input timestamp and windows are implicitly
+			// propagated.
+			switch len(ret) {
+			case 0:
+				return nil, nil
+			case 1:
+				return n.ret1(ws, ts, ret[0])
+			case 2:
+				return n.ret2(ws, ts, ret[0], ret[1])
+			case 3:
+				return n.ret3(ws, ts, ret[0], ret[1], ret[2])
+			case 4:
+				return n.ret4(ws, ts, ret[0], ret[1], ret[2], ret[3])
+			}
+			panic(fmt.Sprintf("invoker: %v has > 4 return values, which is not permitted", n.fn.Fn.Name()))
+		} 
+	}
 }


### PR DESCRIPTION
I committed 3 errors here:
* The test wasn't covering what I thought it was, since none of the TestInvoke functions have shims.
* The breaking error: The type assertion to error on a nil, which isn't permitted. Needs a check first.
* The event time (which is currently sporadically used), wasn't being checked properly, the wrong index was being used.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




