### PR TITLE
[BEAM-6425] - Replace SSLContext.getInstance("SSL")

### DIFF
--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/SSLUtils.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/SSLUtils.java
@@ -53,7 +53,7 @@ public class SSLUtils {
   public static SSLContext ignoreSSLCertificate() {
     try {
       // Install the all-trusting trust manager
-      SSLContext sc = SSLContext.getInstance("SSL");
+      SSLContext sc = SSLContext.getInstance("TLS");
       sc.init(null, trustAllCerts, new java.security.SecureRandom());
       HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
 


### PR DESCRIPTION
Switch to SSLContext.getInstance("TLS") instead of the older SSL algorithm.