### PR TITLE
[BEAM-3580] Use a separate coder for string

### DIFF
--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -113,10 +113,10 @@ func inferCoder(t FullType) (*coder.Coder, error) {
 			}
 			return &coder.Coder{Kind: coder.Custom, T: t, Custom: c}, nil
 
-		case reflectx.String, reflectx.ByteSlice:
-			// TODO(BEAM-3580): we should stop encoding string using the bytecoder. It forces
-			// conversions at runtime in inconvenient places.
+		case reflectx.ByteSlice:
 			return &coder.Coder{Kind: coder.Bytes, T: t}, nil
+		case reflectx.String:
+			return &coder.Coder{Kind: coder.String, T: t}, nil
 		default:
 			// TODO(BEAM-3306): the coder registry should be consulted here for user
 			// specified types and their coders.

--- a/sdks/go/pkg/beam/combine_test.go
+++ b/sdks/go/pkg/beam/combine_test.go
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beam_test
+
+import (
+    "fmt"
+    "strconv"
+    "testing"
+
+    "github.com/apache/beam/sdks/go/pkg/beam"
+    "github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
+    "github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+)
+
+func TestCombine(t *testing.T) {
+    tests := []struct {
+        name      string
+        combineFn interface{}
+        in        []interface{}
+        exp       interface{}
+    }{
+        {
+            name:      "MyCombine",
+            combineFn: &MyCombine{},
+            in:        []interface{}{1, 2, 3, 4},
+            exp:       int(10),
+        },
+        {
+            name:      "MyUniversalCombine", // Test for BEAM-3580.
+            combineFn: &MyUniversalCombine{},
+            in:        []interface{}{"1", "2", "3", "4", "5"},
+            exp:       int(15),
+        },
+    }
+
+    for _, test := range tests {
+        p, s, in := ptest.CreateList(test.in)
+        exp := beam.Create(s, test.exp)
+        passert.Equals(s, beam.Combine(s, test.combineFn, in), exp)
+
+        if err := ptest.Run(p); err != nil {
+            t.Errorf("beam.Combine(%v, %v) != %v: %v", test.name, test.in, test.exp, err)
+        }
+    }
+}
+
+// MyCombine represents a combine with the same Input and Output type (int), but a
+// distinct accumulator type (int64).
+//
+//  InputT == OutputT == int
+//  AccumT == int64
+type MyCombine struct{}
+
+func (*MyCombine) AddInput(a int64, v int) int64 {
+    return a + int64(v)
+}
+
+func (*MyCombine) MergeAccumulators(a, b int64) int64 {
+    return a + b
+}
+
+func (*MyCombine) ExtractOutput(a int64) int {
+    return int(a)
+}
+
+// MyUniversalCombine has universal Input type beam.T, but only accepts
+// underlying type string. It doesn't specify an ExtractOutput.
+//
+//  InputT == beam.T (underlying type string)
+//  AccumT == int
+//  OutputT == int
+type MyUniversalCombine struct{}
+
+func (c *MyUniversalCombine) AddInput(a int, v beam.T) (int, error) {
+    s, ok := v.(string)
+    if !ok {
+        return 0, fmt.Errorf("expecting input type string, got %T", v)
+    }
+
+    num, err := strconv.ParseInt(s, 0, 0)
+    if err != nil {
+        return 0, err
+    }
+    return c.MergeAccumulators(a, int(num)), nil
+}
+
+func (*MyUniversalCombine) MergeAccumulators(a, b int) int {
+    return a + b
+}

--- a/sdks/go/pkg/beam/combine_test.go
+++ b/sdks/go/pkg/beam/combine_test.go
@@ -16,45 +16,45 @@
 package beam_test
 
 import (
-    "fmt"
-    "strconv"
-    "testing"
+	"fmt"
+	"strconv"
+	"testing"
 
-    "github.com/apache/beam/sdks/go/pkg/beam"
-    "github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
-    "github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
 )
 
 func TestCombine(t *testing.T) {
-    tests := []struct {
-        name      string
-        combineFn interface{}
-        in        []interface{}
-        exp       interface{}
-    }{
-        {
-            name:      "MyCombine",
-            combineFn: &MyCombine{},
-            in:        []interface{}{1, 2, 3, 4},
-            exp:       int(10),
-        },
-        {
-            name:      "MyUniversalCombine", // Test for BEAM-3580.
-            combineFn: &MyUniversalCombine{},
-            in:        []interface{}{"1", "2", "3", "4", "5"},
-            exp:       int(15),
-        },
-    }
+	tests := []struct {
+		name      string
+		combineFn interface{}
+		in        []interface{}
+		exp       interface{}
+	}{
+		{
+			name:      "MyCombine",
+			combineFn: &MyCombine{},
+			in:        []interface{}{1, 2, 3, 4},
+			exp:       int(10),
+		},
+		{
+			name:      "MyUniversalCombine", // Test for BEAM-3580.
+			combineFn: &MyUniversalCombine{},
+			in:        []interface{}{"1", "2", "3", "4", "5"},
+			exp:       int(15),
+		},
+	}
 
-    for _, test := range tests {
-        p, s, in := ptest.CreateList(test.in)
-        exp := beam.Create(s, test.exp)
-        passert.Equals(s, beam.Combine(s, test.combineFn, in), exp)
+	for _, test := range tests {
+		p, s, in := ptest.CreateList(test.in)
+		exp := beam.Create(s, test.exp)
+		passert.Equals(s, beam.Combine(s, test.combineFn, in), exp)
 
-        if err := ptest.Run(p); err != nil {
-            t.Errorf("beam.Combine(%v, %v) != %v: %v", test.name, test.in, test.exp, err)
-        }
-    }
+		if err := ptest.Run(p); err != nil {
+			t.Errorf("beam.Combine(%v, %v) != %v: %v", test.name, test.in, test.exp, err)
+		}
+	}
 }
 
 // MyCombine represents a combine with the same Input and Output type (int), but a
@@ -65,15 +65,15 @@ func TestCombine(t *testing.T) {
 type MyCombine struct{}
 
 func (*MyCombine) AddInput(a int64, v int) int64 {
-    return a + int64(v)
+	return a + int64(v)
 }
 
 func (*MyCombine) MergeAccumulators(a, b int64) int64 {
-    return a + b
+	return a + b
 }
 
 func (*MyCombine) ExtractOutput(a int64) int {
-    return int(a)
+	return int(a)
 }
 
 // MyUniversalCombine has universal Input type beam.T, but only accepts
@@ -85,18 +85,18 @@ func (*MyCombine) ExtractOutput(a int64) int {
 type MyUniversalCombine struct{}
 
 func (c *MyUniversalCombine) AddInput(a int, v beam.T) (int, error) {
-    s, ok := v.(string)
-    if !ok {
-        return 0, fmt.Errorf("expecting input type string, got %T", v)
-    }
+	s, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("expecting input type string, got %T", v)
+	}
 
-    num, err := strconv.ParseInt(s, 0, 0)
-    if err != nil {
-        return 0, err
-    }
-    return c.MergeAccumulators(a, int(num)), nil
+	num, err := strconv.ParseInt(s, 0, 0)
+	if err != nil {
+		return 0, err
+	}
+	return c.MergeAccumulators(a, int(num)), nil
 }
 
 func (*MyUniversalCombine) MergeAccumulators(a, b int) int {
-    return a + b
+	return a + b
 }

--- a/sdks/go/pkg/beam/core/funcx/fn.go
+++ b/sdks/go/pkg/beam/core/funcx/fn.go
@@ -304,7 +304,7 @@ func SubReturns(list []ReturnParam, indices ...int) []ReturnParam {
 }
 
 // The order of present parameters and return values must be as follows:
-// func(FnContext?, FnWindow?, FnEventTime?, FnType?, (FnValue, SideInput*)?, FnEmit*) (RetEventTime?, RetEventTime?, RetError?)
+// func(FnContext?, FnWindow?, FnEventTime?, FnType?, (FnValue, SideInput*)?, FnEmit*) (RetEventTime?, RetValue?, RetError?)
 //     where ? indicates 0 or 1, and * indicates any number.
 //     and  a SideInput is one of FnValue or FnIter or FnReIter
 // Note: Fns with inputs must have at least one FnValue as the main input.

--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -122,6 +122,7 @@ type Kind string
 const (
 	Custom        Kind = "Custom" // Implicitly length-prefixed
 	Bytes         Kind = "bytes"  // Implicitly length-prefixed as part of the encoding
+	String        Kind = "string" // Implicitly length-prefixed as part of the encoding
 	VarInt        Kind = "varint"
 	WindowedValue Kind = "W"
 	KV            Kind = "KV"

--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -209,6 +209,11 @@ func NewBytes() *Coder {
 	return &Coder{Kind: Bytes, T: typex.New(reflectx.ByteSlice)}
 }
 
+// NewString returns a new string coder using the built-in scheme.
+func NewString() *Coder {
+	return &Coder{Kind: String, T: typex.New(reflectx.String)}
+}
+
 // NewVarInt returns a new int32 coder using the built-in scheme.
 func NewVarInt() *Coder {
 	return &Coder{Kind: VarInt, T: typex.New(reflectx.Int32)}

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -31,6 +31,7 @@ const (
 	// Model constants
 
 	urnBytesCoder         = "beam:coder:bytes:v1"
+	urnStringCoder        = "beam:coder:string:v1"
 	urnVarIntCoder        = "beam:coder:varint:v1"
 	urnLengthPrefixCoder  = "beam:coder:length_prefix:v1"
 	urnKVCoder            = "beam:coder:kv:v1"
@@ -151,6 +152,9 @@ func (b *CoderUnmarshaller) makeCoder(c *pb.Coder) (*coder.Coder, error) {
 	switch urn {
 	case urnBytesCoder:
 		return coder.NewBytes(), nil
+
+	case urnStringCoder:
+		return coder.NewString(), nil
 
 	case urnVarIntCoder:
 		return coder.NewVarInt(), nil
@@ -361,6 +365,9 @@ func (b *CoderMarshaller) Add(c *coder.Coder) string {
 	case coder.Bytes:
 		// TODO(herohde) 6/27/2017: add length-prefix and not assume nested by context?
 		return b.internBuiltInCoder(urnBytesCoder)
+
+	case coder.String:
+		return b.internBuiltInCoder(urnStringCoder)
 
 	case coder.VarInt:
 		return b.internBuiltInCoder(urnVarIntCoder)

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
@@ -46,6 +46,10 @@ func TestMarshalUnmarshalCoders(t *testing.T) {
 			coder.NewBytes(),
 		},
 		{
+			"string",
+			coder.NewString(),
+		},
+		{
 			"varint",
 			coder.NewVarInt(),
 		},

--- a/sdks/go/pkg/beam/core/runtime/graphx/dataflow.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/dataflow.go
@@ -41,6 +41,7 @@ type CoderRef struct {
 const (
 	windowedValueType = "kind:windowed_value"
 	bytesType         = "kind:bytes"
+	stringType        = "kind:string"
 	varIntType        = "kind:varint"
 	streamType        = "kind:stream"
 	pairType          = "kind:pair"
@@ -148,6 +149,9 @@ func EncodeCoderRef(c *coder.Coder) (*CoderRef, error) {
 		// TODO(herohde) 6/27/2017: add length-prefix and not assume nested by context?
 		return &CoderRef{Type: bytesType}, nil
 
+	case coder.String:
+		return &CoderRef{Type: stringType}, nil
+
 	case coder.VarInt:
 		return &CoderRef{Type: varIntType}, nil
 
@@ -174,6 +178,9 @@ func DecodeCoderRef(c *CoderRef) (*coder.Coder, error) {
 	switch c.Type {
 	case bytesType:
 		return coder.NewBytes(), nil
+
+	case stringType:
+		return coder.NewString(), nil
 
 	case varIntType:
 		return coder.NewVarInt(), nil

--- a/sdks/go/pkg/beam/pipeline.go
+++ b/sdks/go/pkg/beam/pipeline.go
@@ -24,7 +24,7 @@ import (
 // the scope chain form a unique name. The scope chain can also be used for
 // monitoring and visualization purposes.
 type Scope struct {
-	// parent is the scoped insertion point for composite transforms.
+	// scope is the scoped insertion point for composite transforms.
 	scope *graph.Scope
 	// real is the enclosing graph.
 	real *graph.Graph
@@ -56,7 +56,7 @@ func (s Scope) String() string {
 // Pipeline manages a directed acyclic graph of primitive PTransforms, and the
 // PCollections that the PTransforms consume and produce. Each Pipeline is
 // self-contained and isolated from any other Pipeline. The Pipeline owns the
-// PCollections and PTransforms and they can by used by that Pipeline only.
+// PCollections and PTransforms and they can be used by that Pipeline only.
 // Pipelines can safely be executed concurrently.
 type Pipeline struct {
 	// real is the deferred execution Graph as it is being constructed.


### PR DESCRIPTION
This resolves the "[]byte to string" conversion issue that beam.Combine had. That conversion is no longer necessary.

Fixed several typos.

R: @lostluck 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




