### PR TITLE
[BEAM-6473] Materialize all inputs of transforms with side input collections

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyStageFuser.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyStageFuser.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Supplier;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
@@ -169,9 +170,10 @@ public class GreedyStageFuser {
       PCollectionNode candidate,
       Environment environment,
       Set<PCollectionNode> fusedPCollections) {
-    for (PTransformNode node : pipeline.getPerElementConsumers(candidate)) {
-      if (!(GreedyPCollectionFusers.canFuse(
-          node, environment, candidate, fusedPCollections, pipeline))) {
+    for (PTransformNode consumer : pipeline.getPerElementConsumers(candidate)) {
+      if (anyInputsSideInputs(consumer, pipeline)
+          || !(GreedyPCollectionFusers.canFuse(
+              consumer, environment, candidate, fusedPCollections, pipeline))) {
         // Some of the consumers can't be fused into this subgraph, so the PCollection has to be
         // materialized.
         // TODO: Potentially, some of the consumers can be fused back into this stage later
@@ -190,5 +192,17 @@ public class GreedyStageFuser {
   private enum PCollectionFusibility {
     MATERIALIZE,
     FUSE,
+  }
+
+  private static boolean anyInputsSideInputs(PTransformNode consumer, QueryablePipeline pipeline) {
+    for (String inputPCollectionId : consumer.getTransform().getInputsMap().values()) {
+      RunnerApi.PCollection pCollection =
+          pipeline.getComponents().getPcollectionsMap().get(inputPCollectionId);
+      PCollectionNode pCollectionNode = PipelineNode.pCollection(inputPCollectionId, pCollection);
+      if (!pipeline.getSingletonConsumers(pCollectionNode).isEmpty()) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -162,10 +162,6 @@ if __name__ == '__main__':
     def test_error_traceback_includes_user_code(self):
       raise unittest.SkipTest("BEAM-6019")
 
-    def test_flattened_side_input(self):
-      # BEAM-6473
-      super(FlinkRunnerTest, self).test_flattened_side_input(extended=False)
-
     def test_metrics(self):
       """Run a simple DoFn that increments a counter, and verify that its
        expected value is written to a temporary file by the FileReporter"""

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -188,22 +188,21 @@ class FnApiRunnerTest(unittest.TestCase):
               (9, list(range(7, 10)))]),
           label='windowed')
 
-  def test_flattened_side_input(self, extended=True):
+  def test_flattened_side_input(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create([None])
       side1 = p | 'side1' >> beam.Create([('a', 1)])
       side2 = p | 'side2' >> beam.Create([('b', 2)])
-      side3 = p | 'side3' >> beam.Create(['another type'])
+      side3 = p | 'side3' >> beam.Create([('b', 3)])
       side = (side1, side2) | beam.Flatten()
       assert_that(
           main | beam.Map(lambda a, b: (a, b), beam.pvalue.AsDict(side)),
           equal_to([(None, {'a': 1, 'b': 2})]),
           label='CheckFlattenAsSideInput')
-      if extended:
-        assert_that(
-            (side, side3) | 'FlattenAfter' >> beam.Flatten(),
-            equal_to([('a', 1), ('b', 2), ('another type')]),
-            label='CheckFlattenOfSideInput')
+      assert_that(
+          (side, side3) | 'FlattenAfter' >> beam.Flatten(),
+          equal_to([('a', 1), ('b', 2), ('b', 3)]),
+          label='CheckFlattenOfSideInput')
 
   def test_gbk_side_input(self):
     with self.create_pipeline() as p:


### PR DESCRIPTION
In the Python ValidatesRunner test `test_flattened_side_input`, the PCollection `side` is materialized to be used as a side input of a transform. `side` is also used as input to a flatten operation together with the collection `side3`. However, `side3` is fused away and can't be reached for the flatten which is not fused due to `side` being materialized.

The solution is to materialize all inputs to transforms which use side input collections as input.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




