### PR TITLE
[BEAM-6349] & [BEAM-6368] Build worker and use it when running loadtests on Dataflow

### DIFF
--- a/sdks/java/testing/load-tests/build.gradle
+++ b/sdks/java/testing/load-tests/build.gradle
@@ -28,8 +28,6 @@ def mainClass = project.findProperty(mainClassProperty)
 // When running via Gradle, this property can be used to pass commandline arguments
 // to the nexmark launch
 def loadTestArgsProperty = "loadTest.args"
-def loadTestArgs = project.hasProperty(loadTestArgsProperty) ?
-        project.getProperty(loadTestArgsProperty).split() : []
 
 // When running via Gradle, this property sets the runner dependency
 def runnerProperty = "runner"
@@ -38,6 +36,16 @@ def runnerDependency = (project.hasProperty(runnerProperty)
         : ":beam-runners-direct-java")
 
 def shouldProvideSpark = ":beam-runners-spark".equals(runnerDependency)
+def isDataflowRunner = ":beam-runners-google-cloud-dataflow-java".equals(runnerDependency)
+
+if (isDataflowRunner) {
+  /*
+   * We need to rely on manually specifying these evaluationDependsOn to ensure that
+   * the following projects are evaluated before we evaluate this project. This is because
+   * we are attempting to reference a property from the project directly.
+   */
+  evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
+}
 
 configurations {
   // A configuration for running the Load testlauncher directly from Gradle, which
@@ -75,8 +83,22 @@ if (shouldProvideSpark) {
 }
 
 task run(type: JavaExec) {
+  def loadTestArgs = project.findProperty(loadTestArgsProperty) ?: ""
+
+  if (isDataflowRunner) {
+    dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
+
+    def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
+    // Provide job with a customizable worker jar.
+    // With legacy worker jar, containerImage is set to empty (i.e. to use the internal build).
+    // More context and discussions can be found in PR#6694.
+    loadTestArgs = loadTestArgs +
+            " --dataflowWorkerJar=${dataflowWorkerJar} " +
+            " --workerHarnessContainerImage="
+  }
+
   main = mainClass
   classpath = configurations.gradleRun
-  args loadTestArgs
+  args loadTestArgs.split()
 }
 


### PR DESCRIPTION
This forces usage of the newest version of worker code preventing any code mismatches that can occur if the version is stale on Dataflow. 

Similar approach is used for Nexmark and IO performance tests.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




