### PR TITLE
[BEAM-4143] GcsResourceIdTest has had a masked failure

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceIdTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceIdTester.java
@@ -20,9 +20,9 @@ package org.apache.beam.sdk.io.fs;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY;
 import static org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions.RESOLVE_FILE;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.testing.EqualsTester;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceIdTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceIdTester.java
@@ -112,9 +112,9 @@ public final class ResourceIdTester {
 
     ResourceId file = baseDirectory.resolve("file", RESOLVE_FILE);
     try {
-      baseDirectory.resolve("file2", RESOLVE_FILE);
+      file.resolve("file2", RESOLVE_FILE);
       fail(String.format("Should not be able to resolve against file resource %s", file));
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalStateException e) {
       // expected
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalResourceIdTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalResourceIdTest.java
@@ -33,7 +33,6 @@ import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.fs.ResourceIdTester;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -246,7 +245,6 @@ public class LocalResourceIdTest {
   }
 
   @Test
-  @Ignore("https://issues.apache.org/jira/browse/BEAM-4110")
   public void testResourceIdTester() throws Exception {
     ResourceIdTester.runResourceIdBattery(toResourceIdentifier("/tmp/foo/"));
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalResourceIdTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalResourceIdTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.not;
@@ -24,7 +25,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -52,7 +53,7 @@ public class LocalResourceIdTest {
   @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @Test
-  public void testResolveInUnix() throws Exception {
+  public void testResolveInUnix() {
     if (SystemUtils.IS_OS_WINDOWS) {
       // Skip tests
       return;
@@ -81,7 +82,7 @@ public class LocalResourceIdTest {
   }
 
   @Test
-  public void testResolveNormalizationInUnix() throws Exception {
+  public void testResolveNormalizationInUnix() {
     if (SystemUtils.IS_OS_WINDOWS) {
       // Skip tests
       return;
@@ -137,7 +138,7 @@ public class LocalResourceIdTest {
   }
 
   @Test
-  public void testResolveHandleBadInputsInUnix() throws Exception {
+  public void testResolveHandleBadInputsInUnix() {
     if (SystemUtils.IS_OS_WINDOWS) {
       // Skip tests
       return;
@@ -148,14 +149,14 @@ public class LocalResourceIdTest {
   }
 
   @Test
-  public void testResolveInvalidInputs() throws Exception {
+  public void testResolveInvalidInputs() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("The resolved file: [tmp/] should not end with '/'.");
     toResourceIdentifier("/root/").resolve("tmp/", StandardResolveOptions.RESOLVE_FILE);
   }
 
   @Test
-  public void testResolveInvalidNotDirectory() throws Exception {
+  public void testResolveInvalidNotDirectory() {
     ResourceId tmp =
         toResourceIdentifier("/root/").resolve("tmp", StandardResolveOptions.RESOLVE_FILE);
     thrown.expect(IllegalStateException.class);
@@ -164,7 +165,7 @@ public class LocalResourceIdTest {
   }
 
   @Test
-  public void testResolveInWindowsOS() throws Exception {
+  public void testResolveInWindowsOS() {
     if (!SystemUtils.IS_OS_WINDOWS) {
       // Skip tests
       return;
@@ -189,7 +190,7 @@ public class LocalResourceIdTest {
   }
 
   @Test
-  public void testGetCurrentDirectoryInUnix() throws Exception {
+  public void testGetCurrentDirectoryInUnix() {
     // Tests for local files without the scheme.
     assertEquals(
         toResourceIdentifier("/root/tmp/"),
@@ -201,20 +202,20 @@ public class LocalResourceIdTest {
   }
 
   @Test
-  public void testGetScheme() throws Exception {
+  public void testGetScheme() {
     // Tests for local files without the scheme.
     assertEquals("file", toResourceIdentifier("/root/tmp/").getScheme());
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void testEquals() {
     assertEquals(toResourceIdentifier("/root/tmp/"), toResourceIdentifier("/root/tmp/"));
 
     assertNotEquals(toResourceIdentifier("/root/tmp"), toResourceIdentifier("/root/tmp/"));
   }
 
   @Test
-  public void testIsDirectory() throws Exception {
+  public void testIsDirectory() {
     assertTrue(toResourceIdentifier("/").isDirectory());
     assertTrue(toResourceIdentifier("/root/tmp/").isDirectory());
     assertFalse(toResourceIdentifier("/root").isDirectory());
@@ -237,19 +238,19 @@ public class LocalResourceIdTest {
   }
 
   @Test
-  public void testGetFilename() throws Exception {
-    assertEquals(null, toResourceIdentifier("/").getFilename());
+  public void testGetFilename() {
+    assertNull(toResourceIdentifier("/").getFilename());
     assertEquals("tmp", toResourceIdentifier("/root/tmp").getFilename());
     assertEquals("tmp", toResourceIdentifier("/root/tmp/").getFilename());
     assertEquals("xyz.txt", toResourceIdentifier("/root/tmp/xyz.txt").getFilename());
   }
 
   @Test
-  public void testResourceIdTester() throws Exception {
+  public void testResourceIdTester() {
     ResourceIdTester.runResourceIdBattery(toResourceIdentifier("/tmp/foo/"));
   }
 
-  private LocalResourceId toResourceIdentifier(String str) throws Exception {
+  private LocalResourceId toResourceIdentifier(String str) {
     boolean isDirectory;
     if (SystemUtils.IS_OS_WINDOWS) {
       isDirectory = str.endsWith("\\");

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/storage/GcsResourceIdTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/storage/GcsResourceIdTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.gcp.storage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.beam.sdk.io.FileSystems;
@@ -28,7 +29,6 @@ import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.fs.ResourceIdTester;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.gcsfs.GcsPath;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -42,7 +42,7 @@ public class GcsResourceIdTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void testResolve() throws Exception {
+  public void testResolve() {
     // Tests for common gcs paths.
     assertEquals(
         toResourceIdentifier("gs://bucket/tmp/aa"),
@@ -74,7 +74,7 @@ public class GcsResourceIdTest {
   }
 
   @Test
-  public void testResolveHandleBadInputs() throws Exception {
+  public void testResolveHandleBadInputs() {
     assertEquals(
         toResourceIdentifier("gs://my_bucket/tmp/"),
         toResourceIdentifier("gs://my_bucket/")
@@ -82,14 +82,14 @@ public class GcsResourceIdTest {
   }
 
   @Test
-  public void testResolveInvalidInputs() throws Exception {
+  public void testResolveInvalidInputs() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("The resolved file: [tmp/] should not end with '/'.");
     toResourceIdentifier("gs://my_bucket/").resolve("tmp/", StandardResolveOptions.RESOLVE_FILE);
   }
 
   @Test
-  public void testResolveInvalidNotDirectory() throws Exception {
+  public void testResolveInvalidNotDirectory() {
     ResourceId tmpDir =
         toResourceIdentifier("gs://my_bucket/")
             .resolve("tmp dir", StandardResolveOptions.RESOLVE_FILE);
@@ -100,7 +100,7 @@ public class GcsResourceIdTest {
   }
 
   @Test
-  public void testGetCurrentDirectory() throws Exception {
+  public void testGetCurrentDirectory() {
     // Tests gcs paths.
     assertEquals(
         toResourceIdentifier("gs://my_bucket/tmp dir/"),
@@ -118,7 +118,7 @@ public class GcsResourceIdTest {
   }
 
   @Test
-  public void testIsDirectory() throws Exception {
+  public void testIsDirectory() {
     assertTrue(toResourceIdentifier("gs://my_bucket/tmp dir/").isDirectory());
     assertTrue(toResourceIdentifier("gs://my_bucket/").isDirectory());
     assertTrue(toResourceIdentifier("gs://my_bucket").isDirectory());
@@ -127,14 +127,14 @@ public class GcsResourceIdTest {
   }
 
   @Test
-  public void testInvalidGcsPath() throws Exception {
+  public void testInvalidGcsPath() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid GCS URI: gs://");
     toResourceIdentifier("gs://");
   }
 
   @Test
-  public void testGetScheme() throws Exception {
+  public void testGetScheme() {
     // Tests gcs paths.
     assertEquals("gs", toResourceIdentifier("gs://my_bucket/tmp dir/").getScheme());
 
@@ -143,7 +143,7 @@ public class GcsResourceIdTest {
   }
 
   @Test
-  public void testEquals() throws Exception {
+  public void testEquals() {
     assertEquals(
         toResourceIdentifier("gs://my_bucket/tmp/"), toResourceIdentifier("gs://my_bucket/tmp/"));
 
@@ -152,21 +152,20 @@ public class GcsResourceIdTest {
   }
 
   @Test
-  public void testGetFilename() throws Exception {
-    assertEquals(null, toResourceIdentifier("gs://my_bucket/").getFilename());
+  public void testGetFilename() {
+    assertNull(toResourceIdentifier("gs://my_bucket/").getFilename());
     assertEquals("abc", toResourceIdentifier("gs://my_bucket/abc").getFilename());
     assertEquals("abc", toResourceIdentifier("gs://my_bucket/abc/").getFilename());
     assertEquals("xyz.txt", toResourceIdentifier("gs://my_bucket/abc/xyz.txt").getFilename());
   }
 
   @Test
-  @Ignore("https://issues.apache.org/jira/browse/BEAM-4143")
-  public void testResourceIdTester() throws Exception {
+  public void testResourceIdTester() {
     FileSystems.setDefaultPipelineOptions(PipelineOptionsFactory.create());
     ResourceIdTester.runResourceIdBattery(toResourceIdentifier("gs://bucket/foo/"));
   }
 
-  private GcsResourceId toResourceIdentifier(String str) throws Exception {
+  private GcsResourceId toResourceIdentifier(String str) {
     return GcsResourceId.fromGcsPath(GcsPath.fromUri(str));
   }
 }


### PR DESCRIPTION
Reactivate sickbayed test case
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---



