### PR TITLE
[BEAM-3580] Use a custom coder for strings.

### DIFF
--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -106,9 +106,13 @@ func inferCoder(t FullType) (*coder.Coder, error) {
 			}
 			return &coder.Coder{Kind: coder.Custom, T: t, Custom: c}, nil
 
-		case reflectx.String, reflectx.ByteSlice:
-			// TODO(BEAM-3580): we should stop encoding string using the bytecoder. It forces
-			// conversions at runtime in inconvenient places.
+		case reflectx.String:
+			c, err := coderx.NewString()
+			if err != nil {
+				return nil, err
+			}
+			return &coder.Coder{Kind: coder.Custom, T: t, Custom: c}, nil
+		case reflectx.ByteSlice:
 			return &coder.Coder{Kind: coder.Bytes, T: t}, nil
 		default:
 			// TODO(BEAM-3306): the coder registry should be consulted here for user

--- a/sdks/go/pkg/beam/core/runtime/coderx/coderx.shims.go
+++ b/sdks/go/pkg/beam/core/runtime/coderx/coderx.shims.go
@@ -31,6 +31,7 @@ func init() {
 	runtime.RegisterFunction(decFloat)
 	runtime.RegisterFunction(decInt32)
 	runtime.RegisterFunction(decInt64)
+	runtime.RegisterFunction(decString)
 	runtime.RegisterFunction(decUint32)
 	runtime.RegisterFunction(decUint64)
 	runtime.RegisterFunction(decVarIntZ)
@@ -38,6 +39,7 @@ func init() {
 	runtime.RegisterFunction(encFloat)
 	runtime.RegisterFunction(encInt32)
 	runtime.RegisterFunction(encInt64)
+	runtime.RegisterFunction(encString)
 	runtime.RegisterFunction(encUint32)
 	runtime.RegisterFunction(encUint64)
 	runtime.RegisterFunction(encVarIntZ)
@@ -49,6 +51,7 @@ func init() {
 	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type,[]byte) (typex.T,error))(nil)).Elem(), funcMakerReflect۰TypeSliceofByteГTypex۰TError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (int32))(nil)).Elem(), funcMakerSliceofByteГInt32)
 	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (int64))(nil)).Elem(), funcMakerSliceofByteГInt64)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (typex.T))(nil)).Elem(), funcMakerSliceofByteГTypex۰T)
 	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (uint32))(nil)).Elem(), funcMakerSliceofByteГUint32)
 	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (uint64))(nil)).Elem(), funcMakerSliceofByteГUint64)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) ([]byte))(nil)).Elem(), funcMakerTypex۰TГSliceofByte)
@@ -183,6 +186,32 @@ func (c *callerSliceofByteГInt64) Call(args []interface{}) []interface{} {
 }
 
 func (c *callerSliceofByteГInt64) Call1x1(arg0 interface{}) (interface{}) {
+	return c.fn(arg0.([]byte))
+}
+
+type callerSliceofByteГTypex۰T struct {
+	fn func([]byte) (typex.T)
+}
+
+func funcMakerSliceofByteГTypex۰T(fn interface{}) reflectx.Func {
+	f := fn.(func([]byte) (typex.T))
+	return &callerSliceofByteГTypex۰T{fn: f}
+}
+
+func (c *callerSliceofByteГTypex۰T) Name() string {
+	return reflectx.FunctionName(c.fn)
+}
+
+func (c *callerSliceofByteГTypex۰T) Type() reflect.Type {
+	return reflect.TypeOf(c.fn)
+}
+
+func (c *callerSliceofByteГTypex۰T) Call(args []interface{}) []interface{} {
+	out0 := c.fn(args[0].([]byte))
+	return []interface{}{out0}
+}
+
+func (c *callerSliceofByteГTypex۰T) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.([]byte))
 }
 

--- a/sdks/go/pkg/beam/core/runtime/coderx/doc.go
+++ b/sdks/go/pkg/beam/core/runtime/coderx/doc.go
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package coderx contains coders for primitive types that aren't included
+// in the beam model.
+package coderx
+
+//go:generate go install github.com/apache/beam/sdks/go/cmd/starcgen
+//go:generate starcgen --package=coderx --identifiers=encString,decString,encUint32,decUint32,encInt32,decInt32,encUint64,decUint64,encInt64,decInt64,encVarIntZ,decVarIntZ,encVarUintZ,decVarUintZ,encFloat,decFloat

--- a/sdks/go/pkg/beam/core/runtime/coderx/int.go
+++ b/sdks/go/pkg/beam/core/runtime/coderx/int.go
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package coderx contains primitive coders.
 package coderx
 
 import (

--- a/sdks/go/pkg/beam/core/runtime/coderx/string.go
+++ b/sdks/go/pkg/beam/core/runtime/coderx/string.go
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coderx
+
+import (
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+)
+
+// NewString returns a coder for the string type. It uses the native
+// []byte to string conversion.
+func NewString() (*coder.CustomCoder, error) {
+	return coder.NewCustomCoder("string", reflectx.String, encString, decString)
+}
+
+func encString(v typex.T) []byte {
+	return []byte(v.(string))
+}
+
+func decString(data []byte) typex.T {
+	return string(data)
+}

--- a/sdks/go/pkg/beam/core/runtime/coderx/string_test.go
+++ b/sdks/go/pkg/beam/core/runtime/coderx/string_test.go
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coderx
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	tests := []interface{}{
+		"",
+		"A novel set of characters",
+		"Hello, 世界",
+	}
+
+	for _, v := range tests {
+		data := encString(v)
+		result := decString(data)
+
+		if v != result {
+			t.Errorf("dec(enc(%v)) = %v, want %v", v, result, v)
+		}
+	}
+}

--- a/sdks/go/pkg/beam/core/runtime/coderx/varint.go
+++ b/sdks/go/pkg/beam/core/runtime/coderx/varint.go
@@ -24,9 +24,6 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 )
 
-//go:generate go install github.com/apache/beam/sdks/go/cmd/starcgen
-//go:generate starcgen --package=coderx --identifiers=encUint32,decUint32,encInt32,decInt32,encUint64,decUint64,encInt64,decInt64,encVarIntZ,decVarIntZ,encVarUintZ,decVarUintZ,encFloat,decFloat
-
 // NewVarIntZ returns a varint coder for the given integer type. It uses a zig-zag scheme,
 // which is _different_ from the Beam standard coding scheme.
 func NewVarIntZ(t reflect.Type) (*coder.CustomCoder, error) {

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -118,13 +118,9 @@ type bytesEncoder struct{}
 func (*bytesEncoder) Encode(val FullValue, w io.Writer) error {
 	// Encoding: size (varint) + raw data
 	var data []byte
-	switch v := val.Elm.(type) {
-	case []byte:
-		data = v
-	case string:
-		data = []byte(v)
-	default:
-		return fmt.Errorf("received unknown value type: want []byte or string, got %T", v)
+	data, ok := val.Elm.([]byte)
+	if !ok {
+		return fmt.Errorf("received unknown value type: want []byte or string, got %T", val.Elm)
 	}
 	size := len(data)
 

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -120,7 +120,7 @@ func (*bytesEncoder) Encode(val FullValue, w io.Writer) error {
 	var data []byte
 	data, ok := val.Elm.([]byte)
 	if !ok {
-		return fmt.Errorf("received unknown value type: want []byte or string, got %T", val.Elm)
+		return fmt.Errorf("received unknown value type: want []byte, got %T", val.Elm)
 	}
 	size := len(data)
 

--- a/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
@@ -142,35 +142,43 @@ func TestInvoke(t *testing.T) {
 		{
 			// Check ConvertFn is invoked
 			Fn:       func(a string, b []int) (string, int) { return a, len(b) },
-			Opt:      &MainInput{Key: FullValue{Elm: []byte("basketball"), Elm2: []typex.T{23}}},
+			Opt:      &MainInput{Key: FullValue{Elm: "basketball", Elm2: []typex.T{23}}},
 			Expected: "basketball", Expected2: 1,
 		},
 	}
 
-	for _, test := range tests {
-		fn, err := funcx.New(reflectx.MakeFunc(test.Fn))
-		if err != nil {
-			t.Fatalf("function not valid: %v", err)
-		}
+	for i, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%02d:%v", i, reflect.TypeOf(test.Fn)), func(t *testing.T) {
+			defer func() {
+				if p := recover(); p != nil {
+					t.Fatalf("panic: %v", p)
+				}
+			}()
+			fn, err := funcx.New(reflectx.MakeFunc(test.Fn))
+			if err != nil {
+				t.Fatalf("function not valid: %v", err)
+			}
 
-		ts := mtime.ZeroTimestamp.Add(2 * time.Millisecond)
-		if test.ExpectedTime == mtime.ZeroTimestamp {
-			test.ExpectedTime = ts
-		}
+			ts := mtime.ZeroTimestamp.Add(2 * time.Millisecond)
+			if test.ExpectedTime == mtime.ZeroTimestamp {
+				test.ExpectedTime = ts
+			}
 
-		val, err := Invoke(context.Background(), window.SingleGlobalWindow, ts, fn, test.Opt, test.Args...)
-		if err != nil {
-			t.Fatalf("Invoke(%v,%v) failed: %v", fn.Fn.Name(), test.Args, err)
-		}
-		if val != nil && val.Elm != test.Expected {
-			t.Errorf("Invoke(%v,%v) = %v, want %v", fn.Fn.Name(), test.Args, val.Elm, test.Expected)
-		}
-		if val != nil && val.Elm2 != test.Expected2 {
-			t.Errorf("Elm2: Invoke(%v,%v) = %v, want %v", fn.Fn.Name(), test.Args, val.Elm2, test.Expected2)
-		}
-		if val != nil && val.Timestamp != test.ExpectedTime {
-			t.Errorf("EventTime: Invoke(%v,%v) = %v, want %v", fn.Fn.Name(), test.Args, val.Timestamp, test.ExpectedTime)
-		}
+			val, err := Invoke(context.Background(), window.SingleGlobalWindow, ts, fn, test.Opt, test.Args...)
+			if err != nil {
+				t.Fatalf("Invoke(%v,%v) failed: %v", fn.Fn.Name(), test.Args, err)
+			}
+			if val != nil && val.Elm != test.Expected {
+				t.Errorf("Invoke(%v,%v) = %v, want %v", fn.Fn.Name(), test.Args, val.Elm, test.Expected)
+			}
+			if val != nil && val.Elm2 != test.Expected2 {
+				t.Errorf("Elm2: Invoke(%v,%v) = %v, want %v", fn.Fn.Name(), test.Args, val.Elm2, test.Expected2)
+			}
+			if val != nil && val.Timestamp != test.ExpectedTime {
+				t.Errorf("EventTime: Invoke(%v,%v) = %v, want %v", fn.Fn.Name(), test.Args, val.Timestamp, test.ExpectedTime)
+			}
+		})
 	}
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
@@ -179,12 +179,6 @@ func TestConvert(t *testing.T) {
 			want: int(42),
 		},
 		{
-			name: "byte_to_string",
-			to:   reflectx.String,
-			v:    []byte("basketball"),
-			want: "basketball",
-		},
-		{
 			name: "[]typexT_to_[]int",
 			to:   reflect.TypeOf([]int{}),
 			v:    []typex.T{1, 2, 3},

--- a/sdks/go/pkg/beam/core/runtime/exec/optimized/inputs.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/optimized/inputs.go
@@ -1062,15 +1062,6 @@ func (v *iterNative) Value() interface{} {
 	return v.fn
 }
 
-func convToString(v interface{}) string {
-	switch v.(type) {
-	case []byte:
-		return string(v.([]byte))
-	default:
-		return v.(string)
-	}
-}
-
 func (v *iterNative) Reset() error {
 	if err := v.cur.Close(); err != nil {
 		return err
@@ -1206,7 +1197,7 @@ func (v *iterNative) readByteSliceString(key *[]byte, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.([]byte)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -1227,7 +1218,7 @@ func (v *iterNative) readETByteSliceString(et *typex.EventTime, key *[]byte, val
 
 	*et = elm.Timestamp
 	*key = elm.Elm.([]byte)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -2124,7 +2115,7 @@ func (v *iterNative) readBoolString(key *bool, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(bool)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -2145,7 +2136,7 @@ func (v *iterNative) readETBoolString(et *typex.EventTime, key *bool, value *str
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(bool)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -2923,7 +2914,7 @@ func (v *iterNative) readString(val *string) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*val = convToString(elm.Elm)
+	*val = elm.Elm.(string)
 	return true
 }
 
@@ -2943,7 +2934,7 @@ func (v *iterNative) readETString(et *typex.EventTime, val *string) bool {
 	}
 
 	*et = elm.Timestamp
-	*val = convToString(elm.Elm)
+	*val = elm.Elm.(string)
 	return true
 }
 
@@ -2961,7 +2952,7 @@ func (v *iterNative) readStringByteSlice(key *string, value *[]byte) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.([]byte)
 	return true
 }
@@ -2982,7 +2973,7 @@ func (v *iterNative) readETStringByteSlice(et *typex.EventTime, key *string, val
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.([]byte)
 	return true
 }
@@ -3001,7 +2992,7 @@ func (v *iterNative) readStringBool(key *string, value *bool) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(bool)
 	return true
 }
@@ -3022,7 +3013,7 @@ func (v *iterNative) readETStringBool(et *typex.EventTime, key *string, value *b
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(bool)
 	return true
 }
@@ -3041,8 +3032,8 @@ func (v *iterNative) readStringString(key *string, value *string) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
-	*value = convToString(elm.Elm2)
+	*key = elm.Elm.(string)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -3062,8 +3053,8 @@ func (v *iterNative) readETStringString(et *typex.EventTime, key *string, value 
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
-	*value = convToString(elm.Elm2)
+	*key = elm.Elm.(string)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -3081,7 +3072,7 @@ func (v *iterNative) readStringInt(key *string, value *int) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int)
 	return true
 }
@@ -3102,7 +3093,7 @@ func (v *iterNative) readETStringInt(et *typex.EventTime, key *string, value *in
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int)
 	return true
 }
@@ -3121,7 +3112,7 @@ func (v *iterNative) readStringInt8(key *string, value *int8) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int8)
 	return true
 }
@@ -3142,7 +3133,7 @@ func (v *iterNative) readETStringInt8(et *typex.EventTime, key *string, value *i
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int8)
 	return true
 }
@@ -3161,7 +3152,7 @@ func (v *iterNative) readStringInt16(key *string, value *int16) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int16)
 	return true
 }
@@ -3182,7 +3173,7 @@ func (v *iterNative) readETStringInt16(et *typex.EventTime, key *string, value *
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int16)
 	return true
 }
@@ -3201,7 +3192,7 @@ func (v *iterNative) readStringInt32(key *string, value *int32) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int32)
 	return true
 }
@@ -3222,7 +3213,7 @@ func (v *iterNative) readETStringInt32(et *typex.EventTime, key *string, value *
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int32)
 	return true
 }
@@ -3241,7 +3232,7 @@ func (v *iterNative) readStringInt64(key *string, value *int64) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int64)
 	return true
 }
@@ -3262,7 +3253,7 @@ func (v *iterNative) readETStringInt64(et *typex.EventTime, key *string, value *
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(int64)
 	return true
 }
@@ -3281,7 +3272,7 @@ func (v *iterNative) readStringUint(key *string, value *uint) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint)
 	return true
 }
@@ -3302,7 +3293,7 @@ func (v *iterNative) readETStringUint(et *typex.EventTime, key *string, value *u
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint)
 	return true
 }
@@ -3321,7 +3312,7 @@ func (v *iterNative) readStringUint8(key *string, value *uint8) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint8)
 	return true
 }
@@ -3342,7 +3333,7 @@ func (v *iterNative) readETStringUint8(et *typex.EventTime, key *string, value *
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint8)
 	return true
 }
@@ -3361,7 +3352,7 @@ func (v *iterNative) readStringUint16(key *string, value *uint16) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint16)
 	return true
 }
@@ -3382,7 +3373,7 @@ func (v *iterNative) readETStringUint16(et *typex.EventTime, key *string, value 
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint16)
 	return true
 }
@@ -3401,7 +3392,7 @@ func (v *iterNative) readStringUint32(key *string, value *uint32) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint32)
 	return true
 }
@@ -3422,7 +3413,7 @@ func (v *iterNative) readETStringUint32(et *typex.EventTime, key *string, value 
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint32)
 	return true
 }
@@ -3441,7 +3432,7 @@ func (v *iterNative) readStringUint64(key *string, value *uint64) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint64)
 	return true
 }
@@ -3462,7 +3453,7 @@ func (v *iterNative) readETStringUint64(et *typex.EventTime, key *string, value 
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(uint64)
 	return true
 }
@@ -3481,7 +3472,7 @@ func (v *iterNative) readStringFloat32(key *string, value *float32) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(float32)
 	return true
 }
@@ -3502,7 +3493,7 @@ func (v *iterNative) readETStringFloat32(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(float32)
 	return true
 }
@@ -3521,7 +3512,7 @@ func (v *iterNative) readStringFloat64(key *string, value *float64) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(float64)
 	return true
 }
@@ -3542,7 +3533,7 @@ func (v *iterNative) readETStringFloat64(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(float64)
 	return true
 }
@@ -3561,7 +3552,7 @@ func (v *iterNative) readStringTypex_T(key *string, value *typex.T) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.T)
 	return true
 }
@@ -3582,7 +3573,7 @@ func (v *iterNative) readETStringTypex_T(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.T)
 	return true
 }
@@ -3601,7 +3592,7 @@ func (v *iterNative) readStringTypex_U(key *string, value *typex.U) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.U)
 	return true
 }
@@ -3622,7 +3613,7 @@ func (v *iterNative) readETStringTypex_U(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.U)
 	return true
 }
@@ -3641,7 +3632,7 @@ func (v *iterNative) readStringTypex_V(key *string, value *typex.V) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.V)
 	return true
 }
@@ -3662,7 +3653,7 @@ func (v *iterNative) readETStringTypex_V(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.V)
 	return true
 }
@@ -3681,7 +3672,7 @@ func (v *iterNative) readStringTypex_W(key *string, value *typex.W) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.W)
 	return true
 }
@@ -3702,7 +3693,7 @@ func (v *iterNative) readETStringTypex_W(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.W)
 	return true
 }
@@ -3721,7 +3712,7 @@ func (v *iterNative) readStringTypex_X(key *string, value *typex.X) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.X)
 	return true
 }
@@ -3742,7 +3733,7 @@ func (v *iterNative) readETStringTypex_X(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.X)
 	return true
 }
@@ -3761,7 +3752,7 @@ func (v *iterNative) readStringTypex_Y(key *string, value *typex.Y) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.Y)
 	return true
 }
@@ -3782,7 +3773,7 @@ func (v *iterNative) readETStringTypex_Y(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.Y)
 	return true
 }
@@ -3801,7 +3792,7 @@ func (v *iterNative) readStringTypex_Z(key *string, value *typex.Z) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.Z)
 	return true
 }
@@ -3822,7 +3813,7 @@ func (v *iterNative) readETStringTypex_Z(et *typex.EventTime, key *string, value
 	}
 
 	*et = elm.Timestamp
-	*key = convToString(elm.Elm)
+	*key = elm.Elm.(string)
 	*value = elm.Elm2.(typex.Z)
 	return true
 }
@@ -3960,7 +3951,7 @@ func (v *iterNative) readIntString(key *int, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(int)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -3981,7 +3972,7 @@ func (v *iterNative) readETIntString(et *typex.EventTime, key *int, value *strin
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(int)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -4878,7 +4869,7 @@ func (v *iterNative) readInt8String(key *int8, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(int8)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -4899,7 +4890,7 @@ func (v *iterNative) readETInt8String(et *typex.EventTime, key *int8, value *str
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(int8)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -5796,7 +5787,7 @@ func (v *iterNative) readInt16String(key *int16, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(int16)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -5817,7 +5808,7 @@ func (v *iterNative) readETInt16String(et *typex.EventTime, key *int16, value *s
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(int16)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -6714,7 +6705,7 @@ func (v *iterNative) readInt32String(key *int32, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(int32)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -6735,7 +6726,7 @@ func (v *iterNative) readETInt32String(et *typex.EventTime, key *int32, value *s
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(int32)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -7632,7 +7623,7 @@ func (v *iterNative) readInt64String(key *int64, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(int64)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -7653,7 +7644,7 @@ func (v *iterNative) readETInt64String(et *typex.EventTime, key *int64, value *s
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(int64)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -8550,7 +8541,7 @@ func (v *iterNative) readUintString(key *uint, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(uint)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -8571,7 +8562,7 @@ func (v *iterNative) readETUintString(et *typex.EventTime, key *uint, value *str
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(uint)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -9468,7 +9459,7 @@ func (v *iterNative) readUint8String(key *uint8, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(uint8)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -9489,7 +9480,7 @@ func (v *iterNative) readETUint8String(et *typex.EventTime, key *uint8, value *s
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(uint8)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -10386,7 +10377,7 @@ func (v *iterNative) readUint16String(key *uint16, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(uint16)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -10407,7 +10398,7 @@ func (v *iterNative) readETUint16String(et *typex.EventTime, key *uint16, value 
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(uint16)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -11304,7 +11295,7 @@ func (v *iterNative) readUint32String(key *uint32, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(uint32)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -11325,7 +11316,7 @@ func (v *iterNative) readETUint32String(et *typex.EventTime, key *uint32, value 
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(uint32)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -12222,7 +12213,7 @@ func (v *iterNative) readUint64String(key *uint64, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(uint64)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -12243,7 +12234,7 @@ func (v *iterNative) readETUint64String(et *typex.EventTime, key *uint64, value 
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(uint64)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -13140,7 +13131,7 @@ func (v *iterNative) readFloat32String(key *float32, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(float32)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -13161,7 +13152,7 @@ func (v *iterNative) readETFloat32String(et *typex.EventTime, key *float32, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(float32)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -14058,7 +14049,7 @@ func (v *iterNative) readFloat64String(key *float64, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(float64)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -14079,7 +14070,7 @@ func (v *iterNative) readETFloat64String(et *typex.EventTime, key *float64, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(float64)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -14976,7 +14967,7 @@ func (v *iterNative) readTypex_TString(key *typex.T, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(typex.T)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -14997,7 +14988,7 @@ func (v *iterNative) readETTypex_TString(et *typex.EventTime, key *typex.T, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(typex.T)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -15894,7 +15885,7 @@ func (v *iterNative) readTypex_UString(key *typex.U, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(typex.U)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -15915,7 +15906,7 @@ func (v *iterNative) readETTypex_UString(et *typex.EventTime, key *typex.U, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(typex.U)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -16812,7 +16803,7 @@ func (v *iterNative) readTypex_VString(key *typex.V, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(typex.V)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -16833,7 +16824,7 @@ func (v *iterNative) readETTypex_VString(et *typex.EventTime, key *typex.V, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(typex.V)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -17730,7 +17721,7 @@ func (v *iterNative) readTypex_WString(key *typex.W, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(typex.W)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -17751,7 +17742,7 @@ func (v *iterNative) readETTypex_WString(et *typex.EventTime, key *typex.W, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(typex.W)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -18648,7 +18639,7 @@ func (v *iterNative) readTypex_XString(key *typex.X, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(typex.X)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -18669,7 +18660,7 @@ func (v *iterNative) readETTypex_XString(et *typex.EventTime, key *typex.X, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(typex.X)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -19566,7 +19557,7 @@ func (v *iterNative) readTypex_YString(key *typex.Y, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(typex.Y)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -19587,7 +19578,7 @@ func (v *iterNative) readETTypex_YString(et *typex.EventTime, key *typex.Y, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(typex.Y)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -20484,7 +20475,7 @@ func (v *iterNative) readTypex_ZString(key *typex.Z, value *string) bool {
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
 	*key = elm.Elm.(typex.Z)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 
@@ -20505,7 +20496,7 @@ func (v *iterNative) readETTypex_ZString(et *typex.EventTime, key *typex.Z, valu
 
 	*et = elm.Timestamp
 	*key = elm.Elm.(typex.Z)
-	*value = convToString(elm.Elm2)
+	*value = elm.Elm2.(string)
 	return true
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/optimized/inputs.tmpl
+++ b/sdks/go/pkg/beam/core/runtime/exec/optimized/inputs.tmpl
@@ -59,15 +59,6 @@ func (v *iterNative) Value() interface{} {
 	return v.fn
 }
 
-func convToString(v interface{}) string {
-    switch v.(type) {
-    case []byte:
-       return string(v.([]byte))
-    default:
-       return v.(string)
-    }
-}
-
 func (v *iterNative) Reset() error {
 	if err := v.cur.Close(); err != nil {
 		return err
@@ -85,12 +76,7 @@ func (v *iterNative) read{{$x.Name}}(val *{{$x.Type}}) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-
-{{- if eq $x.Type "string"}}
-    *val = convToString(elm.Elm)
-{{- else}}
     *val = elm.Elm.({{$x.Type}})
-{{- end}}
     return true
 }
 
@@ -110,11 +96,7 @@ func (v *iterNative) readET{{$x.Name}}(et *typex.EventTime, val *{{$x.Type}}) bo
 	}
 
     *et = elm.Timestamp
-{{- if eq $x.Type "string"}}
-    *val = convToString(elm.Elm)
-{{- else}}
     *val = elm.Elm.({{$x.Type}})
-{{- end}}
     return true
 }
 
@@ -133,17 +115,8 @@ func (v *iterNative) read{{$x.Name}}{{$y.Name}}(key *{{$x.Type}}, value *{{$y.Ty
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-
-{{- if eq $x.Type "string"}}
-    *key = convToString(elm.Elm)
-{{- else}}
     *key = elm.Elm.({{$x.Type}})
-{{- end}}
-{{- if eq $y.Type "string"}}
-    *value = convToString(elm.Elm2)
-{{- else}}
     *value = elm.Elm2.({{$y.Type}})
-{{- end}}
     return true
 }
 
@@ -163,16 +136,8 @@ func (v *iterNative) readET{{$x.Name}}{{$y.Name}}(et *typex.EventTime, key *{{$x
 	}
 
     *et = elm.Timestamp
-{{- if eq $x.Type "string"}}
-    *key = convToString(elm.Elm)
-{{- else}}
     *key = elm.Elm.({{$x.Type}})
-{{- end}}
-{{- if eq $y.Type "string"}}
-    *value = convToString(elm.Elm2)
-{{- else}}
     *value = elm.Elm2.({{$y.Type}})
-{{- end}}
     return true
 }
 

--- a/sdks/go/pkg/beam/testing/passert/passert.shims.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.shims.go
@@ -312,15 +312,6 @@ func (v *iterNative) Value() interface{} {
 	return v.fn
 }
 
-func convToString(v interface{}) string {
-	switch v.(type) {
-	case []byte:
-		return string(v.([]byte))
-	default:
-		return v.(string)
-	}
-}
-
 func (v *iterNative) Reset() error {
 	if err := v.cur.Close(); err != nil {
 		return err
@@ -361,7 +352,7 @@ func (v *iterNative) readString(value *string) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*value = convToString(elm.Elm)
+	*value = elm.Elm.(string)
 	return true
 }
 

--- a/sdks/go/pkg/beam/transforms/filter/filter.shims.go
+++ b/sdks/go/pkg/beam/transforms/filter/filter.shims.go
@@ -211,15 +211,6 @@ func (v *iterNative) Value() interface{} {
 	return v.fn
 }
 
-func convToString(v interface{}) string {
-	switch v.(type) {
-	case []byte:
-		return string(v.([]byte))
-	default:
-		return v.(string)
-	}
-}
-
 func (v *iterNative) Reset() error {
 	if err := v.cur.Close(); err != nil {
 		return err

--- a/sdks/go/pkg/beam/util/shimx/generate.go
+++ b/sdks/go/pkg/beam/util/shimx/generate.go
@@ -345,15 +345,6 @@ func (v *iterNative) Value() interface{} {
 	return v.fn
 }
 
-func convToString(v interface{}) string {
-	switch v.(type) {
-	case []byte:
-		return string(v.([]byte))
-	default:
-		return v.(string)
-	}
-}
-
 func (v *iterNative) Reset() error {
 	if err := v.cur.Close(); err != nil {
 		return err
@@ -382,16 +373,10 @@ func (v *iterNative) read{{$x.Name}}({{if $x.Time -}} et *typex.EventTime, {{end
 {{- if $x.Time}}
 	*et = elm.Timestamp
 {{- end}}
-{{- if eq $x.Key "string"}}
-	*key = convToString(elm.Elm)
-{{- else if $x.Key}}
+{{- if $x.Key}}
 	*key = elm.Elm.({{$x.Key}})
 {{- end}}
-{{- if eq $x.Val "string"}}
-	*value = convToString(elm.Elm{{- if $x.Key -}} 2 {{- end -}})
-{{- else}}
 	*value = elm.Elm{{- if $x.Key -}} 2 {{- end -}}.({{$x.Val}})
-{{- end}}
 	return true
 }
 

--- a/sdks/go/pkg/beam/x/debug/debug.shims.go
+++ b/sdks/go/pkg/beam/x/debug/debug.shims.go
@@ -318,15 +318,6 @@ func (v *iterNative) Value() interface{} {
 	return v.fn
 }
 
-func convToString(v interface{}) string {
-	switch v.(type) {
-	case []byte:
-		return string(v.([]byte))
-	default:
-		return v.(string)
-	}
-}
-
 func (v *iterNative) Reset() error {
 	if err := v.cur.Close(); err != nil {
 		return err

--- a/sdks/go/test/integration/primitives/primitives_test.go
+++ b/sdks/go/test/integration/primitives/primitives_test.go
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package primitives
+
+import (
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+)
+
+// TestMain invokes ptest.Main to allow running these tests on
+// non-direct runners.
+func TestMain(m *testing.M) {
+	ptest.Main(m)
+}


### PR DESCRIPTION
Use a custom coder for strings in the Go SDK. CustomCoders are already length prefixed, so this does the simple conversion.
This PR also removes all places I could recall do a manual []byte to string conversion which was a consequence of the previous approach. This should yield a mild performance improvement in that the conversions are done earlier rather than right before invocation. Similarly, []bytes are no longer getting checked that they are strings.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




