### PR TITLE
[BEAM-6510] Use TestFlinkRunner for Nexmark tests 

### DIFF
--- a/.test-infra/jenkins/CommonTestProperties.groovy
+++ b/.test-infra/jenkins/CommonTestProperties.groovy
@@ -20,7 +20,7 @@ class CommonTestProperties {
     enum Runner {
         DATAFLOW("DataflowRunner", ":beam-runners-google-cloud-dataflow-java"),
         SPARK("SparkRunner", ":beam-runners-spark"),
-        FLINK("FlinkRunner", ":beam-runners-flink_2.11"),
+        FLINK("TestFlinkRunner", ":beam-runners-flink_2.11"),
         DIRECT("DirectRunner", ":beam-runners-direct-java")
 
         private final String option

--- a/.test-infra/jenkins/job_LoadTests_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Java.groovy
@@ -93,7 +93,6 @@ def smokeTestConfigurations = [
                 itClass      : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
                 runner       : CommonTestProperties.Runner.FLINK,
                 jobProperties: [
-                        flinkMaster      : '[local]',
                         publishToBigQuery: true,
                         bigQueryDataset  : 'load_test_SMOKE',
                         bigQueryTable    : 'flink_gbk',

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Flink.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Flink.groovy
@@ -42,13 +42,12 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
       switches('-Pnexmark.runner=":beam-runners-flink_2.11"' +
               ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
-              '--runner=FlinkRunner',
               '--streaming=false',
               '--suite=SMOKE',
               '--streamTimeout=60' ,
               '--manageResources=false',
-              '--monitorJobs=true',
-              '--flinkMaster=[local]"'].join(' '))
+              '--monitorJobs=true"'
+              ].join(' '))
     }
     shell('echo *** RUN NEXMARK IN STREAMING MODE USING FLINK RUNNER ***')
     gradle {
@@ -58,13 +57,12 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
       switches('-Pnexmark.runner=":beam-runners-flink_2.11"' +
               ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
-              '--runner=FlinkRunner',
               '--streaming=true',
               '--suite=SMOKE',
               '--streamTimeout=60' ,
               '--manageResources=false',
-              '--monitorJobs=true',
-              '--flinkMaster=[local]"'].join(' '))
+              '--monitorJobs=true"'
+              ].join(' '))
     }
     shell('echo *** RUN NEXMARK IN SQL BATCH MODE USING FLINK RUNNER ***')
     gradle {
@@ -74,14 +72,12 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
       switches('-Pnexmark.runner=":beam-runners-flink_2.11"' +
               ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
-              '--runner=FlinkRunner',
               '--queryLanguage=sql',
               '--streaming=false',
               '--suite=SMOKE',
               '--streamTimeout=60' ,
-              '--manageResources=false',
-              '--monitorJobs=true',
-              '--flinkMaster=[local]"'].join(' '))
+              '--manageResources=false"'
+              ].join(' '))
     }
     shell('echo *** RUN NEXMARK IN SQL STREAMING MODE USING FLINK RUNNER ***')
     gradle {
@@ -91,14 +87,13 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
       switches('-Pnexmark.runner=":beam-runners-flink_2.11"' +
               ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
-              '--runner=FlinkRunner',
               '--queryLanguage=sql',
               '--streaming=true',
               '--suite=SMOKE',
               '--streamTimeout=60' ,
               '--manageResources=false',
-              '--monitorJobs=true',
-              '--flinkMaster=[local]"'].join(' '))
+              '--monitorJobs=true"'
+              ].join(' '))
     }
   }
 }
@@ -113,7 +108,6 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Fl
   def final JOB_SPECIFIC_OPTIONS = [
           'suite'        : 'SMOKE',
           'streamTimeout': 60,
-          'flinkMaster'  : '[local]'
   ]
 
   Nexmark.standardJob(delegate, Runner.FLINK, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR)

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
@@ -63,7 +63,6 @@ public class FlinkRunner extends PipelineRunner<PipelineResult> {
    * @return The newly created runner.
    */
   public static FlinkRunner fromOptions(PipelineOptions options) {
-    options.setRunner(FlinkRunner.class);
     FlinkPipelineOptions flinkOptions =
         PipelineOptionsValidator.validate(FlinkPipelineOptions.class, options);
     ArrayList<String> missing = new ArrayList<>();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
@@ -23,7 +23,6 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.options.PipelineOptionsValidator;
 import org.apache.beam.sdk.util.UserCodeException;
 
 /** Test Flink runner. */
@@ -32,6 +31,7 @@ public class TestFlinkRunner extends PipelineRunner<PipelineResult> {
   private FlinkRunner delegate;
 
   private TestFlinkRunner(FlinkPipelineOptions options) {
+    options.setRunner(TestFlinkRunner.class);
     options.setShutdownSourcesOnFinalWatermark(true);
     if (options.getParallelism() == -1) {
       // Limit parallelism to avoid too much memory consumption during local execution
@@ -41,15 +41,12 @@ public class TestFlinkRunner extends PipelineRunner<PipelineResult> {
   }
 
   public static TestFlinkRunner fromOptions(PipelineOptions options) {
-    options.setRunner(TestFlinkRunner.class);
-    FlinkPipelineOptions flinkOptions =
-        PipelineOptionsValidator.validate(FlinkPipelineOptions.class, options);
+    FlinkPipelineOptions flinkOptions = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
     return new TestFlinkRunner(flinkOptions);
   }
 
   public static TestFlinkRunner create(boolean streaming) {
     FlinkPipelineOptions flinkOptions = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
-    flinkOptions.setRunner(TestFlinkRunner.class);
     flinkOptions.setStreaming(streaming);
     return TestFlinkRunner.fromOptions(flinkOptions);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -196,7 +196,7 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
 
     LOG.info(
         "Unbounded Flink Source {}/{} is reading from sources: {}",
-        subtaskIndex,
+        subtaskIndex + 1,
         numSubtasks,
         localSplitSources);
   }


### PR DESCRIPTION
In streaming mode, the FlinkRunner does not shutdown after executing a pipeline
because checkpointing does not work correctly otherwise. There was logic in the
past that did an auto-shutdown in case checkpointing was disabled. The logic has
been removed because it caused confusion for users.

The `TestFlinkRunner` still has the auto-shutdown logic in place.

CC @kennknowles 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




