### PR TITLE
[BEAM-6207] Added option to publish synthetic data to Kafka topic.

### DIFF
--- a/sdks/java/testing/load-tests/build.gradle
+++ b/sdks/java/testing/load-tests/build.gradle
@@ -55,11 +55,14 @@ configurations {
 }
 
 dependencies {
+  shadow library.java.kafka_clients
+
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow project(path: ":beam-runners-direct-java", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-io-synthetic", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-test-utils", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-io-google-cloud-platform", configuration: "shadow")
+  shadow project(path: ":beam-sdks-java-io-kafka", configuration: "shadow")
 
   gradleRun project(path: project.path, configuration: "shadow")
   gradleRun project(path: runnerDependency, configuration: "shadow")

--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/SyntheticDataPublisher.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/SyntheticDataPublisher.java
@@ -36,7 +36,6 @@ import org.apache.beam.sdk.io.synthetic.SyntheticBoundedSource;
 import org.apache.beam.sdk.io.synthetic.SyntheticOptions;
 import org.apache.beam.sdk.io.synthetic.SyntheticSourceOptions;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
-import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -44,6 +43,7 @@ import org.apache.beam.sdk.options.Validation;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
@@ -53,19 +53,22 @@ import org.apache.kafka.common.serialization.StringSerializer;
  *
  * <pre>
  *  ./gradlew :beam-sdks-java-load-tests:run -PloadTest.args='
- *    --insertionPipelineTopic=TOPIC_NAME
+ *    --pubSubTopic=TOPIC_NAME
  *    --kafkaBootstrapServerAddress=SERVER_ADDRESS
+ *    --kafkaTopic=KAFKA_TOPIC_NAME
  *    --sourceOptions={"numRecords":1000,...}'
- *    -PloadTest.mainClass="org.apache.beam.sdk.loadtests.SyntheticDataPubSubPublisher"
+ *    -PloadTest.mainClass="org.apache.beam.sdk.loadtests.SyntheticDataPublisher"
  *  </pre>
  *
- * Parameter kafkaBootstrapServerAddress is optional. If provided, pipeline topic will be treated as
- * Kafka topic name and records will be published to Kafka instead of PubSub.
+ * <p>If parameters related to a specific sink are provided (Kafka or PubSub), the pipeline writes
+ * to the sink. Writing to both sinks is also acceptable.
  */
-public class SyntheticDataPubSubPublisher {
+public class SyntheticDataPublisher {
 
   private static final KvCoder<byte[], byte[]> RECORD_CODER =
       KvCoder.of(ByteArrayCoder.of(), ByteArrayCoder.of());
+
+  private static Options options;
 
   /** Options for the pipeline. */
   public interface Options extends PipelineOptions, ApplicationNameOptions {
@@ -77,58 +80,63 @@ public class SyntheticDataPubSubPublisher {
     void setSourceOptions(String sourceOptions);
 
     @Description("PubSub topic to publish to")
-    @Validation.Required
-    String getInsertionPipelineTopic();
+    String getPubSubTopic();
 
-    void setInsertionPipelineTopic(String topic);
+    void setPubSubTopic(String topic);
 
     @Description("Kafka server address")
-    @Default.String("")
     String getKafkaBootstrapServerAddress();
 
     void setKafkaBootstrapServerAddress(String address);
+
+    @Description("Kafka topic")
+    String getKafkaTopic();
+
+    void setKafkaTopic(String topic);
   }
 
   public static void main(String[] args) throws IOException {
-    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
 
     SyntheticSourceOptions sourceOptions =
         SyntheticOptions.fromJsonString(options.getSourceOptions(), SyntheticSourceOptions.class);
 
     Pipeline pipeline = Pipeline.create(options);
+    PCollection<KV<byte[], byte[]>> syntheticData =
+        pipeline.apply("Read synthetic data", Read.from(new SyntheticBoundedSource(sourceOptions)));
 
-    if (!options.getKafkaBootstrapServerAddress().isEmpty()) {
-      pipeline
-          .apply("Read synthetic data", Read.from(new SyntheticBoundedSource(sourceOptions)))
-          .apply("Map to Kafka messages", MapElements.via(new MapKVToString()))
-          .apply(
-              "Write to Kafka",
-              KafkaIO.<Void, String>write()
-                  .withBootstrapServers(options.getKafkaBootstrapServerAddress())
-                  .withTopic(options.getInsertionPipelineTopic())
-                  .withValueSerializer(StringSerializer.class)
-                  .values());
-    } else {
-      pipeline
-          .apply("Read synthetic data", Read.from(new SyntheticBoundedSource(sourceOptions)))
-          .apply("Map to PubSub messages", MapElements.via(new MapBytesToPubSubMessage()))
-          .apply(
-              "Write to PubSub", PubsubIO.writeMessages().to(options.getInsertionPipelineTopic()));
+    if (options.getKafkaBootstrapServerAddress() != null && options.getKafkaTopic() != null) {
+      writeToKafka(syntheticData);
+    }
+    if (options.getPubSubTopic() != null) {
+      writeToPubSub(syntheticData);
     }
     pipeline.run().waitUntilFinish();
+  }
+
+  private static void writeToPubSub(PCollection<KV<byte[], byte[]>> collection) {
+    collection
+        .apply("Map to PubSub messages", MapElements.via(new MapBytesToPubSubMessage()))
+        .apply("Write to PubSub", PubsubIO.writeMessages().to(options.getPubSubTopic()));
+  }
+
+  private static void writeToKafka(PCollection<KV<byte[], byte[]>> collection) {
+    collection
+        .apply("Map to Kafka messages", MapElements.via(new MapKVToString()))
+        .apply(
+            "Write to Kafka",
+            KafkaIO.<Void, String>write()
+                .withBootstrapServers(options.getKafkaBootstrapServerAddress())
+                .withTopic(options.getKafkaTopic())
+                .withValueSerializer(StringSerializer.class)
+                .values());
   }
 
   private static class MapKVToString extends SimpleFunction<KV<byte[], byte[]>, String> {
     @Override
     public String apply(KV<byte[], byte[]> input) {
-      StringBuilder stringBuilder =
-          new StringBuilder()
-              .append("{")
-              .append(Arrays.toString(input.getKey()))
-              .append(",")
-              .append(Arrays.toString(input.getValue()))
-              .append("}");
-      return stringBuilder.toString();
+      return String.format(
+          "{%s,%s}", Arrays.toString(input.getKey()), Arrays.toString(input.getValue()));
     }
   }
 


### PR DESCRIPTION
SyntheticDataPubSubPublisher now accepts --kafkaBootstrapServerAddress option
which switches it to Kafka publishing mode instead of Google PubSub mode.
Key-Value pairs are published as strings.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




