### PR TITLE
[BEAM-6365] Add ZStandard compression support for Java SDK

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -447,6 +447,7 @@ class BeamModulePlugin implements Plugin<Project> {
         vendored_grpc_1_13_1                        : "org.apache.beam:beam-vendor-grpc-1_13_1:0.2",
         vendored_guava_20_0                         : "org.apache.beam:beam-vendor-guava-20_0:0.1",
         woodstox_core_asl                           : "org.codehaus.woodstox:woodstox-core-asl:4.4.1",
+        zstd_jni                                    : "com.github.luben:zstd-jni:1.3.7-3",
         quickcheck_core                             : "com.pholser:junit-quickcheck-core:$quickcheck_version",
       ],
       groovy: [

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -65,6 +65,7 @@ dependencies {
   shadow library.java.slf4j_api
   shadow library.java.avro
   shadow library.java.snappy_java
+  shadow library.java.zstd_jni
   shadow library.java.joda_time
   shadow "org.tukaani:xz:1.8"
   provided library.java.junit

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -48,14 +48,15 @@ import org.joda.time.Instant;
  * }</pre>
  *
  * <p>Supported compression algorithms are {@link Compression#GZIP}, {@link Compression#BZIP2},
- * {@link Compression#ZIP} and {@link Compression#DEFLATE}. User-defined compression types are
- * supported by implementing a {@link DecompressingChannelFactory}.
+ * {@link Compression#ZIP}, {@link Compression#ZSTD}, and {@link Compression#DEFLATE}. User-defined
+ * compression types are supported by implementing a {@link DecompressingChannelFactory}.
  *
  * <p>By default, the compression algorithm is selected from those supported in {@link Compression}
  * based on the file name provided to the source, namely {@code ".bz2"} indicates {@link
  * Compression#BZIP2}, {@code ".gz"} indicates {@link Compression#GZIP}, {@code ".zip"} indicates
- * {@link Compression#ZIP} and {@code ".deflate"} indicates {@link Compression#DEFLATE}. If the file
- * name does not match any of the supported algorithms, it is assumed to be uncompressed data.
+ * {@link Compression#ZIP}, {@code ".zst"} indicates {@link Compression#ZSTD}, and {@code
+ * ".deflate"} indicates {@link Compression#DEFLATE}. If the file name does not match any of the
+ * supported algorithms, it is assumed to be uncompressed data.
  *
  * @param <T> The type to read from the compressed file.
  */
@@ -86,6 +87,9 @@ public class CompressedSource<T> extends FileBasedSource<T> {
 
     /** @see Compression#ZIP */
     ZIP(Compression.ZIP),
+
+    /** @see Compression#ZSTD */
+    ZSTD(Compression.ZSTD),
 
     /** @see Compression#DEFLATE */
     DEFLATE(Compression.DEFLATE);
@@ -131,6 +135,9 @@ public class CompressedSource<T> extends FileBasedSource<T> {
 
         case ZIP:
           return ZIP;
+
+        case ZSTD:
+          return ZSTD;
 
         case DEFLATE:
           return DEFLATE;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Compression.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Compression.java
@@ -35,6 +35,8 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorInputStream;
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream;
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream;
 
 /** Various compression types for reading/writing files. */
 public enum Compression {
@@ -123,6 +125,24 @@ public enum Compression {
     @Override
     public WritableByteChannel writeCompressed(WritableByteChannel channel) throws IOException {
       throw new UnsupportedOperationException("Writing ZIP files is currently unsupported");
+    }
+  },
+
+  /**
+   * ZStandard compression.
+   *
+   * <p>The {@code .zst} extension is specified in <a href=https://tools.ietf.org/html/rfc8478>RFC
+   * 8478</a>.
+   */
+  ZSTD(".zst", ".zst", ".zstd") {
+    @Override
+    public ReadableByteChannel readDecompressed(ReadableByteChannel channel) throws IOException {
+      return Channels.newChannel(new ZstdCompressorInputStream(Channels.newInputStream(channel)));
+    }
+
+    @Override
+    public WritableByteChannel writeCompressed(WritableByteChannel channel) throws IOException {
+      return Channels.newChannel(new ZstdCompressorOutputStream(Channels.newOutputStream(channel)));
     }
   },
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -141,6 +141,9 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
     /** @see Compression#BZIP2 */
     BZIP2(Compression.BZIP2),
 
+    /** @see Compression#ZSTD */
+    ZSTD(Compression.ZSTD),
+
     /** @see Compression#DEFLATE */
     DEFLATE(Compression.DEFLATE);
 
@@ -182,6 +185,9 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
 
         case ZIP:
           throw new IllegalArgumentException("ZIP is unsupported");
+
+        case ZSTD:
+          return ZSTD;
 
         case DEFLATE:
           return DEFLATE;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -1192,7 +1192,10 @@ public class TextIO {
     /** @see Compression#ZIP */
     ZIP(Compression.ZIP),
 
-    /** @see Compression#ZIP */
+    /** @see Compression#ZSTD */
+    ZSTD(Compression.ZSTD),
+
+    /** @see Compression#DEFLATE */
     DEFLATE(Compression.DEFLATE);
 
     private final Compression canonical;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
@@ -67,6 +67,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream;
 import org.joda.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
@@ -111,6 +112,14 @@ public class CompressedSourceTest {
     source = CompressedSource.from(new ByteSource("input.zip", 1));
     assertFalse(source.isSplittable());
     source = CompressedSource.from(new ByteSource("input.ZIP", 1));
+    assertFalse(source.isSplittable());
+
+    // ZSTD files are not splittable
+    source = CompressedSource.from(new ByteSource("input.zst", 1));
+    assertFalse(source.isSplittable());
+    source = CompressedSource.from(new ByteSource("input.ZST", 1));
+    assertFalse(source.isSplittable());
+    source = CompressedSource.from(new ByteSource("input.zstd", 1));
     assertFalse(source.isSplittable());
 
     // DEFLATE files are not splittable
@@ -178,6 +187,13 @@ public class CompressedSourceTest {
   public void testEmptyReadGzip() throws Exception {
     byte[] input = generateInput(0);
     runReadTest(input, CompressionMode.GZIP);
+  }
+
+  /** Test reading empty input with zstd. */
+  @Test
+  public void testEmptyReadZstd() throws Exception {
+    byte[] input = generateInput(0);
+    runReadTest(input, CompressionMode.ZSTD);
   }
 
   private static byte[] compressGzip(byte[] input) throws IOException {
@@ -258,7 +274,14 @@ public class CompressedSourceTest {
     runReadTest(input, CompressionMode.BZIP2);
   }
 
-  /** Test reading according to filepattern when the file is bzipped. */
+  /** Test reading empty input with zstd. */
+  @Test
+  public void testCompressedReadZstd() throws Exception {
+    byte[] input = generateInput(0);
+    runReadTest(input, CompressionMode.ZSTD);
+  }
+
+  /** Test reading according to filepattern when the file is gzipped. */
   @Test
   public void testCompressedAccordingToFilepatternGzip() throws Exception {
     byte[] input = generateInput(100);
@@ -267,12 +290,21 @@ public class CompressedSourceTest {
     verifyReadContents(input, tmpFile, null /* default auto decompression factory */);
   }
 
-  /** Test reading according to filepattern when the file is gzipped. */
+  /** Test reading according to filepattern when the file is bzipped. */
   @Test
   public void testCompressedAccordingToFilepatternBzip2() throws Exception {
     byte[] input = generateInput(100);
     File tmpFile = tmpFolder.newFile("test.bz2");
     writeFile(tmpFile, input, CompressionMode.BZIP2);
+    verifyReadContents(input, tmpFile, null /* default auto decompression factory */);
+  }
+
+  /** Test reading according to filepattern when the file is zstd compressed. */
+  @Test
+  public void testCompressedAccordingToFilepatternZstd() throws Exception {
+    byte[] input = generateInput(100);
+    File tmpFile = tmpFolder.newFile("test.zst");
+    writeFile(tmpFile, input, CompressionMode.ZSTD);
     verifyReadContents(input, tmpFile, null /* default auto decompression factory */);
   }
 
@@ -299,6 +331,11 @@ public class CompressedSourceTest {
     File bzip2File = tmpFolder.newFile(baseName + ".bz2");
     generated = generateInput(1000, 3);
     writeFile(bzip2File, generated, CompressionMode.BZIP2);
+    expected.addAll(Bytes.asList(generated));
+
+    File zstdFile = tmpFolder.newFile(baseName + ".zst");
+    generated = generateInput(1000, 4);
+    writeFile(zstdFile, generated, CompressionMode.ZSTD);
     expected.addAll(Bytes.asList(generated));
 
     String filePattern = new File(tmpFolder.getRoot().toString(), baseName + ".*").toString();
@@ -359,6 +396,18 @@ public class CompressedSourceTest {
     assertFalse(source.isSplittable());
   }
 
+  @Test
+  public void testZstdFileIsNotSplittable() throws Exception {
+    String baseName = "test-input";
+
+    File compressedFile = tmpFolder.newFile(baseName + ".zst");
+    writeFile(compressedFile, generateInput(10), CompressionMode.ZSTD);
+
+    CompressedSource<Byte> source =
+        CompressedSource.from(new ByteSource(compressedFile.getPath(), 1));
+    assertFalse(source.isSplittable());
+  }
+
   /**
    * Test reading an uncompressed file with {@link CompressionMode#GZIP}, since we must support this
    * due to properties of services that we read from.
@@ -381,6 +430,16 @@ public class CompressedSourceTest {
     Files.write(input, tmpFile);
     thrown.expectMessage("Stream is not in the BZip2 format");
     verifyReadContents(input, tmpFile, CompressionMode.BZIP2);
+  }
+
+  /** Test reading an uncompressed file with {@link Compression#ZSTD}, and show that we fail. */
+  @Test
+  public void testFalseZstdStream() throws Exception {
+    byte[] input = generateInput(1000);
+    File tmpFile = tmpFolder.newFile("test.zst");
+    Files.write(input, tmpFile);
+    thrown.expectMessage("Decompression error: Unknown frame descriptor");
+    verifyReadContents(input, tmpFile, CompressionMode.ZSTD);
   }
 
   /**
@@ -476,6 +535,8 @@ public class CompressedSourceTest {
         return new BZip2CompressorOutputStream(stream);
       case ZIP:
         return new TestZipOutputStream(stream);
+      case ZSTD:
+        return new ZstdCompressorOutputStream(stream);
       case DEFLATE:
         return new DeflateCompressorOutputStream(stream);
       default:


### PR DESCRIPTION
Adds a dependency on `zstd-jni` which declares no transitive dependencies,
but otherwise just fills out enum values to expose the ZStandard support
that already exists in commons-compress.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




