### PR TITLE
[BEAM-6378] Updating Tika

### DIFF
--- a/sdks/java/io/tika/build.gradle
+++ b/sdks/java/io/tika/build.gradle
@@ -22,7 +22,7 @@ applyJavaNature()
 description = "Apache Beam :: SDKs :: Java :: IO :: Tika"
 ext.summary = "Tika Input to parse files."
 
-def tika_version = "1.19.1"
+def tika_version = "1.20"
 def bndlib_version = "1.43.0"
 
 dependencies {


### PR DESCRIPTION
We need to update Apache Tika due to:

[CVE-2018-17197] Apache Tika Denial of Service -- Infinite Loop in Tika's SQLite3Parser