### PR TITLE
[BEAM-6290] Generic schema for metrics 

### DIFF
--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/ConsoleResultPublisher.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/ConsoleResultPublisher.java
@@ -17,11 +17,23 @@
  */
 package org.apache.beam.sdk.loadtests;
 
-/** Writes {@link LoadTestResult} to console. */
-public class ConsoleResultPublisher {
+import static java.lang.String.format;
 
-  static void publish(LoadTestResult result) {
-    System.out.println(String.format("Total bytes: %s", result.getTotalBytesCount()));
-    System.out.println(String.format("Total time (sec): %s", result.getRuntime()));
+import java.util.List;
+import org.apache.beam.sdk.testutils.NamedTestResult;
+
+/** Writes load test metrics results to console. */
+class ConsoleResultPublisher {
+
+  static void publish(List<NamedTestResult> results, String testId, String timestamp) {
+    final String textTemplate = "%24s  %24s";
+
+    System.out.println(
+        format("Load test results for test (ID): %s and timestamp: %s:", testId, timestamp));
+    System.out.println(format(textTemplate, "Metric:", "Value:"));
+
+    results.forEach(
+        (result) ->
+            System.out.println(format(textTemplate, result.getMetric(), result.getValue())));
   }
 }

--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTest.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTest.java
@@ -20,8 +20,12 @@ package org.apache.beam.sdk.loadtests;
 import static org.apache.beam.sdk.io.synthetic.SyntheticOptions.fromJsonString;
 import static org.apache.beam.sdk.loadtests.JobFailure.handleFailure;
 
+import com.google.cloud.Timestamp;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.Read;
@@ -30,6 +34,8 @@ import org.apache.beam.sdk.io.synthetic.SyntheticSourceOptions;
 import org.apache.beam.sdk.io.synthetic.SyntheticStep;
 import org.apache.beam.sdk.io.synthetic.SyntheticUnboundedSource;
 import org.apache.beam.sdk.loadtests.metrics.TimeMonitor;
+import org.apache.beam.sdk.testutils.NamedTestResult;
+import org.apache.beam.sdk.testutils.metrics.MetricsReader;
 import org.apache.beam.sdk.testutils.publishing.BigQueryResultsPublisher;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -37,7 +43,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
 import org.joda.time.Duration;
 
 /**
@@ -83,39 +88,55 @@ abstract class LoadTest<OptionsT extends LoadTestOptions> {
    * Runs the load test, collects and publishes test results to various data store and/or console.
    */
   public PipelineResult run() throws IOException {
-    long testStartTime = System.currentTimeMillis();
+    Timestamp timestamp = Timestamp.now();
 
     loadTest();
 
     PipelineResult pipelineResult = pipeline.run();
     pipelineResult.waitUntilFinish(Duration.standardMinutes(options.getLoadTestTimeout()));
 
-    LoadTestResult testResult =
-        LoadTestResult.create(pipelineResult, metricsNamespace, testStartTime);
-    ConsoleResultPublisher.publish(testResult);
+    String testId = UUID.randomUUID().toString();
+    List metrics = readMetrics(timestamp, pipelineResult, testId);
 
-    handleFailure(pipelineResult, testResult);
+    ConsoleResultPublisher.publish(metrics, testId, timestamp.toString());
+
+    handleFailure(pipelineResult, metrics);
 
     if (options.getPublishToBigQuery()) {
-      publishResultToBigQuery(testResult);
+      publishResultsToBigQuery(metrics);
     }
 
     return pipelineResult;
   }
 
-  private void publishResultToBigQuery(LoadTestResult testResult) {
+  private List<NamedTestResult> readMetrics(
+      Timestamp timestamp, PipelineResult result, String testId) {
+    MetricsReader reader = new MetricsReader(result, metricsNamespace);
+
+    NamedTestResult runtime =
+        NamedTestResult.create(
+            testId,
+            timestamp.toString(),
+            "runtime_sec",
+            (reader.getEndTimeMetric("runtime") - reader.getStartTimeMetric("runtime")) / 1000D);
+
+    NamedTestResult totalBytes =
+        NamedTestResult.create(
+            testId,
+            timestamp.toString(),
+            "total_bytes_count",
+            reader.getCounterMetric("totalBytes.count"));
+
+    return Arrays.asList(runtime, totalBytes);
+  }
+
+  private void publishResultsToBigQuery(List<NamedTestResult> testResults) {
     String dataset = options.getBigQueryDataset();
     String table = options.getBigQueryTable();
     checkBigQueryOptions(dataset, table);
 
-    ImmutableMap<String, String> schema =
-        ImmutableMap.<String, String>builder()
-            .put("timestamp", "timestamp")
-            .put("runtime", "float")
-            .put("total_bytes_count", "integer")
-            .build();
-
-    BigQueryResultsPublisher.create(dataset, schema).publish(testResult, table);
+    BigQueryResultsPublisher.create(dataset, NamedTestResult.getSchema())
+        .publish(testResults, table);
   }
 
   private static void checkBigQueryOptions(String dataset, String table) {

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/NamedTestResult.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/NamedTestResult.java
@@ -77,4 +77,12 @@ public class NamedTestResult implements TestResult {
   public static Map<String, String> getSchema() {
     return schema;
   }
+
+  public String getMetric() {
+    return metric;
+  }
+
+  public double getValue() {
+    return value;
+  }
 }

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/NamedTestResult.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/NamedTestResult.java
@@ -27,10 +27,14 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap
  */
 public class NamedTestResult implements TestResult {
 
-  private final String testID;
+  private final String testId;
+
   private final String timestamp;
+
   private final String metric;
+
   private final double value;
+
   private static final Map<String, String> schema =
       ImmutableMap.<String, String>builder()
           .put("test_id", LegacySQLTypeName.STRING.name())
@@ -39,8 +43,8 @@ public class NamedTestResult implements TestResult {
           .put("value", LegacySQLTypeName.FLOAT.name())
           .build();
 
-  private NamedTestResult(String testID, String timestamp, String metric, double value) {
-    this.testID = testID;
+  private NamedTestResult(String testId, String timestamp, String metric, double value) {
+    this.testId = testId;
     this.timestamp = timestamp;
     this.metric = metric;
     this.value = value;
@@ -49,21 +53,21 @@ public class NamedTestResult implements TestResult {
   /**
    * Creates a NamedTestResult.
    *
-   * @param testID Unique identifier for the test run this result belongs to.
+   * @param testId Unique identifier for the test run this result belongs to.
    * @param timestamp Time at which this result was sampled. Should be in a BigQuery supported
    *     timestamp format.
    * @param metric Name of this result's value.
    * @param value The actual sampled value.
    */
   public static NamedTestResult create(
-      String testID, String timestamp, String metric, double value) {
-    return new NamedTestResult(testID, timestamp, metric, value);
+      String testId, String timestamp, String metric, double value) {
+    return new NamedTestResult(testId, timestamp, metric, value);
   }
 
   @Override
   public Map<String, Object> toMap() {
     return ImmutableMap.<String, Object>builder()
-        .put("test_id", testID)
+        .put("test_id", testId)
         .put("timestamp", timestamp)
         .put("metric", metric)
         .put("value", value)

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/BigQueryClient.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/BigQueryClient.java
@@ -68,25 +68,6 @@ public class BigQueryClient {
     return new BigQueryClient(options.getService(), options.getProjectId(), dataset);
   }
 
-  /**
-   * Creates a new table with given schema when it not exists.
-   *
-   * @param tableName name of the desired table
-   * @param schema schema of consequent table fields (name, type pairs).
-   */
-  public void createTableIfNotExists(String tableName, Map<String, String> schema) {
-    TableId tableId = TableId.of(projectId, dataset, tableName);
-
-    if (client.getTable(tableId, FIELD_OPTIONS) == null) {
-      List<Field> schemaFields =
-          schema.entrySet().stream()
-              .map(entry -> Field.of(entry.getKey(), LegacySQLTypeName.valueOf(entry.getValue())))
-              .collect(Collectors.toList());
-
-      createTable(tableId, Schema.of(schemaFields));
-    }
-  }
-
   private void createTable(TableId tableId, Schema schema) {
     TableInfo tableInfo =
         TableInfo.newBuilder(tableId, StandardTableDefinition.of(schema))
@@ -117,6 +98,18 @@ public class BigQueryClient {
     insertAll(Collections.singletonList(row), table);
   }
 
+  /**
+   * Inserts rows to BigQuery table. Creates table using the given schema if the table does not
+   * exist.
+   *
+   * @see #insertRow(Map, String)
+   * @see #createTableIfNotExists(String, Map) for more details.
+   */
+  public void insertAll(Collection<Map<String, ?>> rows, Map<String, String> schema, String table) {
+    createTableIfNotExists(table, schema);
+    insertAll(rows, table);
+  }
+
   /** Inserts multiple rows of the same schema to a BigQuery table. */
   public void insertAll(Collection<Map<String, ?>> rows, String table) {
     TableId tableId = TableId.of(projectId, dataset, table);
@@ -137,6 +130,25 @@ public class BigQueryClient {
           format(
               "The following errors occurred while inserting to BigQuery: %s",
               response.getInsertErrors()));
+    }
+  }
+
+  /**
+   * Creates a new table with given schema when it not exists.
+   *
+   * @param tableName name of the desired table
+   * @param schema schema of consequent table fields (name, type pairs).
+   */
+  public void createTableIfNotExists(String tableName, Map<String, String> schema) {
+    TableId tableId = TableId.of(projectId, dataset, tableName);
+
+    if (client.getTable(tableId, FIELD_OPTIONS) == null) {
+      List<Field> schemaFields =
+          schema.entrySet().stream()
+              .map(entry -> Field.of(entry.getKey(), LegacySQLTypeName.valueOf(entry.getValue())))
+              .collect(Collectors.toList());
+
+      createTable(tableId, Schema.of(schemaFields));
     }
   }
 }

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/BigQueryResultsPublisher.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/BigQueryResultsPublisher.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.testutils.publishing;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.testutils.TestResult;
@@ -47,6 +49,12 @@ public class BigQueryResultsPublisher {
 
   public void publish(TestResult result, String tableName) {
     client.insertRow(getRowOfSchema(result), schema, tableName);
+  }
+
+  public void publish(Collection<? extends TestResult> results, String tableName) {
+    List<Map<String, ?>> records =
+        results.stream().map(this::getRowOfSchema).collect(Collectors.toList());
+    client.insertAll(records, schema, tableName);
   }
 
   private Map<String, Object> getRowOfSchema(TestResult result) {

--- a/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/fakes/FakeBigQueryClient.java
+++ b/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/fakes/FakeBigQueryClient.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.testutils.fakes;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,11 @@ public class FakeBigQueryClient extends BigQueryClient {
   @Override
   public void createTableIfNotExists(String tableName, Map<String, String> schema) {
     // do nothing. Assume the table exists.
+  }
+
+  @Override
+  public void insertAll(Collection<Map<String, ?>> rows, Map<String, String> schema, String table) {
+    rows.forEach(row -> insertRow(row, table));
   }
 
   @Override

--- a/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/publishing/BigQueryResultsPublisherTest.java
+++ b/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/publishing/BigQueryResultsPublisherTest.java
@@ -20,6 +20,8 @@ package org.apache.beam.sdk.testutils.publishing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.testutils.TestResult;
 import org.apache.beam.sdk.testutils.fakes.FakeBigQueryClient;
@@ -78,6 +80,16 @@ public class BigQueryResultsPublisherTest {
 
     Map<String, ?> rowInTable = bigQueryClient.getRows(TABLE_NAME).get(0);
     assertNull(rowInTable.get("field2"));
+  }
+
+  @Test
+  public void testPublishCollectionOfRecords() {
+    List<SampleTestResult> results =
+        Arrays.asList(new SampleTestResult("a", "b"), new SampleTestResult("a", "b"));
+
+    publisher.publish(results, TABLE_NAME);
+
+    assertEquals(2, bigQueryClient.getRows(TABLE_NAME).size());
   }
 
   private static class SampleTestResult implements TestResult {


### PR DESCRIPTION
A more future-proof solution for saving metrics for load tests. It will require cleaning the existing BigQuery tables but better sooner than later. We do not store valuable data there yet.

@udim @kkucharc could you take a look? 


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




