### PR TITLE
[BEAM-4472] Fix Top accum coder to be liftable.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -158,9 +158,6 @@ func (m *marshaller) updateIfCombineComposite(s *ScopeTree, transform *pb.PTrans
 	}
 
 	edge := s.Edges[1].Edge
-	if !tryAddingCoder(edge.AccumCoder) {
-		return
-	}
 	acID := m.coders.Add(edge.AccumCoder)
 	payload := &pb.CombinePayload{
 		CombineFn: &pb.SdkFunctionSpec{
@@ -173,21 +170,6 @@ func (m *marshaller) updateIfCombineComposite(s *ScopeTree, transform *pb.PTrans
 		AccumulatorCoderId: acID,
 	}
 	transform.Spec = &pb.FunctionSpec{Urn: URNCombinePerKey, Payload: protox.MustEncode(payload)}
-}
-
-// If the accumulator type is unencodable (eg. contains raw interface{})
-// Try encoding the AccumCoder. If the marshaller doesn't panic, it's
-// encodable.
-func tryAddingCoder(c *coder.Coder) (ok bool) {
-	defer func() {
-		if p := recover(); p != nil {
-			ok = false
-			fmt.Printf("Unable to encode combiner for lifting: %v", p)
-		}
-	}()
-	// Try in a new Marshaller to not corrupt state.
-	NewCoderMarshaller().Add(c)
-	return true
 }
 
 func (m *marshaller) addMultiEdge(edge NamedEdge) string {

--- a/sdks/go/pkg/beam/transforms/top/top.shims.go
+++ b/sdks/go/pkg/beam/transforms/top/top.shims.go
@@ -32,9 +32,9 @@ func init() {
 	runtime.RegisterType(reflect.TypeOf((*combineFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*combineFn)(nil)).Elem(), wrapMakerCombineFn)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(accum,accum) (accum))(nil)).Elem(), funcMakerAccumAccumГAccum)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(accum,typex.T) (accum))(nil)).Elem(), funcMakerAccumTypex۰TГAccum)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(accum) ([]typex.T))(nil)).Elem(), funcMakerAccumГSliceofTypex۰T)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]accum) (accum))(nil)).Elem(), funcMakerSliceofAccumГAccum)
 	reflectx.RegisterFunc(reflect.TypeOf((*func() (accum))(nil)).Elem(), funcMakerГAccum)
 }
 
@@ -44,8 +44,34 @@ func wrapMakerCombineFn(fn interface{}) map[string]reflectx.Func {
 		"AddInput": reflectx.MakeFunc(func(a0 accum, a1 typex.T) (accum) { return dfn.AddInput(a0, a1) }),
 		"CreateAccumulator": reflectx.MakeFunc(func() (accum) { return dfn.CreateAccumulator() }),
 		"ExtractOutput": reflectx.MakeFunc(func(a0 accum) ([]typex.T) { return dfn.ExtractOutput(a0) }),
-		"MergeAccumulators": reflectx.MakeFunc(func(a0 []accum) (accum) { return dfn.MergeAccumulators(a0) }),
+		"MergeAccumulators": reflectx.MakeFunc(func(a0 accum, a1 accum) (accum) { return dfn.MergeAccumulators(a0, a1) }),
 	}
+}
+
+type callerAccumAccumГAccum struct {
+	fn func(accum,accum) (accum)
+}
+
+func funcMakerAccumAccumГAccum(fn interface{}) reflectx.Func {
+	f := fn.(func(accum,accum) (accum))
+	return &callerAccumAccumГAccum{fn: f}
+}
+
+func (c *callerAccumAccumГAccum) Name() string {
+	return reflectx.FunctionName(c.fn)
+}
+
+func (c *callerAccumAccumГAccum) Type() reflect.Type {
+	return reflect.TypeOf(c.fn)
+}
+
+func (c *callerAccumAccumГAccum) Call(args []interface{}) []interface{} {
+	out0 := c.fn(args[0].(accum), args[1].(accum))
+	return []interface{}{out0}
+}
+
+func (c *callerAccumAccumГAccum) Call2x1(arg0, arg1 interface{}) (interface{}) {
+	return c.fn(arg0.(accum), arg1.(accum))
 }
 
 type callerAccumTypex۰TГAccum struct {
@@ -98,32 +124,6 @@ func (c *callerAccumГSliceofTypex۰T) Call(args []interface{}) []interface{} {
 
 func (c *callerAccumГSliceofTypex۰T) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.(accum))
-}
-
-type callerSliceofAccumГAccum struct {
-	fn func([]accum) (accum)
-}
-
-func funcMakerSliceofAccumГAccum(fn interface{}) reflectx.Func {
-	f := fn.(func([]accum) (accum))
-	return &callerSliceofAccumГAccum{fn: f}
-}
-
-func (c *callerSliceofAccumГAccum) Name() string {
-	return reflectx.FunctionName(c.fn)
-}
-
-func (c *callerSliceofAccumГAccum) Type() reflect.Type {
-	return reflect.TypeOf(c.fn)
-}
-
-func (c *callerSliceofAccumГAccum) Call(args []interface{}) []interface{} {
-	out0 := c.fn(args[0].([]accum))
-	return []interface{}{out0}
-}
-
-func (c *callerSliceofAccumГAccum) Call1x1(arg0 interface{}) (interface{}) {
-	return c.fn(arg0.([]accum))
 }
 
 type callerГAccum struct {

--- a/sdks/go/pkg/beam/transforms/top/top_test.go
+++ b/sdks/go/pkg/beam/transforms/top/top_test.go
@@ -16,10 +16,12 @@
 package top
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
+
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
 
@@ -29,7 +31,7 @@ func TestCombineFn3String(t *testing.T) {
 	less := func(a, b string) bool {
 		return len(a) < len(b)
 	}
-	fn := &combineFn{N: 3, Less: beam.EncodedFunc{Fn: reflectx.MakeFunc(less)}}
+	fn := newCombineFn(less, 3, typex.New(reflectx.String), false)
 
 	tests := []struct {
 		Elms     []string
@@ -52,12 +54,12 @@ func TestCombineFn3String(t *testing.T) {
 }
 
 // TestCombineFn3RevString verifies that the accumulator correctly
-// maintains the top 3 shorest strings.
+// maintains the top 3 shortest strings.
 func TestCombineFn3RevString(t *testing.T) {
 	less := func(a, b string) bool {
 		return len(a) < len(b)
 	}
-	fn := &combineFn{N: 3, Less: beam.EncodedFunc{Fn: reflectx.MakeFunc(less)}, Reversed: true}
+	fn := newCombineFn(less, 3, typex.New(reflectx.String), true)
 
 	tests := []struct {
 		Elms     []string
@@ -84,28 +86,30 @@ func TestCombineFnMerge(t *testing.T) {
 	less := func(a, b string) bool {
 		return len(a) < len(b)
 	}
-	fn := &combineFn{N: 3, Less: beam.EncodedFunc{Fn: reflectx.MakeFunc(less)}}
-
+	fn := newCombineFn(less, 3, typex.New(reflectx.String), false)
 	tests := []struct {
 		Elms     [][]string
 		Expected []string
 	}{
 		{[][]string{nil}, nil},
 		{[][]string{{"foo"}}, []string{"foo"}},
-		{[][]string{{"1", "2"}, {"3"}, {"4", "5"}}, []string{"1", "2", "3"}},
+		{[][]string{{"1", "2"}, {"3"}, {"4", "5"}, {"6", "7"}}, []string{"1", "2", "3"}},
 		{[][]string{{"a1"}, {"b22", "c22"}, {"d333"}, {"e22"}}, []string{"d333", "b22", "c22"}},
+		{[][]string{{"a55555"}, {"b22", "c4444"}, {"d333"}, {"e22"}}, []string{"a55555", "c4444", "d333"}},
 	}
 
-	for _, test := range tests {
-		var list []accum
-		for _, a := range test.Elms {
-			list = append(list, load(fn, a...))
-		}
-
-		actual := output(fn, fn.MergeAccumulators(list))
-		if !reflect.DeepEqual(actual, test.Expected) {
-			t.Errorf("CombineFn(3; %v) = %v, want %v", test.Elms, actual, test.Expected)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			var list []accum
+			for _, a := range test.Elms {
+				list = append(list, load(fn, a...))
+			}
+			a := merge(t, fn, list...)
+			actual := output(fn, a)
+			if !reflect.DeepEqual(actual, test.Expected) {
+				t.Errorf("CombineFn(3; %v) = %v, want %v", test.Elms, actual, test.Expected)
+			}
+		})
 	}
 }
 
@@ -113,6 +117,23 @@ func load(fn *combineFn, elms ...string) accum {
 	a := fn.CreateAccumulator()
 	for _, elm := range elms {
 		a = fn.AddInput(a, elm)
+	}
+	return a
+}
+
+func merge(t *testing.T, fn *combineFn, as ...accum) accum {
+	t.Helper()
+	a := fn.CreateAccumulator()
+	for i, b := range as {
+		buf, err := b.MarshalJSON()
+		if err != nil {
+			t.Fatalf("failure marshalling accum[%d]: %v, %+v", i, err, b)
+		}
+		var c accum
+		if err := c.UnmarshalJSON(buf); err != nil {
+			t.Fatalf("failure unmarshalling accum[%d]: %v, %+v", i, err, b)
+		}
+		a = fn.MergeAccumulators(a, c)
 	}
 	return a
 }


### PR DESCRIPTION
Top wasn't written correctly initially (it predates much of the execution engine), and wasn't written to be liftable. This changes MergeAccumulators to use a binary transform, and adds a custom encoding for the accumulator type using the JSON override mechanism.

This also removes the hack that was present to allowed an unliftable combiner to do the unlifted variant.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




