### PR TITLE
[BEAM-6553] A Python SDK sink that supports File Loads into BQ

### DIFF
--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -128,8 +128,11 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         project=self.project,
         query=verify_query,
         checksum=expected_checksum)]
+
+    gs_location = 'gs://temp-storage-for-upload-tests/%s' % self.output_table
     extra_opts = {'query': LEGACY_QUERY,
                   'output': self.output_table,
+                  'gs_location': gs_location,
                   'output_schema': DIALECT_OUTPUT_SCHEMA,
                   'use_standard_sql': False,
                   'on_success_matcher': all_of(*pipeline_verifiers)}
@@ -144,8 +147,10 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         project=self.project,
         query=verify_query,
         checksum=expected_checksum)]
+    gs_location = 'gs://temp-storage-for-upload-tests/%s' % self.output_table
     extra_opts = {'query': STANDARD_QUERY,
                   'output': self.output_table,
+                  'gs_location': gs_location,
                   'output_schema': DIALECT_OUTPUT_SCHEMA,
                   'use_standard_sql': True,
                   'on_success_matcher': all_of(*pipeline_verifiers)}
@@ -186,9 +191,11 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         query=verify_query,
         checksum=expected_checksum)]
     self._setup_new_types_env()
+    gs_location = 'gs://temp-storage-for-upload-tests/%s' % self.output_table
     extra_opts = {
         'query': NEW_TYPES_QUERY % (self.dataset_id, NEW_TYPES_INPUT_TABLE),
         'output': self.output_table,
+        'gs_location': gs_location,
         'output_schema': NEW_TYPES_OUTPUT_SCHEMA,
         'use_standard_sql': False,
         'on_success_matcher': all_of(*pipeline_verifiers)}

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
@@ -50,6 +50,9 @@ def run_bq_pipeline(argv=None):
                       help='Output BQ table to write results to.')
   parser.add_argument('--kms_key', default=None,
                       help='Use this Cloud KMS key with BigQuery.')
+  parser.add_argument('--gs_location',
+                      default=None,
+                      help='GCS bucket location to use to store files.')
   known_args, pipeline_args = parser.parse_known_args(argv)
 
   table_schema = parse_table_schema_from_json(known_args.output_schema)
@@ -66,7 +69,8 @@ def run_bq_pipeline(argv=None):
            known_args.output,
            schema=table_schema,
            create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
-           write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY))
+           write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY,
+           gs_location=known_args.gs_location))
 
   result = p.run()
   result.wait_until_finish()

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
@@ -62,12 +62,11 @@ def run_bq_pipeline(argv=None):
   (p | 'read' >> beam.io.Read(beam.io.BigQuerySource(
       query=known_args.query, use_standard_sql=known_args.use_standard_sql,
       kms_key=kms_key))
-   | 'write' >> beam.io.Write(beam.io.BigQuerySink(
+   | 'write' >> beam.io.WriteToBigQuery(
            known_args.output,
            schema=table_schema,
            create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
-           write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY,
-           kms_key=known_args.kms_key)))
+           write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY))
 
   result = p.run()
   result.wait_until_finish()

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -808,6 +808,8 @@ bigquery_v2_messages.TableSchema):
 
   def expand(self, pcoll):
     p = pcoll.pipeline
+
+    # TODO(pabloem): Use a different method to determine if streaming or batch.
     standard_options = p.options.view_as(StandardOptions)
 
     if (not callable(self.table_reference)

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -659,6 +659,8 @@ class WriteToBigQuery(PTransform):
                create_disposition=BigQueryDisposition.CREATE_IF_NEEDED,
                write_disposition=BigQueryDisposition.WRITE_APPEND,
                batch_size=None,
+               max_file_size=None,
+               max_files_per_bundle=None,
                test_client=None,
                gs_location=None):
     """Initialize a WriteToBigQuery transform.
@@ -727,6 +729,8 @@ bigquery_v2_messages.TableSchema`
     self.kms_key = kms_key
     self.test_client = test_client
     self.gs_location = gs_location
+    self.max_file_size = max_file_size
+    self.max_files_per_bundle = max_files_per_bundle
 
   @staticmethod
   def get_table_schema_from_string(schema):
@@ -836,6 +840,8 @@ bigquery_v2_messages.TableSchema):
           schema=self.get_dict_table_schema(self.schema),
           create_disposition=self.create_disposition,
           write_disposition=self.write_disposition,
+          max_file_size=self.max_file_size,
+          max_files_per_bundle=self.max_files_per_bundle,
           gs_location=self.gs_location,
           test_client=self.test_client)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -134,6 +134,7 @@ from apache_beam.internal.gcp.json_value import to_json_value
 from apache_beam.io.gcp import bigquery_tools
 from apache_beam.io.gcp.internal.clients import bigquery
 from apache_beam.options.pipeline_options import GoogleCloudOptions
+from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.runners.dataflow.native_io import iobase as dataflow_io
 from apache_beam.transforms import DoFn
 from apache_beam.transforms import ParDo
@@ -449,6 +450,10 @@ bigquery_v2_messages.TableSchema` object.
         match the expected format.
     """
 
+    import warnings
+    warnings.warn("This class is deprecated and will be permanently removed "
+                  "in a future version of beam.")
+
     # Import here to avoid adding the dependency for local running scenarios.
     try:
       # pylint: disable=wrong-import-order, wrong-import-position
@@ -646,18 +651,29 @@ class BigQueryWriteFn(DoFn):
 
 class WriteToBigQuery(PTransform):
 
-  def __init__(self, table, dataset=None, project=None, schema=None,
+  def __init__(self,
+               table,
+               dataset=None,
+               project=None,
+               schema=None,
                create_disposition=BigQueryDisposition.CREATE_IF_NEEDED,
                write_disposition=BigQueryDisposition.WRITE_APPEND,
-               batch_size=None, kms_key=None, test_client=None):
+               batch_size=None,
+               test_client=None,
+               gs_location=None):
     """Initialize a WriteToBigQuery transform.
 
     Args:
-      table (str): The ID of the table. The ID must contain only letters
-        ``a-z``, ``A-Z``, numbers ``0-9``, or underscores ``_``. If dataset
-        argument is :data:`None` then the table argument must contain the
-        entire table reference specified as: ``'DATASET.TABLE'`` or
-        ``'PROJECT:DATASET.TABLE'``.
+      table (str, callable): The ID of the table, or a callable
+         that returns it. The ID must contain only letters ``a-z``, ``A-Z``,
+         numbers ``0-9``, or underscores ``_``. If dataset argument is
+         :data:`None` then the table argument must contain the entire table
+         reference specified as: ``'DATASET.TABLE'``
+         or ``'PROJECT:DATASET.TABLE'``. If it's a callable, it must receive one
+         argument representing an element to be written to BigQuery, and return
+         a TableReference, or a string table name as specified above.
+         Multiple destinations are only supported on Batch pipelines at the
+         moment.
       dataset (str): The ID of the dataset containing this table or
         :data:`None` if the table reference is specified entirely by the table
         argument.
@@ -697,6 +713,8 @@ bigquery_v2_messages.TableSchema`
       kms_key (str): Experimental. Optional Cloud KMS key name for use when
         creating new tables.
       test_client: Override the default bigquery client used for testing.
+      gs_location (str): A GCS location to store files to be used for file
+        loads into BigQuery.
     """
     self.table_reference = bigquery_tools.parse_table_reference(
         table, dataset, project)
@@ -708,6 +726,7 @@ bigquery_v2_messages.TableSchema`
     self.batch_size = batch_size
     self.kms_key = kms_key
     self.test_client = test_client
+    self.gs_location = gs_location
 
   @staticmethod
   def get_table_schema_from_string(schema):
@@ -788,20 +807,35 @@ bigquery_v2_messages.TableSchema):
       raise TypeError('Unexpected schema argument: %s.' % schema)
 
   def expand(self, pcoll):
-    if self.table_reference.projectId is None:
+    p = pcoll.pipeline
+    standard_options = p.options.view_as(StandardOptions)
+
+    if (not callable(self.table_reference)
+        and self.table_reference.projectId is None):
       self.table_reference.projectId = pcoll.pipeline.options.view_as(
           GoogleCloudOptions).project
-    bigquery_write_fn = BigQueryWriteFn(
-        table_id=self.table_reference.tableId,
-        dataset_id=self.table_reference.datasetId,
-        project_id=self.table_reference.projectId,
-        batch_size=self.batch_size,
-        schema=self.get_dict_table_schema(self.schema),
-        create_disposition=self.create_disposition,
-        write_disposition=self.write_disposition,
-        kms_key=self.kms_key,
-        test_client=self.test_client)
-    return pcoll | 'WriteToBigQuery' >> ParDo(bigquery_write_fn)
+
+    if standard_options.streaming:
+      bigquery_write_fn = BigQueryWriteFn(
+          table_id=self.table_reference.tableId,
+          dataset_id=self.table_reference.datasetId,
+          project_id=self.table_reference.projectId,
+          batch_size=self.batch_size,
+          schema=self.get_dict_table_schema(self.schema),
+          create_disposition=self.create_disposition,
+          write_disposition=self.write_disposition,
+          kms_key=self.kms_key,
+          test_client=self.test_client)
+      return pcoll | 'WriteToBigQuery' >> ParDo(bigquery_write_fn)
+    else:
+      from apache_beam.io.gcp import bigquery_file_loads
+      return pcoll | bigquery_file_loads.BigQueryBatchFileLoads(
+          destination=self.table_reference,
+          schema=self.get_dict_table_schema(self.schema),
+          create_disposition=self.create_disposition,
+          write_disposition=self.write_disposition,
+          gs_location=self.gs_location,
+          test_client=self.test_client)
 
   def display_data(self):
     res = {}

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -1,0 +1,405 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Functionality to perform file loads into BigQuery for Batch and Streaming
+pipelines.
+"""
+
+from __future__ import absolute_import
+
+import datetime
+import logging
+import random
+import time
+import uuid
+
+from future.utils import iteritems
+
+import apache_beam as beam
+from apache_beam import pvalue
+from apache_beam.io import filesystems as fs
+from apache_beam.io.gcp import bigquery_tools
+from apache_beam.options import value_provider as vp
+
+ONE_TERABYTE = (1 << 40)
+
+# The maximum file size for imports is 5TB. We keep our files under that.
+_DEFAULT_MAX_FILE_SIZE = 4 * ONE_TERABYTE
+
+_DEFAULT_MAX_WRITERS_PER_BUNDLE = 20
+
+# The maximum size for a single load job is one terabyte
+_MAXIMUM_LOAD_SIZE = 15 * ONE_TERABYTE
+
+
+def _generate_load_job_name():
+  datetime_component = datetime.datetime.now().strftime("%Y_%m_%d_%H%M%S")
+  # TODO: include job id / pipeline component?
+  return 'beam_load_%s_%s' % (datetime_component, random.randint(0, 100))
+
+
+def _generate_file_prefix(pipeline_gcs_location):
+  # If a gcs location is provided to the pipeline, then we shall use that.
+  # Otherwise, we shall use the temp_location from pipeline options.
+  gcs_base = str(pipeline_gcs_location or
+                 vp.RuntimeValueProvider.get_value('temp_location', str, ''))
+  return fs.FileSystems.join(gcs_base, 'bq_load')
+
+
+def _make_new_file_writer(file_prefix, destination):
+  # TODO: Sanitize destination (or generate hash name for it?)
+
+  directory = fs.FileSystems.join(file_prefix, destination)
+
+  if not fs.FileSystems.exists(directory):
+    fs.FileSystems.mkdirs(directory)
+
+  file_name = str(uuid.uuid4())
+  file_path = fs.FileSystems.join(file_prefix, destination, file_name)
+
+  return file_path, fs.FileSystems.create(file_path, 'application/text')
+
+
+class _AppendDestinationsFn(beam.DoFn):
+  """Adds the destination to an element, making it a KV pair.
+
+  Outputs a PCollection of KV-pairs where the key is a TableReference for the
+  destination, and the value is the record itself.
+
+  Experimental; no backwards compatibility guarantees.
+  """
+
+  def __init__(self, table_reference):
+    self.table_reference = table_reference
+
+  def process(self, element):
+    yield (self.table_reference, element)
+
+
+class _ShardDestinations(beam.DoFn):
+  """Adds a shard number to the key of the KV element.
+
+  Experimental; no backwards compatibility guarantees."""
+  DEFAULT_SHARDING_FACTOR = 10
+
+  def __init__(self, sharding_factor=DEFAULT_SHARDING_FACTOR):
+    self.sharding_factor = sharding_factor
+
+  def start_bundle(self):
+    self._shard_count = random.randrange(self.sharding_factor)
+
+  def process(self, element):
+    destination = element[0]
+    row = element[1]
+
+    sharded_destination = (destination,
+                           self._shard_count % self.sharding_factor)
+    self._shard_count += 1
+    yield (sharded_destination, row)
+
+
+class WriteRecordsToFile(beam.DoFn):
+  """Write input records to files before triggering a load job.
+
+  It outputs two PCollections.
+  """
+
+  UNWRITTEN_RECORD_TAG = 'UnwrittenRecords'
+  WRITTEN_FILE_TAG = 'WrittenFiles'
+
+  def __init__(self,
+               max_files_per_bundle=_DEFAULT_MAX_WRITERS_PER_BUNDLE,
+               max_file_size=_DEFAULT_MAX_FILE_SIZE,
+               coder=None):
+    """Initialize a :class:`WriteRecordsToFile`.
+
+    Args:
+      max_files_per_bundle (int): The maximum number of files that can be kept
+        open during execution of this step in a worker. This is to avoid over-
+        whelming the worker memory.
+      max_file_size (int): The maximum size in bytes for a file to be used in
+        an export job.
+
+    """
+    self.max_files_per_bundle = max_files_per_bundle
+    self.max_file_size = max_file_size
+    self.coder = coder or bigquery_tools.RowAsDictJsonCoder()
+
+  def display_data(self):
+    return {
+        'max_files_per_bundle': self.max_files_per_bundle,
+        'max_file_size': str(self.max_file_size),
+        'coder': self.coder.__class__.__name__
+    }
+
+  def start_bundle(self):
+    self._destination_to_file_writer = {}
+
+  def process(self, element, file_prefix):
+    destination = element[0]
+    row = element[1]
+
+    if destination in self._destination_to_file_writer:
+      writer = self._destination_to_file_writer[destination]
+    elif len(self._destination_to_file_writer) < self.max_files_per_bundle:
+      (file_path, writer) = _make_new_file_writer(file_prefix, destination)
+      self._destination_to_file_writer[destination] = writer
+      yield pvalue.TaggedOutput(WriteRecordsToFile.WRITTEN_FILE_TAG,
+                                (destination, file_path))
+    else:
+      yield pvalue.TaggedOutput(
+          WriteRecordsToFile.UNWRITTEN_RECORD_TAG, element)
+      return
+
+    # TODO: Is it possible for this to throw exception
+    writer.write(self.coder.encode(row))
+    writer.write(b'\n')
+
+    if writer.tell() > self.max_file_size:
+      writer.close()
+      self._destination_to_file_writer.pop(destination)
+
+  def finish_bundle(self):
+    # TODO: Maybe output to WRITTEN_FILE_TAG here instead of at the begining?
+    #  it would permit to add file size.
+    for _, writer in iteritems(self._destination_to_file_writer):
+      writer.close()
+    self._destination_to_file_writer = {}
+
+
+class WriteGroupedRecordsToFile(beam.DoFn):
+  """Receives collection of dest-iterable(records), writes it to files.
+
+  Experimental; no backwards compatibility guarantees.
+  """
+
+  def __init__(self, max_file_size=_DEFAULT_MAX_FILE_SIZE,
+               coder=None):
+    self.max_file_size = max_file_size
+    self.coder = coder or bigquery_tools.RowAsDictJsonCoder()
+
+  def process(self, element, file_prefix):
+    destination = element[0]
+    rows = element[1]
+
+    writer = None
+
+    for row in rows:
+      if writer is None:
+        (file_path, writer) = _make_new_file_writer(file_prefix, destination)
+        yield (destination, file_path)
+
+      writer.write(self.coder.encode(row))
+      writer.write(b'\n')
+
+      if writer.tell() > self.max_file_size:
+        writer.close()
+        writer = None
+
+
+class TriggerLoadJobs(beam.DoFn):
+  """Triggers the import jobs to BQ.
+
+  Experimental; no backwards compatibility guarantees.
+  """
+  def __init__(self,
+               schema=None,
+               create_disposition=None,
+               write_disposition=None,
+               test_client=None):
+    self.schema = schema
+    self.create_disposition = create_disposition
+    self.write_disposition = write_disposition
+    self.test_client = test_client
+
+  def display_data(self):
+    result = {'create_disposition': self.create_disposition,
+              'write_disposition': self.write_disposition}
+    if self.schema is not None:
+      result['schema'] = self.schema
+    else:
+      result['schema'] = 'AUTODETECT'
+
+    return result
+
+  def start_bundle(self):
+    self.bq_wrapper = bigquery_tools.BigQueryWrapper(client=self.test_client)
+
+  def process(self, element, load_job):
+    destination = element[0]
+    files = element[1]
+    job_name = '%s_%s' % (load_job, str(uuid.uuid4()))
+
+    # TODO: MOVE TABLE REFERENCE PARSING UPSTREAM?
+    table_reference = bigquery_tools.parse_table_reference(destination)
+    if table_reference.projectId is None:
+      table_reference.projectId = vp.RuntimeValueProvider.get_value(
+          'project', str, '')
+    if self.schema:
+      parsed_schema = bigquery_tools.parse_table_schema_from_json(self.schema)
+    else:
+      parsed_schema = None
+    job_reference = self.bq_wrapper.perform_load_job(
+        table_reference, list(files), job_name,
+        schema=parsed_schema,
+        write_disposition=self.write_disposition,
+        create_disposition=self.create_disposition)
+    logging.info("Triggered job %s to load data to BigQuery table %s.",
+                 job_reference, table_reference)
+    yield (destination, job_reference)
+
+
+class WaitForBQJobs(beam.DoFn):
+  """Takes in a series of BQ job names as side input, and waits for all of them.
+
+  If any job fails, it will fail. If all jobs succeed, it will succeed.
+
+  Experimental; no backwards compatibility guarantees.
+  """
+  ALL_DONE = object()
+  FAILED = object()
+  WAITING = object()
+
+  def __init__(self, test_client):
+    self.test_client = test_client
+
+  def start_bundle(self):
+    self.bq_wrapper = bigquery_tools.BigQueryWrapper(client=self.test_client)
+
+  def process(self, element, dest_ids_list):
+    job_references = [elm[1] for elm in dest_ids_list]
+
+    while True:
+      status = self._check_job_states(job_references)
+      if status == WaitForBQJobs.FAILED:
+        raise Exception('BigQuery jobs failed. Pipeline ded.')
+      elif status == WaitForBQJobs.ALL_DONE:
+        return
+      time.sleep(10)
+
+  def _check_job_states(self, job_references):
+    for ref in job_references:
+      job = self.bq_wrapper.get_job(ref.projectId,
+                                    ref.jobId,
+                                    ref.location)
+
+      logging.info("Job status: %s", job.status)
+      if job.status.state == 'DONE' and job.status.errorResult:
+        logging.warn("Job %s seems to have failed. Error Result: %s",
+                     ref.jobId, job.status.errorResult)
+        return WaitForBQJobs.FAILED
+      elif job.status.state == 'DONE':
+        continue
+
+    return WaitForBQJobs.ALL_DONE
+
+
+class BigQueryBatchFileLoads(beam.PTransform):
+  """Takes in a set of elements, and inserts them to BigQuery via batch loads.
+
+  """
+
+  DESTINATION_JOBID_PAIRS = 'destination_jobid_pairs'
+  DESTINATION_FILE_PAIRS = 'destination_file_pairs'
+
+  def __init__(
+      self,
+      table_reference,
+      schema=None,
+      gs_location=None,
+      create_disposition=None,
+      write_disposition=None,
+      coder=None,
+      max_file_size=_DEFAULT_MAX_FILE_SIZE,
+      max_files_per_bundle=_DEFAULT_MAX_WRITERS_PER_BUNDLE,
+      test_client=None):
+    self.table_reference = table_reference
+    self.create_disposition = create_disposition
+    self.write_disposition = write_disposition
+    self.max_file_size = max_file_size
+    self.max_files_per_bundle = max_files_per_bundle
+    self._input_gs_location = gs_location
+    self.test_client = test_client
+    self.schema = schema
+    self.coder = coder or bigquery_tools.RowAsDictJsonCoder()
+
+  def expand(self, pcoll):
+    p = pcoll.pipeline
+
+    load_job_name_pcv = pvalue.AsSingleton(
+        p
+        | "ImpulseJobName" >> beam.Create([None])
+        | beam.Map(lambda _: _generate_load_job_name()))
+
+    file_prefix_pcv = pvalue.AsSingleton(
+        p
+        | "CreateFilePrefixView" >> beam.Create([self._input_gs_location])
+        | "GenerateFilePrefix" >> beam.Map(_generate_file_prefix))
+
+    outputs = (
+        pcoll
+        | "AppendDestination" >> beam.ParDo(_AppendDestinationsFn(
+            self.table_reference))
+        | beam.ParDo(
+            WriteRecordsToFile(max_files_per_bundle=self.max_files_per_bundle,
+                               max_file_size=self.max_file_size,
+                               coder=self.coder),
+            file_prefix=file_prefix_pcv).with_outputs(
+                WriteRecordsToFile.UNWRITTEN_RECORD_TAG,
+                WriteRecordsToFile.WRITTEN_FILE_TAG))
+
+    destination_files_kv_pc = outputs[WriteRecordsToFile.WRITTEN_FILE_TAG]
+
+    unwritten_records_pc = outputs[WriteRecordsToFile.UNWRITTEN_RECORD_TAG]
+
+    more_destination_files_kv_pc = (
+        unwritten_records_pc
+        | beam.ParDo(_ShardDestinations())
+        | "GroupShardedRows" >> beam.GroupByKey()
+        | "DropShardNumber" >> beam.Map(lambda x: (x[0][0], x[1]))
+        | "WriteGroupedRecordsToFile" >> beam.ParDo(WriteGroupedRecordsToFile(
+            coder=self.coder))
+    )
+
+    all_destination_file_pairs_pc = (
+        (destination_files_kv_pc, more_destination_files_kv_pc)
+        | "DestinationFilesUnion" >> beam.Flatten())
+
+    grouped_files_pc = (
+        all_destination_file_pairs_pc
+        | "GroupFilesByTableDestinations" >> beam.GroupByKey())
+
+    # TODO: What about the temporary tables?
+    destination_job_ids_pc = (
+        grouped_files_pc | beam.ParDo(TriggerLoadJobs(
+            schema=self.schema,
+            write_disposition=self.write_disposition,
+            create_disposition=self.create_disposition,
+            test_client=self.test_client,
+        ), load_job_name_pcv)
+    )
+
+    _ = (p
+         | "ImpulseMonitorJobs" >> beam.Create([None])
+         | beam.ParDo(WaitForBQJobs(self.test_client),
+                      beam.pvalue.AsList(destination_job_ids_pc)))
+
+    return {
+        self.DESTINATION_JOBID_PAIRS: destination_job_ids_pc,
+        self.DESTINATION_FILE_PAIRS: all_destination_file_pairs_pc,
+    }

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -34,11 +34,11 @@ from future.utils import iteritems
 
 import apache_beam as beam
 from apache_beam import pvalue
-from apache_beam.transforms.combiners import Count
 from apache_beam.io import filesystems as fs
 from apache_beam.io.gcp import bigquery_tools
 from apache_beam.io.gcp.internal.clients import bigquery as bigquery_api
 from apache_beam.options import value_provider as vp
+from apache_beam.transforms.combiners import Count
 
 ONE_TERABYTE = (1 << 40)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -100,7 +100,6 @@ class _AppendDestinationsFn(beam.DoFn):
       self.destination = lambda x: destination
 
   def process(self, element):
-    logging.info((self.destination(element), element))
     yield (self.destination(element), element)
 
 
@@ -261,7 +260,7 @@ class TriggerCopyJobs(beam.DoFn):
       copy_from_reference.projectId = vp.RuntimeValueProvider.get_value(
           'project', str, '')
 
-    logging.info("Must trigger copy job from %s to %s",
+    logging.info("Triggering copy job from %s to %s",
                  copy_from_reference, copy_to_reference)
     job_reference = self.bq_wrapper._insert_copy_job(
         copy_to_reference.projectId,

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -19,7 +19,7 @@
 Functionality to perform file loads into BigQuery for Batch and Streaming
 pipelines.
 
-NOTHING IN THIS FILE HAS BACKWARDS COMPATIBILITY GUARANTEES
+NOTHING IN THIS FILE HAS BACKWARDS COMPATIBILITY GUARANTEES.
 """
 
 from __future__ import absolute_import
@@ -52,7 +52,7 @@ _MAXIMUM_LOAD_SIZE = 15 * ONE_TERABYTE
 
 def _generate_load_job_name():
   datetime_component = datetime.datetime.now().strftime("%Y_%m_%d_%H%M%S")
-  # TODO: include job id / pipeline component?
+  # TODO(pabloem): include job id / pipeline component?
   return 'beam_load_%s_%s' % (datetime_component, random.randint(0, 100))
 
 
@@ -65,7 +65,6 @@ def _generate_file_prefix(pipeline_gcs_location):
 
 
 def _make_new_file_writer(file_prefix, destination):
-  # TODO: Sanitize destination (or generate hash name for it?)
   if isinstance(destination, bigquery_api.TableReference):
     destination = '%s:%s.%s' % (
         destination.projectId, destination.datasetId, destination.tableId)
@@ -79,6 +78,10 @@ def _make_new_file_writer(file_prefix, destination):
   file_path = fs.FileSystems.join(file_prefix, destination, file_name)
 
   return file_path, fs.FileSystems.create(file_path, 'application/text')
+
+
+def _bq_uuid():
+  return str(uuid.uuid4()).replace("-", "")
 
 
 class _AppendDestinationsFn(beam.DoFn):
@@ -176,7 +179,7 @@ class WriteRecordsToFile(beam.DoFn):
           WriteRecordsToFile.UNWRITTEN_RECORD_TAG, element)
       return
 
-    # TODO: Is it possible for this to throw exception
+    # TODO(pabloem): Is it possible for this to throw exception?
     writer.write(self.coder.encode(row))
     writer.write(b'\n')
 
@@ -185,8 +188,8 @@ class WriteRecordsToFile(beam.DoFn):
       self._destination_to_file_writer.pop(destination)
 
   def finish_bundle(self):
-    # TODO: Maybe output to WRITTEN_FILE_TAG here instead of at the begining?
-    #  it would permit to add file size.
+    # TODO(pabloem): Maybe output to WRITTEN_FILE_TAG here instead of the
+    #  begining? - it would permit to add file size.
     for _, writer in iteritems(self._destination_to_file_writer):
       writer.close()
     self._destination_to_file_writer = {}
@@ -222,6 +225,55 @@ class WriteGroupedRecordsToFile(beam.DoFn):
         writer = None
 
 
+class TriggerCopyJobs(beam.DoFn):
+  def __init__(self,
+               create_disposition=None,
+               write_disposition=None,
+               test_client=None,
+               temporary_tables=False):
+    self.create_disposition = create_disposition
+    self.write_disposition = write_disposition
+    self.test_client = test_client
+    self.temporary_tables = temporary_tables
+
+  def start_bundle(self):
+    self.bq_wrapper = bigquery_tools.BigQueryWrapper(client=self.test_client)
+
+  def process(self, element, load_job_name_prefix=None):
+    destination = element[0]
+    job_reference = element[1]
+
+    if not self.temporary_tables:
+      # If we did not use temporary tables, then we do not need to trigger any
+      # copy jobs.
+      return
+
+    copy_job_name = '%s_copy_%s' % (load_job_name_prefix, _bq_uuid())
+
+    copy_to_reference = bigquery_tools.parse_table_reference(destination)
+    if copy_to_reference.projectId is None:
+      copy_to_reference.projectId = vp.RuntimeValueProvider.get_value(
+          'project', str, '')
+
+    copy_from_reference = bigquery_tools.parse_table_reference(destination)
+    copy_from_reference.tableId = job_reference.jobId
+    if copy_from_reference.projectId is None:
+      copy_from_reference.projectId = vp.RuntimeValueProvider.get_value(
+          'project', str, '')
+
+    logging.info("Must trigger copy job from %s to %s",
+                 copy_from_reference, copy_to_reference)
+    job_reference = self.bq_wrapper._insert_copy_job(
+        copy_to_reference.projectId,
+        copy_job_name,
+        copy_from_reference,
+        copy_to_reference,
+        create_disposition=self.create_disposition,
+        write_disposition=self.write_disposition)
+
+    yield (destination, job_reference)
+
+
 class TriggerLoadJobs(beam.DoFn):
   """Triggers the import jobs to BQ.
 
@@ -231,15 +283,23 @@ class TriggerLoadJobs(beam.DoFn):
                schema=None,
                create_disposition=None,
                write_disposition=None,
-               test_client=None):
+               test_client=None,
+               temporary_tables=False):
     self.schema = schema
-    self.create_disposition = create_disposition
-    self.write_disposition = write_disposition
     self.test_client = test_client
+    self.temporary_tables = temporary_tables
+    if self.temporary_tables:
+      # If we are loading into temporary tables, we rely on the default create
+      # and write dispositions, which mean that a new table will be created.
+      self.create_disposition = None
+      self.write_disposition = None
+    else:
+      self.create_disposition = create_disposition
+      self.write_disposition = write_disposition
 
   def display_data(self):
-    result = {'create_disposition': self.create_disposition,
-              'write_disposition': self.write_disposition}
+    result = {'create_disposition': str(self.create_disposition),
+              'write_disposition': str(self.write_disposition)}
     if self.schema is not None:
       result['schema'] = str(self.schema)
     else:
@@ -250,16 +310,20 @@ class TriggerLoadJobs(beam.DoFn):
   def start_bundle(self):
     self.bq_wrapper = bigquery_tools.BigQueryWrapper(client=self.test_client)
 
-  def process(self, element, load_job):
+  def process(self, element, load_job_name_prefix):
     destination = element[0]
     files = element[1]
-    job_name = '%s_%s' % (load_job, str(uuid.uuid4()))
+    job_name = '%s_%s' % (load_job_name_prefix, _bq_uuid())
 
-    # TODO: MOVE TABLE REFERENCE PARSING UPSTREAM?
     table_reference = bigquery_tools.parse_table_reference(destination)
     if table_reference.projectId is None:
       table_reference.projectId = vp.RuntimeValueProvider.get_value(
           'project', str, '')
+
+    if self.temporary_tables:
+      # For temporary tables, we create a new table with the name with JobId.
+      table_reference.tableId = job_name
+      #TODO(pabloem): How to ensure that tables are removed?
 
     job_reference = self.bq_wrapper.perform_load_job(
         table_reference, list(files), job_name,
@@ -294,9 +358,10 @@ class WaitForBQJobs(beam.DoFn):
     while True:
       status = self._check_job_states(job_references)
       if status == WaitForBQJobs.FAILED:
-        raise Exception('BigQuery jobs failed. Pipeline ded.')
+        raise Exception(
+            'BigQuery jobs failed. BQ error: %s', self._latest_error)
       elif status == WaitForBQJobs.ALL_DONE:
-        return
+        return dest_ids_list  # Pass the list of destination-jobs downstream
       time.sleep(10)
 
   def _check_job_states(self, job_references):
@@ -309,6 +374,7 @@ class WaitForBQJobs(beam.DoFn):
       if job.status.state == 'DONE' and job.status.errorResult:
         logging.warn("Job %s seems to have failed. Error Result: %s",
                      ref.jobId, job.status.errorResult)
+        self._latest_error = job.status
         return WaitForBQJobs.FAILED
       elif job.status.state == 'DONE':
         continue
@@ -321,8 +387,9 @@ class BigQueryBatchFileLoads(beam.PTransform):
 
   """
 
-  DESTINATION_JOBID_PAIRS = 'destination_jobid_pairs'
+  DESTINATION_JOBID_PAIRS = 'destination_load_jobid_pairs'
   DESTINATION_FILE_PAIRS = 'destination_file_pairs'
+  DESTINATION_COPY_JOBID_PAIRS = 'destination_copy_jobid_pairs'
 
   def __init__(
       self,
@@ -344,6 +411,12 @@ class BigQueryBatchFileLoads(beam.PTransform):
     self.test_client = test_client
     self.schema = schema
     self.coder = coder or bigquery_tools.RowAsDictJsonCoder()
+
+    # If we have multiple destinations, then we will have multiple load jobs,
+    # thus we will need temporary tables for atomicity.
+    # If the destination is a single one, we assume that we will have only one
+    # job to run - and thus we avoid using temporary tables
+    self.temp_tables = True if callable(destination) else False
 
   def expand(self, pcoll):
     p = pcoll.pipeline
@@ -391,22 +464,41 @@ class BigQueryBatchFileLoads(beam.PTransform):
         all_destination_file_pairs_pc
         | "GroupFilesByTableDestinations" >> beam.GroupByKey())
 
-    # TODO: What about the temporary tables?
+    # Load Jobs are triggered to temporary tables, and those are later copied to
+    # the actual appropriate destination query. This ensures atomicity when only
+    # some of the load jobs would fail but not other.
+    # If any of them fails, then copy jobs are not triggered.
     destination_job_ids_pc = (
         grouped_files_pc | beam.ParDo(TriggerLoadJobs(
             schema=self.schema,
             write_disposition=self.write_disposition,
             create_disposition=self.create_disposition,
             test_client=self.test_client,
-        ), load_job_name_pcv)
+            temporary_tables=self.temp_tables), load_job_name_pcv)
     )
 
+    destination_copy_job_ids_pc = (
+        p
+        | "ImpulseMonitorLoadJobs" >> beam.Create([None])
+        | "WaitForLoadJobs" >> beam.ParDo(
+            WaitForBQJobs(self.test_client),
+            beam.pvalue.AsList(destination_job_ids_pc))
+        | beam.ParDo(TriggerCopyJobs(
+            create_disposition=self.create_disposition,
+            write_disposition=self.write_disposition,
+            temporary_tables=self.temp_tables,
+            test_client=self.test_client), load_job_name_pcv))
+
     _ = (p
-         | "ImpulseMonitorJobs" >> beam.Create([None])
-         | beam.ParDo(WaitForBQJobs(self.test_client),
-                      beam.pvalue.AsList(destination_job_ids_pc)))
+         | "ImpulseMonitorCopyJobs" >> beam.Create([None])
+         | "WaitForCopyJobs" >> beam.ParDo(
+             WaitForBQJobs(self.test_client),
+             beam.pvalue.AsList(destination_copy_job_ids_pc)))
+
+    # TODO: Must delete temporary tables.
 
     return {
         self.DESTINATION_JOBID_PAIRS: destination_job_ids_pc,
         self.DESTINATION_FILE_PAIRS: all_destination_file_pairs_pc,
+        self.DESTINATION_COPY_JOBID_PAIRS: destination_copy_job_ids_pc,
     }

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -335,42 +335,6 @@ class BigQueryFileLoadsIT(unittest.TestCase):
                  self.dataset_id, self.project)
 
   @attr('IT')
-  def test_records_traverse_transform_with_and_without_schema_it(self):
-
-    output_table_1 = '%s%s' % (self.output_table, 1)
-    output_table_2 = '%s%s' % (self.output_table, 2)
-    pipeline_verifiers = [
-        BigqueryFullResultMatcher(
-            project=self.project,
-            query="SELECT * FROM %s" % output_table_1,
-            data=[(d['name'], d['language'])
-                  for d in _NAME_LANGUAGE_ELEMENTS]),
-        BigqueryFullResultMatcher(
-            project=self.project,
-            query="SELECT * FROM %s" % output_table_2,
-            data=[(d['name'], d['language'])
-                  for d in _NAME_LANGUAGE_ELEMENTS])]
-
-    args = self.test_pipeline.get_full_options_as_args(
-        on_success_matcher=all_of(*pipeline_verifiers))
-
-    with beam.Pipeline(argv=args) as p:
-      input = p | beam.Create(_NAME_LANGUAGE_ELEMENTS)
-      _ = (input
-           | "LoadWithSchema" >> bigquery.WriteToBigQuery(
-               table=output_table_1,
-               schema=bigquery_tools.parse_table_schema_from_json(
-                   self.BIG_QUERY_SCHEMA),
-               create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
-               write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY))
-
-      _ = (input
-           | "LoadWithoutSchema" >> bigquery.WriteToBigQuery(
-               table=output_table_2,
-               create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
-               write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY))
-
-  @attr('IT')
   def test_multiple_destinations_transform(self):
     output_table_1 = '%s%s' % (self.output_table, 1)
     output_table_2 = '%s%s' % (self.output_table, 2)

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -1,0 +1,380 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for BigQuery file loads utilities."""
+
+from __future__ import absolute_import
+
+import json
+import logging
+import os
+import random
+import time
+import unittest
+
+import mock
+from hamcrest.core import assert_that as hamcrest_assert
+from hamcrest.core.core.allof import all_of
+from hamcrest.core.core.is_ import is_
+from nose.plugins.attrib import attr
+
+import apache_beam as beam
+from apache_beam.io.filebasedsink_test import _TestCaseWithTempDirCleanUp
+from apache_beam.io.gcp import bigquery_file_loads as bqfl
+from apache_beam.io.gcp import bigquery_tools
+from apache_beam.io.gcp.internal.clients import bigquery as bigquery_api
+from apache_beam.io.gcp.tests.bigquery_matcher import BigqueryFullResultMatcher
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+
+try:
+  from apitools.base.py.exceptions import HttpError
+except ImportError:
+  HttpError = None
+
+
+_DESTINATION_ELEMENT_PAIRS = [
+    # DESTINATION 1
+    ('project1:dataset1.table1', '{"name":"beam", "language":"py"}'),
+    ('project1:dataset1.table1', '{"name":"beam", "language":"java"}'),
+    ('project1:dataset1.table1', '{"name":"beam", "language":"go"}'),
+    ('project1:dataset1.table1', '{"name":"flink", "language":"java"}'),
+    ('project1:dataset1.table1', '{"name":"flink", "language":"scala"}'),
+
+    # DESTINATION 3
+    ('project1:dataset1.table3', '{"name":"spark", "language":"scala"}'),
+
+    # DESTINATION 1
+    ('project1:dataset1.table1', '{"name":"spark", "language":"py"}'),
+    ('project1:dataset1.table1', '{"name":"spark", "language":"scala"}'),
+
+    # DESTINATION 2
+    ('project1:dataset1.table2', '{"name":"beam", "foundation":"apache"}'),
+    ('project1:dataset1.table2', '{"name":"flink", "foundation":"apache"}'),
+    ('project1:dataset1.table2', '{"name":"spark", "foundation":"apache"}'),
+]
+
+_NAME_LANGUAGE_ELEMENTS = [
+    json.loads(elm[1])
+    for elm in _DESTINATION_ELEMENT_PAIRS if "language" in elm[1]
+]
+
+
+_DISTINCT_DESTINATIONS = list(
+    set([elm[0] for elm in _DESTINATION_ELEMENT_PAIRS]))
+
+
+_ELEMENTS = list([elm[1] for elm in _DESTINATION_ELEMENT_PAIRS])
+
+
+@unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')
+class TestWriteRecordsToFile(_TestCaseWithTempDirCleanUp):
+  maxDiff = None
+
+  def _consume_input(self, fn, checks=None):
+    if checks is None:
+      return
+
+    with TestPipeline() as p:
+      output_pcs = (
+          p
+          | beam.Create(_DESTINATION_ELEMENT_PAIRS)
+          | beam.ParDo(fn, self.tmpdir)
+          .with_outputs(fn.WRITTEN_FILE_TAG, fn.UNWRITTEN_RECORD_TAG))
+
+      checks(output_pcs)
+      return output_pcs
+
+  def test_files_created(self):
+    """Test that the files are created and written."""
+
+    fn = bqfl.WriteRecordsToFile()
+    self.tmpdir = self._new_tempdir()
+
+    def check_files_created(output_pcs):
+      dest_file_pc = output_pcs[bqfl.WriteRecordsToFile.WRITTEN_FILE_TAG]
+
+      files = dest_file_pc | "GetFiles" >> beam.Map(lambda x: x[1])
+      file_count = files | "CountFiles" >> beam.combiners.Count.Globally()
+
+      _ = files | "FilesExist" >> beam.Map(
+          lambda x: hamcrest_assert(os.path.exists(x), is_(True)))
+      assert_that(file_count, equal_to([3]), label='check file count')
+
+      destinations = dest_file_pc | "GetDests" >> beam.Map(lambda x: x[0])
+      assert_that(destinations, equal_to(list(_DISTINCT_DESTINATIONS)),
+                  label='check destinations ')
+
+    self._consume_input(fn, check_files_created)
+
+  def test_many_files(self):
+    """Forces records to be written to many files.
+
+    For each destination multiple files are necessary. This is because the max
+    file length is very small, so only a couple records fit in each file.
+    """
+
+    fn = bqfl.WriteRecordsToFile(max_file_size=50)
+    self.tmpdir = self._new_tempdir()
+
+    def check_many_files(output_pcs):
+      dest_file_pc = output_pcs[bqfl.WriteRecordsToFile.WRITTEN_FILE_TAG]
+
+      files_per_dest = (dest_file_pc
+                        | beam.Map(lambda x: x).with_output_types(
+                            beam.typehints.KV[str, str])
+                        | beam.combiners.Count.PerKey())
+      assert_that(files_per_dest,
+                  equal_to([('project1:dataset1.table1', 4),
+                            ('project1:dataset1.table2', 2),
+                            ('project1:dataset1.table3', 1)]))
+
+      # Check that the files exist
+      _ = dest_file_pc | beam.Map(lambda x: x[1]) | beam.Map(
+          lambda x: hamcrest_assert(os.path.exists(x), is_(True)))
+
+    self._consume_input(fn, check_many_files)
+
+  def test_records_are_spilled(self):
+    """Forces records to be written to many files.
+
+    For each destination multiple files are necessary, and at most two files can
+    be created. This forces records to be spilled to the next stage of
+    processing.
+    """
+
+    fn = bqfl.WriteRecordsToFile(max_files_per_bundle=2)
+    self.tmpdir = self._new_tempdir()
+
+    def check_many_files(output_pcs):
+      dest_file_pc = output_pcs[bqfl.WriteRecordsToFile.WRITTEN_FILE_TAG]
+      spilled_records_pc = output_pcs[
+          bqfl.WriteRecordsToFile.UNWRITTEN_RECORD_TAG]
+
+      spilled_records_count = (spilled_records_pc |
+                               beam.combiners.Count.Globally())
+      assert_that(spilled_records_count, equal_to([3]), label='spilled count')
+
+      files_per_dest = (dest_file_pc
+                        | beam.Map(lambda x: x).with_output_types(
+                            beam.typehints.KV[str, str])
+                        | beam.combiners.Count.PerKey())
+
+      # Only table1 and table3 get files. table2 records get spilled.
+      assert_that(files_per_dest,
+                  equal_to([('project1:dataset1.table1', 1),
+                            ('project1:dataset1.table3', 1)]),
+                  label='file count')
+
+      # Check that the files exist
+      _ = dest_file_pc | beam.Map(lambda x: x[1]) | beam.Map(
+          lambda x: hamcrest_assert(os.path.exists(x), is_(True)))
+
+    self._consume_input(fn, check_many_files)
+
+
+@unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')
+class TestWriteGroupedRecordsToFile(_TestCaseWithTempDirCleanUp):
+
+  def _consume_input(self, fn, input, checks):
+    if checks is None:
+      return
+
+    with TestPipeline() as p:
+      res = (p
+             | beam.Create(input)
+             | beam.GroupByKey()
+             | beam.ParDo(fn, self.tmpdir))
+
+      checks(res)
+      return res
+
+  def test_files_are_created(self):
+    """Test that the files are created and written."""
+
+    fn = bqfl.WriteGroupedRecordsToFile()
+    self.tmpdir = self._new_tempdir()
+
+    def check_files_created(output_pc):
+      files = output_pc | "GetFiles" >> beam.Map(lambda x: x[1])
+      file_count = files | "CountFiles" >> beam.combiners.Count.Globally()
+
+      _ = files | "FilesExist" >> beam.Map(
+          lambda x: hamcrest_assert(os.path.exists(x), is_(True)))
+      assert_that(file_count, equal_to([3]), label='check file count')
+
+      destinations = output_pc | "GetDests" >> beam.Map(lambda x: x[0])
+      assert_that(destinations, equal_to(list(_DISTINCT_DESTINATIONS)),
+                  label='check destinations ')
+
+    self._consume_input(
+        fn, _DESTINATION_ELEMENT_PAIRS, check_files_created)
+
+  def test_multiple_files(self):
+    """Forces records to be written to many files.
+
+    For each destination multiple files are necessary. This is because the max
+    file length is very small, so only a couple records fit in each file.
+    """
+    fn = bqfl.WriteGroupedRecordsToFile(max_file_size=50)
+    self.tmpdir = self._new_tempdir()
+
+    def check_multiple_files(output_pc):
+      files_per_dest = output_pc | beam.combiners.Count.PerKey()
+      assert_that(files_per_dest,
+                  equal_to([('project1:dataset1.table1', 4),
+                            ('project1:dataset1.table2', 2),
+                            ('project1:dataset1.table3', 1), ]))
+
+      # Check that the files exist
+      _ = output_pc | beam.Map(lambda x: x[1]) | beam.Map(os.path.exists)
+
+    self._consume_input(fn, _DESTINATION_ELEMENT_PAIRS, check_multiple_files)
+
+
+@unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')
+class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
+
+  def test_records_traverse_transform_with_mocks(self):
+    table_reference = 'project1:dataset1.table1'
+
+    job_reference = bigquery_api.JobReference()
+    job_reference.projectId = 'project1'
+    job_reference.jobId = 'job_name1'
+    result_job = bigquery_api.Job()
+    result_job.jobReference = job_reference
+
+    mock_job = mock.Mock()
+    mock_job.status.state = 'DONE'
+    mock_job.status.errorResult = None
+    mock_job.jobReference = job_reference
+
+    bq_client = mock.Mock()
+    bq_client.jobs.Get.return_value = mock_job
+
+    bq_client.jobs.Insert.return_value = result_job
+
+    transform = bqfl.BigQueryBatchFileLoads(
+        table_reference,
+        gs_location=self._new_tempdir(),
+        test_client=bq_client)
+
+    # Need to test this with the DirectRunner to avoid serializing mocks
+    with TestPipeline('DirectRunner') as p:
+      outputs = p | beam.Create(_ELEMENTS) | transform
+
+      dest_files = outputs[bqfl.BigQueryBatchFileLoads.DESTINATION_FILE_PAIRS]
+      dest_job = outputs[bqfl.BigQueryBatchFileLoads.DESTINATION_JOBID_PAIRS]
+
+      jobs = dest_job | "GetJobs" >> beam.Map(lambda x: x[1])
+
+      files = dest_files | "GetFiles" >> beam.Map(lambda x: x[1])
+      destinations = (dest_files
+                      | "GetUniques" >> beam.combiners.Count.PerKey()
+                      | "GetDests" >> beam.Map(lambda x: x[0]))
+
+      # All files exist
+      _ = (files | beam.Map(
+          lambda x: hamcrest_assert(os.path.exists(x), is_(True))))
+
+      # One file per destination
+      assert_that(files | beam.combiners.Count.Globally(),
+                  equal_to([1]),
+                  label='CountFiles')
+
+      assert_that(destinations,
+                  equal_to([table_reference]), label='CheckDestinations')
+
+      assert_that(jobs,
+                  equal_to([job_reference]), label='CheckJobs')
+
+
+@unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')
+class BigQueryFileLoadsIT(unittest.TestCase):
+
+  BIG_QUERY_DATASET_ID = 'python_bq_file_loads_'
+  BIG_QUERY_SCHEMA = (
+      '{"fields": [{"name": "name","type": "STRING"},'
+      '{"name": "language","type": "STRING"}]}'
+      )
+
+  def setUp(self):
+    self.test_pipeline = TestPipeline(is_integration_test=True)
+    self.runner_name = type(self.test_pipeline.runner).__name__
+    self.project = self.test_pipeline.get_option('project')
+
+    self.dataset_id = '%s%s%d' % (self.BIG_QUERY_DATASET_ID,
+                                  str(int(time.time())),
+                                  random.randint(0, 10000))
+    self.bigquery_client = bigquery_tools.BigQueryWrapper()
+    self.bigquery_client.get_or_create_dataset(self.project, self.dataset_id)
+    self.output_table = "%s.output_table" % (self.dataset_id)
+    logging.info("Created dataset %s in project %s",
+                 self.dataset_id, self.project)
+
+  @attr('IT')
+  def test_records_traverse_transform_with_and_without_schema_it(self):
+
+    output_table_1 = '%s%s' % (self.output_table, 1)
+    output_table_2 = '%s%s' % (self.output_table, 2)
+    pipeline_verifiers = [
+        BigqueryFullResultMatcher(
+            project=self.project,
+            query="SELECT * FROM %s" % output_table_1,
+            data=[(d['name'], d['language'])
+                  for d in _NAME_LANGUAGE_ELEMENTS]),
+        BigqueryFullResultMatcher(
+            project=self.project,
+            query="SELECT * FROM %s" % output_table_2,
+            data=[(d['name'], d['language'])
+                  for d in _NAME_LANGUAGE_ELEMENTS])]
+
+    args = self.test_pipeline.get_full_options_as_args(
+        on_success_matcher=all_of(*pipeline_verifiers))
+
+    with beam.Pipeline(argv=args) as p:
+      input = p | beam.Create(_NAME_LANGUAGE_ELEMENTS)
+      _ = (input
+           | "LoadWithSchema" >> bqfl.BigQueryBatchFileLoads(
+               table_reference=output_table_1,
+               schema=self.BIG_QUERY_SCHEMA,
+               create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
+               write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY))
+
+      _ = (input
+           | "LoadWithoutSchema" >> bqfl.BigQueryBatchFileLoads(
+               table_reference=output_table_2,
+               create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
+               write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY))
+
+  def tearDown(self):
+    request = bigquery_api.BigqueryDatasetsDeleteRequest(
+        projectId=self.project, datasetId=self.dataset_id,
+        deleteContents=True)
+    try:
+      logging.info("Deleting dataset %s in project %s",
+                   self.dataset_id, self.project)
+      self.bigquery_client.client.datasets.Delete(request)
+    except HttpError:
+      logging.debug('Failed to clean up dataset %s in project %s',
+                    self.dataset_id, self.project)
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -520,6 +520,9 @@ class BigQueryWrapper(object):
         raise
     self._delete_dataset(temp_table.projectId, temp_table.datasetId, True)
 
+  @retry.with_exponential_backoff(
+      num_retries=MAX_RETRIES,
+      retry_filter=retry.retry_on_server_errors_and_timeout_filter)
   def get_job(self, project, job_id, location=None):
     request = bigquery.BigqueryJobsGetRequest()
     request.jobId = job_id

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -136,6 +136,8 @@ def parse_table_reference(table, dataset=None, project=None):
 
   if isinstance(table, bigquery.TableReference):
     return table
+  elif callable(table):
+    return table
 
   table_reference = bigquery.TableReference()
   # If dataset argument is not specified, the expectation is that the

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -590,27 +590,6 @@ class DataflowRunner(PipelineRunner):
           PropertyNames.ENCODING: step.encoding,
           PropertyNames.OUTPUT_NAME: PropertyNames.OUT}])
 
-  def apply_WriteToBigQuery(self, transform, pcoll, options):
-    # Make sure this is the WriteToBigQuery class that we expected
-    if not isinstance(transform, beam.io.WriteToBigQuery):
-      return self.apply_PTransform(transform, pcoll, options)
-    standard_options = options.view_as(StandardOptions)
-    if standard_options.streaming:
-      if (transform.write_disposition ==
-          beam.io.BigQueryDisposition.WRITE_TRUNCATE):
-        raise RuntimeError('Can not use write truncation mode in streaming')
-      return self.apply_PTransform(transform, pcoll, options)
-    else:
-      return pcoll  | 'WriteToBigQuery' >> beam.io.Write(
-          beam.io.BigQuerySink(
-              transform.table_reference.tableId,
-              transform.table_reference.datasetId,
-              transform.table_reference.projectId,
-              transform.schema,
-              transform.create_disposition,
-              transform.write_disposition,
-              kms_key=transform.kms_key))
-
   def apply_GroupByKey(self, transform, pcoll, options):
     # Infer coder of parent.
     #

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -684,7 +684,11 @@ class PTransformWithSideInputs(PTransform):
     self._cached_fn = self.fn
 
     # Ensure fn and side inputs are picklable for remote execution.
-    self.fn = pickler.loads(pickler.dumps(self.fn))
+    try:
+      self.fn = pickler.loads(pickler.dumps(self.fn))
+    except RuntimeError:
+      raise RuntimeError('Unable to pickle fn %s' % self.fn)
+
     self.args = pickler.loads(pickler.dumps(self.args))
     self.kwargs = pickler.loads(pickler.dumps(self.kwargs))
 


### PR DESCRIPTION
This PR implements file loads into BQ from the Python SDK for Batch pipelines.

r: @chamikaramj 

### Open question
- Need to improve documentation significantly before merging.

### Features being implemented
- [x] Use of temporary tables for atomicity given a subset of load jobs failed
- [ ] Support for multiple destinations on streaming - **left for later PR.**
- [x] File Loads transform has not been wired up to `WriteToBigQuery`
- [ ] Support for time partitioning - **left for later PR.**
- [x] Support for multiple destinations
- [x] If a worker dies, and the same load job is triggered, it will fail because it willhave the same name as before.

### Test results
- [PreCommit without multiple destinations passing](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Commit/1129/)
- [PreCommit with multiple destinations passing](https://builds.apache.org/job/beam_PreCommit_Python_Commit/3946/console)
- [PreCommit with BQFileLoads as main Batch transform](https://builds.apache.org/job/beam_PreCommit_Python_Commit/3973/), [ValidatesRunner tests](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_PR/55/)
- [PreCommit with temporary tables created for multiple destination loads](https://builds.apache.org/job/beam_PreCommit_Python_Commit/3999/), [PostCommit tests](https://builds.apache.org/job/beam_PostCommit_Python_Verify_PR/329/)