### PR TITLE
[BEAM-6504] Create Portable sideInput handler for Dataflow (Part One)

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactory.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.fn.control;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.SideInputReader;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandlers;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.transforms.Materializations;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataflowSideInputHandlerFactory
+    implements StateRequestHandlers.SideInputHandlerFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(DataflowSideInputHandlerFactory.class);
+
+  private final Map<String, SideInputReader> ptransformIdToSideInputReader;
+  private final Map<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>
+      sideInputIdToPCollectionViewMap;
+
+  static DataflowSideInputHandlerFactory of(
+      Map<String, SideInputReader> ptransformIdToSideInputReader,
+      Map<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>
+          sideInputIdToPCollectionViewMap) {
+    return new DataflowSideInputHandlerFactory(
+        ptransformIdToSideInputReader, sideInputIdToPCollectionViewMap);
+  }
+
+  private DataflowSideInputHandlerFactory(
+      Map<String, SideInputReader> ptransformIdToSideInputReader,
+      Map<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>
+          sideInputIdToPCollectionViewMap) {
+    this.ptransformIdToSideInputReader = ptransformIdToSideInputReader;
+    this.sideInputIdToPCollectionViewMap = sideInputIdToPCollectionViewMap;
+  }
+
+  @Override
+  public <T, V, W extends BoundedWindow> StateRequestHandlers.SideInputHandler<V, W> forSideInput(
+      String pTransformId,
+      String sideInputId,
+      RunnerApi.FunctionSpec accessPattern,
+      Coder<T> elementCoder,
+      Coder<W> windowCoder) {
+    checkArgument(pTransformId != null, String.format("Expect a valid PTransform ID."));
+
+    SideInputReader sideInputReader = ptransformIdToSideInputReader.get(pTransformId);
+    checkState(sideInputReader != null, String.format("Unknown PTransform '%s'", pTransformId));
+
+    PCollectionView<Materializations.MultimapView<Object, Object>> view =
+        (PCollectionView<Materializations.MultimapView<Object, Object>>)
+            sideInputIdToPCollectionViewMap.get(
+                RunnerApi.ExecutableStagePayload.SideInputId.newBuilder()
+                    .setTransformId(pTransformId)
+                    .setLocalName(sideInputId)
+                    .build());
+    checkState(
+        view != null,
+        String.format("Unknown side input '%s' on PTransform '%s'", sideInputId, pTransformId));
+
+    checkState(
+        Materializations.MULTIMAP_MATERIALIZATION_URN.equals(
+            view.getViewFn().getMaterialization().getUrn()),
+        String.format(
+            "Unknown materialization for side input '%s' on PTransform '%s' with urn '%s'",
+            sideInputId, pTransformId, view.getViewFn().getMaterialization().getUrn()));
+
+    checkState(
+        view.getCoderInternal() instanceof KvCoder,
+        String.format(
+            "Materialization of side input '%s' on PTransform '%s' expects %s but received %s.",
+            sideInputId,
+            pTransformId,
+            KvCoder.class.getSimpleName(),
+            view.getCoderInternal().getClass().getSimpleName()));
+
+    KvCoder<?, V> kvCoder = (KvCoder<?, V>) elementCoder;
+
+    return new DataflowSideInputHandler<>(
+        sideInputReader, view, kvCoder.getKeyCoder(), kvCoder.getValueCoder(), windowCoder);
+  }
+
+  private static class DataflowSideInputHandler<K, V, W extends BoundedWindow>
+      implements StateRequestHandlers.SideInputHandler<V, W> {
+
+    private final SideInputReader sideInputReader;
+    PCollectionView<Materializations.MultimapView<Object, Object>> view;
+    private final Coder<K> keyCoder;
+    private final Coder<V> valueCoder;
+    private final Coder<W> windowCoder;
+
+    private DataflowSideInputHandler(
+        SideInputReader sideInputReader,
+        PCollectionView<Materializations.MultimapView<Object, Object>> view,
+        Coder<K> keyCoder,
+        Coder<V> valueCoder,
+        Coder<W> windowCoder) {
+      this.sideInputReader = sideInputReader;
+      this.view = view;
+      this.keyCoder = keyCoder;
+      this.valueCoder = valueCoder;
+      this.windowCoder = windowCoder;
+    }
+
+    @Override
+    public Iterable<V> get(byte[] keyBytes, W window) {
+      K key;
+      try {
+        key = keyCoder.decode(new ByteArrayInputStream(keyBytes));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+
+      Materializations.MultimapView<K, V> sideInput =
+          (Materializations.MultimapView<K, V>)
+              sideInputReader.get(view, (BoundedWindow) windowCoder.structuralValue(window));
+
+      return sideInput.get(key);
+    }
+
+    @Override
+    public Coder<V> resultCoder() {
+      return valueCoder;
+    }
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactory.java
@@ -17,8 +17,8 @@
  */
 package org.apache.beam.runners.dataflow.worker.fn.control;
 
-import static com.google.common.base.Preconditions.checkState;
 import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkState;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** This handles sideinput in Dataflow. The caller should be based on ExecutableStage framework. */
 public class DataflowSideInputHandlerFactory
     implements StateRequestHandlers.SideInputHandlerFactory {
   private static final Logger LOG = LoggerFactory.getLogger(DataflowSideInputHandlerFactory.class);
@@ -65,7 +66,9 @@ public class DataflowSideInputHandlerFactory
       RunnerApi.FunctionSpec accessPattern,
       Coder<T> elementCoder,
       Coder<W> windowCoder) {
-    checkArgument(pTransformId != null, String.format("Expect a valid PTransform ID."));
+    checkArgument(
+        pTransformId != null && pTransformId.length() > 0,
+        String.format("Expect a valid PTransform ID."));
 
     SideInputReader sideInputReader = ptransformIdToSideInputReader.get(pTransformId);
     checkState(sideInputReader != null, String.format("Unknown PTransform '%s'", pTransformId));

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactory.java
@@ -68,7 +68,7 @@ public class DataflowSideInputHandlerFactory
       Coder<W> windowCoder) {
     checkArgument(
         pTransformId != null && pTransformId.length() > 0,
-        String.format("Expect a valid PTransform ID."));
+        "Expect a valid PTransform ID.");
 
     SideInputReader sideInputReader = ptransformIdToSideInputReader.get(pTransformId);
     checkState(sideInputReader != null, String.format("Unknown PTransform '%s'", pTransformId));

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactory.java
@@ -67,8 +67,7 @@ public class DataflowSideInputHandlerFactory
       Coder<T> elementCoder,
       Coder<W> windowCoder) {
     checkArgument(
-        pTransformId != null && pTransformId.length() > 0,
-        "Expect a valid PTransform ID.");
+        pTransformId != null && pTransformId.length() > 0, "Expect a valid PTransform ID.");
 
     SideInputReader sideInputReader = ptransformIdToSideInputReader.get(pTransformId);
     checkState(sideInputReader != null, String.format("Unknown PTransform '%s'", pTransformId));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactoryTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/DataflowSideInputHandlerFactoryTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.fn.control;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.annotation.Nullable;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.InMemoryMultimapSideInputView;
+import org.apache.beam.runners.core.SideInputReader;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.dataflow.worker.DataflowPortabilityPCollectionView;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandlers;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.SideInputHandler;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.coders.VoidCoder;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test for {@link DataflowSideInputHandlerFactory} */
+@RunWith(JUnit4.class)
+public final class DataflowSideInputHandlerFactoryTest {
+
+  private static final String TRANSFORM_ID = "transformId";
+  private static final String SIDE_INPUT_NAME = "testSideInputId";
+  private static final RunnerApi.FunctionSpec MULTIMAP_ACCESS =
+      RunnerApi.FunctionSpec.newBuilder().setUrn(PTransformTranslation.MULTIMAP_SIDE_INPUT).build();
+  private static final byte[] ENCODED_FOO = encode("foo", StringUtf8Coder.of());
+  private static final byte[] ENCODED_FOO2 = encode("foo2", StringUtf8Coder.of());
+
+  private static final PCollectionView view =
+      DataflowPortabilityPCollectionView.with(
+          new TupleTag<>(SIDE_INPUT_NAME),
+          FullWindowedValueCoder.of(
+              KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()), GlobalWindow.Coder.INSTANCE));
+  private static final RunnerApi.ExecutableStagePayload.SideInputId sideInputId =
+      RunnerApi.ExecutableStagePayload.SideInputId.newBuilder()
+          .setTransformId(TRANSFORM_ID)
+          .setLocalName(SIDE_INPUT_NAME)
+          .build();
+  private static SideInputReader fakeSideInputReader;
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() {
+    fakeSideInputReader =
+        new SideInputReader() {
+          @Nullable
+          @Override
+          public <T> T get(PCollectionView<T> view, BoundedWindow window) {
+            assertEquals(GlobalWindow.INSTANCE, window);
+            assertEquals(SIDE_INPUT_NAME, view.getTagInternal().getId());
+
+            return (T)
+                InMemoryMultimapSideInputView.fromIterable(
+                    StringUtf8Coder.of(),
+                    ImmutableList.of(KV.of("foo", 1), KV.of("foo", 4), KV.of("foo", 3)));
+          }
+
+          @Override
+          public <T> boolean contains(PCollectionView<T> view) {
+            return SIDE_INPUT_NAME.equals(view.getTagInternal().getId());
+          }
+
+          @Override
+          public boolean isEmpty() {
+            return false;
+          }
+        };
+  }
+
+  @Test
+  public void invalidSideInputThrowsException() {
+    ImmutableMap<String, SideInputReader> sideInputReadersMap =
+        ImmutableMap.<String, SideInputReader>builder().build();
+
+    ImmutableMap<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>
+        sideInputIdToPCollectionViewMap =
+            ImmutableMap.<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>builder()
+                .build();
+
+    DataflowSideInputHandlerFactory factory =
+        DataflowSideInputHandlerFactory.of(sideInputReadersMap, sideInputIdToPCollectionViewMap);
+    thrown.expect(instanceOf(IllegalStateException.class));
+    factory.forSideInput(
+        TRANSFORM_ID,
+        SIDE_INPUT_NAME,
+        MULTIMAP_ACCESS,
+        KvCoder.of(VoidCoder.of(), VoidCoder.of()),
+        GlobalWindow.Coder.INSTANCE);
+  }
+
+  @Test
+  public void emptyResultForEmptyCollection() {
+    ImmutableMap<String, SideInputReader> sideInputReadersMap =
+        ImmutableMap.<String, SideInputReader>builder()
+            .put(TRANSFORM_ID, fakeSideInputReader)
+            .build();
+
+    ImmutableMap<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>
+        sideInputIdToPCollectionViewMap =
+            ImmutableMap.<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>builder()
+                .put(sideInputId, view)
+                .build();
+
+    DataflowSideInputHandlerFactory factory =
+        DataflowSideInputHandlerFactory.of(sideInputReadersMap, sideInputIdToPCollectionViewMap);
+    SideInputHandler<Integer, GlobalWindow> handler =
+        factory.forSideInput(
+            TRANSFORM_ID,
+            SIDE_INPUT_NAME,
+            MULTIMAP_ACCESS,
+            KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()),
+            GlobalWindow.Coder.INSTANCE);
+
+    Iterable<Integer> result = handler.get(ENCODED_FOO2, GlobalWindow.INSTANCE);
+    assertThat(result, emptyIterable());
+  }
+
+  @Test
+  public void multimapSideInputAsIterable() {
+    ImmutableMap<String, SideInputReader> sideInputReadersMap =
+        ImmutableMap.<String, SideInputReader>builder()
+            .put(TRANSFORM_ID, fakeSideInputReader)
+            .build();
+
+    ImmutableMap<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>
+        sideInputIdToPCollectionViewMap =
+            ImmutableMap.<RunnerApi.ExecutableStagePayload.SideInputId, PCollectionView<?>>builder()
+                .put(sideInputId, view)
+                .build();
+
+    DataflowSideInputHandlerFactory factory =
+        DataflowSideInputHandlerFactory.of(sideInputReadersMap, sideInputIdToPCollectionViewMap);
+
+    StateRequestHandlers.SideInputHandler handler =
+        factory.forSideInput(
+            TRANSFORM_ID,
+            SIDE_INPUT_NAME,
+            MULTIMAP_ACCESS,
+            KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()),
+            GlobalWindow.Coder.INSTANCE);
+    Iterable<String> result = handler.get(ENCODED_FOO, GlobalWindow.INSTANCE);
+    assertThat(result, containsInAnyOrder(1, 4, 3));
+  }
+
+  private static <T> byte[] encode(T value, Coder<T> coder) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try {
+      coder.encode(value, out);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return out.toByteArray();
+  }
+}


### PR DESCRIPTION
This PR creates a SideInput handler inside dataflow fnApi runner. 

There will be another PR (in-progress) to actually wire this independent module into ProcessRemoteBundleOperation. 

With these two PRs, we have majority of validateRunner sideinput tests passing. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




