### PR TITLE
[BEAM-6334] Add throwing exception in case of invalid state or timeout

### DIFF
--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/JobFailure.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/JobFailure.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.loadtests;
+
+import static java.lang.String.format;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.beam.sdk.PipelineResult;
+import org.joda.time.Duration;
+
+/** Class for detecting failures after {@link PipelineResult#waitUntilFinish(Duration)} unblocks. */
+class JobFailure {
+
+  private String cause;
+
+  private boolean requiresCancelling;
+
+  JobFailure(String cause, boolean requiresCancelling) {
+    this.cause = cause;
+    this.requiresCancelling = requiresCancelling;
+  }
+
+  static Optional<JobFailure> assertFailure(PipelineResult pipelineResult,
+      LoadTestResult testResult) {
+    PipelineResult.State state = pipelineResult.getState();
+
+    Optional<JobFailure> stateRelatedFailure = lookForInvalidState(state);
+
+    if (stateRelatedFailure.isPresent()) {
+      return stateRelatedFailure;
+    } else {
+      return lookForMetricResultFailure(testResult);
+    }
+  }
+
+  private static Optional<JobFailure> lookForMetricResultFailure(LoadTestResult testResult) {
+    if (testResult.getRuntime() == -1 || testResult.getTotalBytesCount() == -1) {
+      return of(new JobFailure("Invalid test results", false));
+    } else {
+      return empty();
+    }
+  }
+
+  static Optional<JobFailure> lookForInvalidState(PipelineResult.State state) {
+    switch (state) {
+      case RUNNING:
+      case UNKNOWN:
+        return of(new JobFailure("Job timeout.", true));
+
+      case CANCELLED:
+      case FAILED:
+      case STOPPED:
+      case UPDATED:
+        return of(new JobFailure(format("Invalid job state: %s.", state.toString()), false));
+
+      default:
+        return empty();
+    }
+  }
+
+  static PipelineResult handleFailure(PipelineResult pipelineResult, JobFailure failure)
+      throws IOException {
+
+    if(failure.requiresCancelling) {
+      pipelineResult.cancel();
+    }
+    throw new RuntimeException(failure.cause);
+  }
+}

--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTest.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.loadtests;
 
 import static org.apache.beam.sdk.io.synthetic.SyntheticOptions.fromJsonString;
-import static org.apache.beam.sdk.loadtests.JobFailure.assertFailure;
 import static org.apache.beam.sdk.loadtests.JobFailure.handleFailure;
 
 import java.io.IOException;
@@ -91,19 +90,17 @@ abstract class LoadTest<OptionsT extends LoadTestOptions> {
     PipelineResult pipelineResult = pipeline.run();
     pipelineResult.waitUntilFinish(Duration.standardMinutes(options.getLoadTestTimeout()));
 
-    LoadTestResult testResult = LoadTestResult.create(pipelineResult, metricsNamespace, testStartTime);
+    LoadTestResult testResult =
+        LoadTestResult.create(pipelineResult, metricsNamespace, testStartTime);
     ConsoleResultPublisher.publish(testResult);
 
-    Optional<JobFailure> failure = assertFailure(pipelineResult, testResult);
+    handleFailure(pipelineResult, testResult);
 
-    if(failure.isPresent()) {
-      return handleFailure(pipelineResult, failure.get());
-    } else {
-      if (options.getPublishToBigQuery()) {
-        publishResultToBigQuery(testResult);
-      }
-      return pipelineResult;
+    if (options.getPublishToBigQuery()) {
+      publishResultToBigQuery(testResult);
     }
+
+    return pipelineResult;
   }
 
   private void publishResultToBigQuery(LoadTestResult testResult) {
@@ -148,5 +145,4 @@ abstract class LoadTest<OptionsT extends LoadTestOptions> {
       return input;
     }
   }
-
 }

--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTestOptions.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTestOptions.java
@@ -55,6 +55,12 @@ public interface LoadTestOptions extends PipelineOptions, ApplicationNameOptions
 
   void setBigQueryTable(String tableName);
 
+  @Description("Timeout for a load test expressed in minutes")
+  @Default.Integer(60)
+  Integer getLoadTestTimeout();
+
+  void setLoadTestTimeout(Integer timeout);
+
   static <T extends LoadTestOptions> T readFromArgs(String[] args, Class<T> optionsClass) {
     return PipelineOptionsFactory.fromArgs(args).withValidation().as(optionsClass);
   }

--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTestOptions.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTestOptions.java
@@ -56,7 +56,7 @@ public interface LoadTestOptions extends PipelineOptions, ApplicationNameOptions
   void setBigQueryTable(String tableName);
 
   @Description("Timeout for a load test expressed in minutes")
-  @Default.Integer(60)
+  @Default.Integer(240)
   Integer getLoadTestTimeout();
 
   void setLoadTestTimeout(Integer timeout);


### PR DESCRIPTION

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




