### PR TITLE
[BEAM-6184]Make checkstyle report error on missing javaDocMethod

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ReferenceRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ReferenceRunner.java
@@ -161,9 +161,10 @@ public class ReferenceRunner {
     return res;
   }
 
-  /** First starts all the services needed, then configures and
-   *  starts the {@link ExecutorServiceParallelExecutor}.
-   * */
+  /**
+   * First starts all the services needed, then configures and starts the {@link
+   * ExecutorServiceParallelExecutor}.
+   */
   public void execute() throws Exception {
     ExecutableGraph<PTransformNode, PCollectionNode> graph = PortableGraph.forPipeline(pipeline);
     BundleFactory bundleFactory = ImmutableListBundleFactory.create();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ReferenceRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ReferenceRunner.java
@@ -161,7 +161,9 @@ public class ReferenceRunner {
     return res;
   }
 
-  /** Configures and starts the {@link ExecutorServiceParallelExecutor}. */
+  /** First starts all the services needed, then configures and
+   *  starts the {@link ExecutorServiceParallelExecutor}.
+   * */
   public void execute() throws Exception {
     ExecutableGraph<PTransformNode, PCollectionNode> graph = PortableGraph.forPipeline(pipeline);
     BundleFactory bundleFactory = ImmutableListBundleFactory.create();

--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -131,7 +131,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
     <module name="JavadocMethod">
       <property name="scope" value="public"/>
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
       <property name="minLineCount" value="30"/>
       <property name="allowMissingJavadoc" value="false"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>

--- a/sdks/java/build-tools/src/main/resources/beam/suppressions.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/suppressions.xml
@@ -41,7 +41,7 @@
   <!-- sdk -->
   <suppress checks="JavadocMethod" files=".*sdk.*Experimental\.java" lines="48,112"/>
   <suppress checks="JavadocMethod" files=".*sdk.*DefaultCoder\.java" lines="54"/>
-  <suppress checks="JavadocMethod" files=".*sdk.*FileIO\.java" lines="800"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*FileIO\.java" lines="801"/>
   <suppress checks="JavadocMethod" files=".*sdk.*OffsetRangeTracker\.java" lines="83"/>
   <suppress checks="JavadocMethod" files=".*sdk.*Default\.java" lines="40"/>
   <suppress checks="JavadocMethod" files=".*sdk.*Description\.java" lines="34"/>
@@ -61,6 +61,7 @@
   <suppress checks="JavadocMethod" files=".*sdk.*gcp.*AvroUtils\.java" lines="28"/>
   <suppress checks="JavadocMethod" files=".*sdk.*testing.*BigqueryClient\.java" lines="277,357,454"/>
   <suppress checks="JavadocMethod" files=".*sdk.*gcp.*BigQueryUtils\.java" lines="212"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*transforms.*DoFn\.java" lines="443"/>
 
   <!--  runner/core  -->
   <suppress checks="JavadocMethod" files=".*runners.*core.*ParDoTranslation\.java" lines="163,368"/>
@@ -73,6 +74,7 @@
   <suppress checks="JavadocMethod" files=".*runners.*core.*MetricsTranslation\.java" lines="39,76"/>
   <suppress checks="JavadocMethod" files=".*runners.*core.*TriggerStateMachines\.java" lines="76"/>
   <suppress checks="JavadocMethod" files=".*runners.*core.*TriggerStateMachines\.java" lines="32"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*SplittableParDoViaKeyedWorkItems\.java" lines="329"/>
 
   <!-- Fn harness -->
   <suppress checks="JavadocMethod" files=".*harness.*FnHarness\.java" lines="126"/>

--- a/sdks/java/build-tools/src/main/resources/beam/suppressions.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/suppressions.xml
@@ -30,4 +30,65 @@
   <suppress checks=".*" files=".+[\\\/]generated-src[\\\/].+\.java" />
   <suppress checks=".*" files=".+[\\\/]generated-sources[\\\/].+\.java" />
   <suppress checks=".*" files=".+[\\\/]generated-test-sources[\\\/].+\.java" />
+
+  <!-- Suppression on JavadocMethod violations.
+
+       The goal is to remove all the following suppressions, once they are addressed.
+
+       Tracking JIRA:BEAM-6446
+  -->
+
+  <!-- sdk -->
+  <suppress checks="JavadocMethod" files=".*sdk.*Experimental\.java" lines="48,112"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*DefaultCoder\.java" lines="54"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*FileIO\.java" lines="800"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*OffsetRangeTracker\.java" lines="83"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*Default\.java" lines="40"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*Description\.java" lines="34"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*TransformHierarchy\.java" lines="144"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*Schema\.java" lines="363"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*DefaultSchema\.java" lines="65"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*SchemaFieldName\.java" lines="52"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*Cast\.java" lines="332,391"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*DoFn\.java" lines="444"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*CoGbkResult\.java" lines="72"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*extensions.*Audience\.java" lines="32"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*clickhouse.*ClickHouseIO\.java" lines="467"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*clickhouse.*ClickHouseWriter\.java" lines="47"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*sql.*BeamSetOperatorsTransforms\.java" lines="59"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*nexmark.*GeneratorConfig\.java" lines="89"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*CassandraServiceImpl\.java" lines="112"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*gcp.*AvroUtils\.java" lines="28"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*testing.*BigqueryClient\.java" lines="277,357,454"/>
+  <suppress checks="JavadocMethod" files=".*sdk.*gcp.*BigQueryUtils\.java" lines="212"/>
+
+  <!--  runner/core  -->
+  <suppress checks="JavadocMethod" files=".*runners.*core.*ParDoTranslation\.java" lines="163,368"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*PipelineTranslation\.java" lines="54"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*TriggerTranslation\.java" lines="238"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*WindowingStrategyTranslation\.java" lines="357"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*ReduceFnRunner\.java" lines="206,677"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*SimpleDoFnRunner\.java" lines="136"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*SplittableParDoViaKeyedWorkItems\.java" lines="327"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*MetricsTranslation\.java" lines="39,76"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*TriggerStateMachines\.java" lines="76"/>
+  <suppress checks="JavadocMethod" files=".*runners.*core.*TriggerStateMachines\.java" lines="32"/>
+
+  <!-- Fn harness -->
+  <suppress checks="JavadocMethod" files=".*harness.*FnHarness\.java" lines="126"/>
+  <suppress checks="JavadocMethod" files=".*harness.*BeamFnLoggingClient\.java" lines="104"/>
+  <suppress checks="JavadocMethod" files=".*harness.*FnApiStateAccessor\.java" lines="76"/>
+
+  <!-- Misc -->
+  <suppress checks="JavadocMethod" files=".*io.*JmsIO\.java" lines="117"/>
+  <suppress checks="JavadocMethod" files=".*runners.*samza.*DoFnRunnerWithKeyedInternals\.java" lines="53"/>
+  <suppress checks="JavadocMethod" files=".*runners.*nexmark.*GeneratorConfig\.java" lines="89"/>
+  <suppress checks="JavadocMethod" files=".*runners.*spark.*SparkUnboundedSource\.java" lines="82"/>
+  <suppress checks="JavadocMethod" files=".*runners.*apex.*ApexParDoOperator\.java" lines="143"/>
+  <suppress checks="JavadocMethod" files=".*runners.*dataflow.*TriggerStateMachines\.java" lines="76"/>
+  <suppress checks="JavadocMethod" files=".*runners.*dataflow.*CustomSources\.java" lines="62"/>
+  <suppress checks="JavadocMethod" files=".*flink.*metrics.*FlinkMetricContainer\.java" lines="112"/>
+  <suppress checks="JavadocMethod" files=".*flink.*wrappers.*ExecutableStageDoFnOperator\.java" lines="119"/>
+  <!-- End of Suppression on JavadocMethod violations. -->
+
 </suppressions>


### PR DESCRIPTION
1. Turn on javadocmethod checkstyle (i.e. now reports error)
2. Added suppressions to all the violations. 

Also created another beam-6446 to track the future progress of removing suppressions. 


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




