### PR TITLE
[BEAM-5392] GroupByKey optimized for non-merging windows

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/BeamSparkRunnerRegistrator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/BeamSparkRunnerRegistrator.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import org.apache.beam.runners.spark.io.MicrobatchSource;
 import org.apache.beam.runners.spark.stateful.SparkGroupAlsoByWindowViaWindowSet.StateAndTimers;
 import org.apache.beam.runners.spark.translation.GroupCombineFunctions;
+import org.apache.beam.runners.spark.translation.GroupNonMergingWindowsFunctions.WindowedKey;
 import org.apache.beam.runners.spark.util.ByteArray;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.KV;
@@ -61,6 +62,7 @@ public class BeamSparkRunnerRegistrator implements KryoRegistrator {
     kryo.register(HashBasedTable.class);
     kryo.register(KV.class);
     kryo.register(PaneInfo.class);
+    kryo.register(WindowedKey.class);
 
     try {
       kryo.register(

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
@@ -96,8 +96,8 @@ public class GroupNonMergingWindowsFunctions {
     private final Coder<V> valueCoder;
     private final WindowingStrategy<?, W> windowingStrategy;
     private final FullWindowedValueCoder<byte[]> windowedValueCoder;
-    private boolean hasNext = true;
 
+    private boolean hasNext = true;
     private WindowedKey currentKey = null;
 
     GroupByKeyIterator(
@@ -140,7 +140,7 @@ public class GroupNonMergingWindowsFunctions {
 
       boolean usedAsIterable = false;
       private final PeekingIterator<Tuple2<WindowedKey, byte[]>> inner;
-      private WindowedKey currentKey;
+      private final WindowedKey currentKey;
 
       ValueIterator(PeekingIterator<Tuple2<WindowedKey, byte[]>> inner, WindowedKey currentKey) {
         this.inner = inner;
@@ -222,11 +222,11 @@ public class GroupNonMergingWindowsFunctions {
       return result;
     }
 
-    public byte[] getKey() {
+    byte[] getKey() {
       return key;
     }
 
-    public byte[] getWindow() {
+    byte[] getWindow() {
       return window;
     }
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Objects;
+import org.apache.beam.runners.spark.coders.CoderHelpers;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.AbstractIterator;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterables;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterators;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.PeekingIterator;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.primitives.UnsignedBytes;
+import org.apache.spark.HashPartitioner;
+import org.apache.spark.api.java.JavaRDD;
+import org.joda.time.Instant;
+import scala.Tuple2;
+
+/** Functions for GroupByKey with Non-Merging windows translations to Spark. */
+public class GroupNonMergingWindowsFunctions {
+
+  static <K, V, W extends BoundedWindow>
+      JavaRDD<WindowedValue<KV<K, Iterable<V>>>> groupByKeyAndWindow(
+          JavaRDD<WindowedValue<KV<K, V>>> rdd,
+          Coder<K> keyCoder,
+          Coder<V> valueCoder,
+          WindowingStrategy<?, W> windowingStrategy) {
+    final Coder<W> windowCoder = windowingStrategy.getWindowFn().windowCoder();
+    final WindowedValue.FullWindowedValueCoder<byte[]> windowedValueCoder =
+        WindowedValue.getFullCoder(ByteArrayCoder.of(), windowCoder);
+    return rdd.flatMapToPair(
+            (WindowedValue<KV<K, V>> windowedValue) -> {
+              final byte[] keyBytes =
+                  CoderHelpers.toByteArray(windowedValue.getValue().getKey(), keyCoder);
+              final byte[] valueBytes =
+                  CoderHelpers.toByteArray(windowedValue.getValue().getValue(), valueCoder);
+              return Iterators.transform(
+                  windowedValue.explodeWindows().iterator(),
+                  item -> {
+                    Objects.requireNonNull(item, "Exploded window can not be null.");
+                    @SuppressWarnings("unchecked")
+                    final W window = (W) Iterables.getOnlyElement(item.getWindows());
+                    final byte[] windowBytes = CoderHelpers.toByteArray(window, windowCoder);
+                    final byte[] windowValueBytes =
+                        CoderHelpers.toByteArray(
+                            WindowedValue.of(
+                                valueBytes, item.getTimestamp(), window, item.getPane()),
+                            windowedValueCoder);
+                    final WindowedKey windowedKey = new WindowedKey(keyBytes, windowBytes);
+                    return new Tuple2<>(windowedKey, windowValueBytes);
+                  });
+            })
+        .repartitionAndSortWithinPartitions(new HashPartitioner(rdd.getNumPartitions()))
+        .mapPartitions(
+            it ->
+                new GroupByKeyIterator<>(
+                    it, keyCoder, valueCoder, windowingStrategy, windowedValueCoder))
+        .filter(Objects::nonNull); // filter last null element from GroupByKeyIterator
+  }
+
+  /**
+   * Transform stream of sorted key values into stream of value iterators for each key. This
+   * iterator can be iterated only once!
+   *
+   * @param <K> type of key iterator emits
+   * @param <V> type of value iterator emits
+   */
+  static class GroupByKeyIterator<K, V, W extends BoundedWindow>
+      implements Iterator<WindowedValue<KV<K, Iterable<V>>>> {
+
+    private final PeekingIterator<Tuple2<WindowedKey, byte[]>> inner;
+    private final Coder<K> keyCoder;
+    private final Coder<V> valueCoder;
+    private final WindowingStrategy<?, W> windowingStrategy;
+    private final FullWindowedValueCoder<byte[]> windowedValueCoder;
+    private boolean hasNext = true;
+
+    private WindowedKey currentKey = null;
+
+    GroupByKeyIterator(
+        Iterator<Tuple2<WindowedKey, byte[]>> inner,
+        Coder<K> keyCoder,
+        Coder<V> valueCoder,
+        WindowingStrategy<?, W> windowingStrategy,
+        WindowedValue.FullWindowedValueCoder<byte[]> windowedValueCoder) {
+      this.inner = Iterators.peekingIterator(inner);
+      this.keyCoder = keyCoder;
+      this.valueCoder = valueCoder;
+      this.windowingStrategy = windowingStrategy;
+      this.windowedValueCoder = windowedValueCoder;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return hasNext;
+    }
+
+    @Override
+    public WindowedValue<KV<K, Iterable<V>>> next() {
+      while (inner.hasNext()) {
+        final WindowedKey nextKey = inner.peek()._1;
+        if (nextKey.equals(currentKey)) {
+          // we still did not see all values for a given key
+          inner.next();
+          continue;
+        }
+        currentKey = nextKey;
+        final WindowedValue<KV<K, V>> decodedItem = decodeItem(inner.peek());
+        return decodedItem.withValue(
+            KV.of(decodedItem.getValue().getKey(), new ValueIterator(inner, currentKey)));
+      }
+      hasNext = false;
+      return null;
+    }
+
+    class ValueIterator implements Iterable<V> {
+
+      boolean usedAsIterable = false;
+      private final PeekingIterator<Tuple2<WindowedKey, byte[]>> inner;
+      private WindowedKey currentKey;
+
+      ValueIterator(PeekingIterator<Tuple2<WindowedKey, byte[]>> inner, WindowedKey currentKey) {
+        this.inner = inner;
+        this.currentKey = currentKey;
+      }
+
+      @Override
+      public Iterator<V> iterator() {
+        if (usedAsIterable) {
+          throw new IllegalStateException(
+              "ValueIterator can't be iterated more than once,"
+                  + "otherwise there could be data lost");
+        }
+        usedAsIterable = true;
+        return new AbstractIterator<V>() {
+          @Override
+          protected V computeNext() {
+            if (inner.hasNext() && currentKey.equals(inner.peek()._1)) {
+              return decodeValue(inner.next()._2);
+            }
+            return endOfData();
+          }
+        };
+      }
+    }
+
+    private V decodeValue(byte[] windowedValueBytes) {
+      final WindowedValue<byte[]> windowedValue =
+          CoderHelpers.fromByteArray(windowedValueBytes, windowedValueCoder);
+      return CoderHelpers.fromByteArray(windowedValue.getValue(), valueCoder);
+    }
+
+    private WindowedValue<KV<K, V>> decodeItem(Tuple2<WindowedKey, byte[]> item) {
+      final K key = CoderHelpers.fromByteArray(item._1.getKey(), keyCoder);
+      final WindowedValue<byte[]> windowedValue =
+          CoderHelpers.fromByteArray(item._2, windowedValueCoder);
+      final V value = CoderHelpers.fromByteArray(windowedValue.getValue(), valueCoder);
+      @SuppressWarnings("unchecked")
+      final W window = (W) Iterables.getOnlyElement(windowedValue.getWindows());
+      final Instant timestamp =
+          windowingStrategy
+              .getTimestampCombiner()
+              .assign(
+                  window,
+                  windowingStrategy
+                      .getWindowFn()
+                      .getOutputTime(windowedValue.getTimestamp(), window));
+      return WindowedValue.of(KV.of(key, value), timestamp, window, windowedValue.getPane());
+    }
+  }
+
+  /** Composite key of key and window for groupByKey transformation. */
+  public static class WindowedKey implements Comparable<WindowedKey>, Serializable {
+
+    private final byte[] key;
+    private final byte[] window;
+
+    WindowedKey(byte[] key, byte[] window) {
+      this.key = key;
+      this.window = window;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      WindowedKey that = (WindowedKey) o;
+      return Arrays.equals(key, that.key) && Arrays.equals(window, that.window);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Arrays.hashCode(key);
+      result = 31 * result + Arrays.hashCode(window);
+      return result;
+    }
+
+    public byte[] getKey() {
+      return key;
+    }
+
+    public byte[] getWindow() {
+      return window;
+    }
+
+    @Override
+    public int compareTo(WindowedKey o) {
+      int keyCompare = UnsignedBytes.lexicographicalComparator().compare(this.getKey(), o.getKey());
+      if (keyCompare == 0) {
+        return UnsignedBytes.lexicographicalComparator().compare(this.getWindow(), o.getWindow());
+      }
+      return keyCompare;
+    }
+  }
+}

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
@@ -42,6 +42,14 @@ import scala.Tuple2;
 /** Functions for GroupByKey with Non-Merging windows translations to Spark. */
 public class GroupNonMergingWindowsFunctions {
 
+  /**
+   * Creates composite key of K and W and group all values for that composite key with Spark's
+   * repartitionAndSortWithinPartitions. Stream of sorted by composite key's is transformed to key
+   * with iterator of all values for that key (via {@link GroupByKeyIterator}).
+   *
+   * <p>repartitionAndSortWithinPartitions is used because all values are not collected into memory
+   * at once, but streamed with iterator unlike GroupByKey (it minimizes memory pressure).
+   */
   static <K, V, W extends BoundedWindow>
       JavaRDD<WindowedValue<KV<K, Iterable<V>>>> groupByKeyAndWindow(
           JavaRDD<WindowedValue<KV<K, V>>> rdd,
@@ -84,6 +92,8 @@ public class GroupNonMergingWindowsFunctions {
   /**
    * Transform stream of sorted key values into stream of value iterators for each key. This
    * iterator can be iterated only once!
+   *
+   * <p>From Iterator<K, V> transform to <K, Iterator<V>>.
    *
    * @param <K> type of key iterator emits
    * @param <V> type of value iterator emits

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/CacheTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/CacheTest.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.Create.Values;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.Test;
@@ -70,15 +71,16 @@ public class CacheTest {
     options.setRunner(TestSparkRunner.class);
     options.setCacheDisabled(true);
     Pipeline pipeline = Pipeline.create(options);
-    PCollection<String> pCollection = pipeline.apply(Create.of("foo", "bar"));
+    Values<String> createInput = Create.of("foo", "bar");
+    PCollection<String> pCollection = pipeline.apply(createInput);
 
     JavaSparkContext jsc = SparkContextFactory.getSparkContext(options);
     EvaluationContext ctxt = new EvaluationContext(jsc, pipeline, options);
     ctxt.getCacheCandidates().put(pCollection, 2L);
 
-    assertFalse(ctxt.shouldCache(pCollection));
+    assertFalse(ctxt.shouldCache(pCollection, createInput));
 
     options.setCacheDisabled(false);
-    assertTrue(ctxt.shouldCache(pCollection));
+    assertTrue(ctxt.shouldCache(pCollection, createInput));
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/CacheTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/CacheTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.spark;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import org.apache.beam.runners.spark.translation.Dataset;
 import org.apache.beam.runners.spark.translation.EvaluationContext;
@@ -31,6 +32,7 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Create.Values;
+import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.Test;
@@ -43,10 +45,8 @@ public class CacheTest {
    * pipeline.
    */
   @Test
-  public void cacheCandidatesUpdaterTest() throws Exception {
-    SparkPipelineOptions options =
-        PipelineOptionsFactory.create().as(TestSparkPipelineOptions.class);
-    options.setRunner(TestSparkRunner.class);
+  public void cacheCandidatesUpdaterTest() {
+    SparkPipelineOptions options = createOptions();
     Pipeline pipeline = Pipeline.create(options);
     PCollection<String> pCollection = pipeline.apply(Create.of("foo", "bar"));
     // first read
@@ -65,22 +65,31 @@ public class CacheTest {
   }
 
   @Test
-  public void cacheDisabledOptionTest() {
-    SparkPipelineOptions options =
-        PipelineOptionsFactory.create().as(TestSparkPipelineOptions.class);
-    options.setRunner(TestSparkRunner.class);
+  public void shouldCacheTest() {
+    SparkPipelineOptions options = createOptions();
     options.setCacheDisabled(true);
     Pipeline pipeline = Pipeline.create(options);
-    Values<String> createInput = Create.of("foo", "bar");
-    PCollection<String> pCollection = pipeline.apply(createInput);
+
+    Values<String> valuesTransform = Create.of("foo", "bar");
+    PCollection pCollection = mock(PCollection.class);
 
     JavaSparkContext jsc = SparkContextFactory.getSparkContext(options);
     EvaluationContext ctxt = new EvaluationContext(jsc, pipeline, options);
     ctxt.getCacheCandidates().put(pCollection, 2L);
 
-    assertFalse(ctxt.shouldCache(pCollection, createInput));
+    assertFalse(ctxt.shouldCache(valuesTransform, pCollection));
 
     options.setCacheDisabled(false);
-    assertTrue(ctxt.shouldCache(pCollection, createInput));
+    assertTrue(ctxt.shouldCache(valuesTransform, pCollection));
+
+    GroupByKey<String, String> gbkTransform = GroupByKey.create();
+    assertFalse(ctxt.shouldCache(gbkTransform, pCollection));
+  }
+
+  private SparkPipelineOptions createOptions() {
+    SparkPipelineOptions options =
+        PipelineOptionsFactory.create().as(TestSparkPipelineOptions.class);
+    options.setRunner(TestSparkRunner.class);
+    return options;
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctionsTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctionsTest.java
@@ -80,7 +80,7 @@ public class GroupNonMergingWindowsFunctionsTest {
     }
   }
 
-  GroupByKeyIterator<String, Integer, GlobalWindow> createGbkIterator() {
+  private GroupByKeyIterator<String, Integer, GlobalWindow> createGbkIterator() {
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
     BigEndianIntegerCoder valueCoder = BigEndianIntegerCoder.of();
     WindowingStrategy<Object, GlobalWindow> winStrategy = WindowingStrategy.of(new GlobalWindows());
@@ -108,7 +108,7 @@ public class GroupNonMergingWindowsFunctionsTest {
     private final WindowedValue.FullWindowedValueCoder<byte[]> winValCoder;
     private final byte[] globalWindow;
 
-    public ItemFactory(
+    ItemFactory(
         Coder<K> keyCoder,
         Coder<V> valueCoder,
         FullWindowedValueCoder<byte[]> winValCoder,

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctionsTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctionsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.beam.runners.spark.coders.CoderHelpers;
+import org.apache.beam.runners.spark.translation.GroupNonMergingWindowsFunctions.GroupByKeyIterator;
+import org.apache.beam.runners.spark.translation.GroupNonMergingWindowsFunctions.WindowedKey;
+import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+import scala.Tuple2;
+
+/** Unit tests of {@link GroupNonMergingWindowsFunctions}. */
+public class GroupNonMergingWindowsFunctionsTest {
+
+  @Test
+  public void testGroupByKeyIterator() {
+    GroupByKeyIterator<String, Integer, GlobalWindow> iteratorUnderTest = createGbkIterator();
+
+    Assert.assertTrue(iteratorUnderTest.hasNext());
+    WindowedValue<KV<String, Iterable<Integer>>> k1Win = iteratorUnderTest.next();
+    // testing that calling 2x hasNext doesn't move to next key iterator
+    Assert.assertTrue(iteratorUnderTest.hasNext());
+    Assert.assertTrue(iteratorUnderTest.hasNext());
+
+    Iterator<Integer> valuesIteratorForK1 = k1Win.getValue().getValue().iterator();
+
+    Assert.assertTrue("Now we expect first value for K1 to pop up.", valuesIteratorForK1.hasNext());
+    assertEquals(1L, valuesIteratorForK1.next().longValue());
+    Assert.assertTrue(valuesIteratorForK1.hasNext());
+    Assert.assertTrue(valuesIteratorForK1.hasNext());
+    assertEquals(2L, valuesIteratorForK1.next().longValue());
+
+    WindowedValue<KV<String, Iterable<Integer>>> k2Win = iteratorUnderTest.next();
+    Iterator<Integer> valuesIteratorForK2 = k2Win.getValue().getValue().iterator();
+    assertEquals(3L, valuesIteratorForK2.next().longValue());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testGbkIteratorValuesCannotBeReiterated() {
+    GroupByKeyIterator<String, Integer, GlobalWindow> iteratorUnderTest = createGbkIterator();
+    WindowedValue<KV<String, Iterable<Integer>>> firstEl = iteratorUnderTest.next();
+    Iterable<Integer> value = firstEl.getValue().getValue();
+    for (Integer i : value) {
+      // first iteration
+    }
+    for (Integer i : value) {
+      // second iteration should throw IllegalStateException
+    }
+  }
+
+  GroupByKeyIterator<String, Integer, GlobalWindow> createGbkIterator() {
+    StringUtf8Coder keyCoder = StringUtf8Coder.of();
+    BigEndianIntegerCoder valueCoder = BigEndianIntegerCoder.of();
+    WindowingStrategy<Object, GlobalWindow> winStrategy = WindowingStrategy.of(new GlobalWindows());
+
+    final WindowedValue.FullWindowedValueCoder<byte[]> winValCoder =
+        WindowedValue.getFullCoder(ByteArrayCoder.of(), winStrategy.getWindowFn().windowCoder());
+
+    ItemFactory<String, Integer> factory =
+        new ItemFactory<>(
+            keyCoder, valueCoder, winValCoder, winStrategy.getWindowFn().windowCoder());
+    List<Tuple2<WindowedKey, byte[]>> items =
+        Arrays.asList(
+            factory.create("k1", 1),
+            factory.create("k1", 2),
+            factory.create("k2", 3),
+            factory.create("k2", 4),
+            factory.create("k2", 5));
+    return new GroupByKeyIterator<>(
+        items.iterator(), keyCoder, valueCoder, winStrategy, winValCoder);
+  }
+
+  private static class ItemFactory<K, V> {
+    private final Coder<K> keyCoder;
+    private final Coder<V> valueCoder;
+    private final WindowedValue.FullWindowedValueCoder<byte[]> winValCoder;
+    private final byte[] globalWindow;
+
+    public ItemFactory(
+        Coder<K> keyCoder,
+        Coder<V> valueCoder,
+        FullWindowedValueCoder<byte[]> winValCoder,
+        Coder<GlobalWindow> winCoder) {
+      this.keyCoder = keyCoder;
+      this.valueCoder = valueCoder;
+      this.winValCoder = winValCoder;
+      this.globalWindow = CoderHelpers.toByteArray(GlobalWindow.INSTANCE, winCoder);
+    }
+
+    private Tuple2<WindowedKey, byte[]> create(K key, V value) {
+      WindowedKey kaw = new WindowedKey(CoderHelpers.toByteArray(key, keyCoder), globalWindow);
+
+      byte[] valueInbytes = CoderHelpers.toByteArray(value, valueCoder);
+
+      WindowedValue<byte[]> windowedValue =
+          WindowedValue.of(
+              valueInbytes, Instant.now(), GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING);
+      return new Tuple2<>(kaw, CoderHelpers.toByteArray(windowedValue, winValCoder));
+    }
+  }
+}


### PR DESCRIPTION
- used spark `repartitionAndSortWithinPartitions` instead `groupByKey` to not store all records for key in memory
- For non-merging windows, window is put itself into the key resulting in smaller groupings.

Tested on our job with 64TB shuffle read in one stage.

more info https://issues.apache.org/jira/browse/BEAM-5392

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




