### PR TITLE
[BEAM-6030] Split metrics related options out of PipelineOptions

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsPusher.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsPusher.java
@@ -32,8 +32,8 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsFilter;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.metrics.MetricsSink;
-import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.InstanceBuilder;
 
 /** Component that regularly merges metrics and pushes them to a metrics sink. */
@@ -48,7 +48,7 @@ public class MetricsPusher implements Serializable {
 
   public MetricsPusher(
       MetricsContainerStepMap metricsContainerStepMap,
-      PipelineOptions pipelineOptions,
+      MetricsOptions pipelineOptions,
       PipelineResult pipelineResult) {
     this.metricsContainerStepMap = metricsContainerStepMap;
     this.pipelineResult = pipelineResult;
@@ -58,7 +58,7 @@ public class MetricsPusher implements Serializable {
     metricsSink =
         InstanceBuilder.ofType(MetricsSink.class)
             .fromClass(pipelineOptions.getMetricsSink())
-            .withArg(PipelineOptions.class, pipelineOptions)
+            .withArg(MetricsOptions.class, pipelineOptions)
             .build();
   }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/NoOpMetricsSink.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/NoOpMetricsSink.java
@@ -18,8 +18,8 @@
 package org.apache.beam.runners.core.metrics;
 
 import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.metrics.MetricsSink;
-import org.apache.beam.sdk.options.PipelineOptions;
 
 /**
  * This is the default metrics sink that does nothing. When it is set, MetricsPusher does not start
@@ -27,7 +27,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
  */
 public class NoOpMetricsSink implements MetricsSink {
 
-  public NoOpMetricsSink(PipelineOptions pipelineOptions) {}
+  public NoOpMetricsSink(MetricsOptions pipelineOptions) {}
 
   @Override
   public void writeMetrics(MetricQueryResults metricQueryResults) throws Exception {}

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsPusherTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsPusherTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertThat;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
-import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesAttemptedMetrics;
 import org.apache.beam.sdk.testing.UsesCounterMetrics;
@@ -53,7 +53,7 @@ public class MetricsPusherTest {
   @Before
   public void init() {
     TestMetricsSink.clear();
-    PipelineOptions options = pipeline.getOptions();
+    MetricsOptions options = pipeline.getOptions().as(MetricsOptions.class);
     options.setMetricsSink(TestMetricsSink.class);
   }
 
@@ -67,7 +67,8 @@ public class MetricsPusherTest {
         .apply(ParDo.of(new CountingDoFn()));
     pipeline.run();
     // give metrics pusher time to push
-    Thread.sleep((pipeline.getOptions().getMetricsPushPeriod() + 1L) * 1000);
+    Thread.sleep(
+        (pipeline.getOptions().as(MetricsOptions.class).getMetricsPushPeriod() + 1L) * 1000);
     assertThat(TestMetricsSink.getCounterValue(), is(NUM_ELEMENTS));
   }
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/TestMetricsSink.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/TestMetricsSink.java
@@ -18,8 +18,8 @@
 package org.apache.beam.runners.core.metrics;
 
 import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.metrics.MetricsSink;
-import org.apache.beam.sdk.options.PipelineOptions;
 
 /**
  * This sink just stores in a static field the first counter (if it exists) attempted value. This is
@@ -29,7 +29,7 @@ public class TestMetricsSink implements MetricsSink {
 
   private static long counterValue;
 
-  public TestMetricsSink(PipelineOptions pipelineOptions) {}
+  public TestMetricsSink(MetricsOptions pipelineOptions) {}
 
   public static long getCounterValue() {
     return counterValue;

--- a/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSink.java
+++ b/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSink.java
@@ -30,8 +30,8 @@ import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.GaugeResult;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.metrics.MetricsSink;
-import org.apache.beam.sdk.options.PipelineOptions;
 
 /**
  * Sink to push metrics to Graphite. Graphite requires a timestamp. So metrics are reported with the
@@ -49,7 +49,7 @@ public class MetricsGraphiteSink implements MetricsSink {
   private final int port;
   private final Charset charset;
 
-  public MetricsGraphiteSink(PipelineOptions pipelineOptions) {
+  public MetricsGraphiteSink(MetricsOptions pipelineOptions) {
     this.address = pipelineOptions.getMetricsGraphiteHost();
     this.port = pipelineOptions.getMetricsGraphitePort();
     this.charset = UTF_8;

--- a/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSink.java
+++ b/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSink.java
@@ -31,15 +31,15 @@ import java.nio.charset.StandardCharsets;
 import javax.xml.ws.http.HTTPException;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.metrics.MetricsSink;
-import org.apache.beam.sdk.options.PipelineOptions;
 
 /** HTTP Sink to push metrics in a POST HTTP request. */
 public class MetricsHttpSink implements MetricsSink {
   private final String urlString;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  public MetricsHttpSink(PipelineOptions pipelineOptions) {
+  public MetricsHttpSink(MetricsOptions pipelineOptions) {
     this.urlString = pipelineOptions.getMetricsHttpSinkUrl();
   }
 

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSinkTest.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSinkTest.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.concurrent.CountDownLatch;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
-import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -59,7 +59,7 @@ public class MetricsGraphiteSinkTest {
   @Test
   public void testWriteMetricsWithCommittedSupported() throws Exception {
     MetricQueryResults metricQueryResults = new CustomMetricQueryResults(true);
-    PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+    MetricsOptions pipelineOptions = PipelineOptionsFactory.create().as(MetricsOptions.class);
     pipelineOptions.setMetricsGraphitePort(port);
     pipelineOptions.setMetricsGraphiteHost("127.0.0.1");
     MetricsGraphiteSink metricsGraphiteSink = new MetricsGraphiteSink(pipelineOptions);
@@ -89,7 +89,7 @@ public class MetricsGraphiteSinkTest {
   @Test
   public void testWriteMetricsWithCommittedUnSupported() throws Exception {
     MetricQueryResults metricQueryResults = new CustomMetricQueryResults(false);
-    PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+    MetricsOptions pipelineOptions = PipelineOptionsFactory.create().as(MetricsOptions.class);
     pipelineOptions.setMetricsGraphitePort(port);
     pipelineOptions.setMetricsGraphiteHost("127.0.0.1");
     MetricsGraphiteSink metricsGraphiteSink = new MetricsGraphiteSink(pipelineOptions);

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSinkTest.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSinkTest.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
-import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -80,7 +80,7 @@ public class MetricsHttpSinkTest {
   @Test
   public void testWriteMetricsWithCommittedSupported() throws Exception {
     MetricQueryResults metricQueryResults = new CustomMetricQueryResults(true);
-    PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+    MetricsOptions pipelineOptions = PipelineOptionsFactory.create().as(MetricsOptions.class);
     pipelineOptions.setMetricsHttpSinkUrl(String.format("http://localhost:%s", port));
     MetricsHttpSink metricsHttpSink = new MetricsHttpSink(pipelineOptions);
     countDownLatch = new CountDownLatch(1);
@@ -102,7 +102,7 @@ public class MetricsHttpSinkTest {
   @Test
   public void testWriteMetricsWithCommittedUnSupported() throws Exception {
     MetricQueryResults metricQueryResults = new CustomMetricQueryResults(false);
-    PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+    MetricsOptions pipelineOptions = PipelineOptionsFactory.create().as(MetricsOptions.class);
     pipelineOptions.setMetricsHttpSinkUrl(String.format("http://localhost:%s", port));
     MetricsHttpSink metricsHttpSink = new MetricsHttpSink(pipelineOptions);
     countDownLatch = new CountDownLatch(1);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
 import org.apache.beam.sdk.runners.TransformHierarchy;
@@ -133,7 +134,9 @@ public class FlinkRunner extends PipelineRunner<PipelineResult> {
           new FlinkRunnerResult(accumulators, result.getNetRuntime());
       MetricsPusher metricsPusher =
           new MetricsPusher(
-              flinkRunnerResult.getMetricsContainerStepMap(), options, flinkRunnerResult);
+              flinkRunnerResult.getMetricsContainerStepMap(),
+              options.as(MetricsOptions.class),
+              flinkRunnerResult);
       metricsPusher.start();
       return flinkRunnerResult;
     }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunner.java
@@ -45,6 +45,7 @@ import org.apache.beam.runners.spark.util.GlobalWatermarkHolder.WatermarkAdvanci
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
@@ -237,7 +238,8 @@ public final class SparkRunner extends PipelineRunner<SparkPipelineResult> {
     // runner-specific
     // MetricsContainerStepMap
     MetricsPusher metricsPusher =
-        new MetricsPusher(MetricsAccumulator.getInstance().value(), mOptions, result);
+        new MetricsPusher(
+            MetricsAccumulator.getInstance().value(), mOptions.as(MetricsOptions.class), result);
     metricsPusher.start();
     return result;
   }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/metrics/SparkMetricsPusherTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/metrics/SparkMetricsPusherTest.java
@@ -28,7 +28,7 @@ import org.apache.beam.runners.spark.io.CreateStream;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
-import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Create;
@@ -63,7 +63,7 @@ public class SparkMetricsPusherTest {
   @Before
   public void init() {
     TestMetricsSink.clear();
-    PipelineOptions options = pipeline.getOptions();
+    MetricsOptions options = pipeline.getOptions().as(MetricsOptions.class);
     options.setMetricsSink(TestMetricsSink.class);
   }
 
@@ -94,7 +94,8 @@ public class SparkMetricsPusherTest {
 
     pipeline.run();
     // give metrics pusher time to push
-    Thread.sleep((pipeline.getOptions().getMetricsPushPeriod() + 1L) * 1000);
+    Thread.sleep(
+        (pipeline.getOptions().as(MetricsOptions.class).getMetricsPushPeriod() + 1L) * 1000);
     assertThat(TestMetricsSink.getCounterValue(), is(6L));
   }
 
@@ -119,7 +120,8 @@ public class SparkMetricsPusherTest {
 
     pipeline.run();
     // give metrics pusher time to push
-    Thread.sleep((pipeline.getOptions().getMetricsPushPeriod() + 1L) * 1000);
+    Thread.sleep(
+        (pipeline.getOptions().as(MetricsOptions.class).getMetricsPushPeriod() + 1L) * 1000);
     assertThat(TestMetricsSink.getCounterValue(), is(6L));
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricsOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricsOptions.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.metrics;
+
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.DefaultValueFactory;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
+
+/** Extension of {@link PipelineOptions} that defines {@link MetricsSink} specific options */
+public interface MetricsOptions extends PipelineOptions {
+  @Description("The beam sink class to which the metrics will be pushed")
+  @Default.InstanceFactory(NoOpMetricsSink.class)
+  Class<? extends MetricsSink> getMetricsSink();
+
+  void setMetricsSink(Class<? extends MetricsSink> metricsSink);
+
+  /**
+   * A {@link DefaultValueFactory} that obtains the class of the {@code NoOpMetricsSink} if it
+   * exists on the classpath, and throws an exception otherwise.
+   *
+   * <p>As the {@code NoOpMetricsSink} is in an independent module, it cannot be directly referenced
+   * as the {@link Default}. However, it should still be used if available.
+   */
+  class NoOpMetricsSink implements DefaultValueFactory<Class<? extends MetricsSink>> {
+    @Override
+    public Class<? extends MetricsSink> create(PipelineOptions options) {
+      try {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Class<? extends MetricsSink> noOpMetricsSinkClass =
+            (Class<? extends MetricsSink>)
+                Class.forName(
+                    "org.apache.beam.runners.core.metrics.NoOpMetricsSink",
+                    true,
+                    ReflectHelpers.findClassLoader());
+        return noOpMetricsSinkClass;
+      } catch (ClassNotFoundException e) {
+        throw new IllegalArgumentException(
+            String.format("NoOpMetricsSink was not found on classpath"));
+      }
+    }
+  }
+
+  @Description("The metrics push period in seconds")
+  @Default.Long(5)
+  Long getMetricsPushPeriod();
+
+  void setMetricsPushPeriod(Long period);
+
+  @Description("MetricsHttpSink url")
+  String getMetricsHttpSinkUrl();
+
+  void setMetricsHttpSinkUrl(String metricsSink);
+
+  @Description("The graphite metrics host")
+  String getMetricsGraphiteHost();
+
+  void setMetricsGraphiteHost(String host);
+
+  @Description("The graphite metrics port")
+  @Default.Integer(2003)
+  Integer getMetricsGraphitePort();
+
+  void setMetricsGraphitePort(Integer port);
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineRunner;
-import org.apache.beam.sdk.metrics.MetricsSink;
 import org.apache.beam.sdk.options.ProxyInvocationHandler.Deserializer;
 import org.apache.beam.sdk.options.ProxyInvocationHandler.Serializer;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -402,58 +401,4 @@ public interface PipelineOptions extends HasDisplayData {
       return String.format("%s/%s", info.getName(), info.getVersion()).replace(" ", "_");
     }
   }
-
-  @Description("The beam sink class to which the metrics will be pushed")
-  @Default.InstanceFactory(NoOpMetricsSink.class)
-  Class<? extends MetricsSink> getMetricsSink();
-
-  void setMetricsSink(Class<? extends MetricsSink> metricsSink);
-
-  /**
-   * A {@link DefaultValueFactory} that obtains the class of the {@code NoOpMetricsSink} if it
-   * exists on the classpath, and throws an exception otherwise.
-   *
-   * <p>As the {@code NoOpMetricsSink} is in an independent module, it cannot be directly referenced
-   * as the {@link Default}. However, it should still be used if available.
-   */
-  class NoOpMetricsSink implements DefaultValueFactory<Class<? extends MetricsSink>> {
-    @Override
-    public Class<? extends MetricsSink> create(PipelineOptions options) {
-      try {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        Class<? extends MetricsSink> noOpMetricsSinkClass =
-            (Class<? extends MetricsSink>)
-                Class.forName(
-                    "org.apache.beam.runners.core.metrics.NoOpMetricsSink",
-                    true,
-                    ReflectHelpers.findClassLoader());
-        return noOpMetricsSinkClass;
-      } catch (ClassNotFoundException e) {
-        throw new IllegalArgumentException(
-            String.format("NoOpMetricsSink was not found on classpath"));
-      }
-    }
-  }
-
-  @Description("The metrics push period in seconds")
-  @Default.Long(5)
-  Long getMetricsPushPeriod();
-
-  void setMetricsPushPeriod(Long period);
-
-  @Description("MetricsHttpSink url")
-  String getMetricsHttpSinkUrl();
-
-  void setMetricsHttpSinkUrl(String metricsSink);
-
-  @Description("The graphite metrics host")
-  String getMetricsGraphiteHost();
-
-  void setMetricsGraphiteHost(String host);
-
-  @Description("The graphite metrics port")
-  @Default.Integer(2003)
-  Integer getMetricsGraphitePort();
-
-  void setMetricsGraphitePort(Integer port);
 }


### PR DESCRIPTION
I chose to put all metrics related options in a single class (as native spark does) rather than extracting only sink options (in either one class or one per sink) because it would have seemed strange to separate sink class choice from its configuration.
R: @kennknowles 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




