### PR TITLE
[BEAM-6332] Lazy serialization of aggregation results in Spark runner.

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/BeamSparkRunnerRegistrator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/BeamSparkRunnerRegistrator.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import org.apache.beam.runners.spark.io.MicrobatchSource;
 import org.apache.beam.runners.spark.stateful.SparkGroupAlsoByWindowViaWindowSet.StateAndTimers;
+import org.apache.beam.runners.spark.translation.GroupCombineFunctions;
 import org.apache.beam.runners.spark.util.ByteArray;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.KV;
@@ -44,6 +45,10 @@ public class BeamSparkRunnerRegistrator implements KryoRegistrator {
   public void registerClasses(Kryo kryo) {
     // MicrobatchSource is serialized as data and may not be Kryo-serializable.
     kryo.register(MicrobatchSource.class, new StatelessJavaSerializer());
+
+    kryo.register(
+        GroupCombineFunctions.SerializableAccumulator.class,
+        new GroupCombineFunctions.KryoAccumulatorSerializer());
 
     kryo.register(WrappedArray.ofRef.class);
     kryo.register(Object[].class);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
@@ -241,8 +241,7 @@ public final class TransformTranslator {
         JavaRDD<WindowedValue<OutputT>> outRdd;
 
         Optional<Iterable<WindowedValue<AccumT>>> maybeAccumulated =
-            GroupCombineFunctions.combineGlobally(
-                inRdd, sparkCombineFn, iCoder, aCoder, windowingStrategy);
+            GroupCombineFunctions.combineGlobally(inRdd, sparkCombineFn, aCoder, windowingStrategy);
 
         if (maybeAccumulated.isPresent()) {
           Iterable<WindowedValue<OutputT>> output =
@@ -313,12 +312,7 @@ public final class TransformTranslator {
 
         JavaPairRDD<K, Iterable<WindowedValue<KV<K, AccumT>>>> accumulatePerKey =
             GroupCombineFunctions.combinePerKey(
-                inRdd,
-                sparkCombineFn,
-                inputCoder.getKeyCoder(),
-                inputCoder.getValueCoder(),
-                vaCoder,
-                windowingStrategy);
+                inRdd, sparkCombineFn, inputCoder.getKeyCoder(), vaCoder, windowingStrategy);
 
         JavaRDD<WindowedValue<KV<K, OutputT>>> outRdd =
             accumulatePerKey

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/GroupCombineFunctionsTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/GroupCombineFunctionsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.common.collect.Lists;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.apache.beam.runners.spark.coders.CoderHelpers;
+import org.apache.beam.runners.spark.translation.GroupCombineFunctions.KryoAccumulatorSerializer;
+import org.apache.beam.runners.spark.translation.GroupCombineFunctions.SerializableAccumulator;
+import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Unit tests of {@link GroupCombineFunctions}. */
+public class GroupCombineFunctionsTest {
+
+  @Test
+  public void serializableAccumulatorTest() {
+
+    Iterable<WindowedValue<Integer>> accumulatedValue =
+        Lists.newArrayList(winVal(0), winVal(1), winVal(3), winVal(4));
+
+    final WindowedValue.FullWindowedValueCoder<Integer> wvaCoder =
+        WindowedValue.FullWindowedValueCoder.of(
+            BigEndianIntegerCoder.of(), GlobalWindow.Coder.INSTANCE);
+
+    final IterableCoder<WindowedValue<Integer>> iterAccumCoder = IterableCoder.of(wvaCoder);
+
+    SerializableAccumulator<Integer> accUnderTest =
+        SerializableAccumulator.of(accumulatedValue, iterAccumCoder);
+    Assert.assertEquals(accumulatedValue, accUnderTest.getOrDecode(iterAccumCoder));
+
+    byte[] bytes = accUnderTest.toBytes();
+    Assert.assertEquals(accumulatedValue, CoderHelpers.fromByteArray(bytes, iterAccumCoder));
+
+    SerializableAccumulator<Integer> accFromBytes = SerializableAccumulator.ofBytes(bytes);
+    Assert.assertEquals(accumulatedValue, accFromBytes.getOrDecode(iterAccumCoder));
+  }
+
+  @Test
+  public void serializableAccumulatorSerializationTest()
+      throws IOException, ClassNotFoundException {
+
+    @SuppressWarnings("unchecked")
+    Iterable<WindowedValue<Integer>> accumulatedValue =
+        Lists.newArrayList(winVal(0), winVal(1), winVal(3), winVal(4));
+
+    final WindowedValue.FullWindowedValueCoder<Integer> wvaCoder =
+        WindowedValue.FullWindowedValueCoder.of(
+            BigEndianIntegerCoder.of(), GlobalWindow.Coder.INSTANCE);
+
+    final IterableCoder<WindowedValue<Integer>> iterAccumCoder = IterableCoder.of(wvaCoder);
+
+    SerializableAccumulator<Integer> accUnderTest =
+        SerializableAccumulator.of(accumulatedValue, iterAccumCoder);
+
+    ByteArrayOutputStream inMemOut = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(inMemOut);
+    oos.writeObject(accUnderTest);
+
+    ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(inMemOut.toByteArray()));
+
+    @SuppressWarnings("unchecked")
+    SerializableAccumulator<Integer> materialized =
+        (SerializableAccumulator<Integer>) ois.readObject();
+    Assert.assertEquals(accumulatedValue, materialized.getOrDecode(iterAccumCoder));
+  }
+
+  @Test
+  public void serializableAccumulatorKryoTest() throws IOException, ClassNotFoundException {
+
+    Iterable<WindowedValue<Integer>> accumulatedValue =
+        Lists.newArrayList(winVal(0), winVal(1), winVal(3), winVal(4));
+
+    final WindowedValue.FullWindowedValueCoder<Integer> wvaCoder =
+        WindowedValue.FullWindowedValueCoder.of(
+            BigEndianIntegerCoder.of(), GlobalWindow.Coder.INSTANCE);
+
+    final IterableCoder<WindowedValue<Integer>> iterAccumCoder = IterableCoder.of(wvaCoder);
+
+    SerializableAccumulator<Integer> accUnderTest =
+        SerializableAccumulator.of(accumulatedValue, iterAccumCoder);
+
+    KryoAccumulatorSerializer kryoSerializer = new KryoAccumulatorSerializer();
+    Kryo kryo = new Kryo();
+    kryo.register(SerializableAccumulator.class, kryoSerializer);
+
+    ByteArrayOutputStream inMemOut = new ByteArrayOutputStream();
+    Output out = new Output(inMemOut);
+    kryo.writeObject(out, accUnderTest);
+    out.close();
+
+    Input input = new Input(new ByteArrayInputStream(inMemOut.toByteArray()));
+
+    @SuppressWarnings("unchecked")
+    SerializableAccumulator<Integer> materialized =
+        (SerializableAccumulator<Integer>) kryo.readObject(input, SerializableAccumulator.class);
+    input.close();
+
+    Assert.assertEquals(accumulatedValue, materialized.getOrDecode(iterAccumCoder));
+  }
+
+  private <T> WindowedValue<T> winVal(T val) {
+    return WindowedValue.of(val, Instant.now(), GlobalWindow.INSTANCE, PaneInfo.NO_FIRING);
+  }
+}


### PR DESCRIPTION
Introducing `SerializableAccumulator` to avoid unnecessary serializations for each aggregated element. Both Sparks serialization mechanism are supported (Kryo and Java serialization).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




