### PR TITLE
[release][BEAM-5396] Assign portable operator uids 

### DIFF
--- a/runners/flink/job-server/flink_job_server.gradle
+++ b/runners/flink/job-server/flink_job_server.gradle
@@ -111,6 +111,7 @@ def portableValidatesRunnerTask(String name, Boolean streaming) {
   def pipelineOptions = [
       // Limit resource consumption via parallelism
       "--parallelism=2",
+      "--shutdownSourcesOnFinalWatermark",
   ]
   if (streaming) {
     pipelineOptions += "--streaming"

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -235,13 +235,8 @@ public class FlinkExecutionEnvironments {
             .getCheckpointConfig()
             .setMinPauseBetweenCheckpoints(minPauseBetweenCheckpoints);
       }
-
       boolean failOnCheckpointingErrors = options.getFailOnCheckpointingErrors();
       flinkStreamEnv.getCheckpointConfig().setFailOnCheckpointingErrors(failOnCheckpointingErrors);
-    } else {
-      // https://issues.apache.org/jira/browse/FLINK-2491
-      // Checkpointing is disabled, we can allow shutting down sources when they're done
-      options.setShutdownSourcesOnFinalWatermark(true);
     }
 
     applyLatencyTrackingInterval(flinkStreamEnv.getConfig(), options);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -19,10 +19,12 @@ package org.apache.beam.runners.flink;
 
 import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.runners.core.construction.PipelineResources;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 /**
@@ -120,5 +122,15 @@ class FlinkPipelineExecutionEnvironment {
     } else {
       throw new IllegalStateException("The Pipeline has not yet been translated.");
     }
+  }
+
+  /**
+   * Retrieves the generated JobGraph which can be submitted against the cluster. For testing
+   * purposes.
+   */
+  @VisibleForTesting
+  JobGraph getJobGraph(Pipeline p) {
+    translate(p);
+    return flinkStreamEnv.getStreamGraph().getJobGraph();
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.flink;
 
 import static org.apache.beam.runners.core.construction.PipelineResources.detectClassPathResourcesToStage;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,6 +40,7 @@ import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Joiner;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.client.program.DetachedEnvironment;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +63,7 @@ public class FlinkRunner extends PipelineRunner<PipelineResult> {
    * @return The newly created runner.
    */
   public static FlinkRunner fromOptions(PipelineOptions options) {
+    options.setRunner(FlinkRunner.class);
     FlinkPipelineOptions flinkOptions =
         PipelineOptionsValidator.validate(FlinkPipelineOptions.class, options);
     ArrayList<String> missing = new ArrayList<>();
@@ -143,6 +146,7 @@ public class FlinkRunner extends PipelineRunner<PipelineResult> {
   }
 
   /** For testing. */
+  @VisibleForTesting
   public FlinkPipelineOptions getPipelineOptions() {
     return options;
   }
@@ -193,5 +197,11 @@ public class FlinkRunner extends PipelineRunner<PipelineResult> {
               + "versions of the Flink runner will require deterministic key coders.",
           ptransformViewNamesWithNonDeterministicKeyCoders);
     }
+  }
+
+  @VisibleForTesting
+  JobGraph getJobGraph(Pipeline p) {
+    FlinkPipelineExecutionEnvironment env = new FlinkPipelineExecutionEnvironment(options);
+    return env.getJobGraph(p);
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -242,8 +242,8 @@ public class FlinkStreamingPortablePipelineTranslator
 
   private <T> void translateFlatten(
       String id, RunnerApi.Pipeline pipeline, StreamingTranslationContext context) {
-    Map<String, String> allInputs =
-        pipeline.getComponents().getTransformsOrThrow(id).getInputsMap();
+    RunnerApi.PTransform transform = pipeline.getComponents().getTransformsOrThrow(id);
+    Map<String, String> allInputs = transform.getInputsMap();
 
     if (allInputs.isEmpty()) {
 
@@ -264,10 +264,7 @@ public class FlinkStreamingPortablePipelineTranslator
                   new CoderTypeInformation<>(
                       WindowedValue.getFullCoder(
                           (Coder<T>) VoidCoder.of(), GlobalWindow.Coder.INSTANCE)));
-      context.addDataStream(
-          Iterables.getOnlyElement(
-              pipeline.getComponents().getTransformsOrThrow(id).getOutputsMap().values()),
-          result);
+      context.addDataStream(Iterables.getOnlyElement(transform.getOutputsMap().values()), result);
     } else {
       DataStream<T> result = null;
 
@@ -298,10 +295,7 @@ public class FlinkStreamingPortablePipelineTranslator
         result = (result == null) ? current : result.union(current);
       }
 
-      context.addDataStream(
-          Iterables.getOnlyElement(
-              pipeline.getComponents().getTransformsOrThrow(id).getOutputsMap().values()),
-          result);
+      context.addDataStream(Iterables.getOnlyElement(transform.getOutputsMap().values()), result);
     }
   }
 
@@ -347,6 +341,8 @@ public class FlinkStreamingPortablePipelineTranslator
             windowedInputCoder,
             pTransform.getUniqueName(),
             context);
+    // Assign a unique but consistent id to re-map operator state
+    outputDataStream.uid(pTransform.getUniqueName());
 
     context.addDataStream(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()), outputDataStream);
@@ -668,6 +664,8 @@ public class FlinkStreamingPortablePipelineTranslator
                 .transform(operatorName, outputTypeInformation, doFnOperator);
       }
     }
+    // Assign a unique but consistent id to re-map operator state
+    outputStream.uid(transform.getUniqueName());
 
     if (mainOutputTag != null) {
       context.addDataStream(outputs.get(mainOutputTag.getId()), outputStream);
@@ -788,10 +786,9 @@ public class FlinkStreamingPortablePipelineTranslator
         sideInputs.entrySet()) {
       TupleTag<?> tag = sideInput.getValue().getTagInternal();
       final int intTag = tagToIntMapping.get(tag);
-      String collectionId =
-          components
-              .getTransformsOrThrow(sideInput.getKey().getTransformId())
-              .getInputsOrThrow(sideInput.getKey().getLocalName());
+      RunnerApi.PTransform pTransform =
+          components.getTransformsOrThrow(sideInput.getKey().getTransformId());
+      String collectionId = pTransform.getInputsOrThrow(sideInput.getKey().getLocalName());
       DataStream<WindowedValue<?>> sideInputStream = context.getDataStreamOrThrow(collectionId);
 
       // insert GBK to materialize side input view
@@ -808,6 +805,8 @@ public class FlinkStreamingPortablePipelineTranslator
               kvCoder,
               viewName,
               context);
+      // Assign a unique but consistent id to re-map operator state
+      viewStream.uid(pTransform.getUniqueName() + "-" + sideInput.getKey().getLocalName());
 
       DataStream<RawUnionValue> unionValueStream =
           viewStream

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
@@ -37,6 +37,7 @@ public class TestFlinkRunner extends PipelineRunner<PipelineResult> {
   }
 
   public static TestFlinkRunner fromOptions(PipelineOptions options) {
+    options.setRunner(TestFlinkRunner.class);
     FlinkPipelineOptions flinkOptions =
         PipelineOptionsValidator.validate(FlinkPipelineOptions.class, options);
     return new TestFlinkRunner(flinkOptions);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -698,14 +698,12 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
   public void onEventTime(InternalTimer<Object, TimerData> timer) throws Exception {
     // We don't have to cal checkInvokeStartBundle() because it's already called in
     // processWatermark*().
-    timerInternals.cleanupPendingTimer(timer.getNamespace());
     fireTimer(timer);
   }
 
   @Override
   public void onProcessingTime(InternalTimer<Object, TimerData> timer) throws Exception {
     checkInvokeStartBundle();
-    timerInternals.cleanupPendingTimer(timer.getNamespace());
     fireTimer(timer);
   }
 
@@ -716,6 +714,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
     // This is a user timer, so namespace must be WindowNamespace
     checkArgument(namespace instanceof WindowNamespace);
     BoundedWindow window = ((WindowNamespace) namespace).getWindow();
+    timerInternals.cleanupPendingTimer(timer.getNamespace());
     pushbackDoFnRunner.onTimer(
         timerData.getTimerId(), window, timerData.getTimestamp(), timerData.getDomain());
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -155,6 +155,7 @@ public class SplittableDoFnOperator<InputT, OutputT, RestrictionT>
 
   @Override
   public void fireTimer(InternalTimer<?, TimerInternals.TimerData> timer) {
+    timerInternals.cleanupPendingTimer(timer.getNamespace());
     if (timer.getNamespace().getDomain().equals(TimeDomain.EVENT_TIME)) {
       // ignore this, it can only be a state cleanup timers from StatefulDoFnRunner and ProcessFn
       // does its own state cleanup and should never set event-time timers.

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
@@ -122,6 +122,7 @@ public class WindowDoFnOperator<K, InputT, OutputT>
 
   @Override
   public void fireTimer(InternalTimer<?, TimerData> timer) {
+    timerInternals.cleanupPendingTimer(timer.getNamespace());
     doFnRunner.processElement(
         WindowedValue.valueInGlobalWindow(
             KeyedWorkItems.timersWorkItem(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -416,9 +416,9 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
 
     if (context.isRestored()) {
       isRestored = true;
-      LOG.info("Having restore state in the UnbounedSourceWrapper.");
+      LOG.info("Restoring state in the UnboundedSourceWrapper.");
     } else {
-      LOG.info("No restore state for UnbounedSourceWrapper.");
+      LOG.info("No restore state for UnboundedSourceWrapper.");
     }
   }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSavepointTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSavepointTest.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.google.common.collect.Iterables;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.construction.Environments;
+import org.apache.beam.runners.core.construction.PipelineTranslation;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.GenerateSequence;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.sdk.state.BagState;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.Timer;
+import org.apache.beam.sdk.state.TimerSpec;
+import org.apache.beam.sdk.state.TimerSpecs;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.Impulse;
+import org.apache.beam.sdk.transforms.InferableFunction;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.util.concurrent.ListeningExecutorService;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Tests that Flink's Savepoints work with the Flink Runner. */
+public class FlinkSavepointTest implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FlinkSavepointTest.class);
+
+  /** Static for synchronization between the pipeline state and the test. */
+  private static CountDownLatch oneShotLatch;
+
+  @ClassRule public static transient TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static transient MiniCluster flinkCluster;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    final int parallelism = 4;
+
+    Configuration config = new Configuration();
+    // Avoid port collision in parallel tests
+    config.setInteger(RestOptions.PORT, 0);
+    config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+    // It is necessary to configure the checkpoint directory for the state backend,
+    // even though we only create savepoints in this test.
+    config.setString(
+        CheckpointingOptions.CHECKPOINTS_DIRECTORY,
+        "file://" + tempFolder.getRoot().getAbsolutePath());
+    // Checkpoints will go into a subdirectory of this directory
+    config.setString(
+        CheckpointingOptions.SAVEPOINT_DIRECTORY,
+        "file://" + tempFolder.getRoot().getAbsolutePath());
+
+    MiniClusterConfiguration clusterConfig =
+        new MiniClusterConfiguration.Builder()
+            .setConfiguration(config)
+            .setNumTaskManagers(2)
+            .setNumSlotsPerTaskManager(2)
+            .build();
+
+    flinkCluster = new MiniCluster(clusterConfig);
+    flinkCluster.start();
+
+    TestStreamEnvironment.setAsContext(flinkCluster, parallelism);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    TestStreamEnvironment.unsetAsContext();
+    flinkCluster.close();
+  }
+
+  @After
+  public void afterTest() throws Exception {
+    for (JobStatusMessage jobStatusMessage : flinkCluster.listJobs().get()) {
+      if (jobStatusMessage.getJobState() == JobStatus.RUNNING) {
+        flinkCluster.cancelJob(jobStatusMessage.getJobId()).get();
+      }
+    }
+  }
+
+  @Test(timeout = 60_000)
+  public void testSavepointRestoreLegacy() throws Exception {
+    runSavepointAndRestore(false);
+  }
+
+  @Test(timeout = 60_000)
+  public void testSavepointRestorePortable() throws Exception {
+    runSavepointAndRestore(true);
+  }
+
+  private void runSavepointAndRestore(boolean isPortablePipeline) throws Exception {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setStreaming(true);
+    // savepoint assumes local file system
+    options.setParallelism(1);
+    options.setRunner(FlinkRunner.class);
+
+    oneShotLatch = new CountDownLatch(1);
+    Pipeline pipeline = Pipeline.create(options);
+    createStreamingJob(pipeline, false, isPortablePipeline);
+
+    final JobID jobID;
+    if (isPortablePipeline) {
+      jobID = executePortable(pipeline);
+    } else {
+      jobID = executeLegacy(pipeline);
+    }
+    oneShotLatch.await();
+    String savepointDir = takeSavepointAndCancelJob(jobID);
+
+    oneShotLatch = new CountDownLatch(1);
+    pipeline = Pipeline.create(options);
+    createStreamingJob(pipeline, true, isPortablePipeline);
+
+    if (isPortablePipeline) {
+      restoreFromSavepointPortable(pipeline, savepointDir);
+    } else {
+      restoreFromSavepointLegacy(pipeline, savepointDir);
+    }
+    oneShotLatch.await();
+  }
+
+  private JobID executeLegacy(Pipeline pipeline) throws Exception {
+    JobGraph jobGraph = getJobGraph(pipeline);
+    flinkCluster.submitJob(jobGraph).get();
+    return jobGraph.getJobID();
+  }
+
+  private JobID executePortable(Pipeline pipeline) throws Exception {
+    pipeline
+        .getOptions()
+        .as(PortablePipelineOptions.class)
+        .setDefaultEnvironmentType(Environments.ENVIRONMENT_EMBEDDED);
+    pipeline
+        .getOptions()
+        .as(FlinkPipelineOptions.class)
+        .setFlinkMaster(
+            flinkCluster.getRestAddress().getHost()
+                + ":"
+                + flinkCluster.getRestAddress().getPort());
+
+    RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(pipeline);
+
+    ListeningExecutorService executorService =
+        MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
+    try {
+      FlinkJobInvocation jobInvocation =
+          FlinkJobInvocation.create(
+              "id",
+              "none",
+              executorService,
+              pipelineProto,
+              pipeline.getOptions().as(FlinkPipelineOptions.class),
+              null,
+              Collections.emptyList());
+
+      jobInvocation.start();
+
+      return waitForJobToBeReady();
+    } finally {
+      executorService.shutdown();
+    }
+  }
+
+  private JobID waitForJobToBeReady() throws InterruptedException, ExecutionException {
+    while (true) {
+      JobStatusMessage jobStatus = Iterables.getFirst(flinkCluster.listJobs().get(), null);
+      if (jobStatus != null && jobStatus.getJobState() == JobStatus.RUNNING) {
+        return jobStatus.getJobId();
+      }
+      Thread.sleep(100);
+    }
+  }
+
+  private String takeSavepointAndCancelJob(JobID jobID) throws Exception {
+    Exception exception = null;
+    // try multiple times because the job might not be ready yet
+    for (int i = 0; i < 10; i++) {
+      try {
+        return flinkCluster.triggerSavepoint(jobID, null, true).get();
+      } catch (Exception e) {
+        exception = e;
+        Thread.sleep(100);
+      }
+    }
+    throw exception;
+  }
+
+  private void restoreFromSavepointLegacy(Pipeline pipeline, String savepointDir)
+      throws ExecutionException, InterruptedException {
+    JobGraph jobGraph = getJobGraph(pipeline);
+    SavepointRestoreSettings savepointSettings = SavepointRestoreSettings.forPath(savepointDir);
+    jobGraph.setSavepointRestoreSettings(savepointSettings);
+    flinkCluster.submitJob(jobGraph).get();
+  }
+
+  private void restoreFromSavepointPortable(Pipeline pipeline, String savepointDir)
+      throws Exception {
+    FlinkPipelineOptions flinkOptions = pipeline.getOptions().as(FlinkPipelineOptions.class);
+    flinkOptions.setSavepointPath(savepointDir);
+    executePortable(pipeline);
+  }
+
+  private JobGraph getJobGraph(Pipeline pipeline) {
+    FlinkRunner flinkRunner = FlinkRunner.fromOptions(pipeline.getOptions());
+    return flinkRunner.getJobGraph(pipeline);
+  }
+
+  private static PCollection createStreamingJob(
+      Pipeline pipeline, boolean restored, boolean isPortablePipeline) {
+    final PCollection<KV<String, Long>> key;
+    if (isPortablePipeline) {
+      key =
+          pipeline
+              .apply(Impulse.create())
+              .apply(
+                  MapElements.via(
+                      new InferableFunction<byte[], KV<String, Void>>() {
+                        @Override
+                        public KV<String, Void> apply(byte[] input) throws Exception {
+                          return KV.of("key", null);
+                        }
+                      }))
+              .apply(
+                  ParDo.of(
+                      new DoFn<KV<String, Void>, KV<String, Long>>() {
+                        @StateId("valueState")
+                        private final StateSpec<ValueState<Long>> valueStateSpec =
+                            StateSpecs.value();
+
+                        @TimerId("timer")
+                        private final TimerSpec timer =
+                            TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+                        @ProcessElement
+                        public void processElement(
+                            ProcessContext context, @TimerId("timer") Timer timer) {
+
+                          timer.offset(Duration.ZERO).setRelative();
+                        }
+
+                        @OnTimer("timer")
+                        public void onTimer(
+                            OnTimerContext context,
+                            @StateId("valueState") ValueState<Long> intValueState,
+                            @TimerId("timer") Timer timer) {
+                          Long current = intValueState.read();
+                          if (current == null) {
+                            current = -1L;
+                          }
+                          long next = current + 1;
+                          context.output(KV.of("key", next));
+                          intValueState.write(next);
+                          timer.offset(Duration.millis(100)).setRelative();
+                        }
+                      }));
+    } else {
+      key =
+          pipeline
+              .apply(GenerateSequence.from(0))
+              .apply(
+                  ParDo.of(
+                      new DoFn<Long, KV<String, Long>>() {
+                        @ProcessElement
+                        public void processElement(ProcessContext context) {
+                          context.output(KV.of("key", context.element()));
+                        }
+                      }));
+    }
+    if (restored) {
+      return key.apply(
+          ParDo.of(
+              new DoFn<KV<String, Long>, String>() {
+
+                @StateId("valueState")
+                private final StateSpec<ValueState<Integer>> valueStateSpec = StateSpecs.value();
+
+                @StateId("bagState")
+                private final StateSpec<BagState<Integer>> bagStateSpec = StateSpecs.bag();
+
+                @ProcessElement
+                public void processElement(
+                    ProcessContext context,
+                    @StateId("valueState") ValueState<Integer> intValueState,
+                    @StateId("bagState") BagState<Integer> intBagState) {
+                  Integer read = intValueState.read();
+                  assertNotNull(read);
+                  if (read == 42) {
+                    intValueState.write(0);
+                    oneShotLatch.countDown();
+                  }
+                }
+              }));
+    } else {
+      return key.apply(
+          ParDo.of(
+              new DoFn<KV<String, Long>, String>() {
+
+                @StateId("valueState")
+                private final StateSpec<ValueState<Integer>> valueStateSpec = StateSpecs.value();
+
+                @StateId("bagState")
+                private final StateSpec<BagState<Integer>> bagStateSpec = StateSpecs.bag();
+
+                @ProcessElement
+                public void processElement(
+                    ProcessContext context,
+                    @StateId("valueState") ValueState<Integer> intValueState,
+                    @StateId("bagState") BagState<Integer> intBagState) {
+                  Long value = context.element().getValue();
+                  assertNotNull(value);
+                  if (value == 0L) {
+                    intValueState.write(42);
+                    intBagState.add(40);
+                    intBagState.add(1);
+                    intBagState.add(1);
+                    oneShotLatch.countDown();
+                  }
+                }
+              }));
+    }
+  }
+}

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableExecutionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableExecutionTest.java
@@ -86,6 +86,7 @@ public class PortableExecutionTest implements Serializable {
     options.as(FlinkPipelineOptions.class).setFlinkMaster("[local]");
     options.as(FlinkPipelineOptions.class).setStreaming(isStreaming);
     options.as(FlinkPipelineOptions.class).setParallelism(2);
+    options.as(FlinkPipelineOptions.class).setShutdownSourcesOnFinalWatermark(true);
     options
         .as(PortablePipelineOptions.class)
         .setDefaultEnvironmentType(Environments.ENVIRONMENT_EMBEDDED);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableStateExecutionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableStateExecutionTest.java
@@ -87,6 +87,7 @@ public class PortableStateExecutionTest implements Serializable {
     options.as(FlinkPipelineOptions.class).setFlinkMaster("[local]");
     options.as(FlinkPipelineOptions.class).setStreaming(isStreaming);
     options.as(FlinkPipelineOptions.class).setParallelism(2);
+    options.as(FlinkPipelineOptions.class).setShutdownSourcesOnFinalWatermark(true);
     options
         .as(PortablePipelineOptions.class)
         .setDefaultEnvironmentType(Environments.ENVIRONMENT_EMBEDDED);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableTimersExecutionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableTimersExecutionTest.java
@@ -93,6 +93,7 @@ public class PortableTimersExecutionTest implements Serializable {
     options.as(FlinkPipelineOptions.class).setFlinkMaster("[local]");
     options.as(FlinkPipelineOptions.class).setStreaming(isStreaming);
     options.as(FlinkPipelineOptions.class).setParallelism(2);
+    options.as(FlinkPipelineOptions.class).setShutdownSourcesOnFinalWatermark(true);
     options
         .as(PortablePipelineOptions.class)
         .setDefaultEnvironmentType(Environments.ENVIRONMENT_EMBEDDED);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/GroupByWithNullValuesTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/GroupByWithNullValuesTest.java
@@ -47,6 +47,7 @@ public class GroupByWithNullValuesTest implements Serializable {
 
     options.setRunner(FlinkRunner.class);
     options.setStreaming(true);
+    options.setShutdownSourcesOnFinalWatermark(true);
 
     Pipeline pipeline = Pipeline.create(options);
     PCollection<Integer> result =

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -749,6 +749,15 @@ class FlinkOptions(PipelineOptions):
                         help=
                         ('The degree of parallelism to be used when '
                          'distributing operations onto workers.'))
+    parser.add_argument('--shutdown_sources_on_final_watermark',
+                        default=False,
+                        action='store_true',
+                        help=
+                        ('If set to true, allows sources to shutdown '
+                         'after emitting the final Watermark. '
+                         'Note: Checkpoints/Savepoints can only be '
+                         'taken when all operators, including sources, '
+                         'are running.'))
 
 
 class TestOptions(PipelineOptions):

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -130,6 +130,7 @@ if __name__ == '__main__':
       options = super(FlinkRunnerTest, self).create_options()
       options.view_as(DebugOptions).experiments = ['beam_fn_api']
       options.view_as(FlinkOptions).parallelism = 1
+      options.view_as(FlinkOptions).shutdown_sources_on_final_watermark = True
       options.view_as(PortableOptions).environment_type = (
           environment_type.upper())
       if environment_config:

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -221,6 +221,8 @@ def portableWordCountTask(name, streaming) {
               "--output=/tmp/py-wordcount-direct",
               "--runner=PortableRunner",
               "--experiments=worker_threads=100",
+              "--parallelism=2",
+              "--shutdown_sources_on_final_watermark",
       ]
       if (streaming)
         options += ["--streaming"]


### PR DESCRIPTION
Backported from master.

CC @tweise 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




