### PR TITLE
[BEAM-5959] DO NOT MERGE: KMS support for FileBasedSink, GCS

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -324,7 +324,8 @@ class BeamModulePlugin implements Plugin<Project> {
     // Maven artifacts.
     def generated_grpc_beta_version = "0.19.0"
     def generated_grpc_ga_version = "1.18.0"
-    def google_cloud_bigdataoss_version = "1.9.0"
+    // TODO: do not merge this change
+    def google_cloud_bigdataoss_version = "1.9.12-SNAPSHOT"
     def bigtable_version = "1.4.0"
     def google_clients_version = "1.27.0"
     def google_auth_version = "0.10.0"

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -1223,7 +1223,10 @@ public class AvroIO {
     /**
      * Sets Key Management System key name for use in creating new files on filesystems that support
      * it.
+     *
+     * <p>TODO(BEAM-5959): Not yet supported.
      */
+    @Experimental(Kind.FILESYSTEM)
     public TypedWrite<UserT, DestinationT, OutputT> withKmsKey(String kmsKey) {
       return toBuilder().setKmsKey(kmsKey).build();
     }
@@ -1429,6 +1432,7 @@ public class AvroIO {
     }
 
     /** See {@link TypedWrite#withKmsKey} . */
+    @Experimental(Kind.FILESYSTEM)
     public Write<T> withKmsKey(String kmsKey) {
       return new Write<>(inner.withKmsKey(kmsKey));
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
@@ -38,9 +38,10 @@ class AvroSink<UserT, DestinationT, OutputT> extends FileBasedSink<UserT, Destin
   AvroSink(
       ValueProvider<ResourceId> outputPrefix,
       DynamicAvroDestinations<UserT, DestinationT, OutputT> dynamicDestinations,
-      boolean genericRecords) {
+      boolean genericRecords,
+      String kmsKey) {
     // Avro handle compression internally using the codec.
-    super(outputPrefix, dynamicDestinations, Compression.UNCOMPRESSED);
+    super(outputPrefix, dynamicDestinations, Compression.UNCOMPRESSED, kmsKey);
     this.genericRecords = genericRecords;
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -391,8 +391,6 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
 
   /** KMS key used to create new files. */
   @Experimental(Kind.FILESYSTEM)
-  // TODO: Intellij warning?
-  @Nullable
   protected String kmsKey;
 
   /**
@@ -965,7 +963,8 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
 
       CreateOptions createOptions =
           CreateOptions.StandardCreateOptions.builder()
-              // The factory may force a MIME type or it may return null, indicating to use the sink's MIME.
+              // The factory may force a MIME type or it may return null, indicating to use the
+              // sink's MIME.
               .setMimeType(firstNonNull(factory.getMimeType(), mimeType))
               .setKmsKey(getWriteOperation().getSink().kmsKey)
               .build();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -1167,7 +1168,10 @@ public class FileIO {
     /**
      * Specifies a Key Management System key name to use for encrypting writes. Possible values and
      * behavior of this feature are filesystem dependent.
+     *
+     * <p>TODO(BEAM-5959): Not yet supported.
      */
+    @Experimental(Kind.FILESYSTEM)
     public Write<DestinationT, UserT> withKmsKey(String kmsKey) {
       return toBuilder().setKmsKey(kmsKey).build();
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -894,6 +894,9 @@ public class FileIO {
 
     abstract boolean getIgnoreWindowing();
 
+    @Nullable
+    abstract String getKmsKey();
+
     abstract Builder<DestinationT, UserT> toBuilder();
 
     @AutoValue.Builder
@@ -937,6 +940,8 @@ public class FileIO {
           PTransform<PCollection<UserT>, PCollectionView<Integer>> sharding);
 
       abstract Builder<DestinationT, UserT> setIgnoreWindowing(boolean ignoreWindowing);
+
+      abstract Builder<DestinationT, UserT> setKmsKey(@Nullable String kmsKey);
 
       abstract Write<DestinationT, UserT> build();
     }
@@ -1159,6 +1164,14 @@ public class FileIO {
       return toBuilder().setIgnoreWindowing(true).build();
     }
 
+    /**
+     * Specifies a Key Management System key name to use for encrypting writes. Possible values and
+     * behavior of this feature are filesystem dependent.
+     */
+    public Write<DestinationT, UserT> withKmsKey(String kmsKey) {
+      return toBuilder().setKmsKey(kmsKey).build();
+    }
+
     @VisibleForTesting
     Contextful<Fn<DestinationT, FileNaming>> resolveFileNamingFn() {
       if (getDynamic()) {
@@ -1243,6 +1256,7 @@ public class FileIO {
       resolvedSpec.setNumShards(getNumShards());
       resolvedSpec.setSharding(getSharding());
       resolvedSpec.setIgnoreWindowing(getIgnoreWindowing());
+      resolvedSpec.setKmsKey(getKmsKey());
 
       Write<DestinationT, UserT> resolved = resolvedSpec.build();
       WriteFiles<UserT, DestinationT, ?> writeFiles =
@@ -1293,7 +1307,8 @@ public class FileIO {
                 spec.getTempDirectory(),
                 input -> FileSystems.matchNewResource(input, true /* isDirectory */)),
             new DynamicDestinationsAdapter<>(spec),
-            spec.getCompression());
+            spec.getCompression(),
+            spec.getKmsKey());
         this.spec = spec;
       }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
@@ -110,7 +110,7 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
   @Deprecated
   protected void copy(List<ResourceIdT> srcResourceIds, List<ResourceIdT> destResourceIds)
       throws IOException {
-    throw new UnsupportedOperationException("deprecated");
+    throw new UnsupportedOperationException("deprecated - do not implement this method");
   }
 
   /**
@@ -151,7 +151,7 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
   @Deprecated
   protected void rename(List<ResourceIdT> srcResourceIds, List<ResourceIdT> destResourceIds)
       throws IOException {
-    throw new UnsupportedOperationException("deprecated");
+    throw new UnsupportedOperationException("deprecated - do not implement this method");
   }
 
   /**
@@ -188,7 +188,7 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
    */
   @Deprecated
   protected void delete(Collection<ResourceIdT> resourceIds) throws IOException {
-    throw new UnsupportedOperationException("deprecated");
+    throw new UnsupportedOperationException("deprecated - do not implement this method");
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
@@ -27,7 +27,10 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.fs.CreateOptions;
 import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.MoveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * File system interface in Beam.
@@ -39,6 +42,8 @@ import org.apache.beam.sdk.io.fs.ResourceId;
  */
 @Experimental(Kind.FILESYSTEM)
 public abstract class FileSystem<ResourceIdT extends ResourceId> {
+  private static final Logger LOG = LoggerFactory.getLogger(FileSystem.class);
+
   /**
    * This is the entry point to convert user-provided specs to {@link ResourceIdT ResourceIds}.
    * Callers should use {@link #match} to resolve users specs ambiguities before calling other
@@ -102,8 +107,31 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
    *     resource might or might not be copied. In such scenarios, callers can use {@code match()}
    *     to determine the state of the resources.
    */
-  protected abstract void copy(List<ResourceIdT> srcResourceIds, List<ResourceIdT> destResourceIds)
-      throws IOException;
+  @Deprecated
+  protected void copy(List<ResourceIdT> srcResourceIds, List<ResourceIdT> destResourceIds)
+      throws IOException {
+    throw new UnsupportedOperationException("deprecated");
+  }
+
+  /**
+   * Copies a {@link List} of file-like resources from one location to another.
+   *
+   * <p>The number of source resources must equal the number of destination resources. Destination
+   * resources will be created recursively.
+   *
+   * @param srcResourceIds the references of the source resources
+   * @param destResourceIds the references of the destination resources
+   * @param moveOptions additional settings passed to the underlying implementation
+   * @throws FileNotFoundException if the source resources are missing. When copy throws, each
+   *     resource might or might not be copied. In such scenarios, callers can use {@code match()}
+   *     to determine the state of the resources.
+   */
+  protected void copy(
+      List<ResourceIdT> srcResourceIds, List<ResourceIdT> destResourceIds, MoveOptions moveOptions)
+      throws IOException {
+    LOG.warn("Using deprecated copy");
+    copy(srcResourceIds, destResourceIds);
+  }
 
   /**
    * Renames a {@link List} of file-like resources from one location to another.
@@ -120,8 +148,35 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
    *     possible. In such scenarios, callers can use {@code match()} to determine the state of the
    *     resource.
    */
-  protected abstract void rename(
-      List<ResourceIdT> srcResourceIds, List<ResourceIdT> destResourceIds) throws IOException;
+  @Deprecated
+  protected void rename(List<ResourceIdT> srcResourceIds, List<ResourceIdT> destResourceIds)
+      throws IOException {
+    throw new UnsupportedOperationException("deprecated");
+  }
+
+  /**
+   * Renames a {@link List} of file-like resources from one location to another.
+   *
+   * <p>The number of source resources must equal the number of destination resources. Destination
+   * resources will be created recursively.
+   *
+   * @param srcResourceIds the references of the source resources
+   * @param destResourceIds the references of the destination resources
+   * @param moveOptions additional settings passed to the underlying implementation
+   * @throws FileNotFoundException if the source resources are missing. When rename throws, the
+   *     state of the resources is unknown but safe: for every (source, destination) pair of
+   *     resources, the following are possible: a) source exists, b) destination exists, c) source
+   *     and destination both exist. Thus no data is lost, however, duplicated resource are
+   *     possible. In such scenarios, callers can use {@code match()} to determine the state of the
+   *     resource.
+   * @throws IOException
+   */
+  protected void rename(
+      List<ResourceIdT> srcResourceIds, List<ResourceIdT> destResourceIds, MoveOptions moveOptions)
+      throws IOException {
+    LOG.warn("Using deprecated rename");
+    rename(srcResourceIds, destResourceIds);
+  }
 
   /**
    * Deletes a collection of resources.
@@ -131,7 +186,25 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
    *     or might not be deleted. In such scenarios, callers can use {@code match()} to determine
    *     the state of the resources.
    */
-  protected abstract void delete(Collection<ResourceIdT> resourceIds) throws IOException;
+  @Deprecated
+  protected void delete(Collection<ResourceIdT> resourceIds) throws IOException {
+    throw new UnsupportedOperationException("deprecated");
+  }
+
+  /**
+   * Deletes a collection of resources.
+   *
+   * @param resourceIds the references of the resources to delete.
+   * @param moveOptions additional settings passed to the underlying implementation
+   * @throws FileNotFoundException if resources are missing. When delete throws, each resource might
+   *     or might not be deleted. In such scenarios, callers can use {@code match()} to determine
+   *     the state of the resources.
+   */
+  protected void delete(Collection<ResourceIdT> resourceIds, MoveOptions moveOptions)
+      throws IOException {
+    LOG.warn("Using deprecated delete");
+    delete(resourceIds);
+  }
 
   /**
    * Returns a new {@link ResourceId} for this filesystem that represents the named resource. The

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -296,9 +296,7 @@ public class FileSystems {
 
     List<ResourceId> srcToCopy = srcResourceIds;
     List<ResourceId> destToCopy = destResourceIds;
-    // TODO: search for all uses of IGNORE_MISSING_FILES and remove Sets usage.
-    if (Sets.newHashSet(moveOptions)
-        .contains(MoveOptions.StandardMoveOptions.IGNORE_MISSING_FILES)) {
+    if (moveOptions.getIgnoreMissingFiles()) {
       KV<List<ResourceId>, List<ResourceId>> existings =
           filterMissingFiles(srcResourceIds, destResourceIds);
       srcToCopy = existings.getKey();
@@ -394,8 +392,7 @@ public class FileSystems {
     }
 
     Collection<ResourceId> resourceIdsToDelete;
-    if (Sets.newHashSet(moveOptions)
-        .contains(MoveOptions.StandardMoveOptions.IGNORE_MISSING_FILES)) {
+    if (moveOptions.getIgnoreMissingFiles()) {
       resourceIdsToDelete =
           FluentIterable.from(matchResources(Lists.newArrayList(resourceIds)))
               .filter(matchResult -> !matchResult.status().equals(Status.NOT_FOUND))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
@@ -116,6 +116,7 @@ class LocalFileSystem extends FileSystem<LocalResourceId> {
     return inputStream.getChannel();
   }
 
+  // TODO: update to undeprecated version, in this and other FileSystems
   @Override
   protected void copy(List<LocalResourceId> srcResourceIds, List<LocalResourceId> destResourceIds)
       throws IOException {
@@ -147,6 +148,7 @@ class LocalFileSystem extends FileSystem<LocalResourceId> {
     }
   }
 
+  // TODO: update to undeprecated version, in this and other FileSystems
   @Override
   protected void rename(List<LocalResourceId> srcResourceIds, List<LocalResourceId> destResourceIds)
       throws IOException {
@@ -177,6 +179,7 @@ class LocalFileSystem extends FileSystem<LocalResourceId> {
     }
   }
 
+  // TODO: update to undeprecated version, in this and other FileSystems
   @Override
   protected void delete(Collection<LocalResourceId> resourceIds) throws IOException {
     for (LocalResourceId resourceId : resourceIds) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
@@ -234,6 +234,7 @@ public class TFRecordIO {
     /**
      * Key Management System key name for use in creating new files on filesystems that support it.
      */
+    @Experimental(Kind.FILESYSTEM)
     @Nullable
     abstract String getKmsKey();
 
@@ -251,6 +252,7 @@ public class TFRecordIO {
 
       abstract Builder setCompression(Compression compression);
 
+      @Experimental(Kind.FILESYSTEM)
       abstract Builder setKmsKey(String kmsKey);
 
       abstract Write build();
@@ -351,7 +353,10 @@ public class TFRecordIO {
     /**
      * Sets Key Management System key name for use in creating new files on filesystems that support
      * it.
+     *
+     * <p>TODO(BEAM-5959): Not yet supported.
      */
+    @Experimental(Kind.FILESYSTEM)
     public Write withKmsKey(String kmsKey) {
       return toBuilder().setKmsKey(kmsKey).build();
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -631,6 +631,7 @@ public class TextIO {
     abstract boolean getWindowedWrites();
 
     /** Optional Key Management System encryption key. */
+    @Experimental(Kind.FILESYSTEM)
     @Nullable
     abstract String getKmsKey();
 
@@ -678,6 +679,7 @@ public class TextIO {
 
       abstract Builder<UserT, DestinationT> setWindowedWrites(boolean windowedWrites);
 
+      @Experimental(Kind.FILESYSTEM)
       abstract Builder<UserT, DestinationT> setKmsKey(@Nullable String kmsKey);
 
       abstract Builder<UserT, DestinationT> setWritableByteChannelFactory(
@@ -910,7 +912,10 @@ public class TextIO {
      * Sets a Key Management System key for each created file.
      *
      * <p>Files will be encrypted using the given KMS key on supported filesystems.
+     *
+     * <p>TODO(BEAM-5959): Not yet supported.
      */
+    @Experimental(Kind.FILESYSTEM)
     public TypedWrite<UserT, DestinationT> withKmsKey(@Nullable String kmsKey) {
       return toBuilder().setKmsKey(kmsKey).build();
     }
@@ -998,9 +1003,6 @@ public class TextIO {
       if (getWindowedWrites()) {
         write = write.withWindowedWrites();
       }
-      // TODO: remove
-      //System.err.println("kmsKey: "+getKmsKey());
-      //write = write.withKmsKey(getKmsKey());
       return input.apply("WriteFiles", write);
     }
 
@@ -1166,7 +1168,6 @@ public class TextIO {
     }
 
     /** See {@link TypedWrite#withKmsKey}. */
-    // TODO: mark new public interfaces as experimental
     @Experimental(Kind.FILESYSTEM)
     public Write withKmsKey(@Nullable String kmsKey) {
       // TODO: check if FileIO kmsKey is in use

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSink.java
@@ -45,8 +45,9 @@ class TextSink<UserT, DestinationT> extends FileBasedSink<UserT, DestinationT, S
       char[] delimiter,
       @Nullable String header,
       @Nullable String footer,
-      WritableByteChannelFactory writableByteChannelFactory) {
-    super(baseOutputFilename, dynamicDestinations, writableByteChannelFactory);
+      WritableByteChannelFactory writableByteChannelFactory,
+      String kmsKey) {
+    super(baseOutputFilename, dynamicDestinations, writableByteChannelFactory, kmsKey);
     this.header = header;
     this.footer = footer;
     this.delimiter = delimiter;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/CreateOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/CreateOptions.java
@@ -18,15 +18,26 @@
 package org.apache.beam.sdk.io.fs;
 
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 
 /** An abstract class that contains common configuration options for creating resources. */
 public abstract class CreateOptions {
   /** The file-like resource mime type. */
   public abstract String mimeType();
 
+  /**
+   * Specifies the Key Management System key name to use to encrypt the new file with.
+   *
+   * <p>Only relevant to filesystems that support KMS features.
+   */
+  @Nullable
+  public abstract String kmsKey();
+
   /** An abstract builder for {@link CreateOptions}. */
   public abstract static class Builder<BuilderT extends CreateOptions.Builder<BuilderT>> {
     public abstract BuilderT setMimeType(String value);
+
+    public abstract BuilderT setKmsKey(@Nullable String value);
   }
 
   /** A standard configuration options with builder. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/CreateOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/CreateOptions.java
@@ -19,6 +19,8 @@ package org.apache.beam.sdk.io.fs;
 
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /** An abstract class that contains common configuration options for creating resources. */
 public abstract class CreateOptions {
@@ -30,6 +32,7 @@ public abstract class CreateOptions {
    *
    * <p>Only relevant to filesystems that support KMS features.
    */
+  @Experimental(Kind.FILESYSTEM)
   @Nullable
   public abstract String kmsKey();
 
@@ -37,6 +40,7 @@ public abstract class CreateOptions {
   public abstract static class Builder<BuilderT extends CreateOptions.Builder<BuilderT>> {
     public abstract BuilderT setMimeType(String value);
 
+    @Experimental(Kind.FILESYSTEM)
     public abstract BuilderT setKmsKey(@Nullable String value);
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MoveOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MoveOptions.java
@@ -19,6 +19,8 @@ package org.apache.beam.sdk.io.fs;
 
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.FileSystems;
 
 /**
@@ -38,6 +40,7 @@ public abstract class MoveOptions {
    *
    * <p>Only relevant to operations that create new files and filesystems that support KMS features.
    */
+  @Experimental(Kind.FILESYSTEM)
   @Nullable
   public abstract String getDestKmsKey();
 
@@ -51,6 +54,7 @@ public abstract class MoveOptions {
     @Override
     public abstract boolean getIgnoreMissingFiles();
 
+    @Experimental(Kind.FILESYSTEM)
     @Override
     @Nullable
     public abstract String getDestKmsKey();
@@ -64,6 +68,7 @@ public abstract class MoveOptions {
 
       public abstract Builder setIgnoreMissingFiles(boolean ignoreMissingFiles);
 
+      @Experimental(Kind.FILESYSTEM)
       public abstract Builder setDestKmsKey(String kmsKey);
 
       public abstract StandardMoveOptions build();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MoveOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MoveOptions.java
@@ -17,16 +17,56 @@
  */
 package org.apache.beam.sdk.io.fs;
 
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.io.FileSystems;
 
 /**
  * An object that configures {@link FileSystems#copy}, {@link FileSystems#rename}, and {@link
  * FileSystems#delete}.
  */
-public interface MoveOptions {
+public abstract class MoveOptions {
+
+  /**
+   * If false, operations will abort on errors arising from missing files. Otherwise, operations
+   * will ignore such errors.
+   */
+  public abstract boolean getIgnoreMissingFiles();
+
+  /**
+   * Specifies the Key Management System key name to use to encrypt new files with.
+   *
+   * <p>Only relevant to operations that create new files and filesystems that support KMS features.
+   */
+  @Nullable
+  public abstract String getDestKmsKey();
 
   /** Defines the standard {@link MoveOptions}. */
-  enum StandardMoveOptions implements MoveOptions {
-    IGNORE_MISSING_FILES,
+  @AutoValue
+  public abstract static class StandardMoveOptions extends MoveOptions {
+    // This is a convenience member for backwards compatibility.
+    public static final MoveOptions IGNORE_MISSING_FILES =
+        StandardMoveOptions.builder().setIgnoreMissingFiles(true).build();
+
+    @Override
+    public abstract boolean getIgnoreMissingFiles();
+
+    @Override
+    @Nullable
+    public abstract String getDestKmsKey();
+
+    public static Builder builder() {
+      return new AutoValue_MoveOptions_StandardMoveOptions.Builder().setIgnoreMissingFiles(false);
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      public abstract Builder setIgnoreMissingFiles(boolean ignoreMissingFiles);
+
+      public abstract Builder setDestKmsKey(String kmsKey);
+
+      public abstract StandardMoveOptions build();
+    }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -1288,5 +1288,14 @@ public class AvroIOTest implements Serializable {
           displayData,
           hasItem(hasDisplayItem("filePattern")));
     }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testKmsKey() throws Exception {
+      writePipeline
+          .apply(Create.of("element"))
+          .apply(AvroIO.write(String.class).to("testkmskey://").withKmsKey("test_kms_key"));
+      writePipeline.run();
+    }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FakeFileSystem.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FakeFileSystem.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.auto.service.AutoService;
+import com.google.auto.value.AutoValue;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.io.fs.CreateOptions;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
+import org.apache.beam.sdk.io.fs.MatchResult.Status;
+import org.apache.beam.sdk.io.fs.MoveOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+
+/**
+ * Implements a FileSystem with verification tests.
+ *
+ * <p>Not all operations are fully supported or are well behaved. File and directory contents are
+ * not stored.
+ *
+ * <p>This class was created to verify that IO parameters (such as withKmsKey in FileIO) get passed
+ * down to FileSystems calls. Since FileSystems is implemented as static methods that makes it hard
+ * to intercept these calls.
+ *
+ * <p>Usage: Create a FileSystemRegistrar class that instantiates a FakeFileSystem with a unique
+ * scheme, then do I/O on files using that scheme. Search the codebase for examples.
+ */
+@AutoValue
+abstract class FakeFileSystem extends FileSystem<FakeResourceId> {
+
+  @Override
+  protected abstract String getScheme();
+
+  @Nullable
+  public abstract String getRequireKmsKey();
+
+  static Builder builder() {
+    return new AutoValue_FakeFileSystem.Builder().setRequireKmsKey(null);
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    /** Required URI prefix for this FS. Should be unique among all tests. */
+    abstract Builder setScheme(String scheme);
+
+    /**
+     * Expect this KMS key in operations that use CreateOptions and MoveOptions. A value of null
+     * means no verification is performed.
+     */
+    abstract Builder setRequireKmsKey(@Nullable String kmsKey);
+
+    abstract FakeFileSystem build();
+  }
+
+  /** A channel that has no output and discards all input. */
+  private static class NullByteChannel implements ReadableByteChannel, WritableByteChannel {
+
+    private boolean open = true;
+
+    @Override
+    public int read(ByteBuffer byteBuffer) throws IOException {
+      return 0;
+    }
+
+    @Override
+    public int write(ByteBuffer byteBuffer) throws IOException {
+      int written = byteBuffer.remaining();
+      byteBuffer.position(byteBuffer.position() + written);
+      return written;
+    }
+
+    @Override
+    public boolean isOpen() {
+      return open;
+    }
+
+    @Override
+    public void close() throws IOException {
+      open = false;
+    }
+  }
+
+  /** Always finds files. */
+  @Override
+  protected List<MatchResult> match(List<String> specs) throws IOException {
+    List<Metadata> metadata = new ArrayList<>();
+    for (String spec : specs) {
+      metadata.add(
+          Metadata.builder()
+              .setResourceId(new FakeResourceId(getScheme(), parseSpec(spec), false))
+              .setIsReadSeekEfficient(false)
+              .setSizeBytes(0)
+              .build());
+    }
+    List<MatchResult> result = new ArrayList<>();
+    result.add(MatchResult.create(Status.OK, metadata));
+    return result;
+  }
+
+  @Override
+  protected ReadableByteChannel open(FakeResourceId resourceId) throws IOException {
+    return new NullByteChannel();
+  }
+
+  private String parseSpec(String resourceSpec) {
+    String prefix = getScheme() + "://";
+    if (!resourceSpec.startsWith(prefix)) {
+      throw new UnsupportedOperationException(
+          String.format("expected prefix of %s: %s", prefix, resourceSpec));
+    }
+    return resourceSpec.substring(prefix.length());
+  }
+
+  @Override
+  protected FakeResourceId matchNewResource(String singleResourceSpec, boolean isDirectory) {
+    return new FakeResourceId(getScheme(), parseSpec(singleResourceSpec), isDirectory);
+  }
+
+  @Override
+  protected WritableByteChannel create(FakeResourceId resourceId, CreateOptions createOptions)
+      throws IOException {
+    if (getRequireKmsKey() != null) {
+      assertEquals(getRequireKmsKey(), createOptions.kmsKey());
+    }
+    return new NullByteChannel();
+  }
+
+  @Override
+  protected void copy(
+      List<FakeResourceId> srcResourceIds,
+      List<FakeResourceId> destResourceIds,
+      MoveOptions moveOptions)
+      throws IOException {
+    if (getRequireKmsKey() != null) {
+      assertEquals(getRequireKmsKey(), moveOptions.getDestKmsKey());
+    }
+  }
+
+  @Override
+  protected void rename(
+      List<FakeResourceId> srcResourceIds,
+      List<FakeResourceId> destResourceIds,
+      MoveOptions moveOptions)
+      throws IOException {
+    if (getRequireKmsKey() != null) {
+      assertEquals(getRequireKmsKey(), moveOptions.getDestKmsKey());
+    }
+  }
+
+  @Override
+  protected void delete(Collection<FakeResourceId> resourceIds, MoveOptions moveOptions)
+      throws IOException {
+    // Don't check kmsKey on deletes, since it doesn't matter for this operation.
+  }
+
+  /**
+   * This scheme performs stateless checks of the presence of kmsKey settings on relevant
+   * operations.
+   */
+  @AutoService(FileSystemRegistrar.class)
+  @Experimental(Kind.FILESYSTEM)
+  public static class TestKmsKeyFileSystemRegistrar implements FileSystemRegistrar {
+    @Override
+    public Iterable<FileSystem> fromOptions(@Nullable PipelineOptions options) {
+      return ImmutableList.of(
+          FakeFileSystem.builder()
+              .setScheme("testkmskey")
+              .setRequireKmsKey("test_kms_key")
+              .build());
+    }
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FakeResourceId.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FakeResourceId.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io;
+
+import org.apache.beam.sdk.io.fs.ResolveOptions;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
+
+/** Implements a resource for FakeFileSystem. */
+class FakeResourceId implements ResourceId {
+
+  private final String scheme;
+  private final String filename;
+  private final boolean isDirectory;
+
+  FakeResourceId(String scheme, String filename, boolean isDirectory) {
+    this.scheme = scheme;
+    this.filename = filename;
+    this.isDirectory = isDirectory;
+  }
+
+  @Override
+  public FakeResourceId getCurrentDirectory() {
+    return this;
+  }
+
+  @Override
+  public String getScheme() {
+    return scheme;
+  }
+
+  @Override
+  public String getFilename() {
+    return filename;
+  }
+
+  @Override
+  public boolean isDirectory() {
+    return isDirectory;
+  }
+
+  @Override
+  public ResourceId resolve(String other, ResolveOptions resolveOptions) {
+    if (other.equals("..")
+        || other.equals("*")
+        || !(resolveOptions instanceof StandardResolveOptions)) {
+      throw new UnsupportedOperationException();
+    }
+    switch ((StandardResolveOptions) resolveOptions) {
+      case RESOLVE_DIRECTORY:
+        return new FakeResourceId(getScheme(), other, true);
+      case RESOLVE_FILE:
+        return new FakeResourceId(getScheme(), other, false);
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s://%s", getScheme(), getFilename());
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordIOTest.java
@@ -386,4 +386,14 @@ public class TFRecordIOTest {
       c.output(c.element().getBytes(Charsets.UTF_8));
     }
   }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testKmsKey() throws Exception {
+    writePipeline
+        .apply(Create.of("element"))
+        .apply(ParDo.of(new StringToByteArray()))
+        .apply(TFRecordIO.write().to("testkmskey://").withKmsKey("test_kms_key"));
+    writePipeline.run();
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOWriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOWriteTest.java
@@ -700,4 +700,12 @@ public class TextIOWriteTest {
 
     assertEquals(Arrays.asList("header", "a", "b", "c", "footer"), readLinesFromFile(f));
   }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testKmsKey() throws Exception {
+    p.apply(Create.of("element"))
+        .apply(TextIO.write().to("testkmskey://").withKmsKey("test_kms_key"));
+    p.run();
+  }
 }

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/storage/GcsCreateOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/storage/GcsCreateOptions.java
@@ -28,7 +28,7 @@ public abstract class GcsCreateOptions extends CreateOptions {
 
   /**
    * The buffer size (in bytes) to use when uploading files to GCS. Please see the documentation for
-   * {@link AbstractGoogleAsyncWriteChannel#setUploadBufferSize} for more information on the
+   * {@link AbstractGoogleAsyncWriteChannel#setUploadChunkSize} for more information on the
    * restrictions and performance implications of this value.
    */
   @Nullable

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilIT.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilIT.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+// TODO: Multi-part rerwrite test: read wikipedia set file (see Python test), write to GCS using GcsUtil low-level code
+
+/**
+ * Integration tests for {@link GcsUtil}. These tests are designed to run against production Google
+ * Cloud Storage.
+ *
+ * <p>This is a runnerless integration test, even though the Beam IT framework assumes one. Thus,
+ * this test should only be run against single runner (such as DirectRunner).
+ */
+@RunWith(JUnit4.class)
+public class GcsUtilIT {
+  /** Tests a rewrite operation that requires multiple API calls (using a continuation token). */
+  @Test
+  public void testRewriteMultiPart() {
+    // TODO
+  }
+}

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilIT.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilIT.java
@@ -21,7 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-// TODO: Multi-part rerwrite test: read wikipedia set file (see Python test), write to GCS using GcsUtil low-level code
+// TODO: Multi-part rerwrite test: read wikipedia set file (see Python test), write to GCS using
+// GcsUtil low-level code
 
 /**
  * Integration tests for {@link GcsUtil}. These tests are designed to run against production Google

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilTest.java
@@ -842,17 +842,20 @@ public class GcsUtilTest {
     GcsUtil gcsUtil = gcsOptionsWithTestCredential().getGcsUtil();
 
     // Small number of files fits in 1 batch
-    List<BatchRequest> batches = gcsUtil.makeCopyBatches(makeStrings("s", 3), makeStrings("d", 3));
+    String destKmsKey = null;
+    List<BatchRequest> batches =
+        gcsUtil.makeCopyBatches(makeStrings("s", 3), makeStrings("d", 3), destKmsKey);
     assertThat(batches.size(), equalTo(1));
     assertThat(sumBatchSizes(batches), equalTo(3));
 
     // 1 batch of files fits in 1 batch
-    batches = gcsUtil.makeCopyBatches(makeStrings("s", 100), makeStrings("d", 100));
+    destKmsKey = "test_kms_key";
+    batches = gcsUtil.makeCopyBatches(makeStrings("s", 100), makeStrings("d", 100), destKmsKey);
     assertThat(batches.size(), equalTo(1));
     assertThat(sumBatchSizes(batches), equalTo(100));
 
     // A little more than 5 batches of files fits in 6 batches
-    batches = gcsUtil.makeCopyBatches(makeStrings("s", 501), makeStrings("d", 501));
+    batches = gcsUtil.makeCopyBatches(makeStrings("s", 501), makeStrings("d", 501), destKmsKey);
     assertThat(batches.size(), equalTo(6));
     assertThat(sumBatchSizes(batches), equalTo(501));
   }
@@ -863,7 +866,7 @@ public class GcsUtilTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Number of source files 3");
 
-    gcsUtil.makeCopyBatches(makeStrings("s", 3), makeStrings("d", 1));
+    gcsUtil.makeCopyBatches(makeStrings("s", 3), makeStrings("d", 1), null);
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsKmsKeyIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsKmsKeyIT.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.storage;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+
+import com.google.common.collect.Iterables;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.PipelineResult.State;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
+import org.apache.beam.sdk.io.AvroIO;
+import org.apache.beam.sdk.io.FileIO;
+import org.apache.beam.sdk.io.FileIO.Sink;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.TFRecordIO;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.FileChecksumMatcher;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.util.GcsUtil;
+import org.apache.beam.sdk.util.gcsfs.GcsPath;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+// Run a specific test using:
+//   ./gradlew :beam-sdks-java-io-google-cloud-platform:integrationTest --tests GcsKmsKeyIT.testFileIOWithKmsKey --info
+
+/** Integration test for GCS CMEK support. */
+@RunWith(JUnit4.class)
+public class GcsKmsKeyIT {
+
+  private static final String INPUT_FILE = "gs://dataflow-samples/shakespeare/kinglear.txt";
+  private static final String EXPECTED_CHECKSUM = "b9778bfac7fa8b934e42a322ef4bd4706b538fd0";
+  private static final String KMS_KEY =
+      "projects/apache-beam-testing/locations/global/keyRings/beam-it/cryptoKeys/test/cryptoKeyVersions/1";
+
+  @BeforeClass
+  public static void setup() {
+    PipelineOptionsFactory.register(TestPipelineOptions.class);
+  }
+
+  /**
+   * Tests TextIO writing to GCS with kmsKey. This includes writing temporary files with kmsKey and
+   * performing a rename operation with destKmsKey. Verifies that resulting output uses specified
+   * key and is readable. Does not verify temporary file encryption.
+   */
+  @Test
+  public void testTextIOWithKmsKey() {
+    TestPipelineOptions options =
+        TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+
+    ResourceId filenamePrefix =
+        FileSystems.matchNewResource(options.getTempRoot(), true)
+            .resolve(
+                String.format("GcsKmsKeyIT-%tF-%<tH-%<tM-%<tS-%<tL.output", new Date()),
+                StandardResolveOptions.RESOLVE_FILE);
+
+    Pipeline p = Pipeline.create(options);
+    p.apply("ReadLines", TextIO.read().from(INPUT_FILE))
+        .apply("WriteLines", TextIO.write().to(filenamePrefix).withKmsKey(KMS_KEY));
+
+    PipelineResult result = p.run();
+    State state = result.waitUntilFinish();
+    assertThat(state, equalTo(State.DONE));
+
+    String filePattern = filenamePrefix + "*-of-*";
+    assertThat(result, new FileChecksumMatcher(EXPECTED_CHECKSUM, filePattern));
+
+    try {
+      MatchResult matchResult =
+          Iterables.getOnlyElement(FileSystems.match(Collections.singletonList(filePattern)));
+      GcsOptions gcsOptions = options.as(GcsOptions.class);
+      GcsUtil gcsUtil = gcsOptions.getGcsUtil();
+      for (Metadata metadata : matchResult.metadata()) {
+        String kmsKey = gcsUtil.kmsKey(GcsPath.fromUri(metadata.resourceId().toString()));
+        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY));
+      }
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static class TextSink implements Sink<String> {
+    private PrintWriter writer;
+
+    @Override
+    public void open(WritableByteChannel channel) throws IOException {
+      writer = new PrintWriter(Channels.newWriter(channel, StandardCharsets.UTF_8.name()));
+    }
+
+    @Override
+    public void write(String element) throws IOException {
+      writer.println(element);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      writer.flush();
+    }
+  }
+
+  /** Like testTextIOWithKmsKey, but using FileIO. */
+  @Test
+  public void testFileIOWithKmsKey() {
+    TestPipelineOptions options =
+        TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+
+    ResourceId outputDirectory =
+        FileSystems.matchNewResource(options.getTempRoot(), true)
+            .resolve(
+                String.format("GcsKmsKeyIT-%tF-%<tH-%<tM-%<tS-%<tL", new Date()),
+                StandardResolveOptions.RESOLVE_FILE);
+    String filenamePrefix = "output";
+
+    Pipeline p = Pipeline.create(options);
+    p.apply("ReadLines", TextIO.read().from(INPUT_FILE))
+        .apply(
+            "WriteLines",
+            FileIO.<String>write()
+                .via(new TextSink())
+                .to(outputDirectory.toString())
+                .withPrefix(filenamePrefix)
+                .withKmsKey(KMS_KEY));
+
+    PipelineResult result = p.run();
+    State state = result.waitUntilFinish();
+    assertThat(state, equalTo(State.DONE));
+
+    String filePattern = outputDirectory + "/" + filenamePrefix + "*-of-*";
+    assertThat(result, new FileChecksumMatcher(EXPECTED_CHECKSUM, filePattern));
+
+    try {
+      MatchResult matchResult =
+          Iterables.getOnlyElement(FileSystems.match(Collections.singletonList(filePattern)));
+      GcsOptions gcsOptions = options.as(GcsOptions.class);
+      GcsUtil gcsUtil = gcsOptions.getGcsUtil();
+      for (Metadata metadata : matchResult.metadata()) {
+        String kmsKey = gcsUtil.kmsKey(GcsPath.fromUri(metadata.resourceId().toString()));
+        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY));
+      }
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  /**
+   * Like testTextIOWithKmsKey, but using AvroIO.
+   *
+   * <p>Doesn't verify output contents.
+   */
+  @Test
+  public void testAvroIOWithKmsKey() {
+    TestPipelineOptions options =
+        TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+
+    ResourceId filenamePrefix =
+        FileSystems.matchNewResource(options.getTempRoot(), true)
+            .resolve(
+                String.format("GcsKmsKeyIT-%tF-%<tH-%<tM-%<tS-%<tL.output", new Date()),
+                StandardResolveOptions.RESOLVE_FILE);
+
+    Pipeline p = Pipeline.create(options);
+    p.apply("ReadLines", TextIO.read().from(INPUT_FILE))
+        .apply("WriteLines", AvroIO.write(String.class).to(filenamePrefix).withKmsKey(KMS_KEY));
+
+    PipelineResult result = p.run();
+    State state = result.waitUntilFinish();
+    assertThat(state, equalTo(State.DONE));
+
+    String filePattern = filenamePrefix + "*-of-*";
+    try {
+      MatchResult matchResult =
+          Iterables.getOnlyElement(FileSystems.match(Collections.singletonList(filePattern)));
+      GcsOptions gcsOptions = options.as(GcsOptions.class);
+      GcsUtil gcsUtil = gcsOptions.getGcsUtil();
+      for (Metadata metadata : matchResult.metadata()) {
+        GcsPath gcsPath = GcsPath.fromUri(metadata.resourceId().toString());
+        assertThat(gcsUtil.fileSize(gcsPath), greaterThan(0L));
+        String kmsKey = gcsUtil.kmsKey(gcsPath);
+        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY));
+      }
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static class StringToBytesFn extends DoFn<String, byte[]> {
+    @ProcessElement
+    public void process(@Element String e, OutputReceiver<byte[]> output) {
+      output.output(e.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  /**
+   * Like testTextIOWithKmsKey, but using TFRecordIO.
+   *
+   * <p>Doesn't verify output contents.
+   */
+  @Test
+  public void testTFRecordIOWithKmsKey() {
+    TestPipelineOptions options =
+        TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+
+    ResourceId filenamePrefix =
+        FileSystems.matchNewResource(options.getTempRoot(), true)
+            .resolve(
+                String.format("GcsKmsKeyIT-%tF-%<tH-%<tM-%<tS-%<tL.output", new Date()),
+                StandardResolveOptions.RESOLVE_FILE);
+
+    Pipeline p = Pipeline.create(options);
+    p.apply("ReadLines", TextIO.read().from(INPUT_FILE))
+        .apply("LinesToBytes", ParDo.of(new StringToBytesFn()))
+        .apply("WriteBytes", TFRecordIO.write().to(filenamePrefix).withKmsKey(KMS_KEY));
+
+    PipelineResult result = p.run();
+    State state = result.waitUntilFinish();
+    assertThat(state, equalTo(State.DONE));
+
+    String filePattern = filenamePrefix + "*-of-*";
+    try {
+      MatchResult matchResult =
+          Iterables.getOnlyElement(FileSystems.match(Collections.singletonList(filePattern)));
+      GcsOptions gcsOptions = options.as(GcsOptions.class);
+      GcsUtil gcsUtil = gcsOptions.getGcsUtil();
+      for (Metadata metadata : matchResult.metadata()) {
+        GcsPath gcsPath = GcsPath.fromUri(metadata.resourceId().toString());
+        assertThat(gcsUtil.fileSize(gcsPath), greaterThan(0L));
+        String kmsKey = gcsUtil.kmsKey(gcsPath);
+        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY));
+      }
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsKmsKeyIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsKmsKeyIT.java
@@ -57,7 +57,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 // Run a specific test using:
-//   ./gradlew :beam-sdks-java-io-google-cloud-platform:integrationTest --tests GcsKmsKeyIT.testFileIOWithKmsKey --info
+//   ./gradlew :beam-sdks-java-io-google-cloud-platform:integrationTest --tests
+// GcsKmsKeyIT.testFileIOWithKmsKey --info
 
 /** Integration test for GCS CMEK support. */
 @RunWith(JUnit4.class)
@@ -66,6 +67,9 @@ public class GcsKmsKeyIT {
   private static final String INPUT_FILE = "gs://dataflow-samples/shakespeare/kinglear.txt";
   private static final String EXPECTED_CHECKSUM = "b9778bfac7fa8b934e42a322ef4bd4706b538fd0";
   private static final String KMS_KEY =
+      "projects/apache-beam-testing/locations/global/keyRings/beam-it/cryptoKeys/test";
+  // The key used has key rotation disabled such that the current version is always 1.
+  private static final String KMS_KEY_WITH_VERSION =
       "projects/apache-beam-testing/locations/global/keyRings/beam-it/cryptoKeys/test/cryptoKeyVersions/1";
 
   @BeforeClass
@@ -107,7 +111,7 @@ public class GcsKmsKeyIT {
       GcsUtil gcsUtil = gcsOptions.getGcsUtil();
       for (Metadata metadata : matchResult.metadata()) {
         String kmsKey = gcsUtil.kmsKey(GcsPath.fromUri(metadata.resourceId().toString()));
-        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY));
+        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY_WITH_VERSION));
       }
     } catch (IOException e) {
       throw new AssertionError(e);
@@ -170,7 +174,7 @@ public class GcsKmsKeyIT {
       GcsUtil gcsUtil = gcsOptions.getGcsUtil();
       for (Metadata metadata : matchResult.metadata()) {
         String kmsKey = gcsUtil.kmsKey(GcsPath.fromUri(metadata.resourceId().toString()));
-        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY));
+        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY_WITH_VERSION));
       }
     } catch (IOException e) {
       throw new AssertionError(e);
@@ -211,7 +215,7 @@ public class GcsKmsKeyIT {
         GcsPath gcsPath = GcsPath.fromUri(metadata.resourceId().toString());
         assertThat(gcsUtil.fileSize(gcsPath), greaterThan(0L));
         String kmsKey = gcsUtil.kmsKey(gcsPath);
-        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY));
+        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY_WITH_VERSION));
       }
     } catch (IOException e) {
       throw new AssertionError(e);
@@ -260,7 +264,7 @@ public class GcsKmsKeyIT {
         GcsPath gcsPath = GcsPath.fromUri(metadata.resourceId().toString());
         assertThat(gcsUtil.fileSize(gcsPath), greaterThan(0L));
         String kmsKey = gcsUtil.kmsKey(gcsPath);
-        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY));
+        assertThat(metadata.resourceId().toString(), kmsKey, equalTo(KMS_KEY_WITH_VERSION));
       }
     } catch (IOException e) {
       throw new AssertionError(e);


### PR DESCRIPTION
Adds kmsKey setting to file creation (create, copy) for FileBasedSink IOs.
Supported transforms: FileIO, TextIO, AvroIO, TFRecordIO

Not yet ready:
- Requires google_cloud_bigdataoss_version = "1.9.12" (or later)
- Still missing some tests.

Note to reviewers: I've tried to maintain backwards compatibility in public APIs. Please verify.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




