### PR TITLE
[BEAM-2713] Allow native type hints nested in Beam type hints.

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -85,6 +85,17 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
   @unittest.skipIf(sys.version_info[0] == 3 and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
                    'This test still needs to be fixed on Python 3.')
+  def test_convert_nested_to_beam_type(self):
+    self.assertEqual(
+        typehints.List[typing.Any],
+        typehints.List[typehints.Any])
+    self.assertEqual(
+        typehints.List[typing.Dict[int, str]],
+        typehints.List[typehints.Dict[int, str]])
+
+  @unittest.skipIf(sys.version_info[0] == 3 and
+                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                   'This test still needs to be fixed on Python 3.')
   def test_convert_to_beam_types(self):
     typing_types = [bytes, typing.List[bytes],
                     typing.List[typing.Tuple[bytes, int]],

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -225,7 +225,7 @@ class SequenceTypeConstraint(IndexableTypeConstraint):
   """
 
   def __init__(self, inner_type, sequence_type):
-    self.inner_type = inner_type
+    self.inner_type = normalize(inner_type)
     self._sequence_type = sequence_type
 
   def __eq__(self, other):
@@ -349,7 +349,8 @@ def validate_composite_type_param(type_param, error_msg_prefix):
     possible_classes.append(types.__dict__["ClassType"])
   is_not_type_constraint = (
       not isinstance(type_param, tuple(possible_classes))
-      and type_param is not None)
+      and type_param is not None
+      and getattr(type_param, '__module__', None) != 'typing')
   is_forbidden_type = (isinstance(type_param, type) and
                        type_param in DISALLOWED_PRIMITIVE_TYPES)
 
@@ -472,7 +473,7 @@ class UnionHint(CompositeTypeHint):
   class UnionConstraint(TypeConstraint):
 
     def __init__(self, union_types):
-      self.union_types = set(union_types)
+      self.union_types = set(normalize(t) for t in union_types)
 
     def __eq__(self, other):
       return (isinstance(other, UnionHint.UnionConstraint)
@@ -595,7 +596,7 @@ class TupleHint(CompositeTypeHint):
   class TupleConstraint(IndexableTypeConstraint):
 
     def __init__(self, type_params):
-      self.tuple_types = tuple(type_params)
+      self.tuple_types = tuple(normalize(t) for t in type_params)
 
     def __eq__(self, other):
       return (isinstance(other, TupleHint.TupleConstraint)
@@ -774,8 +775,8 @@ class DictHint(CompositeTypeHint):
   class DictConstraint(TypeConstraint):
 
     def __init__(self, key_type, value_type):
-      self.key_type = key_type
-      self.value_type = value_type
+      self.key_type = normalize(key_type)
+      self.value_type = normalize(value_type)
 
     def __repr__(self):
       return 'Dict[%s, %s]' % (_unified_repr(self.key_type),
@@ -970,7 +971,7 @@ class IteratorHint(CompositeTypeHint):
   class IteratorTypeConstraint(TypeConstraint):
 
     def __init__(self, t):
-      self.yielded_type = t
+      self.yielded_type = normalize(t)
 
     def __repr__(self):
       return 'Iterator[%s]' % _unified_repr(self.yielded_type)
@@ -1020,7 +1021,7 @@ class WindowedTypeConstraint(with_metaclass(GetitemConstructor,
   """
 
   def __init__(self, inner_type):
-    self.inner_type = inner_type
+    self.inner_type = normalize(inner_type)
 
   def __eq__(self, other):
     return (isinstance(other, WindowedTypeConstraint)
@@ -1075,20 +1076,36 @@ Generator = GeneratorHint()
 WindowedValue = WindowedTypeConstraint
 
 
-_KNOWN_PRIMITIVE_TYPES = {
+# There is a circular dependency between defining this mapping
+# and using it in normalize().  Initialize it here and populate
+# it below.
+_KNOWN_PRIMITIVE_TYPES = {}
+
+
+def normalize(x):
+  if x in _KNOWN_PRIMITIVE_TYPES:
+    return _KNOWN_PRIMITIVE_TYPES[x]
+  elif getattr(x, '__module__', None) == 'typing':
+    # Avoid circular imports
+    from apache_beam.typehints import native_type_compatibility
+    beam_type = native_type_compatibility.convert_to_beam_type(x)
+    if beam_type != x:
+      # We were able to do the conversion.
+      return beam_type
+    else:
+      # It might be a compatible type we don't understand.
+      return Any
+  return x
+
+
+_KNOWN_PRIMITIVE_TYPES.update({
     dict: Dict[Any, Any],
     list: List[Any],
     tuple: Tuple[Any, ...],
     set: Set[Any],
     # Using None for the NoneType is a common convention.
     None: type(None),
-}
-
-
-def normalize(x):
-  if x in _KNOWN_PRIMITIVE_TYPES:
-    return _KNOWN_PRIMITIVE_TYPES[x]
-  return x
+})
 
 
 def is_consistent_with(sub, base):

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1082,8 +1082,11 @@ WindowedValue = WindowedTypeConstraint
 _KNOWN_PRIMITIVE_TYPES = {}
 
 
-def normalize(x):
-  if x in _KNOWN_PRIMITIVE_TYPES:
+def normalize(x, none_as_type=False):
+    # None is inconsistantly used for Any, unknown, or NoneType.
+  if none_as_type and x is None:
+    return type(None)
+  elif x in _KNOWN_PRIMITIVE_TYPES:
     return _KNOWN_PRIMITIVE_TYPES[x]
   elif getattr(x, '__module__', None) == 'typing':
     # Avoid circular imports
@@ -1103,8 +1106,6 @@ _KNOWN_PRIMITIVE_TYPES.update({
     list: List[Any],
     tuple: Tuple[Any, ...],
     set: Set[Any],
-    # Using None for the NoneType is a common convention.
-    None: type(None),
 })
 
 
@@ -1122,8 +1123,8 @@ def is_consistent_with(sub, base):
     return True
   if isinstance(sub, AnyTypeConstraint) or isinstance(base, AnyTypeConstraint):
     return True
-  sub = normalize(sub)
-  base = normalize(base)
+  sub = normalize(sub, none_as_type=True)
+  base = normalize(base, none_as_type=True)
   if isinstance(base, TypeConstraint):
     if isinstance(sub, UnionConstraint):
       return all(is_consistent_with(c, base) for c in sub.union_types)


### PR DESCRIPTION
This prevents against rejection of, for example, `typehints.List[typehints.Dict[...]]` when `typehints.List[typing.Dict[...]]` is expected. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




