### PR TITLE
[SQL] Fix CREATE EXTERNAL TABLE in non-default schema

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateExternalTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateExternalTable.java
@@ -151,7 +151,7 @@ public class SqlCreateExternalTable extends SqlCreate implements SqlExecutableSt
   private Table toTable() {
     return Table.builder()
         .type(SqlDdlNodes.getString(type))
-        .name(name.getSimple())
+        .name(SqlDdlNodes.name(name))
         .schema(columnList.stream().collect(toSchema()))
         .comment(SqlDdlNodes.getString(comment))
         .location(SqlDdlNodes.getString(location))

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDdlNodes.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDdlNodes.java
@@ -48,20 +48,25 @@ public class SqlDdlNodes {
   /** Returns the schema in which to create an object. */
   static Pair<CalciteSchema, String> schema(
       CalcitePrepare.Context context, boolean mutable, SqlIdentifier id) {
-    final String name;
     final List<String> path;
     if (id.isSimple()) {
       path = context.getDefaultSchemaPath();
-      name = id.getSimple();
     } else {
       path = Util.skipLast(id.names);
-      name = Util.last(id.names);
     }
     CalciteSchema schema = mutable ? context.getMutableRootSchema() : context.getRootSchema();
     for (String p : path) {
       schema = schema.getSubSchema(p, true);
     }
-    return Pair.of(schema, name);
+    return Pair.of(schema, name(id));
+  }
+
+  static String name(SqlIdentifier id) {
+    if (id.isSimple()) {
+      return id.getSimple();
+    } else {
+      return Util.last(id.names);
+    }
   }
 
   static @Nullable String getString(SqlNode n) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnvTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnvTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import org.apache.beam.sdk.extensions.sql.meta.provider.test.TestTableProvider;
+import org.junit.Test;
+
+/** Tests for {@link BeamSqlEnv}. */
+public class BeamSqlEnvTest {
+
+  @Test
+  public void testCreateExternalTableInNestedTableProvider() throws Exception {
+    TestTableProvider root = new TestTableProvider();
+    TestTableProvider nested = new TestTableProvider();
+    TestTableProvider anotherOne = new TestTableProvider();
+
+    BeamSqlEnv env = BeamSqlEnv.withTableProvider(root);
+    env.addSchema("nested", nested);
+    env.addSchema("anotherOne", anotherOne);
+
+    Connection connection = env.connection;
+    connection.createStatement().execute("CREATE EXTERNAL TABLE nested.person (id INT) TYPE test");
+    connection.createStatement().execute("INSERT INTO nested.person(id) VALUES (1), (2), (6)");
+
+    ResultSet rs = connection.createStatement().executeQuery("SELECT SUM(id) FROM nested.person");
+    rs.next();
+
+    assertEquals(9, rs.getInt(1));
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
@@ -21,7 +21,6 @@ import static org.apache.beam.sdk.schemas.Schema.toSchema;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
@@ -171,10 +170,10 @@ public class BeamDDLTest {
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(rootProvider);
     env.addSchema("test", testProvider);
 
+    assertNull(testProvider.getTables().get("person"));
     env.executeDdl("CREATE EXTERNAL TABLE test.person (id INT) TYPE text");
-    env.parseQuery("SELECT COUNT(*) FROM test.person");
 
-    assertTrue(testProvider.getTables().containsKey("person"));
+    assertNotNull(testProvider.getTables().get("person"));
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.schemas.Schema.toSchema;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
@@ -160,6 +161,20 @@ public class BeamDDLTest {
             .properties(new JSONObject())
             .build(),
         tableProvider.getTables().get("person"));
+  }
+
+  @Test
+  public void testParseCreateExternalTable_withDatabase() throws Exception {
+    TestTableProvider rootProvider = new TestTableProvider();
+    TestTableProvider testProvider = new TestTableProvider();
+
+    BeamSqlEnv env = BeamSqlEnv.withTableProvider(rootProvider);
+    env.addSchema("test", testProvider);
+
+    env.executeDdl("CREATE EXTERNAL TABLE test.person (id INT) TYPE text");
+    env.parseQuery("SELECT COUNT(*) FROM test.person");
+
+    assertTrue(testProvider.getTables().containsKey("person"));
   }
 
   @Test


### PR DESCRIPTION
With `BeamSqlEnv#addSchema` it's possible to add new schemas, however, 
"CREATE EXTERNAL TABLE" didn't work.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




