### PR TITLE
[BEAM-4030] Add CombineFn.compact for Python.

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -250,7 +250,7 @@ class FnApiRunnerTest(unittest.TestCase):
                    'TODO: BEAM-5692')
   def test_pardo_state_only(self):
     index_state_spec = userstate.CombiningValueStateSpec(
-        'index', beam.coders.VarIntCoder(), sum)
+        'index', beam.coders.IterableCoder(beam.coders.VarIntCoder()), sum)
 
     # TODO(ccy): State isn't detected with Map/FlatMap.
     class AddIndex(beam.DoFn):

--- a/sdks/python/apache_beam/runners/worker/operations.pxd
+++ b/sdks/python/apache_beam/runners/worker/operations.pxd
@@ -98,7 +98,7 @@ cdef class CombineOperation(Operation):
 cdef class PGBKCVOperation(Operation):
   cdef public object combine_fn
   cdef public object combine_fn_add_input
-  cdef public object combine_fn_compact_accumulator
+  cdef public object combine_fn_compact
   cdef dict table
   cdef long max_keys
   cdef long key_count

--- a/sdks/python/apache_beam/runners/worker/operations.pxd
+++ b/sdks/python/apache_beam/runners/worker/operations.pxd
@@ -98,6 +98,7 @@ cdef class CombineOperation(Operation):
 cdef class PGBKCVOperation(Operation):
   cdef public object combine_fn
   cdef public object combine_fn_add_input
+  cdef public object combine_fn_compact_accumulator
   cdef dict table
   cdef long max_keys
   cdef long key_count

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -635,13 +635,13 @@ class PGBKCVOperation(Operation):
     fn, args, kwargs = pickler.loads(self.spec.combine_fn)[:3]
     self.combine_fn = curry_combine_fn(fn, args, kwargs)
     self.combine_fn_add_input = self.combine_fn.add_input
-    base_compact_accumulator = (
-        core.CombineFn.compact_accumulator if sys.version_info >= (3,)
-        else core.CombineFn.compact_accumulator.__func__)
-    if self.combine_fn.compact_accumulator.__func__ is base_compact_accumulator:
-      self.combine_fn_compact_accumulator = None
+    base_compact = (
+        core.CombineFn.compact if sys.version_info >= (3,)
+        else core.CombineFn.compact.__func__)
+    if self.combine_fn.compact.__func__ is base_compact:
+      self.combine_fn_compact = None
     else:
-      self.combine_fn_compact_accumulator = self.combine_fn.compact_accumulator
+      self.combine_fn_compact = self.combine_fn.compact
     # Optimization for the (known tiny accumulator, often wide keyspace)
     # combine functions.
     # TODO(b/36567833): Bound by in-memory size rather than key count.
@@ -692,10 +692,10 @@ class PGBKCVOperation(Operation):
 
   def output_key(self, wkey, accumulator):
     windows, key = wkey
-    if self.combine_fn_compact_accumulator is None:
+    if self.combine_fn_compact is None:
       value = accumulator
     else:
-      value = self.combine_fn_compact_accumulator(accumulator)
+      value = self.combine_fn_compact(accumulator)
     if windows is 0:
       self.output(_globally_windowed_value.with_value((key, value)))
     else:

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 
 import collections
 import logging
+import sys
 from builtins import filter
 from builtins import object
 from builtins import zip
@@ -634,6 +635,13 @@ class PGBKCVOperation(Operation):
     fn, args, kwargs = pickler.loads(self.spec.combine_fn)[:3]
     self.combine_fn = curry_combine_fn(fn, args, kwargs)
     self.combine_fn_add_input = self.combine_fn.add_input
+    base_compact_accumulator = (
+        core.CombineFn.compact_accumulator if sys.version_info >= (3,)
+        else core.CombineFn.compact_accumulator.__func__)
+    if self.combine_fn.compact_accumulator.__func__ is base_compact_accumulator:
+      self.combine_fn_compact_accumulator = None
+    else:
+      self.combine_fn_compact_accumulator = self.combine_fn.compact_accumulator
     # Optimization for the (known tiny accumulator, often wide keyspace)
     # combine functions.
     # TODO(b/36567833): Bound by in-memory size rather than key count.
@@ -682,8 +690,12 @@ class PGBKCVOperation(Operation):
     self.table = {}
     self.key_count = 0
 
-  def output_key(self, wkey, value):
+  def output_key(self, wkey, accumulator):
     windows, key = wkey
+    if self.combine_fn_compact_accumulator is None:
+      value = accumulator
+    else:
+      value = self.combine_fn_compact_accumulator(accumulator)
     if windows is 0:
       self.output(_globally_windowed_value.with_value((key, value)))
     else:

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -722,8 +722,8 @@ class _CurriedFn(core.CombineFn):
   def extract_output(self, accumulator):
     return self.fn.extract_output(accumulator, *self.args, **self.kwargs)
 
-  def compact_accumulator(self, accumulator):
-    return self.fn.compact_accumulator(accumulator, *self.args, **self.kwargs)
+  def compact(self, accumulator):
+    return self.fn.compact(accumulator, *self.args, **self.kwargs)
 
   def apply(self, elements):
     return self.fn.apply(elements, *self.args, **self.kwargs)

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -722,6 +722,9 @@ class _CurriedFn(core.CombineFn):
   def extract_output(self, accumulator):
     return self.fn.extract_output(accumulator, *self.args, **self.kwargs)
 
+  def compact_accumulator(self, accumulator):
+    return self.fn.compact_accumulator(accumulator, *self.args, **self.kwargs)
+
   def apply(self, elements):
     return self.fn.apply(elements, *self.args, **self.kwargs)
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -610,7 +610,7 @@ class CombineFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
     """
     raise NotImplementedError(str(self))
 
-  def compact_accumulator(self, accumulator, *args, **kwargs):
+  def compact(self, accumulator, *args, **kwargs):
     """Optionally returns a more compact represenation of the accumulator.
 
     This is called before an accumulator is sent across the wire, and can
@@ -753,7 +753,7 @@ class CallableWrapperCombineFn(CombineFn):
   def merge_accumulators(self, accumulators, *args, **kwargs):
     return [self._fn(_ReiterableChain(accumulators), *args, **kwargs)]
 
-  def compact_accumulator(self, accumulator, *args, **kwargs):
+  def compact(self, accumulator, *args, **kwargs):
     if len(accumulator) <= 1:
       return accumulator
     else:
@@ -831,7 +831,7 @@ class NoSideInputsCallableWrapperCombineFn(CallableWrapperCombineFn):
   def merge_accumulators(self, accumulators):
     return [self._fn(_ReiterableChain(accumulators))]
 
-  def compact_accumulator(self, accumulator):
+  def compact(self, accumulator):
     if len(accumulator) <= 1:
       return accumulator
     else:
@@ -1609,8 +1609,7 @@ class _CombinePerKeyWithHotKeyFanout(PTransform):
       create_accumulator = combine_fn.create_accumulator
       add_input = combine_fn.add_input
       merge_accumulators = combine_fn.merge_accumulators
-      # TODO(BEAM-4030): Remove the getattr indirection.
-      compact = getattr(combine_fn, 'compact', None)
+      compact = combine_fn.compact
 
     class PostCombineFn(CombineFn):
       @staticmethod
@@ -1622,8 +1621,7 @@ class _CombinePerKeyWithHotKeyFanout(PTransform):
           return combine_fn.add_input(accumulator, value)
       create_accumulator = combine_fn.create_accumulator
       merge_accumulators = combine_fn.merge_accumulators
-      # TODO(BEAM-4030): Remove the getattr indirection.
-      compact = getattr(combine_fn, 'compact', None)
+      compact = combine_fn.compact
       extract_output = combine_fn.extract_output
 
     def StripNonce(nonce_key_value):

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -624,7 +624,7 @@ class PTransformWithSideInputs(PTransform):
     if isinstance(fn, type) and issubclass(fn, WithTypeHints):
       # Don't treat Fn class objects as callables.
       raise ValueError('Use %s() not %s.' % (fn.__name__, fn.__name__))
-    self.fn = self.make_fn(fn)
+    self.fn = self.make_fn(fn, bool(args or kwargs))
     # Now that we figure out the label, initialize the super-class.
     super(PTransformWithSideInputs, self).__init__()
 
@@ -720,7 +720,7 @@ class PTransformWithSideInputs(PTransform):
     """
     raise NotImplementedError
 
-  def make_fn(self, fn):
+  def make_fn(self, fn, has_side_inputs):
     # TODO(silviuc): Add comment describing that this is meant to be overriden
     # by methods detecting callables and wrapping them in DoFns.
     return fn

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -119,7 +119,7 @@ class _CombiningValueStateTag(_StateTag):
       create_accumulator = self.combine_fn.create_accumulator
       add_input = self.combine_fn.add_input
       merge_accumulators = self.combine_fn.merge_accumulators
-      compact_accumulator = self.combine_fn.compact_accumulator
+      compact = self.combine_fn.compact
       extract_output = staticmethod(lambda x: x)
     return _CombiningValueStateTag(self.tag, NoExtractionCombineFn())
 

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -114,6 +114,15 @@ class _CombiningValueStateTag(_StateTag):
   def with_prefix(self, prefix):
     return _CombiningValueStateTag(prefix + self.tag, self.combine_fn)
 
+  def without_extraction(self):
+    class NoExtractionCombineFn(core.CombineFn):
+      create_accumulator = self.combine_fn.create_accumulator
+      add_input = self.combine_fn.add_input
+      merge_accumulators = self.combine_fn.merge_accumulators
+      compact_accumulator = self.combine_fn.compact_accumulator
+      extract_output = staticmethod(lambda x: x)
+    return _CombiningValueStateTag(self.tag, NoExtractionCombineFn())
+
 
 class _ListStateTag(_StateTag):
   """StateTag pointing to a list of elements."""
@@ -838,24 +847,21 @@ class MergeableStateAdapter(SimpleState):
     if isinstance(tag, _ValueStateTag):
       raise ValueError(
           'Merging requested for non-mergeable state tag: %r.' % tag)
+    elif isinstance(tag, _CombiningValueStateTag):
+      tag = tag.without_extraction()
     self.raw_state.add_state(self._get_id(window), tag, value)
 
   def get_state(self, window, tag):
+    if isinstance(tag, _CombiningValueStateTag):
+      original_tag, tag = tag, tag.without_extraction()
     values = [self.raw_state.get_state(window_id, tag)
               for window_id in self._get_ids(window)]
     if isinstance(tag, _ValueStateTag):
       raise ValueError(
           'Merging requested for non-mergeable state tag: %r.' % tag)
     elif isinstance(tag, _CombiningValueStateTag):
-      # TODO(robertwb): Strip combine_fn.extract_output from raw_state tag.
-      if not values:
-        accumulator = tag.combine_fn.create_accumulator()
-      elif len(values) == 1:
-        accumulator = values[0]
-      else:
-        accumulator = tag.combine_fn.merge_accumulators(values)
-        # TODO(robertwb): Store the merged value in the first tag.
-      return tag.combine_fn.extract_output(accumulator)
+      return original_tag.combine_fn.extract_output(
+          original_tag.combine_fn.merge_accumulators(values))
     elif isinstance(tag, _ListStateTag):
       return [v for vs in values for v in vs]
     elif isinstance(tag, _WatermarkHoldStateTag):
@@ -1211,6 +1217,7 @@ class InMemoryUnmergedState(UnmergedState):
     if isinstance(tag, _ValueStateTag):
       self.state[window][tag.tag] = value
     elif isinstance(tag, _CombiningValueStateTag):
+      # TODO(robertwb): Store merged accumulators.
       self.state[window][tag.tag].append(value)
     elif isinstance(tag, _ListStateTag):
       self.state[window][tag.tag].append(value)


### PR DESCRIPTION
Also updates CallabelCombineFn to take advantage of this compaction, and introduces a side-input free variant. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

