### PR TITLE
Deflake statesampler_test

### DIFF
--- a/sdks/python/apache_beam/runners/worker/statesampler_test.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler_test.py
@@ -36,9 +36,9 @@ class StateSamplerTest(unittest.TestCase):
 
   # Due to somewhat non-deterministic nature of state sampling and sleep,
   # this test is flaky when state duraiton is low.
-  # Since increasing state duration significantly would als slow down
-  # the test suite, we are retrying once on failure as a mitigation.
-  @retry(reraise=True, stop=stop_after_attempt(2))
+  # Since increasing state duration significantly would also slow down
+  # the test suite, we are retrying twice on failure as a mitigation.
+  @retry(reraise=True, stop=stop_after_attempt(3))
   def test_basic_sampler(self):
     # Set up state sampler.
     counter_factory = CounterFactory()

--- a/sdks/python/apache_beam/runners/worker/statesampler_test.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler_test.py
@@ -24,6 +24,9 @@ import time
 import unittest
 from builtins import range
 
+from tenacity import retry
+from tenacity import stop_after_attempt
+
 from apache_beam.runners.worker import statesampler
 from apache_beam.utils.counters import CounterFactory
 from apache_beam.utils.counters import CounterName
@@ -31,33 +34,41 @@ from apache_beam.utils.counters import CounterName
 
 class StateSamplerTest(unittest.TestCase):
 
+  # Due to somewhat non-deterministic nature of state sampling and sleep,
+  # this test is flaky when state duraiton is low.
+  # Since increasing state duration significantly would als slow down
+  # the test suite, we are retrying once on failure as a mitigation.
+  @retry(reraise=True, stop=stop_after_attempt(2))
   def test_basic_sampler(self):
     # Set up state sampler.
     counter_factory = CounterFactory()
     sampler = statesampler.StateSampler('basic', counter_factory,
                                         sampling_period_ms=1)
 
+    # Duration of the fastest state. Total test duration is 6 times longer.
+    state_duration_ms = 1000
+    margin_of_error = 0.25
     # Run basic workload transitioning between 3 states.
     sampler.start()
     with sampler.scoped_state('step1', 'statea'):
-      time.sleep(0.1)
+      time.sleep(state_duration_ms / 1000)
       self.assertEqual(
           sampler.current_state().name,
           CounterName(
               'statea-msecs', step_name='step1', stage_name='basic'))
       with sampler.scoped_state('step1', 'stateb'):
-        time.sleep(0.2 / 2)
+        time.sleep(state_duration_ms / 1000)
         self.assertEqual(
             sampler.current_state().name,
             CounterName(
                 'stateb-msecs', step_name='step1', stage_name='basic'))
         with sampler.scoped_state('step1', 'statec'):
-          time.sleep(0.3)
+          time.sleep(3 * state_duration_ms / 1000)
           self.assertEqual(
               sampler.current_state().name,
               CounterName(
                   'statec-msecs', step_name='step1', stage_name='basic'))
-        time.sleep(0.2 / 2)
+        time.sleep(state_duration_ms / 1000)
 
     sampler.stop()
     sampler.commit_counters()
@@ -68,9 +79,12 @@ class StateSamplerTest(unittest.TestCase):
 
     # Test that sampled state timings are close to their expected values.
     expected_counter_values = {
-        CounterName('statea-msecs', step_name='step1', stage_name='basic'): 100,
-        CounterName('stateb-msecs', step_name='step1', stage_name='basic'): 200,
-        CounterName('statec-msecs', step_name='step1', stage_name='basic'): 300,
+        CounterName('statea-msecs', step_name='step1', stage_name='basic'):
+            state_duration_ms,
+        CounterName('stateb-msecs', step_name='step1', stage_name='basic'):
+            2 * state_duration_ms,
+        CounterName('statec-msecs', step_name='step1', stage_name='basic'):
+            3 * state_duration_ms,
     }
     for counter in counter_factory.get_counters():
       self.assertIn(counter.name, expected_counter_values)
@@ -78,8 +92,8 @@ class StateSamplerTest(unittest.TestCase):
       actual_value = counter.value()
       deviation = float(abs(actual_value - expected_value)) / expected_value
       logging.info('Sampling deviation from expectation: %f', deviation)
-      self.assertGreater(actual_value, expected_value * 0.75)
-      self.assertLess(actual_value, expected_value * 1.25)
+      self.assertGreater(actual_value, expected_value * (1.0 - margin_of_error))
+      self.assertLess(actual_value, expected_value * (1.0 + margin_of_error))
 
   def test_sampler_transition_overhead(self):
     # Set up state sampler.

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -133,10 +133,11 @@ REQUIRED_PACKAGES = [
 
 REQUIRED_TEST_PACKAGES = [
     'nose>=1.3.7',
+    'numpy>=1.14.3,<2',
     'pandas>=0.23.4,<0.24',
     'parameterized>=0.6.0,<0.7.0',
-    'numpy>=1.14.3,<2',
     'pyhamcrest>=1.9,<2.0',
+    'tenacity>=5.0.2,<6.0',
     ]
 
 GCP_REQUIREMENTS = [


### PR DESCRIPTION
1. Add a dependency on Tenacity, a general-purpose retry library: https://github.com/jd/tenacity.
2. Make statesampler_test easier to configure and adjust it to reduce flakiness: make the fastest state last 1 second, or total test runtime to last 6 seconds, and retry once if the test fails. This should reduce flakiness below 1 in 100000. Alternative considered: keep current state duration, but retry 5 times. The alternative would be less sensitive to a potential change in statesampler that would result in real loss of precision in measurement. 
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




