### PR TITLE
[SQL] Multiple schemas support

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamQueryPlanner.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamQueryPlanner.java
@@ -54,9 +54,13 @@ import org.slf4j.LoggerFactory;
 class BeamQueryPlanner {
   private static final Logger LOG = LoggerFactory.getLogger(BeamQueryPlanner.class);
 
-  private final FrameworkConfig config;
+  private JdbcConnection connection;
 
   BeamQueryPlanner(JdbcConnection connection) {
+    this.connection = connection;
+  }
+
+  public FrameworkConfig config() {
     final CalciteConnectionConfig config = connection.config();
     final SqlParser.ConfigBuilder parserConfig =
         SqlParser.configBuilder()
@@ -85,17 +89,16 @@ class BeamQueryPlanner {
     final SqlOperatorTable opTab0 =
         connection.config().fun(SqlOperatorTable.class, SqlStdOperatorTable.instance());
 
-    this.config =
-        Frameworks.newConfigBuilder()
-            .parserConfig(parserConfig.build())
-            .defaultSchema(defaultSchema)
-            .traitDefs(traitDefs)
-            .context(Contexts.of(connection.config()))
-            .ruleSets(BeamRuleSets.getRuleSets())
-            .costFactory(null)
-            .typeSystem(connection.getTypeFactory().getTypeSystem())
-            .operatorTable(ChainedSqlOperatorTable.of(opTab0, catalogReader))
-            .build();
+    return Frameworks.newConfigBuilder()
+        .parserConfig(parserConfig.build())
+        .defaultSchema(defaultSchema)
+        .traitDefs(traitDefs)
+        .context(Contexts.of(connection.config()))
+        .ruleSets(BeamRuleSets.getRuleSets())
+        .costFactory(null)
+        .typeSystem(connection.getTypeFactory().getTypeSystem())
+        .operatorTable(ChainedSqlOperatorTable.of(opTab0, catalogReader))
+        .build();
   }
 
   /** Parse input SQL query, and return a {@link SqlNode} as grammar tree. */
@@ -141,6 +144,6 @@ class BeamQueryPlanner {
   }
 
   private Planner getPlanner() {
-    return Frameworks.getPlanner(config);
+    return Frameworks.getPlanner(config());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
@@ -80,6 +80,10 @@ public class BeamSqlEnv {
     }
   }
 
+  public void addSchema(String name, TableProvider tableProvider) {
+    connection.setSchema(name, tableProvider);
+  }
+
   /** Register a UDF function which can be used in SQL expression. */
   public void registerUdf(String functionName, Class<?> clazz, String method) {
     connection.getCurrentSchemaPlus().add(functionName, UdfImpl.create(clazz, method));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.extensions.sql.impl;
 
 import java.lang.reflect.Method;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -82,6 +83,14 @@ public class BeamSqlEnv {
 
   public void addSchema(String name, TableProvider tableProvider) {
     connection.setSchema(name, tableProvider);
+  }
+
+  public void setCurrentSchema(String name) {
+    try {
+      connection.setSchema(name);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /** Register a UDF function which can be used in SQL expression. */

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcConnection.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcConnection.java
@@ -64,6 +64,7 @@ public class JdbcConnection extends CalciteConnectionWrapper {
 
     JdbcConnection jdbcConnection = new JdbcConnection(connection);
     jdbcConnection.setPipelineOptionsMap(extractPipelineOptions(connection));
+    jdbcConnection.getRootSchema().setCacheEnabled(false);
     jdbcConnection.setSchema(
         connection.getSchema(), BeamCalciteSchemaFactory.fromInitialEmptySchema(jdbcConnection));
     return jdbcConnection;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlMultipleSchemasTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlMultipleSchemasTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import org.apache.beam.sdk.extensions.sql.impl.schema.BeamPCollectionTable;
+import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
+import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Ad-hoc tests for CAST. */
+public class BeamSqlMultipleSchemasTest {
+
+  private static final Schema ROW_SCHEMA =
+      Schema.builder().addInt32Field("f_int").addStringField("f_string").build();
+
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public ExpectedException exceptions = ExpectedException.none();
+
+  @Test
+  public void testSelectFromQualifiedPCollection() {
+    PCollection<Row> input = pipeline.apply(create(row(1, "strstr")));
+
+    PCollection<Row> result =
+        input.apply(SqlTransform.query("SELECT f_int, f_string FROM beam.PCOLLECTION"));
+
+    PAssert.that(result).containsInAnyOrder(row(1, "strstr"));
+    pipeline.run();
+  }
+
+  @Test
+  public void testSelectFromUnqualifiedPCollection() {
+    PCollection<Row> input = pipeline.apply(create(row(1, "strstr")));
+
+    PCollection<Row> result =
+        input.apply(SqlTransform.query("SELECT f_int, f_string FROM PCOLLECTION"));
+
+    PAssert.that(result).containsInAnyOrder(row(1, "strstr"));
+    pipeline.run();
+  }
+
+  @Test
+  public void testSelectFromExtraSchema() {
+    PCollection<Row> inputMain =
+        pipeline.apply("mainInput", create(row(1, "pcollection_1"), row(2, "pcollection_2")));
+
+    PCollection<Row> inputExtra =
+        pipeline.apply("extraInput", create(row(1, "_extra_table_1"), row(2, "_extra_table_2")));
+
+    TableProvider extraInputProvider = extraTableProvider("extraTable", inputExtra);
+
+    PCollection<Row> result =
+        inputMain.apply(
+            SqlTransform.query("SELECT f_int, f_string FROM extraSchema.extraTable")
+                .withTableProvider("extraSchema", extraInputProvider));
+
+    PAssert.that(result).containsInAnyOrder(row(1, "_extra_table_1"), row(2, "_extra_table_2"));
+    pipeline.run();
+  }
+
+  @Test
+  public void testOverrideUnqualifiedMainSchema() {
+    PCollection<Row> inputMain =
+        pipeline.apply("mainInput", create(row(1, "pcollection_1"), row(2, "pcollection_2")));
+
+    PCollection<Row> inputExtra =
+        pipeline.apply("extraInput", create(row(1, "_extra_table_1"), row(2, "_extra_table_2")));
+
+    TableProvider extraInputProvider = extraTableProvider("extraTable", inputExtra);
+
+    PCollection<Row> result =
+        inputMain.apply(
+            SqlTransform.query("SELECT f_int, f_string FROM extraTable")
+                .withTableProvider("beam", extraInputProvider));
+
+    PAssert.that(result).containsInAnyOrder(row(1, "_extra_table_1"), row(2, "_extra_table_2"));
+    pipeline.run();
+  }
+
+  @Test
+  public void testOverrideQualifiedMainSchema() {
+    PCollection<Row> inputMain =
+        pipeline.apply("mainInput", create(row(1, "pcollection_1"), row(2, "pcollection_2")));
+
+    PCollection<Row> inputExtra =
+        pipeline.apply("extraInput", create(row(1, "_extra_table_1"), row(2, "_extra_table_2")));
+
+    TableProvider extraInputProvider = extraTableProvider("extraTable", inputExtra);
+
+    PCollection<Row> result =
+        inputMain.apply(
+            SqlTransform.query("SELECT f_int, f_string FROM beam.extraTable")
+                .withTableProvider("beam", extraInputProvider));
+
+    PAssert.that(result).containsInAnyOrder(row(1, "_extra_table_1"), row(2, "_extra_table_2"));
+    pipeline.run();
+  }
+
+  @Test
+  public void testJoinWithExtraSchema() {
+    PCollection<Row> inputMain =
+        pipeline.apply("mainInput", create(row(1, "pcollection_1"), row(2, "pcollection_2")));
+
+    PCollection<Row> inputExtra =
+        pipeline.apply("extraInput", create(row(1, "_extra_table_1"), row(2, "_extra_table_2")));
+
+    TableProvider extraInputProvider = extraTableProvider("extraTable", inputExtra);
+
+    PCollection<Row> result =
+        inputMain.apply(
+            SqlTransform.query(
+                    "SELECT extra.f_int, main.f_string || extra.f_string AS f_string \n"
+                        + "FROM extraSchema.extraTable AS extra \n"
+                        + "   INNER JOIN \n"
+                        + " PCOLLECTION AS main \n"
+                        + "   ON main.f_int = extra.f_int")
+                .withTableProvider("extraSchema", extraInputProvider));
+
+    PAssert.that(result)
+        .containsInAnyOrder(
+            row(1, "pcollection_1_extra_table_1"), row(2, "pcollection_2_extra_table_2"));
+    pipeline.run();
+  }
+
+  @Test
+  public void testJoinQualifiedMainWithExtraSchema() {
+    PCollection<Row> inputMain =
+        pipeline.apply("mainInput", create(row(1, "pcollection_1"), row(2, "pcollection_2")));
+
+    PCollection<Row> inputExtra =
+        pipeline.apply("extraInput", create(row(1, "_extra_table_1"), row(2, "_extra_table_2")));
+
+    TableProvider extraInputProvider = extraTableProvider("extraTable", inputExtra);
+
+    PCollection<Row> result =
+        inputMain.apply(
+            SqlTransform.query(
+                    "SELECT extra.f_int, main.f_string || extra.f_string AS f_string \n"
+                        + "FROM extraSchema.extraTable AS extra \n"
+                        + "   INNER JOIN \n"
+                        + " beam.PCOLLECTION AS main \n"
+                        + "   ON main.f_int = extra.f_int")
+                .withTableProvider("extraSchema", extraInputProvider));
+
+    PAssert.that(result)
+        .containsInAnyOrder(
+            row(1, "pcollection_1_extra_table_1"), row(2, "pcollection_2_extra_table_2"));
+    pipeline.run();
+  }
+
+  private TableProvider extraTableProvider(String tableName, PCollection<Row> rows) {
+    return new ReadOnlyTableProvider(
+        "testExtraTableProvider", ImmutableMap.of(tableName, new BeamPCollectionTable<>(rows)));
+  }
+
+  private Row row(int fIntValue, String fStringValue) {
+    return Row.withSchema(ROW_SCHEMA).addValues(fIntValue, fStringValue).build();
+  }
+
+  private PTransform<PBegin, PCollection<Row>> create(Row... rows) {
+    return Create.of(Arrays.asList(rows)).withRowSchema(ROW_SCHEMA);
+  }
+}


### PR DESCRIPTION
Adds support for multiple top-level schemas in `SqlTransform`. Allows use cases of joining `PCollections` with other sources by providing them in a separate `TableProvider`. Allows changing the default schema from `beam` to something else.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




