### PR TITLE
[BEAM-6382] SamzaRunner: add an option to read configs using a user-defined factory

### DIFF
--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
@@ -21,16 +21,25 @@ import java.util.Map;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.samza.config.ConfigFactory;
+import org.apache.samza.config.factories.PropertiesConfigFactory;
 
 /** Options which can be used to configure a Samza PipelineRunner. */
 public interface SamzaPipelineOptions extends PipelineOptions {
 
   @Description(
-      "The config for Samza using a properties file. It is *optional*. "
+      "The config file for Samza. It is *optional*. "
           + "Without a config file, Samza uses a default config for local execution.")
   String getConfigFilePath();
 
   void setConfigFilePath(String filePath);
+
+  @Description(
+      "The factory to read config file from config file path. ")
+  @Default.Class(PropertiesConfigFactory.class)
+  Class<? extends ConfigFactory> getConfigFactory();
+
+  void setConfigFactory(Class<? extends ConfigFactory> configFactory);
 
   @Description(
       "The config override to set programmatically. It will be applied on "

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
@@ -28,14 +28,14 @@ import org.apache.samza.config.factories.PropertiesConfigFactory;
 public interface SamzaPipelineOptions extends PipelineOptions {
 
   @Description(
-      "The config file for Samza. It is *optional*. "
+      "The config file for Samza. It is *optional*. By default Samza supports properties config."
           + "Without a config file, Samza uses a default config for local execution.")
   String getConfigFilePath();
 
   void setConfigFilePath(String filePath);
 
   @Description(
-      "The factory to read config file from config file path. ")
+      "The factory to read config file from config file path.")
   @Default.Class(PropertiesConfigFactory.class)
   Class<? extends ConfigFactory> getConfigFactory();
 

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineResult.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineResult.java
@@ -19,14 +19,12 @@ package org.apache.beam.runners.samza;
 
 import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
 
-import java.io.IOException;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.job.ApplicationStatus;
 import org.apache.samza.runtime.ApplicationRunner;
-import org.apache.samza.runtime.LocalApplicationRunner;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,40 +50,41 @@ public class SamzaPipelineResult implements PipelineResult {
   }
 
   @Override
-  public State cancel() throws IOException {
+  public State cancel() {
     runner.kill(app);
-
-    //TODO: runner.waitForFinish() after SAMZA-1653 done
-    return getState();
+    return waitUntilFinish();
   }
 
   @Override
   public State waitUntilFinish(Duration duration) {
-    //TODO: SAMZA-1653
-    throw new UnsupportedOperationException(
-        "waitUntilFinish(duration) is not supported by the SamzaRunner");
+    try {
+      runner.waitForFinish(java.time.Duration.ofMillis(duration.getMillis()));
+    } catch (Exception e) {
+      throw new Pipeline.PipelineExecutionException(e);
+    }
+
+    final StateInfo stateInfo = getStateInfo();
+    if (stateInfo.state == State.FAILED) {
+      throw stateInfo.error;
+    }
+
+    return stateInfo.state;
   }
 
   @Override
   public State waitUntilFinish() {
-    if (runner instanceof LocalApplicationRunner) {
-      try {
-        ((LocalApplicationRunner) runner).waitForFinish();
-      } catch (Exception e) {
-        throw new Pipeline.PipelineExecutionException(e);
-      }
-
-      final StateInfo stateInfo = getStateInfo();
-      if (stateInfo.state == State.FAILED) {
-        throw stateInfo.error;
-      }
-
-      return stateInfo.state;
-    } else {
-      // TODO: SAMZA-1653 support waitForFinish in remote runner too
-      throw new UnsupportedOperationException(
-          "waitUntilFinish is not supported by the SamzaRunner when running remotely");
+    try {
+      runner.waitForFinish();
+    } catch (Exception e) {
+      throw new Pipeline.PipelineExecutionException(e);
     }
+
+    final StateInfo stateInfo = getStateInfo();
+    if (stateInfo.state == State.FAILED) {
+      throw stateInfo.error;
+    }
+
+    return stateInfo.state;
   }
 
   @Override

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineResult.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineResult.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.samza;
 
 import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
 
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.metrics.MetricResults;
@@ -56,9 +57,13 @@ public class SamzaPipelineResult implements PipelineResult {
   }
 
   @Override
-  public State waitUntilFinish(Duration duration) {
+  public State waitUntilFinish(@Nullable  Duration duration) {
     try {
-      runner.waitForFinish(java.time.Duration.ofMillis(duration.getMillis()));
+      if (duration == null) {
+        runner.waitForFinish();
+      } else {
+        runner.waitForFinish(java.time.Duration.ofMillis(duration.getMillis()));
+      }
     } catch (Exception e) {
       throw new Pipeline.PipelineExecutionException(e);
     }
@@ -73,18 +78,7 @@ public class SamzaPipelineResult implements PipelineResult {
 
   @Override
   public State waitUntilFinish() {
-    try {
-      runner.waitForFinish();
-    } catch (Exception e) {
-      throw new Pipeline.PipelineExecutionException(e);
-    }
-
-    final StateInfo stateInfo = getStateInfo();
-    if (stateInfo.state == State.FAILED) {
-      throw stateInfo.error;
-    }
-
-    return stateInfo.state;
+    return waitUntilFinish(null);
   }
 
   @Override

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/container/BeamContainerRunner.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/container/BeamContainerRunner.java
@@ -17,14 +17,36 @@
  */
 package org.apache.beam.runners.samza.container;
 
+import java.time.Duration;
+import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.ShellCommandConfig;
+import org.apache.samza.job.ApplicationStatus;
 import org.apache.samza.runtime.LocalContainerRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Runs the beam Yarn container, using the static global job model. */
 public class BeamContainerRunner extends LocalContainerRunner {
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerCfgFactory.class);
 
   public BeamContainerRunner(Config config) {
     super(ContainerCfgFactory.jobModel, System.getenv(ShellCommandConfig.ENV_CONTAINER_ID()));
+  }
+
+  @Override
+  public ApplicationStatus status(StreamApplication app) {
+    return ApplicationStatus.Running;
+  }
+
+  @Override
+  public void waitForFinish() {
+    LOG.info("Container has stopped");
+  }
+
+  @Override
+  public boolean waitForFinish(Duration timeout) {
+    LOG.info("Container has stopped");
+    return true;
   }
 }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/container/ContainerCfgFactory.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/container/ContainerCfgFactory.java
@@ -18,9 +18,12 @@
 package org.apache.beam.runners.samza.container;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.ConfigFactory;
+import org.apache.samza.config.MapConfig;
 import org.apache.samza.config.ShellCommandConfig;
 import org.apache.samza.container.SamzaContainer;
 import org.apache.samza.job.model.JobModel;
@@ -49,6 +52,8 @@ public class ContainerCfgFactory implements ConfigFactory {
       }
     }
 
-    return jobModel.getConfig();
+    final Map<String, String> config = new HashMap<>(jobModel.getConfig());
+    config.put("app.runner.class", BeamContainerRunner.class.getName());
+    return new MapConfig(config);
   }
 }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ConfigBuilder.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ConfigBuilder.java
@@ -92,6 +92,8 @@ public class ConfigBuilder {
       final ConfigFactory configFactory = options.getConfigFactory().getDeclaredConstructor().newInstance();
 
       // Config file must exist for default properties config
+      // TODO: add check to all non-empty files once we don't need to
+      // pass the command-line args through the containers
       if (configFactory instanceof PropertiesConfigFactory) {
         checkArgument(configFile.exists(), "Config file %s does not exist", configFilePath);
       }


### PR DESCRIPTION
We need an option to read configs from a factory which supports user-defined file format and will be used in Yarn to read configs in containers. By default this config factory is to read property file. Also clean up some previous code which has been resolved by latest Samza version.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




