### PR TITLE
[BEAM-6351] Divide separate job for "smoke" load test suites

### DIFF
--- a/.test-infra/jenkins/LoadTestsBuilder.groovy
+++ b/.test-infra/jenkins/LoadTestsBuilder.groovy
@@ -19,22 +19,11 @@
 import CommonJobProperties as commonJobProperties
 import CommonTestProperties.Runner
 
-// Class for building Load Tests jobs and suites
 class LoadTestsBuilder {
 
-    private static Map<String, Object> defaultOptions = [
-            project             :'apache-beam-testing',
-            tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
-    ]
-
-    static void buildTest(context, String title, Runner runner, Map<String, Object> jobSpecificOptions, String mainClass) {
-        Map<String, Object> options = jobSpecificOptions + defaultOptions
+    static void loadTest(context, String title, Runner runner, Map<String, Object> options, String mainClass) {
         options.put('runner', runner.option)
 
-        suite(context, title, runner, options, mainClass)
-    }
-
-    static void suite(context, String title, Runner runner, Map<String, Object> options, String mainClass) {
         context.steps {
             shell("echo *** ${title} ***")
             gradle {

--- a/.test-infra/jenkins/job_LoadTests_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Java.groovy
@@ -71,6 +71,22 @@ def smokeTestConfigurations = [
                         fanout           : 10,
                         iterations       : 1,
                 ]
+        ],
+        [
+                title        : 'GroupByKey load test Dataflow',
+                itClass      : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                runner       : CommonTestProperties.Runner.DATAFLOW,
+                jobProperties: [
+                        project          : 'apache-beam-testing',
+                        tempLocation     : 'gs://temp-storage-for-perf-tests/smoketests',
+                        publishToBigQuery: true,
+                        bigQueryDataset  : 'load_test_SMOKE',
+                        bigQueryTable    : 'dataflow_gbk',
+                        sourceOptions    : '{"numRecords":100000,"splitPointFrequencyRecords":1}',
+                        stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true}',
+                        fanout           : 10,
+                        iterations       : 1,
+                ]
         ]
 ]
 

--- a/.test-infra/jenkins/job_LoadTests_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Java.groovy
@@ -102,6 +102,21 @@ def smokeTestConfigurations = [
                         fanout           : 10,
                         iterations       : 1,
                 ]
+        ],
+        [
+                title        : 'GroupByKey load test Spark',
+                itClass      : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                runner       : CommonTestProperties.Runner.SPARK,
+                jobProperties: [
+                        sparkMaster      : 'local[4]',
+                        publishToBigQuery: true,
+                        bigQueryDataset  : 'load_test_SMOKE',
+                        bigQueryTable    : 'spark_gbk',
+                        sourceOptions    : '{"numRecords":100000,"splitPointFrequencyRecords":1}',
+                        stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true}',
+                        fanout           : 10,
+                        iterations       : 1,
+                ]
         ]
 ]
 

--- a/.test-infra/jenkins/job_LoadTests_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Java.groovy
@@ -20,25 +20,7 @@ import CommonJobProperties as commonJobProperties
 import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 
-def testsConfigurations = [
-        [
-                jobName           : 'beam_Java_LoadTests_GroupByKey_Direct_Small',
-                jobDescription    : 'Runs GroupByKey load tests on direct runner small records 10b',
-                itClass           : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
-                prCommitStatusName: 'Java GroupByKey Small Java Load Test Direct',
-                prTriggerPhrase   : 'Run GroupByKey Small Java Load Test Direct',
-                runner            : CommonTestProperties.Runner.DIRECT,
-                jobProperties     : [
-                        publishToBigQuery: true,
-                        bigQueryDataset  : 'load_test_PRs',
-                        bigQueryTable    : 'direct_gbk_small',
-                        sourceOptions    : '{"numRecords":1000000000,"splitPointFrequencyRecords":1,"keySizeBytes":1,"valueSizeBytes":9,"numHotKeys":0,"hotKeyFraction":0,"seed":123456,"bundleSizeDistribution":{"type":"const","const":42},"forceNumInitialBundles":100,"progressShape":"LINEAR","initializeDelayDistribution":{"type":"const","const":42}}',
-                        stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true,"perBundleDelay":10000,"perBundleDelayType":"MIXED","cpuUtilizationInMixedDelay":0.5}',
-                        fanout           : 10,
-                        iterations       : 1,
-                ]
-
-        ],
+def loadTestConfigurations = [
         [
                 jobName           : 'beam_Java_LoadTests_GroupByKey_Dataflow_Small',
                 jobDescription    : 'Runs GroupByKey load tests on Dataflow runner small records 10b',
@@ -62,7 +44,7 @@ def testsConfigurations = [
         ],
 ]
 
-for (testConfiguration in testsConfigurations) {
+for (testConfiguration in loadTestConfigurations) {
     PhraseTriggeringPostCommitBuilder.postCommitJob(
             testConfiguration.jobName,
             testConfiguration.prTriggerPhrase,
@@ -72,5 +54,36 @@ for (testConfiguration in testsConfigurations) {
         description(testConfiguration.jobDescription)
         commonJobProperties.setTopLevelMainJobProperties(delegate)
         loadTestsBuilder.loadTest(delegate, testConfiguration.jobDescription, testConfiguration.runner, testConfiguration.jobProperties, testConfiguration.itClass)
+    }
+}
+
+def smokeTestConfigurations = [
+        [
+                title        : 'GroupByKey load test Direct',
+                itClass      : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                runner       : CommonTestProperties.Runner.DIRECT,
+                jobProperties: [
+                        publishToBigQuery: true,
+                        bigQueryDataset  : 'load_test_SMOKE',
+                        bigQueryTable    : 'direct_gbk',
+                        sourceOptions    : '{"numRecords":100000,"splitPointFrequencyRecords":1}',
+                        stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true}',
+                        fanout           : 10,
+                        iterations       : 1,
+                ]
+        ]
+]
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_Java_LoadTests_Smoke',
+        'Run Java Load Tests Smoke',
+        'Java Load Tests Smoke',
+        this
+) {
+    description("Runs load tests in \"smoke\" mode to check if everything works well")
+    commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 120)
+
+    for (testConfiguration in smokeTestConfigurations) {
+      loadTestsBuilder.loadTest(delegate, testConfiguration.title, testConfiguration.runner, testConfiguration.jobProperties, testConfiguration.itClass)
     }
 }

--- a/.test-infra/jenkins/job_LoadTests_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Java.groovy
@@ -87,6 +87,21 @@ def smokeTestConfigurations = [
                         fanout           : 10,
                         iterations       : 1,
                 ]
+        ],
+        [
+                title        : 'GroupByKey load test Flink',
+                itClass      : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                runner       : CommonTestProperties.Runner.FLINK,
+                jobProperties: [
+                        flinkMaster      : '[local]',
+                        publishToBigQuery: true,
+                        bigQueryDataset  : 'load_test_SMOKE',
+                        bigQueryTable    : 'flink_gbk',
+                        sourceOptions    : '{"numRecords":100000,"splitPointFrequencyRecords":1}',
+                        stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true}',
+                        fanout           : 10,
+                        iterations       : 1,
+                ]
         ]
 ]
 

--- a/.test-infra/jenkins/job_LoadTests_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Java.groovy
@@ -47,6 +47,8 @@ def testsConfigurations = [
                 prTriggerPhrase   : 'Run GroupByKey Small Java Load Test Dataflow',
                 runner            : CommonTestProperties.Runner.DATAFLOW,
                 jobProperties     : [
+                        project             : 'apache-beam-testing',
+                        tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                         publishToBigQuery   : true,
                         bigQueryDataset     : 'load_test_PRs',
                         bigQueryTable       : 'dataflow_gbk_small',
@@ -69,6 +71,6 @@ for (testConfiguration in testsConfigurations) {
     ) {
         description(testConfiguration.jobDescription)
         commonJobProperties.setTopLevelMainJobProperties(delegate)
-        loadTestsBuilder.buildTest(delegate, testConfiguration.jobDescription, testConfiguration.runner, testConfiguration.jobProperties, testConfiguration.itClass)
+        loadTestsBuilder.loadTest(delegate, testConfiguration.jobDescription, testConfiguration.runner, testConfiguration.jobProperties, testConfiguration.itClass)
     }
 }


### PR DESCRIPTION
Added a separate job that will run "smoke" load test suite to verify if everything's going well. More tests can be added to the smoke suite in the future. The idea is to have one "smoke" job and separate load test jobs.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




