### PR TITLE
[BEAM-6545] Cherrypick #7667 to release-2.10.0: Remove useless allowance of null constructor in ByteArrayShufflePosition

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/GroupingShuffleReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/GroupingShuffleReader.java
@@ -235,8 +235,12 @@ public class GroupingShuffleReader<K, V> extends NativeReader<WindowedValue<KV<K
         this.groups =
             new GroupingShuffleEntryIterator(
                 entryReader,
-                ByteArrayShufflePosition.fromBase64(parentReader.startShufflePosition),
-                ByteArrayShufflePosition.fromBase64(parentReader.stopShufflePosition)) {
+                parentReader.startShufflePosition == null
+                    ? null
+                    : ByteArrayShufflePosition.fromBase64(parentReader.startShufflePosition),
+                parentReader.stopShufflePosition == null
+                    ? null
+                    : ByteArrayShufflePosition.fromBase64(parentReader.stopShufflePosition)) {
               @Override
               protected void notifyElementRead(long byteSize) {
                 // We accumulate the sum of bytes read in a local variable. This sum will be counted

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PartitioningShuffleReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PartitioningShuffleReader.java
@@ -119,8 +119,12 @@ public class PartitioningShuffleReader<K, V> extends NativeReader<WindowedValue<
         PartitioningShuffleReader<K, V> shuffleReader, ShuffleEntryReader entryReader) {
       this.iterator =
           entryReader.read(
-              ByteArrayShufflePosition.fromBase64(shuffleReader.startShufflePosition),
-              ByteArrayShufflePosition.fromBase64(shuffleReader.stopShufflePosition));
+              shuffleReader.startShufflePosition == null
+                  ? null
+                  : ByteArrayShufflePosition.fromBase64(shuffleReader.startShufflePosition),
+              shuffleReader.stopShufflePosition == null
+                  ? null
+                  : ByteArrayShufflePosition.fromBase64(shuffleReader.stopShufflePosition));
       this.shuffleReader = shuffleReader;
       this.entryReader = entryReader;
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/UngroupedShuffleReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/UngroupedShuffleReader.java
@@ -88,8 +88,12 @@ public class UngroupedShuffleReader<T> extends NativeReader<T> {
         UngroupedShuffleReader<T> shuffleReader, ShuffleEntryReader entryReader) {
       this.iterator =
           entryReader.read(
-              ByteArrayShufflePosition.fromBase64(shuffleReader.startShufflePosition),
-              ByteArrayShufflePosition.fromBase64(shuffleReader.stopShufflePosition));
+              shuffleReader.startShufflePosition == null
+                  ? null
+                  : ByteArrayShufflePosition.fromBase64(shuffleReader.startShufflePosition),
+              shuffleReader.stopShufflePosition == null
+                  ? null
+                  : ByteArrayShufflePosition.fromBase64(shuffleReader.stopShufflePosition));
       this.shuffleReader = shuffleReader;
       this.entryReader = entryReader;
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ByteArrayShufflePosition.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ByteArrayShufflePosition.java
@@ -38,11 +38,11 @@ public class ByteArrayShufflePosition implements Comparable<ShufflePosition>, Sh
     this.position = position;
   }
 
-  public static ByteArrayShufflePosition fromBase64(@Nullable String position) {
+  public static ByteArrayShufflePosition fromBase64(String position) {
     return ByteArrayShufflePosition.of(decodeBase64(position));
   }
 
-  public static ByteArrayShufflePosition of(@Nullable byte[] position) {
+  public static ByteArrayShufflePosition of(byte[] position) {
     if (position == null) {
       return null;
     }


### PR DESCRIPTION
This is a release blocker to cherrypick

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

