### PR TITLE
[BEAM-4520] Warn when UnboundedSources are used without checkpointing

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -26,6 +26,8 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The class that instantiates and manages the execution of a given job. Depending on if the job is
@@ -36,6 +38,9 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
  * (translated) job.
  */
 class FlinkPipelineExecutionEnvironment {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(FlinkPipelineExecutionEnvironment.class);
 
   private final FlinkPipelineOptions options;
 
@@ -76,6 +81,8 @@ class FlinkPipelineExecutionEnvironment {
     this.flinkBatchEnv = null;
     this.flinkStreamEnv = null;
 
+    pipeline.replaceAll(FlinkTransformOverrides.getDefaultOverrides(options));
+
     PipelineTranslationModeOptimizer optimizer = new PipelineTranslationModeOptimizer(options);
     optimizer.translate(pipeline);
 
@@ -84,6 +91,11 @@ class FlinkPipelineExecutionEnvironment {
       this.flinkStreamEnv =
           FlinkExecutionEnvironments.createStreamExecutionEnvironment(
               options, options.getFilesToStage());
+      if (optimizer.hasUnboundedSources()
+          && !flinkStreamEnv.getCheckpointConfig().isCheckpointingEnabled()) {
+        LOG.warn(
+            "UnboundedSources present which rely on checkpointing, but checkpointing is disabled.");
+      }
       translator = new FlinkStreamingPipelineTranslator(flinkStreamEnv, options);
     } else {
       this.flinkBatchEnv =
@@ -92,7 +104,6 @@ class FlinkPipelineExecutionEnvironment {
       translator = new FlinkBatchPipelineTranslator(flinkBatchEnv, options);
     }
 
-    pipeline.replaceAll(FlinkTransformOverrides.getDefaultOverrides(options));
     prepareFilesToStageForRemoteClusterExecution(options);
 
     translator.translate(pipeline);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironmentTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironmentTest.java
@@ -19,13 +19,18 @@ package org.apache.beam.runners.flink;
 
 import static java.util.Arrays.asList;
 import static org.apache.beam.sdk.testing.RegexMatcher.matches;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Every.everyItem;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
+import com.google.common.base.Charsets;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
@@ -133,6 +138,43 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
       assertThat(
           overridesList.size(), is(FlinkTransformOverrides.getDefaultOverrides(options).size()));
     }
+  }
+
+  @Test
+  public void shouldLogWarningWhenCheckpointingIsDisabled() {
+    Pipeline pipeline = Pipeline.create();
+    pipeline.getOptions().setRunner(TestFlinkRunner.class);
+
+    pipeline
+        // Add an UnboundedSource to check for the warning if checkpointing is disabled
+        .apply(GenerateSequence.from(0))
+        .apply(
+            ParDo.of(
+                new DoFn<Long, Void>() {
+                  @ProcessElement
+                  public void processElement(ProcessContext ctx) {
+                    throw new RuntimeException("Failing here is ok.");
+                  }
+                }));
+
+    final PrintStream oldErr = System.err;
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    PrintStream replacementStdErr = new PrintStream(byteArrayOutputStream);
+    try {
+      System.setErr(replacementStdErr);
+      // Run pipeline and fail during execution
+      pipeline.run();
+      fail("Should have failed");
+    } catch (Exception e) {
+      // We want to fail here
+    } finally {
+      System.setErr(oldErr);
+    }
+    replacementStdErr.flush();
+    assertThat(
+        new String(byteArrayOutputStream.toByteArray(), Charsets.UTF_8),
+        containsString(
+            "UnboundedSources present which rely on checkpointing, but checkpointing is disabled."));
   }
 
   private FlinkPipelineOptions testPreparingResourcesToStage(String flinkMaster)

--- a/website/src/documentation/runners/flink.md
+++ b/website/src/documentation/runners/flink.md
@@ -177,6 +177,9 @@ You can monitor a running Flink job using the Flink JobManager Dashboard or its 
 
 If your pipeline uses an unbounded data source or sink, the Flink Runner will automatically switch to streaming mode. You can enforce streaming mode by using the `streaming` setting mentioned below.
 
+Note: The Runner will print a warning message when unbounded sources are used and checkpointing is not enabled.
+Many sources like `PubSubIO` rely on their checkpoints to be acknowledged which can only be done when checkpointing is enabled for the `FlinkRunner`. To enable checkpointing, please set <span class="language-java">`checkpointingInterval`</span><span class="language-py">`checkpointing_interval`</span> to the desired checkpointing interval in milliseconds.
+
 ## Pipeline options for the Flink Runner
 
 When executing your pipeline with the Flink Runner, you can set these pipeline options.


### PR DESCRIPTION
This prints a warning when checkpointing is disabled and pipelines are run with
the FlinkRunner which contain UnboundedSources. Most UnboundedSources rely on
checkpoint acknowledgement, e.g. PubSubIO.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

