### PR TITLE
[BEAM-4776] make AutoValues for MetricResults, MetricQueryResults

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
@@ -217,7 +217,7 @@ public class MetricsContainerStepMap implements Serializable {
       return new QueryResults(filter);
     }
 
-    private class QueryResults implements MetricQueryResults {
+    private class QueryResults extends MetricQueryResults {
       private final MetricsFilter filter;
 
       private QueryResults(MetricsFilter filter) {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.direct;
 
 import static java.util.Arrays.asList;
 
-import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -39,7 +38,6 @@ import org.apache.beam.runners.core.metrics.MetricUpdates.MetricUpdate;
 import org.apache.beam.runners.core.metrics.MetricsMap;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.GaugeResult;
-import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;
@@ -224,28 +222,6 @@ class DirectMetrics extends MetricResults {
 
   private final MetricsMap<MetricKey, DirectMetric<GaugeData, GaugeResult>> gauges;
 
-  @AutoValue
-  abstract static class DirectMetricResult<T> implements MetricResult<T> {
-    // need to define these here so they appear in the correct order
-    // and the generated constructor is usable and consistent
-    @Override
-    public abstract MetricName getName();
-
-    @Override
-    public abstract String getStep();
-
-    @Override
-    public abstract T getCommitted();
-
-    @Override
-    public abstract T getAttempted();
-
-    public static <T> MetricResult<T> create(
-        MetricName name, String scope, T committed, T attempted) {
-      return new AutoValue_DirectMetrics_DirectMetricResult<>(name, scope, committed, attempted);
-    }
-  }
-
   DirectMetrics(ExecutorService executorService) {
     this.counters = new MetricsMap<>(unusedKey -> new DirectMetric<>(COUNTER, executorService));
     this.distributions =
@@ -280,7 +256,7 @@ class DirectMetrics extends MetricResults {
       Map.Entry<MetricKey, ? extends DirectMetric<?, ResultT>> entry) {
     if (MetricFiltering.matches(filter, entry.getKey())) {
       resultsBuilder.add(
-          DirectMetricResult.create(
+          MetricResult.create(
               entry.getKey().metricName(),
               entry.getKey().stepName(),
               entry.getValue().extractCommitted(),

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
@@ -225,16 +225,6 @@ class DirectMetrics extends MetricResults {
   private final MetricsMap<MetricKey, DirectMetric<GaugeData, GaugeResult>> gauges;
 
   @AutoValue
-  abstract static class DirectMetricQueryResults implements MetricQueryResults {
-    public static MetricQueryResults create(
-        Iterable<MetricResult<Long>> counters,
-        Iterable<MetricResult<DistributionResult>> distributions,
-        Iterable<MetricResult<GaugeResult>> gauges) {
-      return new AutoValue_DirectMetrics_DirectMetricQueryResults(counters, distributions, gauges);
-    }
-  }
-
-  @AutoValue
   abstract static class DirectMetricResult<T> implements MetricResult<T> {
     // need to define these here so they appear in the correct order
     // and the generated constructor is usable and consistent
@@ -280,7 +270,7 @@ class DirectMetrics extends MetricResults {
       maybeExtractResult(filter, gaugeResults, gauge);
     }
 
-    return DirectMetricQueryResults.create(
+    return MetricQueryResults.create(
         counterResults.build(), distributionResults.build(), gaugeResults.build());
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/DirectMetrics.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.direct.portable;
 
 import static java.util.Arrays.asList;
 
-import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -39,7 +38,6 @@ import org.apache.beam.runners.core.metrics.MetricUpdates.MetricUpdate;
 import org.apache.beam.runners.core.metrics.MetricsMap;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.GaugeResult;
-import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;
@@ -235,28 +233,6 @@ class DirectMetrics extends MetricResults {
   private MetricsMap<MetricKey, DirectMetric<GaugeData, GaugeResult>> gauges =
       new MetricsMap<>(unusedKey -> new DirectMetric<>(GAUGE));
 
-  @AutoValue
-  abstract static class DirectMetricResult<T> implements MetricResult<T> {
-    // need to define these here so they appear in the correct order
-    // and the generated constructor is usable and consistent
-    @Override
-    public abstract MetricName getName();
-
-    @Override
-    public abstract String getStep();
-
-    @Override
-    public abstract T getCommitted();
-
-    @Override
-    public abstract T getAttempted();
-
-    public static <T> MetricResult<T> create(
-        MetricName name, String scope, T committed, T attempted) {
-      return new AutoValue_DirectMetrics_DirectMetricResult<>(name, scope, committed, attempted);
-    }
-  }
-
   @Override
   public MetricQueryResults queryMetrics(@Nullable MetricsFilter filter) {
     ImmutableList.Builder<MetricResult<Long>> counterResults = ImmutableList.builder();
@@ -284,7 +260,7 @@ class DirectMetrics extends MetricResults {
       Map.Entry<MetricKey, ? extends DirectMetric<?, ResultT>> entry) {
     if (MetricFiltering.matches(filter, entry.getKey())) {
       resultsBuilder.add(
-          DirectMetricResult.create(
+          MetricResult.create(
               entry.getKey().metricName(),
               entry.getKey().stepName(),
               entry.getValue().extractCommitted(),

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/DirectMetrics.java
@@ -236,16 +236,6 @@ class DirectMetrics extends MetricResults {
       new MetricsMap<>(unusedKey -> new DirectMetric<>(GAUGE));
 
   @AutoValue
-  abstract static class DirectMetricQueryResults implements MetricQueryResults {
-    public static MetricQueryResults create(
-        Iterable<MetricResult<Long>> counters,
-        Iterable<MetricResult<DistributionResult>> distributions,
-        Iterable<MetricResult<GaugeResult>> gauges) {
-      return new AutoValue_DirectMetrics_DirectMetricQueryResults(counters, distributions, gauges);
-    }
-  }
-
-  @AutoValue
   abstract static class DirectMetricResult<T> implements MetricResult<T> {
     // need to define these here so they appear in the correct order
     // and the generated constructor is usable and consistent
@@ -284,7 +274,7 @@ class DirectMetrics extends MetricResults {
       maybeExtractResult(filter, gaugeResults, gauge);
     }
 
-    return DirectMetricQueryResults.create(
+    return MetricQueryResults.create(
         counterResults.build(), distributionResults.build(), gaugeResults.build());
   }
 

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/CustomMetricQueryResults.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/CustomMetricQueryResults.java
@@ -28,7 +28,7 @@ import org.apache.beam.sdk.metrics.MetricsSink;
 import org.joda.time.Instant;
 
 /** Test class to be used as a input to {@link MetricsSink} implementations tests. */
-class CustomMetricQueryResults implements MetricQueryResults {
+class CustomMetricQueryResults extends MetricQueryResults {
 
   private final boolean isCommittedSupported;
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
@@ -98,7 +98,7 @@ class DataflowMetrics extends MetricResults {
       jobMetrics = getJobMetrics();
     } catch (IOException e) {
       LOG.warn("Unable to query job metrics.\n");
-      return DataflowMetricQueryResults.create(counters, distributions, gauges);
+      return MetricQueryResults.create(counters, distributions, gauges);
     }
     metricUpdates = firstNonNull(jobMetrics.getMetrics(), Collections.<MetricUpdate>emptyList());
     return populateMetricQueryResults(metricUpdates, filter);
@@ -322,21 +322,10 @@ class DataflowMetrics extends MetricResults {
         extractor.addMetricResult(
             metricKey, committedByName.get(metricKey), tentativeByName.get(metricKey));
       }
-      return DataflowMetricQueryResults.create(
+      return MetricQueryResults.create(
           extractor.getCounterResults(),
           extractor.getDistributionResults(),
           extractor.getGaugeResults());
-    }
-  }
-
-  @AutoValue
-  abstract static class DataflowMetricQueryResults implements MetricQueryResults {
-    public static MetricQueryResults create(
-        Iterable<MetricResult<Long>> counters,
-        Iterable<MetricResult<DistributionResult>> distributions,
-        Iterable<MetricResult<GaugeResult>> gauges) {
-      return new AutoValue_DataflowMetrics_DataflowMetricQueryResults(
-          counters, distributions, gauges);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/DefaultMetricResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/DefaultMetricResult.java
@@ -18,34 +18,29 @@
 package org.apache.beam.sdk.metrics;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.google.auto.value.AutoValue;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 
-/**
- * The results of a single current metric. TODO(BEAM-6265): Decouple wire formats from internal
- * formats, remove usage of MetricName.
- */
+/** The results of a single current metric. */
 @Experimental(Kind.METRICS)
 @JsonFilter("committedMetrics")
-public interface MetricResult<T> {
-  /** Return the name of the metric. */
-  MetricName getName();
+@AutoValue
+public abstract class DefaultMetricResult<T> implements MetricResult<T> {
+  @Override
+  public abstract MetricName getName();
 
-  /** Return the step context to which this metric result applies. */
-  String getStep();
+  @Override
+  public abstract String getStep();
 
-  /**
-   * Return the value of this metric across all successfully completed parts of the pipeline.
-   *
-   * <p>Not all runners will support committed metrics. If they are not supported, the runner will
-   * throw an {@link UnsupportedOperationException}.
-   */
-  T getCommitted();
+  @Override
+  public abstract T getCommitted();
 
-  /** Return the value of this metric across all attempts of executing all parts of the pipeline. */
-  T getAttempted();
+  @Override
+  public abstract T getAttempted();
 
-  static <T> DefaultMetricResult<T> create(MetricName name, String step, T committed, T attempted) {
+  public static <T> DefaultMetricResult<T> create(
+      MetricName name, String step, T committed, T attempted) {
     return new AutoValue_DefaultMetricResult<>(name, step, committed, attempted);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricQueryResults.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricQueryResults.java
@@ -17,20 +17,29 @@
  */
 package org.apache.beam.sdk.metrics;
 
+import com.google.auto.value.AutoValue;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /**
  * The results of a query for metrics. Allows accessing all of the metrics that matched the filter.
  */
+@AutoValue
 @Experimental(Kind.METRICS)
-public interface MetricQueryResults {
-  /** Return the metric results for the counters that matched the filter. */
-  Iterable<MetricResult<Long>> getCounters();
+public abstract class MetricQueryResults {
+  /** Return the metric results for the getCounters that matched the filter. */
+  public abstract Iterable<MetricResult<Long>> getCounters();
 
-  /** Return the metric results for the distributions that matched the filter. */
-  Iterable<MetricResult<DistributionResult>> getDistributions();
+  /** Return the metric results for the getDistributions that matched the filter. */
+  public abstract Iterable<MetricResult<DistributionResult>> getDistributions();
 
-  /** Return the metric results for the gauges that matched the filter. */
-  Iterable<MetricResult<GaugeResult>> getGauges();
+  /** Return the metric results for the getGauges that matched the filter. */
+  public abstract Iterable<MetricResult<GaugeResult>> getGauges();
+
+  public static MetricQueryResults create(
+      Iterable<MetricResult<Long>> counters,
+      Iterable<MetricResult<DistributionResult>> distributions,
+      Iterable<MetricResult<GaugeResult>> gauges) {
+    return new AutoValue_MetricQueryResults(counters, distributions, gauges);
+  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricResults.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricResults.java
@@ -54,7 +54,7 @@ public abstract class MetricResults {
    *     .addNameFilter("my-counter")
    *     .addStepFilter("myStepName1").addStepFilter("myStepName2")
    *     .build());
-   * Iterable<MetricResult<Long>> counters = metricResults.counters();
+   * Iterable<MetricResult<Long>> counters = metricResults.getCounters();
    * // counters should contain the value of my-counter reported from each of the ParDo
    * // applications.
    * }</pre>


### PR DESCRIPTION
… and remove duplicated implementations from `direct` and `direct/portable` runners

This is an early bit of cleanup that came out of work I'm doing to plumb metrics over the job API (cf. [BEAM-4776](https://issues.apache.org/jira/browse/BEAM-4776)). In later work I re-use these same concrete `@AutoValue` classes a third time.

R: @mxm, @ajamato 
CC: @youngoli 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




