### PR TITLE
[BEAM-6305] Update Cassandra java driver to version 3.6.0

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -351,6 +351,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def kafka_version = "1.0.0"
     def quickcheck_version = "0.8"
     def google_cloud_core_version = "1.36.0"
+    def cassandra_driver_version = "3.6.0"
 
     // A map of maps containing common libraries used per language. To use:
     // dependencies {
@@ -377,6 +378,8 @@ class BeamModulePlugin implements Plugin<Project> {
         bigtable_client_core                        : "com.google.cloud.bigtable:bigtable-client-core:$bigtable_version",
         bigtable_protos                             : "com.google.api.grpc:grpc-google-cloud-bigtable-v2:$generated_grpc_beta_version",
         byte_buddy                                  : "net.bytebuddy:byte-buddy:1.9.3",
+        cassandra_driver_core                       : "com.datastax.cassandra:cassandra-driver-core:$cassandra_driver_version",
+        cassandra_driver_mapping                    : "com.datastax.cassandra:cassandra-driver-mapping:$cassandra_driver_version",
         commons_compress                            : "org.apache.commons:commons-compress:1.16.1",
         commons_csv                                 : "org.apache.commons:commons-csv:1.4",
         commons_io_1x                               : "commons-io:commons-io:1.3.2",

--- a/sdks/java/io/cassandra/build.gradle
+++ b/sdks/java/io/cassandra/build.gradle
@@ -29,14 +29,12 @@ enableJavaPerformanceTesting()
 description = "Apache Beam :: SDKs :: Java :: IO :: Cassandra"
 ext.summary = "IO to read and write with Apache Cassandra database"
 
-def cassandra_version = "3.5.0"
-
 dependencies {
   shadow library.java.vendored_guava_20_0
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.slf4j_api
-  shadow "com.datastax.cassandra:cassandra-driver-core:$cassandra_version"
-  shadow "com.datastax.cassandra:cassandra-driver-mapping:$cassandra_version"
+  shadow library.java.cassandra_driver_core
+  shadow library.java.cassandra_driver_mapping
   testCompile project(path: ":beam-runners-direct-java", configuration: "shadow")
   testCompile project(path: ":beam-sdks-java-io-common", configuration: "shadowTest")
   testCompile library.java.junit

--- a/sdks/java/io/hadoop-format/build.gradle
+++ b/sdks/java/io/hadoop-format/build.gradle
@@ -28,8 +28,6 @@ ext.summary = "IO to read data from sources and to write data to sinks that impl
 
 def log4j_version = "2.6.2"
 def elastic_search_version = "5.0.0"
-// Migrate to using a version of the driver compatible with Guava 20
-def cassandra_driver = "3.2.0"
 
 configurations.create("sparkRunner")
 configurations.sparkRunner {
@@ -76,9 +74,9 @@ dependencies {
     exclude group: "org.apache.spark", module: "spark-sql_2.10"
     exclude group: "org.apache.storm", module: "storm-core"
   }
-  testCompile "com.datastax.cassandra:cassandra-driver-mapping:$cassandra_driver"
+  testCompile library.java.cassandra_driver_core
+  testCompile library.java.cassandra_driver_mapping
   testCompile "org.apache.cassandra:cassandra-all:3.11.3"
-  testCompile "com.datastax.cassandra:cassandra-driver-core:$cassandra_driver"
   testCompile library.java.postgres
   testCompile "org.apache.logging.log4j:log4j-core:$log4j_version"
   testCompile library.java.slf4j_jdk14

--- a/sdks/java/io/hadoop-input-format/build.gradle
+++ b/sdks/java/io/hadoop-input-format/build.gradle
@@ -26,8 +26,6 @@ ext.summary = "IO to read data from sources that implement Hadoop Input Format."
 
 def log4j_version = "2.6.2"
 def elastic_search_version = "5.0.0"
-// Migrate to using a version of the driver compatible with Guava 20
-def cassandra_driver = "3.2.0"
 
 // Ban dependencies from the test runtime classpath
 configurations.testRuntimeClasspath {
@@ -66,9 +64,9 @@ dependencies {
     exclude group: "org.apache.spark", module: "spark-sql_2.10"
     exclude group: "org.apache.storm", module: "storm-core"
   }
-  testCompile "com.datastax.cassandra:cassandra-driver-mapping:$cassandra_driver"
+  testCompile library.java.cassandra_driver_core
+  testCompile library.java.cassandra_driver_mapping
   testCompile "org.apache.cassandra:cassandra-all:3.11.3"
-  testCompile "com.datastax.cassandra:cassandra-driver-core:$cassandra_driver"
   testCompile project(path: ":beam-sdks-java-io-jdbc", configuration: "shadow")
   testCompile library.java.postgres
   testCompile "org.apache.logging.log4j:log4j-core:$log4j_version"


### PR DESCRIPTION
This also unifies versions for all modules that use Cassandra driver, e.g. hadoop-input-format and hadoop-format
R: @aromanenko-dev 