### PR TITLE
[BEAM-6489] Remove usages of a deprecated flag and simplify SDK dependencies' version spec.

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 import os
 import platform
-import sys
 import warnings
 from distutils.version import StrictVersion
 
@@ -101,20 +100,14 @@ else:
   except ImportError:
     cythonize = lambda *args, **kwargs: []
 
-REQUIRED_PACKAGES_PY2_ONLY = [
-    'avro>=1.8.1,<2.0.0',
-    'dill>=0.2.6,<=0.2.8.2',
-]
-
-REQUIRED_PACKAGES_PY3_ONLY = [
-    'avro-python3>=1.8.1,<2.0.0',
-    'dill==0.2.9.dev0'
-]
-
 REQUIRED_PACKAGES = [
+    'avro>=1.8.1,<2.0.0; python_version < "3.0"',
+    'avro-python3>=1.8.1,<2.0.0; python_version >= "3.0"',
     'crcmod>=1.7,<2.0',
+    'dill>=0.2.9,<0.2.10',
     'fastavro>=0.21.4,<0.22',
-    'pyarrow>=0.11.1,<0.12.0',
+    'future>=0.16.0,<1.0.0',
+    'futures>=3.1.1,<4.0.0',
     'grpcio>=1.8,<2',
     'hdfs>=2.1.0,<3.0.0',
     'httplib2>=0.8,<=0.11.3',
@@ -122,13 +115,14 @@ REQUIRED_PACKAGES = [
     'oauth2client>=2.0.1,<4',
     # grpcio 1.8.1 and above requires protobuf 3.5.0.post1.
     'protobuf>=3.5.0.post1,<4',
+    # pyarrow is not supported on Windows for Python 2 [BEAM-6287]
+    ('pyarrow>=0.11.1,<0.12.0; python_version >= "3.0" or '
+     'platform_system != "Windows"'),
     'pydot>=1.2.0,<1.3',
     'pytz>=2018.3',
-    'pyyaml>=3.12,<4.0.0',
     'pyvcf>=0.6.8,<0.7.0',
+    'pyyaml>=3.12,<4.0.0',
     'typing>=3.6.0,<3.7.0; python_version < "3.5.0"',
-    'futures>=3.1.1,<4.0.0',
-    'future>=0.16.0,<1.0.0',
     ]
 
 REQUIRED_TEST_PACKAGES = [
@@ -149,22 +143,6 @@ GCP_REQUIREMENTS = [
     # GCP packages required by tests
     'google-cloud-bigquery>=1.6.0,<1.7.0',
 ]
-
-if sys.version_info[0] == 2:
-  REQUIRED_PACKAGES = REQUIRED_PACKAGES + REQUIRED_PACKAGES_PY2_ONLY
-  DEPENDENCY_LINKS = []
-elif sys.version_info[0] >= 3:
-  REQUIRED_PACKAGES = REQUIRED_PACKAGES + REQUIRED_PACKAGES_PY3_ONLY
-  # TODO(BEAM-6135): Revert when new dill version released
-  DEPENDENCY_LINKS = ['git+https://github.com/uqfoundation/dill.git'
-                      '@7a73fbe3d6aa445f93f58f266687b7315d14a3ac'
-                      '#egg=dill-0.2.9.dev0']
-
-# pyarrow is not supported on Windows Python 2 [BEAM-6287]
-if platform.system() == 'Windows' and sys.version_info[0] == 2:
-  REQUIRED_PACKAGES = [
-      x for x in REQUIRED_PACKAGES if not x.startswith("pyarrow")
-  ]
 
 
 # We must generate protos after setup_requires are installed.
@@ -213,7 +191,6 @@ setuptools.setup(
         'apache_beam/utils/windowed_value.py',
     ]),
     install_requires=REQUIRED_PACKAGES,
-    dependency_links=DEPENDENCY_LINKS,
     python_requires=python_requires,
     test_suite='nose.collector',
     tests_require=REQUIRED_TEST_PACKAGES,

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -41,7 +41,7 @@ deps =
 # Otherwise we get "OSError: [Errno 2] No such file or directory" errors.
 # Source:
 # https://github.com/tox-dev/tox/issues/123#issuecomment-284714629
-install_command = {envbindir}/python {envbindir}/pip install --retries 10 --process-dependency-links {opts} {packages}
+install_command = {envbindir}/python {envbindir}/pip install --retries 10 {opts} {packages}
 list_dependencies_command = {envbindir}/python {envbindir}/pip freeze
 
 [testenv:py27]


### PR DESCRIPTION
This change:
- Adds the dependency to newly released dill==0.2.9, which removes the necessity to pass --process-dependency-links to pip, since we no longer need to pick up an unreleased change.
- Cleans up tox.ini to use platform-specific dependecy declaration https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies 
- Sorts the SDK dependencies alphabetically.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




