### PR TITLE
[BEAM-6488] Portable Flink runner support for running cross-language …

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
@@ -177,17 +177,6 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
 
   @Override
   public void close() throws Exception {
-    // Tear down common servers.
-    for (WrappedSdkHarnessClient client : environmentCache.asMap().values()) {
-      ServerInfo serverInfo = client.getServerInfo();
-      try (AutoCloseable stateServer = serverInfo.getStateServer();
-          AutoCloseable dateServer = serverInfo.getDataServer();
-          AutoCloseable controlServer = serverInfo.getControlServer();
-          AutoCloseable loggingServer = serverInfo.getLoggingServer();
-          AutoCloseable retrievalServer = serverInfo.getRetrievalServer();
-          AutoCloseable provisioningServer = serverInfo.getProvisioningServer()) {}
-    }
-
     // Clear the cache. This closes all active environments.
     // note this may cause open calls to be cancelled by the peer
     environmentCache.invalidateAll();
@@ -307,6 +296,12 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
       try (AutoCloseable envCloser = environment) {
         // Wrap resources in try-with-resources to ensure all are cleaned up.
       }
+      try (AutoCloseable stateServer = serverInfo.getStateServer();
+          AutoCloseable dateServer = serverInfo.getDataServer();
+          AutoCloseable controlServer = serverInfo.getControlServer();
+          AutoCloseable loggingServer = serverInfo.getLoggingServer();
+          AutoCloseable retrievalServer = serverInfo.getRetrievalServer();
+          AutoCloseable provisioningServer = serverInfo.getProvisioningServer()) {}
       // TODO: Wait for executor shutdown?
     }
   }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
@@ -53,7 +53,6 @@ import org.apache.beam.sdk.fn.IdGenerators;
 import org.apache.beam.vendor.grpc.v1p13p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p13p1.com.google.protobuf.Struct;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -82,6 +81,15 @@ public class DefaultJobBundleFactoryTest {
   private final IdGenerator stageIdGenerator = IdGenerators.incrementingLongs();
   private final InstructionResponse instructionResponse =
       InstructionResponse.newBuilder().setInstructionId("instruction-id").build();
+  private final EnvironmentFactory.Provider envFactoryProvider =
+      (GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
+          GrpcFnServer<GrpcLoggingService> loggingServiceServer,
+          GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
+          GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
+          ControlClientPool clientPool,
+          IdGenerator idGenerator) -> envFactory;
+  private final Map<String, EnvironmentFactory.Provider> envFactoryProviderMap =
+      ImmutableMap.of(environment.getUrn(), envFactoryProvider);
 
   @Before
   public void setUpMocks() throws Exception {
@@ -100,7 +108,7 @@ public class DefaultJobBundleFactoryTest {
   public void createsCorrectEnvironment() throws Exception {
     try (DefaultJobBundleFactory bundleFactory =
         new DefaultJobBundleFactory(
-            envFactory,
+            envFactoryProviderMap,
             stageIdGenerator,
             controlServer,
             loggingServer,
@@ -174,7 +182,7 @@ public class DefaultJobBundleFactoryTest {
   }
 
   @Test
-  public void failedCreatingMultipleEnvironmentFromMultipleTypes() throws Exception {
+  public void creatingMultipleEnvironmentFromMultipleTypes() throws Exception {
     ServerFactory serverFactory = ServerFactory.createDefault();
 
     Environment environmentA = Environment.newBuilder().setUrn("env:urn:a").build();
@@ -206,16 +214,17 @@ public class DefaultJobBundleFactoryTest {
             JobInfo.create("testJob", "testJob", "token", Struct.getDefaultInstance()),
             environmentFactoryProviderMap)) {
       bundleFactory.forStage(getExecutableStage(environmentB));
-      thrown.expectCause(Matchers.any(IllegalArgumentException.class));
       bundleFactory.forStage(getExecutableStage(environmentA));
     }
+    verify(envFactoryA).createEnvironment(environmentA);
+    verify(envFactoryB).createEnvironment(environmentB);
   }
 
   @Test
   public void closesEnvironmentOnCleanup() throws Exception {
     DefaultJobBundleFactory bundleFactory =
         new DefaultJobBundleFactory(
-            envFactory,
+            envFactoryProviderMap,
             stageIdGenerator,
             controlServer,
             loggingServer,
@@ -233,7 +242,7 @@ public class DefaultJobBundleFactoryTest {
   public void cachesEnvironment() throws Exception {
     try (DefaultJobBundleFactory bundleFactory =
         new DefaultJobBundleFactory(
-            envFactory,
+            envFactoryProviderMap,
             stageIdGenerator,
             controlServer,
             loggingServer,
@@ -258,6 +267,9 @@ public class DefaultJobBundleFactoryTest {
     Environment envFoo = Environment.newBuilder().setUrn("dummy:urn:another").build();
     RemoteEnvironment remoteEnvFoo = mock(RemoteEnvironment.class);
     InstructionRequestHandler fooInstructionHandler = mock(InstructionRequestHandler.class);
+    Map<String, EnvironmentFactory.Provider> envFactoryProviderMapFoo =
+        ImmutableMap.of(
+            environment.getUrn(), envFactoryProvider, envFoo.getUrn(), envFactoryProvider);
     when(envFactory.createEnvironment(envFoo)).thenReturn(remoteEnvFoo);
     when(remoteEnvFoo.getInstructionRequestHandler()).thenReturn(fooInstructionHandler);
     // Don't bother creating a distinct instruction response because we don't use it here.
@@ -266,7 +278,7 @@ public class DefaultJobBundleFactoryTest {
 
     try (DefaultJobBundleFactory bundleFactory =
         new DefaultJobBundleFactory(
-            envFactory,
+            envFactoryProviderMapFoo,
             stageIdGenerator,
             controlServer,
             loggingServer,

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
@@ -164,7 +164,7 @@ public class DefaultJobBundleFactoryTest {
       verify(envFactoryA, Mockito.times(0)).createEnvironment(environmentAA);
 
       bundleFactory.forStage(getExecutableStage(environmentAA));
-      verify(environmentProviderFactoryA, Mockito.times(1))
+      verify(environmentProviderFactoryA, Mockito.times(2))
           .createEnvironmentFactory(any(), any(), any(), any(), any(), any());
       verify(environmentProviderFactoryB, Mockito.times(0))
           .createEnvironmentFactory(any(), any(), any(), any(), any(), any());


### PR DESCRIPTION
Multi-language support in `DefaultJobBundleFactory`.

Current status:
- `DefaultJobBundleFactory` reuses a set of grpc servers if a new environment shares the same URN.
- `DefaultJobBundleFactory` initializes a set of grpc servers as instance variables and creates `WrappedSdkHarnessClient` from them.

Proposed changes:
- Remove the usage of instance variables and refactor them to an immutable data structure `AutoValue_ServerInfo` to enable thread-safe initialization of `WrappedSdkHarnessClient`.
- Allow multiple sets of grpc servers for each payload of the same URN so that we can use multiple docker images of different URL per language.
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

