### PR TITLE
[BEAM-6361][BEAM-6364] fix user-metric-prefix checking in Flink portable metrics update

### DIFF
--- a/model/fn-execution/src/main/proto/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/beam_fn_api.proto
@@ -335,7 +335,7 @@ message Annotation {
 
 // Populated MonitoringInfoSpecs for specific URNs.
 // Indicating the required fields to be set.
-// SDKS and RunnerHarnesses can load these instances into memory and write a
+// SDKs and RunnerHarnesses can load these instances into memory and write a
 // validator or code generator to assist with populating and validating
 // MonitoringInfo protos.
 message MonitoringInfoSpecs {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilder.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilder.java
@@ -77,7 +77,7 @@ public class SimpleMonitoringInfoBuilder {
     for (MonitoringInfoSpecs.Enum val : MonitoringInfoSpecs.Enum.values()) {
       // The enum iterator inserts an UNRECOGNIZED = -1 value which isn't explicitly added in
       // the proto files.
-      if (!((Enum) val).name().equals("UNRECOGNIZED")) {
+      if (!val.name().equals("UNRECOGNIZED")) {
         MonitoringInfoSpec spec =
             val.getValueDescriptor().getOptions().getExtension(BeamFnApi.monitoringInfoSpec);
         SimpleMonitoringInfoBuilder.specs.put(spec.getUrn(), spec);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
@@ -119,16 +119,17 @@ public class FlinkMetricContainer {
             BeamFnApi.Metric metric = monitoringInfo.getMetric();
             if (metric.hasCounterData()) {
               BeamFnApi.CounterData counterData = metric.getCounterData();
-              org.apache.beam.sdk.metrics.Counter counter = metricsContainer.getCounter(metricName);
               if (counterData.getValueCase() == BeamFnApi.CounterData.ValueCase.INT64_VALUE) {
+                org.apache.beam.sdk.metrics.Counter counter =
+                    metricsContainer.getCounter(metricName);
                 counter.inc(counterData.getInt64Value());
               } else {
-                throw new IllegalArgumentException("Unsupported CounterData type: " + counterData);
+                LOG.warn("Unsupported CounterData type: {}", counterData);
               }
             } else if (metric.hasDistributionData()) {
               BeamFnApi.DistributionData distributionData = metric.getDistributionData();
-              Distribution distribution = metricsContainer.getDistribution(metricName);
               if (distributionData.hasIntDistributionData()) {
+                Distribution distribution = metricsContainer.getDistribution(metricName);
                 BeamFnApi.IntDistributionData intDistributionData =
                     distributionData.getIntDistributionData();
                 distribution.update(
@@ -137,12 +138,11 @@ public class FlinkMetricContainer {
                     intDistributionData.getMin(),
                     intDistributionData.getMax());
               } else {
-                throw new IllegalArgumentException(
-                    "Unsupported DistributionData type: " + distributionData);
+                LOG.warn("Unsupported DistributionData type: {}", distributionData);
               }
             } else if (metric.hasExtremaData()) {
               BeamFnApi.ExtremaData extremaData = metric.getExtremaData();
-              throw new IllegalArgumentException("Extrema metric unsupported: " + extremaData);
+              LOG.warn("Extrema metric unsupported: {}", extremaData);
             }
           }
         });

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
@@ -17,8 +17,8 @@
  */
 package org.apache.beam.runners.flink.metrics;
 
-import static org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfoUrns.Enum.USER_COUNTER_URN_PREFIX;
 import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
+import static org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder.USER_COUNTER_URN_PREFIX;
 
 import java.util.HashMap;
 import java.util.List;
@@ -98,8 +98,8 @@ public class FlinkMetricContainer {
    * <p>TODO: not flink-specific; where should it live?
    */
   public static MetricName parseUrn(String urn) {
-    if (urn.startsWith(USER_COUNTER_URN_PREFIX.toString())) {
-      urn = urn.substring(USER_COUNTER_URN_PREFIX.toString().length());
+    if (urn.startsWith(USER_COUNTER_URN_PREFIX)) {
+      urn = urn.substring(USER_COUNTER_URN_PREFIX.length());
     }
     // If it is not a user counter, just use the first part of the URN, i.e. 'beam'
     String[] pieces = urn.split(":", 2);


### PR DESCRIPTION
two small follow-ups to #7183:
- [BEAM-6361](https://issues.apache.org/jira/browse/BEAM-6361): fix incorrect user-metric-prefix check
- [BEAM-6364](https://issues.apache.org/jira/browse/BEAM-6364): WARN instead of `throw` on as-yet-unsupported metrics types

They're each pretty small, and the tests of the latter depend on the former, so I put them both in this PR; let me know if it would be better if I split them out.

R: @ajamato 
R: @robertwb (we'd previously discussed the [BEAM-6364](https://issues.apache.org/jira/browse/BEAM-6364) portion of this in particular)

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




