### PR TITLE
[BEAM-6291] Generic BigQuery schema load tests metrics

### DIFF
--- a/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
@@ -84,24 +84,23 @@ from __future__ import absolute_import
 
 import json
 import logging
+import os
 import unittest
 
 import apache_beam as beam
 from apache_beam.testing import synthetic_pipeline
+from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
+from apache_beam.testing.load_tests.load_test_metrics_utils import MetricsMonitor
 from apache_beam.testing.test_pipeline import TestPipeline
-
-try:
-  from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
-  from apache_beam.testing.load_tests.load_test_metrics_utils import MetricsMonitor
-  from google.cloud import bigquery as bq
-except ImportError:
-  bq = None
 
 INPUT_TAG = 'pc1'
 CO_INPUT_TAG = 'pc2'
+load_test_enabled = False
+if os.environ.get('LOAD_TEST_ENABLED') == 'true':
+  load_test_enabled = True
 
 
-@unittest.skipIf(bq is None, 'BigQuery for storing metrics not installed')
+@unittest.skipIf(not load_test_enabled, 'Enabled only for phrase triggering.')
 class CoGroupByKeyTest(unittest.TestCase):
 
   def parseTestPipelineOptions(self, options):
@@ -121,7 +120,7 @@ class CoGroupByKeyTest(unittest.TestCase):
     }
 
   def setUp(self):
-    self.pipeline = TestPipeline(is_integration_test=True)
+    self.pipeline = TestPipeline()
     self.input_options = json.loads(self.pipeline.get_option('input_options'))
     self.co_input_options = json.loads(
         self.pipeline.get_option('co_input_options'))

--- a/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
@@ -99,7 +99,6 @@ except ImportError:
 
 INPUT_TAG = 'pc1'
 CO_INPUT_TAG = 'pc2'
-RUNTIME_LABEL = 'runtime'
 
 
 @unittest.skipIf(bq is None, 'BigQuery for storing metrics not installed')
@@ -134,14 +133,10 @@ class CoGroupByKeyTest(unittest.TestCase):
     check = metrics_project_id and self.metrics_namespace and metrics_dataset\
             is not None
     if check:
-      measured_values = [{'name': RUNTIME_LABEL,
-                          'type': 'FLOAT',
-                          'mode': 'REQUIRED'}]
       self.metrics_monitor = MetricsMonitor(
           project_name=metrics_project_id,
           table=self.metrics_namespace,
           dataset=metrics_dataset,
-          schema_map=measured_values
       )
     else:
       logging.error('One or more of parameters for collecting metrics '

--- a/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
@@ -20,10 +20,12 @@ input options there are additional options:
 * project (optional) - the gcp project in case of saving
 metrics in Big Query (in case of Dataflow Runner
 it is required to specify project of runner),
-* metrics_namespace (optional) - name of BigQuery table where metrics
+* publish_to_big_query - if metrics should be published in big query,
+* metrics_namespace (optional) - name of BigQuery dataset where metrics
 will be stored,
-in case of lack of any of both options metrics won't be saved
-* input_options - options for Synthetic Sources
+* metrics_table (optional) - name of BigQuery table where metrics
+will be stored,
+* input_options - options for Synthetic Sources,
 * co_input_options - options for  Synthetic Sources.
 
 Example test run on DirectRunner:
@@ -31,6 +33,7 @@ Example test run on DirectRunner:
 python setup.py nosetests \
     --test-pipeline-options="
       --project=big-query-project
+      --publish_to_big_query=true
       --metrics_dataset=python_load_tests
       --metrics_table=co_gbk
       --input_options='{
@@ -58,6 +61,7 @@ python setup.py nosetests \
         --staging_location=gs://...
         --temp_location=gs://...
         --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
+        --publish_to_big_query=true
         --metrics_dataset=python_load_tests
         --metrics_table=co_gbk
         --input_options='{
@@ -125,21 +129,23 @@ class CoGroupByKeyTest(unittest.TestCase):
     self.co_input_options = json.loads(
         self.pipeline.get_option('co_input_options'))
 
+    self.metrics_monitor = self.pipeline.get_option('publish_to_big_query')
     metrics_project_id = self.pipeline.get_option('project')
     self.metrics_namespace = self.pipeline.get_option('metrics_table')
     metrics_dataset = self.pipeline.get_option('metrics_dataset')
-    self.metrics_monitor = None
     check = metrics_project_id and self.metrics_namespace and metrics_dataset\
             is not None
-    if check:
+    if not self.metrics_monitor:
+      logging.info('Metrics will not be collected')
+    elif check:
       self.metrics_monitor = MetricsMonitor(
           project_name=metrics_project_id,
           table=self.metrics_namespace,
           dataset=metrics_dataset,
       )
     else:
-      logging.error('One or more of parameters for collecting metrics '
-                    'are empty. Metrics will not be collected')
+      raise ValueError('One or more of parameters for collecting metrics '
+                       'are empty.')
 
   class _Ungroup(beam.DoFn):
     def process(self, element):

--- a/sdks/python/apache_beam/testing/load_tests/combine_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/combine_test.py
@@ -20,9 +20,11 @@ input options there are additional options:
 * project (optional) - the gcp project in case of saving
 metrics in Big Query (in case of Dataflow Runner
 it is required to specify project of runner),
-* metrics_namespace (optional) - name of BigQuery table where metrics
+* publish_to_big_query - if metrics should be published in big query,
+* metrics_namespace (optional) - name of BigQuery dataset where metrics
 will be stored,
-in case of lack of any of both options metrics won't be saved
+* metrics_table (optional) - name of BigQuery table where metrics
+will be stored,
 * input_options - options for Synthetic Sources.
 
 Example test run on DirectRunner:
@@ -30,6 +32,7 @@ Example test run on DirectRunner:
 python setup.py nosetests \
     --test-pipeline-options="
     --project=big-query-project
+    --publish_to_big_query=true
     --metrics_dataset=python_load_tests
     --metrics_table=combine
     --input_options='{
@@ -51,6 +54,7 @@ python setup.py nosetests \
         --staging_location=gs://...
         --temp_location=gs://...
         --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
+        --publish_to_big_query=true
         --metrics_dataset=python_load_tests
         --metrics_table=combine
         --input_options='{

--- a/sdks/python/apache_beam/testing/load_tests/combine_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/combine_test.py
@@ -69,21 +69,21 @@ from __future__ import absolute_import
 
 import json
 import logging
+import os
 import unittest
 
 import apache_beam as beam
 from apache_beam.testing import synthetic_pipeline
+from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
+from apache_beam.testing.load_tests.load_test_metrics_utils import MetricsMonitor
 from apache_beam.testing.test_pipeline import TestPipeline
 
-try:
-  from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
-  from apache_beam.testing.load_tests.load_test_metrics_utils import MetricsMonitor
-  from google.cloud import bigquery as bq
-except ImportError:
-  bq = None
+load_test_enabled = False
+if os.environ.get('LOAD_TEST_ENABLED') == 'true':
+  load_test_enabled = True
 
 
-@unittest.skipIf(bq is None, 'BigQuery for storing metrics not installed')
+@unittest.skipIf(not load_test_enabled, 'Enabled only for phrase triggering.')
 class CombineTest(unittest.TestCase):
   def parseTestPipelineOptions(self):
     return {
@@ -102,7 +102,7 @@ class CombineTest(unittest.TestCase):
     }
 
   def setUp(self):
-    self.pipeline = TestPipeline(is_integration_test=True)
+    self.pipeline = TestPipeline()
     self.input_options = json.loads(self.pipeline.get_option('input_options'))
 
     self.metrics_monitor = self.pipeline.get_option('publish_to_big_query')
@@ -115,9 +115,9 @@ class CombineTest(unittest.TestCase):
       logging.info('Metrics will not be collected')
     elif check:
       self.metrics_monitor = MetricsMonitor(
-        project_name=metrics_project_id,
-        table=self.metrics_namespace,
-        dataset=metrics_dataset,
+          project_name=metrics_project_id,
+          table=self.metrics_namespace,
+          dataset=metrics_dataset,
       )
     else:
       raise ValueError('One or more of parameters for collecting metrics '

--- a/sdks/python/apache_beam/testing/load_tests/combine_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/combine_test.py
@@ -105,21 +105,23 @@ class CombineTest(unittest.TestCase):
     self.pipeline = TestPipeline(is_integration_test=True)
     self.input_options = json.loads(self.pipeline.get_option('input_options'))
 
+    self.metrics_monitor = self.pipeline.get_option('publish_to_big_query')
     metrics_project_id = self.pipeline.get_option('project')
     self.metrics_namespace = self.pipeline.get_option('metrics_table')
     metrics_dataset = self.pipeline.get_option('metrics_dataset')
-    self.metrics_monitor = None
     check = metrics_project_id and self.metrics_namespace and metrics_dataset \
             is not None
-    if check:
+    if not self.metrics_monitor:
+      logging.info('Metrics will not be collected')
+    elif check:
       self.metrics_monitor = MetricsMonitor(
-          project_name=metrics_project_id,
-          table=self.metrics_namespace,
-          dataset=metrics_dataset
+        project_name=metrics_project_id,
+        table=self.metrics_namespace,
+        dataset=metrics_dataset,
       )
     else:
-      logging.error('One or more of parameters for collecting metrics '
-                    'are empty. Metrics will not be collected')
+      raise ValueError('One or more of parameters for collecting metrics '
+                       'are empty.')
 
   class _GetElement(beam.DoFn):
     def process(self, element):

--- a/sdks/python/apache_beam/testing/load_tests/combine_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/combine_test.py
@@ -82,8 +82,6 @@ try:
 except ImportError:
   bq = None
 
-RUNTIME_LABEL = 'runtime'
-
 
 @unittest.skipIf(bq is None, 'BigQuery for storing metrics not installed')
 class CombineTest(unittest.TestCase):
@@ -114,12 +112,10 @@ class CombineTest(unittest.TestCase):
     check = metrics_project_id and self.metrics_namespace and metrics_dataset \
             is not None
     if check:
-      schema = [{'name': RUNTIME_LABEL, 'type': 'FLOAT', 'mode': 'REQUIRED'}]
       self.metrics_monitor = MetricsMonitor(
           project_name=metrics_project_id,
           table=self.metrics_namespace,
-          dataset=metrics_dataset,
-          schema_map=schema
+          dataset=metrics_dataset
       )
     else:
       logging.error('One or more of parameters for collecting metrics '

--- a/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
@@ -20,9 +20,11 @@ input options there are additional options:
 * project (optional) - the gcp project in case of saving
 metrics in Big Query (in case of Dataflow Runner
 it is required to specify project of runner),
-* metrics_namespace (optional) - name of BigQuery table where metrics
+* publish_to_big_query - if metrics should be published in big query,
+* metrics_namespace (optional) - name of BigQuery dataset where metrics
 will be stored,
-in case of lack of any of both options metrics won't be saved
+* metrics_table (optional) - name of BigQuery table where metrics
+will be stored,
 * input_options - options for Synthetic Sources.
 
 Example test run on DirectRunner:
@@ -30,6 +32,7 @@ Example test run on DirectRunner:
 python setup.py nosetests \
     --test-pipeline-options="
     --project=big-query-project
+    --publish_to_big_query=true
     --metrics_dataset=python_load_tests
     --metrics_table=gbk
     --input_options='{
@@ -51,6 +54,7 @@ python setup.py nosetests \
         --staging_location=gs://...
         --temp_location=gs://...
         --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
+        --publish_to_big_query=true
         --metrics_dataset=python_load_tests
         --metrics_table=gbk
         --input_options='{
@@ -109,7 +113,6 @@ class GroupByKeyTest(unittest.TestCase):
     metrics_project_id = self.pipeline.get_option('project')
     self.metrics_namespace = self.pipeline.get_option('metrics_table')
     metrics_dataset = self.pipeline.get_option('metrics_dataset')
-    self.metrics_monitor = None
 
     check = metrics_project_id and self.metrics_namespace and metrics_dataset \
             is not None

--- a/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
@@ -82,8 +82,6 @@ try:
 except ImportError:
   bq = None
 
-RUNTIME_LABEL = 'runtime'
-
 
 @unittest.skipIf(bq is None, 'BigQuery for storing metrics not installed')
 class GroupByKeyTest(unittest.TestCase):
@@ -114,12 +112,10 @@ class GroupByKeyTest(unittest.TestCase):
     check = metrics_project_id and self.metrics_namespace and metrics_dataset \
             is not None
     if check:
-      schema = [{'name': RUNTIME_LABEL, 'type': 'FLOAT', 'mode': 'REQUIRED'}]
       self.metrics_monitor = MetricsMonitor(
           project_name=metrics_project_id,
           table=self.metrics_namespace,
           dataset=metrics_dataset,
-          schema_map=schema
       )
     else:
       logging.error('One or more of parameters for collecting metrics '

--- a/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
@@ -105,21 +105,25 @@ class GroupByKeyTest(unittest.TestCase):
     self.pipeline = TestPipeline(is_integration_test=True)
     self.input_options = json.loads(self.pipeline.get_option('input_options'))
 
+    self.metrics_monitor = self.pipeline.get_option('publish_to_big_query')
     metrics_project_id = self.pipeline.get_option('project')
     self.metrics_namespace = self.pipeline.get_option('metrics_table')
     metrics_dataset = self.pipeline.get_option('metrics_dataset')
     self.metrics_monitor = None
+
     check = metrics_project_id and self.metrics_namespace and metrics_dataset \
             is not None
-    if check:
+    if not self.metrics_monitor:
+      logging.info('Metrics will not be collected')
+    elif check:
       self.metrics_monitor = MetricsMonitor(
-          project_name=metrics_project_id,
-          table=self.metrics_namespace,
-          dataset=metrics_dataset,
+        project_name=metrics_project_id,
+        table=self.metrics_namespace,
+        dataset=metrics_dataset,
       )
     else:
-      logging.error('One or more of parameters for collecting metrics '
-                    'are empty. Metrics will not be collected')
+      raise ValueError('One or more of parameters for collecting metrics '
+                       'are empty.')
 
   def testGroupByKey(self):
     with self.pipeline as p:

--- a/sdks/python/apache_beam/testing/load_tests/load_test_metrics_utils.py
+++ b/sdks/python/apache_beam/testing/load_tests/load_test_metrics_utils.py
@@ -59,21 +59,20 @@ SCHEMA = [
     {'name': ID_LABEL,
      'type': 'STRING',
      'mode': 'REQUIRED'
-     },
+    },
     {'name': SUBMIT_TIMESTAMP_LABEL,
      'type': 'TIMESTAMP',
      'mode': 'REQUIRED'
-     },
+    },
     {'name': METRICS_TYPE_LABEL,
      'type': 'STRING',
      'mode': 'REQUIRED'
-     },
+    },
     {'name': VALUE_LABEL,
      'type': 'FLOAT',
      'mode': 'REQUIRED'
-     }
+    }
 ]
-
 
 
 def get_schema_field(schema_field):
@@ -130,7 +129,7 @@ class BigQueryClient(object):
       raise ValueError(
           'Dataset {} does not exist in your project. '
           'You have to create table first.'
-            .format(dataset_name))
+          .format(dataset_name))
     return bq_dataset
 
   def _get_or_create_table(self, bq_schemas, dataset):

--- a/sdks/python/apache_beam/testing/load_tests/load_test_metrics_utils.py
+++ b/sdks/python/apache_beam/testing/load_tests/load_test_metrics_utils.py
@@ -56,22 +56,22 @@ METRICS_TYPE_LABEL = 'metric'
 VALUE_LABEL = 'value'
 
 SCHEMA = [
-  {'name': ID_LABEL,
-   'type': 'STRING',
-   'mode': 'REQUIRED'
-   },
-  {'name': SUBMIT_TIMESTAMP_LABEL,
-   'type': 'TIMESTAMP',
-   'mode': 'REQUIRED'
-   },
-  {'name': METRICS_TYPE_LABEL,
-   'type': 'STRING',
-   'mode': 'REQUIRED'
-   },
-  {'name': VALUE_LABEL,
-   'type': 'FLOAT',
-   'mode': 'REQUIRED'
-   }
+    {'name': ID_LABEL,
+     'type': 'STRING',
+     'mode': 'REQUIRED'
+     },
+    {'name': SUBMIT_TIMESTAMP_LABEL,
+     'type': 'TIMESTAMP',
+     'mode': 'REQUIRED'
+     },
+    {'name': METRICS_TYPE_LABEL,
+     'type': 'STRING',
+     'mode': 'REQUIRED'
+     },
+    {'name': VALUE_LABEL,
+     'type': 'FLOAT',
+     'mode': 'REQUIRED'
+     }
 ]
 
 

--- a/sdks/python/apache_beam/testing/load_tests/pardo_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/pardo_test.py
@@ -76,21 +76,21 @@ from __future__ import absolute_import
 
 import json
 import logging
+import os
 import unittest
 
 import apache_beam as beam
 from apache_beam.testing import synthetic_pipeline
+from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
+from apache_beam.testing.load_tests.load_test_metrics_utils import MetricsMonitor
 from apache_beam.testing.test_pipeline import TestPipeline
 
-try:
-  from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
-  from apache_beam.testing.load_tests.load_test_metrics_utils import MetricsMonitor
-  from google.cloud import bigquery as bq
-except ImportError:
-  bq = None
+load_test_enabled = False
+if os.environ.get('LOAD_TEST_ENABLED') == 'true':
+  load_test_enabled = True
 
 
-@unittest.skipIf(bq is None, 'BigQuery for storing metrics not installed')
+@unittest.skipIf(not load_test_enabled, 'Enabled only for phrase triggering.')
 class ParDoTest(unittest.TestCase):
   def parseTestPipelineOptions(self):
     return {'numRecords': self.input_options.get('num_records'),
@@ -110,7 +110,7 @@ class ParDoTest(unittest.TestCase):
            }
 
   def setUp(self):
-    self.pipeline = TestPipeline(is_integration_test=True)
+    self.pipeline = TestPipeline()
 
     self.output = self.pipeline.get_option('output')
     self.iterations = self.pipeline.get_option('number_of_counter_operations')
@@ -126,9 +126,9 @@ class ParDoTest(unittest.TestCase):
       logging.info('Metrics will not be collected')
     elif check:
       self.metrics_monitor = MetricsMonitor(
-        project_name=metrics_project_id,
-        table=self.metrics_namespace,
-        dataset=metrics_dataset,
+          project_name=metrics_project_id,
+          table=self.metrics_namespace,
+          dataset=metrics_dataset,
       )
     else:
       raise ValueError('One or more of parameters for collecting metrics '

--- a/sdks/python/apache_beam/testing/load_tests/pardo_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/pardo_test.py
@@ -21,11 +21,13 @@ input options there are additional options:
 * project (optional) - the gcp project in case of saving
 metrics in Big Query (in case of Dataflow Runner
 it is required to specify project of runner),
-* metrics_namespace (optional) - name of BigQuery table where metrics
+* publish_to_big_query - if metrics should be published in big query,
+* metrics_namespace (optional) - name of BigQuery dataset where metrics
 will be stored,
-in case of lack of any of both options metrics won't be saved
+* metrics_table (optional) - name of BigQuery table where metrics
+will be stored,
 * output (optional) - destination to save output, in case of no option
-output won't be written
+output won't be written,
 * input_options - options for Synthetic Sources.
 
 Example test run on DirectRunner:
@@ -35,6 +37,7 @@ python setup.py nosetests \
     --number_of_counter_operations=1000
     --output=gs://...
     --project=big-query-project
+    --publish_to_big_query=true
     --metrics_dataset=python_load_tests
     --metrics_table=pardo
     --input_options='{
@@ -58,6 +61,7 @@ python setup.py nosetests \
         --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
         --output=gs://...
         --number_of_counter_operations=1000
+        --publish_to_big_query=true
         --metrics_dataset=python_load_tests
         --metrics_table=pardo
         --input_options='{
@@ -120,6 +124,7 @@ class ParDoTest(unittest.TestCase):
     metrics_project_id = self.pipeline.get_option('project')
     self.metrics_namespace = self.pipeline.get_option('metrics_table')
     metrics_dataset = self.pipeline.get_option('metrics_dataset')
+
     check = metrics_project_id and self.metrics_namespace and metrics_dataset \
             is not None
     if not self.metrics_monitor:

--- a/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
@@ -92,7 +92,7 @@ if os.environ.get('LOAD_TEST_ENABLED') == 'true':
   load_test_enabled = True
 
 
-@unittest.skipIf(not load_test_enabled, 'Enabled only for phase triggering.')
+@unittest.skipIf(not load_test_enabled, 'Enabled only for phrase triggering.')
 class SideInputTest(unittest.TestCase):
   def _parseTestPipelineOptions(self):
     return {

--- a/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
@@ -21,18 +21,18 @@ input options there are additional options:
 * project (optional) - the gcp project in case of saving
 metrics in Big Query (in case of Dataflow Runner
 it is required to specify project of runner),
+* publish_to_big_query - if metrics should be published in big query,
+* metrics_namespace (optional) - name of BigQuery dataset where metrics
+will be stored,
 * metrics_table (optional) - name of BigQuery table where metrics
 will be stored,
-in case of lack of any of both options metrics won't be saved
-* metrics_dataset (optional) - name of BigQuery dataset where metrics
-will be stored,
-in case of lack of all three options metrics won't be saved
 * input_options - options for Synthetic Sources.
 
 To run test on DirectRunner
 
 python setup.py nosetests \
     --project=big-query-project
+    --publish_to_big_query=true
     --metrics_dataset=python_load_tests
     --metrics_table=side_input
     --test-pipeline-options="
@@ -54,6 +54,7 @@ python setup.py nosetests \
     --test-pipeline-options="
         --runner=TestDataflowRunner
         --project=...
+        --publish_to_big_query=true
         --metrics_dataset=python_load_tests
         --metrics_table=side_input
         --staging_location=gs://...
@@ -134,23 +135,24 @@ class SideInputTest(unittest.TestCase):
       self.iterations = 1
     self.iterations = int(self.iterations)
 
+    self.metrics_monitor = self.pipeline.get_option('publish_to_big_query')
     metrics_project_id = self.pipeline.get_option('project')
     self.metrics_namespace = self.pipeline.get_option('metrics_table')
-    if not self.metrics_namespace:
-      self.metrics_namespace = self.__class__.__name__
     metrics_dataset = self.pipeline.get_option('metrics_dataset')
-    self.metrics_monitor = None
+
     check = metrics_project_id and self.metrics_namespace and metrics_dataset \
             is not None
-    if check:
+    if not self.metrics_monitor:
+      logging.info('Metrics will not be collected')
+    elif check:
       self.metrics_monitor = MetricsMonitor(
           project_name=metrics_project_id,
           table=self.metrics_namespace,
           dataset=metrics_dataset,
       )
     else:
-      logging.error('One or more of parameters for collecting metrics '
-                    'are empty. Metrics will not be collected')
+      raise ValueError('One or more of parameters for collecting metrics '
+                       'are empty.')
 
   def testSideInput(self):
     def join_fn(element, side_input, iterations):

--- a/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
@@ -91,8 +91,6 @@ load_test_enabled = False
 if os.environ.get('LOAD_TEST_ENABLED') == 'true':
   load_test_enabled = True
 
-RUNTIME_LABEL = 'runtime'
-
 
 @unittest.skipIf(not load_test_enabled, 'Enabled only for phase triggering.')
 class SideInputTest(unittest.TestCase):
@@ -145,14 +143,10 @@ class SideInputTest(unittest.TestCase):
     check = metrics_project_id and self.metrics_namespace and metrics_dataset \
             is not None
     if check:
-      measured_values = [
-          {'name': RUNTIME_LABEL, 'type': 'FLOAT', 'mode': 'REQUIRED'},
-      ]
       self.metrics_monitor = MetricsMonitor(
           project_name=metrics_project_id,
           table=self.metrics_namespace,
           dataset=metrics_dataset,
-          schema_map=measured_values
       )
     else:
       logging.error('One or more of parameters for collecting metrics '


### PR DESCRIPTION
It was decided to change tables to have `metrics` column where it will be name of metric which is collected.
Also added two minor changes:
* added an env variable to disable load tests,
* added pipeline option to disable saving metrics

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




