### PR TITLE
[BEAM-4775] Metrics improvements: make wordcount.py work with attempted metrics

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/metrics/MetricKey.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/metrics/MetricKey.java
@@ -34,6 +34,11 @@ public abstract class MetricKey implements Serializable {
   /** The name of the metric. */
   public abstract MetricName metricName();
 
+  @Override
+  public String toString() {
+    return String.format("%s:%s", stepName(), metricName());
+  }
+
   public static MetricKey create(String stepName, MetricName metricName) {
     return new AutoValue_MetricKey(stepName, metricName);
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
@@ -213,6 +213,11 @@ public class MetricsContainerStepMap implements Serializable {
     }
 
     @Override
+    public String toString() {
+      return queryMetrics(null).toString();
+    }
+
+    @Override
     public MetricQueryResults queryMetrics(@Nullable MetricsFilter filter) {
       return new QueryResults(filter);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricName.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricName.java
@@ -50,6 +50,11 @@ public abstract class MetricName implements Serializable {
   /** The name of this metric. */
   public abstract String getName();
 
+  @Override
+  public String toString() {
+    return String.format("%s:%s", getNamespace(), getName());
+  }
+
   /**
    * The name of this metric.
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricQueryResults.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricQueryResults.java
@@ -29,13 +29,13 @@ import org.apache.beam.vendor.grpc.v1p13p1.com.google.common.collect.ImmutableLi
 @AutoValue
 @Experimental(Kind.METRICS)
 public abstract class MetricQueryResults {
-  /** Return the metric results for the getCounters that matched the filter. */
+  /** Return the metric results for the counters that matched the filter. */
   public abstract Iterable<MetricResult<Long>> getCounters();
 
-  /** Return the metric results for the getDistributions that matched the filter. */
+  /** Return the metric results for the distributions that matched the filter. */
   public abstract Iterable<MetricResult<DistributionResult>> getDistributions();
 
-  /** Return the metric results for the getGauges that matched the filter. */
+  /** Return the metric results for the gauges that matched the filter. */
   public abstract Iterable<MetricResult<GaugeResult>> getGauges();
 
   static <T> void printMetrics(String type, Iterable<MetricResult<T>> metrics, StringBuilder sb) {

--- a/sdks/python/apache_beam/examples/wordcount.py
+++ b/sdks/python/apache_beam/examples/wordcount.py
@@ -122,13 +122,13 @@ def run(argv=None):
     query_result = result.metrics().query(empty_lines_filter)
     if query_result['counters']:
       empty_lines_counter = query_result['counters'][0]
-      logging.info('number of empty lines: %d', empty_lines_counter.committed)
+      logging.info('number of empty lines: %d', empty_lines_counter.result)
 
     word_lengths_filter = MetricsFilter().with_name('word_len_dist')
     query_result = result.metrics().query(word_lengths_filter)
     if query_result['distributions']:
       word_lengths_dist = query_result['distributions'][0]
-      logging.info('average word length: %d', word_lengths_dist.committed.mean)
+      logging.info('average word length: %d', word_lengths_dist.result.mean)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/metrics/execution.py
+++ b/sdks/python/apache_beam/metrics/execution.py
@@ -122,6 +122,13 @@ class MetricResult(object):
     return 'MetricResult(key={}, committed={}, attempted={})'.format(
         self.key, str(self.committed), str(self.attempted))
 
+  @property
+  def result(self):
+    """Short-hand for falling back to attempted metrics if it seems that
+    committed was not populated (e.g. due to not being supported on a given
+    runner"""
+    return self.committed if self.committed else self.attempted
+
 
 class _MetricsEnvironment(object):
   """Holds the MetricsContainer for every thread and other metric information.


### PR DESCRIPTION
also add some `toString`s for Metrics-related classes that have been useful for debugging/logging, and fixes some comment typos that slipped in in #7621.

These were pulled out of #7641 to try to keep it simpler

R: @tweise, @mxm 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




