### PR TITLE
[BEAM-5091] New wordcount integration test on DataflowRunner in Python 3

### DIFF
--- a/sdks/python/apache_beam/examples/wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/wordcount_it_test.py
@@ -19,18 +19,71 @@
 
 from __future__ import absolute_import
 
+import argparse
 import logging
+import re
 import time
 import unittest
 
 from hamcrest.core.core.allof import all_of
 from nose.plugins.attrib import attr
+from past.builtins import unicode
 
+import apache_beam as beam
 from apache_beam.examples import wordcount
+from apache_beam.io import ReadFromText
+from apache_beam.io import WriteToText
+from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.testing.pipeline_verifiers import FileChecksumMatcher
 from apache_beam.testing.pipeline_verifiers import PipelineStateMatcher
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.test_utils import delete_files
+
+
+def run_wordcount_without_save_main_session(argv):
+  """Defines and runs a simple version of wordcount pipeline.
+
+  This pipeline is the same as wordcount example except replace customized
+  DoFn class with transform function and disable save_main_session option
+  due to BEAM-6158."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--input',
+                      dest='input',
+                      default='gs://dataflow-samples/shakespeare/kinglear.txt',
+                      help='Input file to process.')
+  parser.add_argument('--output',
+                      dest='output',
+                      required=True,
+                      help='Output file to write results to.')
+  known_args, pipeline_args = parser.parse_known_args(argv)
+
+  p = beam.Pipeline(options=PipelineOptions(pipeline_args))
+
+  # Count the occurrences of each word.
+  def count_ones(word_ones):
+    (word, ones) = word_ones
+    return (word, sum(ones))
+
+  # Parse each line of input text into words.
+  def extract_words(line):
+    return re.findall(r'[\w\']+', line, re.UNICODE)
+
+  # Format the counts into a PCollection of strings.
+  def format_result(word_count):
+    (word, count) = word_count
+    return '%s: %d' % (word, count)
+
+  # pylint: disable=expression-not-assigned
+  (p | 'read' >> ReadFromText(known_args.input)
+   | 'split' >> (beam.ParDo(extract_words).with_output_types(unicode))
+   | 'pair_with_one' >> beam.Map(lambda x: (x, 1))
+   | 'group' >> beam.GroupByKey()
+   | 'count' >> beam.Map(count_ones)
+   | 'format' >> beam.Map(format_result)
+   | 'write' >> WriteToText(known_args.output))
+
+  result = p.run()
+  result.wait_until_finish()
 
 
 class WordCountIT(unittest.TestCase):
@@ -44,13 +97,20 @@ class WordCountIT(unittest.TestCase):
 
   @attr('IT')
   def test_wordcount_it(self):
-    self._run_wordcount_it()
+    self._run_wordcount_it(wordcount.run)
 
   @attr('IT', 'ValidatesContainer')
   def test_wordcount_fnapi_it(self):
-    self._run_wordcount_it(experiment='beam_fn_api')
+    self._run_wordcount_it(wordcount.run, experiment='beam_fn_api')
 
-  def _run_wordcount_it(self, **opts):
+  @attr('Py3IT')
+  # TODO: Delete this test and use test_wordcount_fnapi_it instead
+  # once BEAM-6158 is fixed.
+  def test_wordcount_without_save_main_session(self):
+    self._run_wordcount_it(run_wordcount_without_save_main_session,
+                           experiment='beam_fn_api')
+
+  def _run_wordcount_it(self, run_wordcount, **opts):
     test_pipeline = TestPipeline(is_integration_test=True)
 
     # Set extra options to the pipeline for test purpose
@@ -72,7 +132,7 @@ class WordCountIT(unittest.TestCase):
 
     # Get pipeline options from command argument: --test-pipeline-options,
     # and start pipeline job by calling pipeline main function.
-    wordcount.run(test_pipeline.get_full_options_as_args(**extra_opts))
+    run_wordcount(test_pipeline.get_full_options_as_args(**extra_opts))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is an integration test that runs a simple version of wordcount pipeline and verifies output file content in Python 3.

Due to BEAM-6158, the test disables `save_main_sessions` flag. Since it duplicates from the existing wordcout example's behavior, we don't need to run it in existing Python 2 suite. Create `Py3IT` tag for integration tests that's available in Python 3.

Tests are done by running this test using DataflowRunner in Python 3.5.

@tvalentyn @aaltay @RobbeSneyders 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




