### PR TITLE
[BEAM-6346] Inspect the docker container state

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerCommand.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerCommand.java
@@ -96,6 +96,26 @@ class DockerCommand {
   }
 
   /**
+   * Check if the given container state is running.
+   *
+   * @param containerId Id of the container to check
+   */
+  public boolean isContainerRunning(String containerId)
+      throws IOException, TimeoutException, InterruptedException {
+    checkArgument(!containerId.isEmpty(), "Docker containerId required");
+    // TODO: Validate args?
+    return runShortCommand(
+            ImmutableList.<String>builder()
+                .add(dockerExecutable)
+                .add("inspect")
+                .add("-f")
+                .add("{{.State.Running}}")
+                .add(containerId)
+                .build())
+        .equalsIgnoreCase("true");
+  }
+
+  /**
    * Kills a docker container by container id.
    *
    * @throws IOException if an IOException occurs or if the given container id does not exist

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
@@ -153,8 +153,10 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
       // Wait on a client from the gRPC server.
       while (instructionHandler == null) {
         try {
-          instructionHandler = clientSource.take(workerId, Duration.ofMinutes(2));
+          instructionHandler = clientSource.take(workerId, Duration.ofMinutes(1));
         } catch (TimeoutException timeoutEx) {
+          Preconditions.checkArgument(
+              docker.isContainerRunning(containerId), "No container running for id " + containerId);
           LOG.info(
               "Still waiting for startup of environment {} for worker id {}",
               dockerPayload.getContainerImage(),

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/DockerCommandTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/DockerCommandTest.java
@@ -57,12 +57,14 @@ public class DockerCommandTest {
         docker.runImage(
             "debian", ImmutableList.of(), ImmutableList.of("/bin/bash", "-c", "sleep 60"));
     Stopwatch stopwatch = Stopwatch.createStarted();
+    assertThat("Container should be running.", docker.isContainerRunning(container), is(true));
     docker.killContainer(container);
     long elapsedSec = stopwatch.elapsed(TimeUnit.SECONDS);
     assertThat(
         "Container termination should complete before image self-exits",
         elapsedSec,
         is(lessThan(60L)));
+    assertThat("Container should be terminated.", docker.isContainerRunning(container), is(false));
   }
 
   @Test

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.fnexecution.environment;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -89,6 +90,7 @@ public class DockerEnvironmentFactoryTest {
   public void createsCorrectEnvironment() throws Exception {
     when(docker.runImage(Mockito.eq(IMAGE_NAME), Mockito.any(), Mockito.any()))
         .thenReturn(CONTAINER_ID);
+    when(docker.isContainerRunning(Mockito.eq(CONTAINER_ID))).thenReturn(true);
 
     RemoteEnvironment handle = factory.createEnvironment(ENVIRONMENT);
     assertThat(handle.getInstructionRequestHandler(), is(client));
@@ -99,6 +101,7 @@ public class DockerEnvironmentFactoryTest {
   public void destroysCorrectContainer() throws Exception {
     when(docker.runImage(Mockito.eq(IMAGE_NAME), Mockito.any(), Mockito.any()))
         .thenReturn(CONTAINER_ID);
+    when(docker.isContainerRunning(Mockito.eq(CONTAINER_ID))).thenReturn(true);
 
     RemoteEnvironment handle = factory.createEnvironment(ENVIRONMENT);
     handle.close();
@@ -107,6 +110,7 @@ public class DockerEnvironmentFactoryTest {
 
   @Test
   public void createsMultipleEnvironments() throws Exception {
+    when(docker.isContainerRunning(anyString())).thenReturn(true);
     Environment fooEnv = Environments.createDockerEnvironment("foo");
     RemoteEnvironment fooHandle = factory.createEnvironment(fooEnv);
     assertThat(fooHandle.getEnvironment(), is(equalTo(fooEnv)));


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




