### PR TITLE
[BEAM-3742] Checkpointing for SDF over FnAPI in Python SDK and FnApiRunner.

### DIFF
--- a/sdks/python/apache_beam/io/restriction_trackers.py
+++ b/sdks/python/apache_beam/io/restriction_trackers.py
@@ -78,10 +78,11 @@ class OffsetRestrictionTracker(RestrictionTracker):
 
   def __init__(self, start_position, stop_position):
     self._range = OffsetRange(start_position, stop_position)
-    self._current_position = None
+    self._current_position = None  # start_position - 1?
     self._last_claim_attempt = None
+    self._deferred_residual = None
     self._checkpointed = False
-    self._lock = threading.Lock()
+    self._lock = threading.RLock()
 
   def check_done(self):
     with self._lock:
@@ -126,6 +127,7 @@ class OffsetRestrictionTracker(RestrictionTracker):
 
       return False
 
+  # TODO(SDF): Re-use try_split(0).
   def checkpoint(self):
     with self._lock:
       # If self._current_position is 'None' no records have been claimed so
@@ -139,3 +141,12 @@ class OffsetRestrictionTracker(RestrictionTracker):
 
       self._range = OffsetRange(self._range.start, end_position)
       return residual_range
+
+  def defer_remainder(self, watermark=None):
+    with self._lock:
+      self._deferred_watermark = watermark
+      self._deferred_residual = self.checkpoint()
+
+  def deferred_status(self):
+    if self._deferred_residual:
+      return (self._deferred_residual, self._deferred_watermark)

--- a/sdks/python/apache_beam/portability/common_urns.py
+++ b/sdks/python/apache_beam/portability/common_urns.py
@@ -49,6 +49,8 @@ composites = PropertiesFromEnumType(
     beam_runner_api_pb2.StandardPTransforms.Composites)
 combine_components = PropertiesFromEnumType(
     beam_runner_api_pb2.StandardPTransforms.CombineComponents)
+sdf_components = PropertiesFromEnumType(
+    beam_runner_api_pb2.StandardPTransforms.SplittableParDoComponents)
 
 side_inputs = PropertiesFromEnumType(
     beam_runner_api_pb2.StandardSideInputTypes.Enum)

--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -82,6 +82,9 @@ cdef class PerWindowInvoker(DoFnInvoker):
   cdef bint has_windowed_inputs
   cdef bint cache_globally_windowed_args
   cdef object process_method
+  cdef bint is_splittable
+  cdef object restriction_tracker
+  cdef WindowedValue current_windowed_value
 
 
 cdef class DoFnRunner(Receiver):

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -211,7 +211,7 @@ class DoFnSignature(object):
     self.start_bundle_method = MethodWrapper(do_fn, 'start_bundle')
     self.finish_bundle_method = MethodWrapper(do_fn, 'finish_bundle')
 
-    restriction_provider = self._get_restriction_provider(do_fn)
+    restriction_provider = self.get_restriction_provider()
     self.initial_restriction_method = (
         MethodWrapper(restriction_provider, 'initial_restriction')
         if restriction_provider else None)
@@ -237,7 +237,7 @@ class DoFnSignature(object):
         method = timer_spec._attached_callback
         self.timer_methods[timer_spec] = MethodWrapper(do_fn, method.__name__)
 
-  def _get_restriction_provider(self, do_fn):
+  def get_restriction_provider(self):
     result = _find_param_with_default(self.process_method,
                                       default_as_type=RestrictionProvider)
     return result[1] if result else None
@@ -434,6 +434,9 @@ class PerWindowInvoker(DoFnInvoker):
         (core.DoFn.WindowParam in default_arg_values) or
         signature.is_stateful_dofn())
     self.user_state_context = user_state_context
+    self.is_splittable = signature.is_splittable_dofn()
+    self.restriction_tracker = None
+    self.current_windowed_value = None
 
     # Try to prepare all the arguments that can just be filled in
     # without any additional work. in the process function.
@@ -515,7 +518,16 @@ class PerWindowInvoker(DoFnInvoker):
     # or if the process accesses the window parameter. We can just call it once
     # otherwise as none of the arguments are changing
 
+    if self.is_splittable and not restriction_tracker:
+      restriction = self.invoke_initial_restriction(windowed_value.value)
+      restriction_tracker = self.invoke_create_tracker(restriction)
+
     if restriction_tracker:
+      if len(windowed_value.windows) > 1 and self.has_windowed_inputs:
+        # Should never get here due to window explosion in
+        # the upstream pair-with-restriction.
+        raise NotImplementedError(
+            'SDFs in multiply-windowed values with windowed arguments.')
       restriction_tracker_param = _find_param_with_default(
           self.signature.process_method,
           default_as_type=core.RestrictionProvider)[0]
@@ -524,7 +536,17 @@ class PerWindowInvoker(DoFnInvoker):
             'A RestrictionTracker %r was provided but DoFn does not have a '
             'RestrictionTrackerParam defined' % restriction_tracker)
       additional_kwargs[restriction_tracker_param] = restriction_tracker
-    if self.has_windowed_inputs and len(windowed_value.windows) != 1:
+      try:
+        self.current_windowed_value = windowed_value
+        self.restriction_tracker = restriction_tracker
+        return self._invoke_per_window(
+            windowed_value, additional_args, additional_kwargs,
+            output_processor)
+      finally:
+        self.restriction_tracker = None
+        self.current_windowed_value = windowed_value
+
+    elif self.has_windowed_inputs and len(windowed_value.windows) != 1:
       for w in windowed_value.windows:
         self._invoke_per_window(
             WindowedValue(windowed_value.value, windowed_value.timestamp, (w,)),
@@ -601,6 +623,15 @@ class PerWindowInvoker(DoFnInvoker):
     else:
       output_processor.process_outputs(
           windowed_value, self.process_method(*args_for_process))
+
+    if self.is_splittable:
+      deferred_status = self.restriction_tracker.deferred_status()
+      if deferred_status:
+        deferred_restriction, deferred_watermark = deferred_status
+        return (
+            windowed_value.with_value(
+                (windowed_value.value, deferred_restriction)),
+            deferred_watermark)
 
 
 class DoFnRunner(Receiver):
@@ -679,9 +710,16 @@ class DoFnRunner(Receiver):
 
   def process(self, windowed_value):
     try:
-      self.do_fn_invoker.invoke_process(windowed_value)
+      return self.do_fn_invoker.invoke_process(windowed_value)
     except BaseException as exn:
       self._reraise_augmented(exn)
+
+  def process_with_restriction(self, windowed_value):
+    element, restriction = windowed_value.value
+    return self.do_fn_invoker.invoke_process(
+        windowed_value.with_value(element),
+        restriction_tracker=self.do_fn_invoker.invoke_create_tracker(
+            restriction))
 
   def process_user_timer(self, timer_spec, key, window, timestamp):
     try:

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -76,7 +76,6 @@ class SwitchingDirectRunner(PipelineRunner):
       use_fnapi_runner = False
 
     from apache_beam.pipeline import PipelineVisitor
-    from apache_beam.runners.common import DoFnSignature
     from apache_beam.runners.dataflow.native_io.iobase import NativeSource
     from apache_beam.runners.dataflow.native_io.iobase import _NativeWrite
     from apache_beam.testing.test_stream import TestStream
@@ -103,9 +102,6 @@ class SwitchingDirectRunner(PipelineRunner):
           self.supported_by_fnapi_runner = False
         if isinstance(transform, beam.ParDo):
           dofn = transform.dofn
-          # The FnApiRunner does not support execution of SplittableDoFns.
-          if DoFnSignature(dofn).is_splittable_dofn():
-            self.supported_by_fnapi_runner = False
           # The FnApiRunner does not support execution of CombineFns with
           # deferred side inputs.
           if isinstance(dofn, CombineValuesDoFn):

--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner_test.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner_test.py
@@ -35,7 +35,6 @@ from apache_beam.pvalue import AsSingleton
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
-from apache_beam.transforms.core import ProcessContinuation
 from apache_beam.transforms.core import RestrictionProvider
 from apache_beam.transforms.trigger import AccumulationMode
 from apache_beam.transforms.window import SlidingWindows
@@ -83,7 +82,7 @@ class ReadFiles(DoFn):
         output_count += 1
 
         if self._resume_count and output_count == self._resume_count:
-          yield ProcessContinuation()
+          restriction_tracker.defer_remainder()
           break
 
         pos += len_line

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -211,6 +211,9 @@ if __name__ == '__main__':
                 counter_name, line)
         )
 
+    def test_sdf(self):
+      raise unittest.SkipTest("BEAM-2939")
+
     # Inherits all other tests.
 
   # Run the tests.

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -30,6 +30,7 @@ import re
 from builtins import next
 from builtins import object
 
+from google import protobuf
 from future.utils import itervalues
 
 import apache_beam as beam
@@ -43,6 +44,7 @@ from apache_beam.portability import common_urns
 from apache_beam.portability import python_urns
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.runners import common
 from apache_beam.runners import pipeline_context
 from apache_beam.runners.dataflow import dataflow_runner
 from apache_beam.runners.worker import operation_specs
@@ -474,10 +476,12 @@ class BundleProcessor(object):
         expected_inputs.append(op)
 
     try:
+      execution_context = ExecutionContext()
       self.state_sampler.start()
       # Start all operations.
       for op in reversed(self.ops.values()):
         logging.debug('start %s', op)
+        op.execution_context = execution_context
         op.start()
 
       # Inject inputs from data plane.
@@ -499,8 +503,31 @@ class BundleProcessor(object):
       for op in self.ops.values():
         logging.debug('finish %s', op)
         op.finish()
+
+      return [
+          self.delayed_bundle_application(op, residual)
+          for op, residual in execution_context.delayed_applications]
+
     finally:
       self.state_sampler.stop_if_still_running()
+
+  def delayed_bundle_application(self, op, deferred_remainder):
+    ptransform_id, main_input_tag, main_input_coder, outputs = op.input_info
+    # TODO(SDF): For non-root nodes, need main_input_coder + residual_coder.
+    element_and_restriction, watermark = deferred_remainder
+    if watermark:
+      proto_watermark = protobuf.Timestamp()
+      proto_watermark.FromMicroseconds(watermark.micros)
+      output_watermarks = {output: proto_watermark for output in outputs}
+    else:
+      output_watermarks = None
+    return beam_fn_api_pb2.DelayedBundleApplication(
+        application=beam_fn_api_pb2.BundleApplication(
+            ptransform_id=ptransform_id,
+            input_id=main_input_tag,
+            output_watermarks=output_watermarks,
+            element=main_input_coder.get_impl().encode_nested(
+                element_and_restriction)))
 
   def metrics(self):
     # DEPRECATED
@@ -551,6 +578,11 @@ class BundleProcessor(object):
       if len(actual_output_tags) == 1:
         monitoring_info.labels['TAG'] = actual_output_tags[0]
     return monitoring_info
+
+
+class ExecutionContext(object):
+  def __init__(self):
+    self.delayed_applications = []
 
 
 class BeamTransformFactory(object):
@@ -766,6 +798,70 @@ def create(factory, transform_id, transform_proto, serialized_fn, consumers):
 
 
 @BeamTransformFactory.register_urn(
+    common_urns.sdf_components.PAIR_WITH_RESTRICTION.urn,
+    beam_runner_api_pb2.ParDoPayload)
+def create(*args):
+
+  class CreateRestriction(beam.DoFn):
+    def __init__(self, fn, restriction_provider):
+      self.restriction_provider = restriction_provider
+
+    # An unused window is requested to force explosion of multi-window
+    # WindowedValues.
+    def process(
+        self, element, _unused_window=beam.DoFn.WindowParam, *args, **kwargs):
+      # TODO(SDF): Do we want to allow mutation of the element?
+      # (E.g. it could be nice to shift bulky description to the portion
+      # that can be distributed.)
+      yield element, self.restriction_provider.initial_restriction(element)
+
+  return _create_sdf_operation(CreateRestriction, *args)
+
+
+@BeamTransformFactory.register_urn(
+    common_urns.sdf_components.SPLIT_RESTRICTION.urn,
+    beam_runner_api_pb2.ParDoPayload)
+def create(*args):
+
+  class SplitRestriction(beam.DoFn):
+    def __init__(self, fn, restriction_provider):
+      self.restriction_provider = restriction_provider
+
+    def process(self, element_restriction, *args, **kwargs):
+      element, restriction = element_restriction
+      for part in self.restriction_provider.split(element, restriction):
+        yield element, part
+
+  return _create_sdf_operation(SplitRestriction, *args)
+
+
+@BeamTransformFactory.register_urn(
+    common_urns.sdf_components.PROCESS_ELEMENTS.urn,
+    beam_runner_api_pb2.ParDoPayload)
+def create(factory, transform_id, transform_proto, parameter, consumers):
+  assert parameter.do_fn.spec.urn == python_urns.PICKLED_DOFN_INFO
+  serialized_fn = parameter.do_fn.spec.payload
+  return _create_pardo_operation(
+      factory, transform_id, transform_proto, consumers,
+      serialized_fn, parameter,
+      operation_cls=operations.SdfProcessElements)
+
+
+def _create_sdf_operation(
+    proxy_dofn,
+    factory, transform_id, transform_proto, parameter, consumers):
+
+  dofn_data = pickler.loads(parameter.do_fn.spec.payload)
+  dofn = dofn_data[0]
+  restriction_provider = common.DoFnSignature(dofn).get_restriction_provider()
+  serialized_fn = pickler.dumps(
+      (proxy_dofn(dofn, restriction_provider),) + dofn_data[1:])
+  return _create_pardo_operation(
+      factory, transform_id, transform_proto, consumers,
+      serialized_fn, parameter)
+
+
+@BeamTransformFactory.register_urn(
     common_urns.primitives.PAR_DO.urn, beam_runner_api_pb2.ParDoPayload)
 def create(factory, transform_id, transform_proto, parameter, consumers):
   assert parameter.do_fn.spec.urn == python_urns.PICKLED_DOFN_INFO
@@ -777,7 +873,7 @@ def create(factory, transform_id, transform_proto, parameter, consumers):
 
 def _create_pardo_operation(
     factory, transform_id, transform_proto, consumers,
-    serialized_fn, pardo_proto=None):
+    serialized_fn, pardo_proto=None, operation_cls=operations.DoOperation):
 
   if pardo_proto and pardo_proto.side_inputs:
     input_tags_to_coders = factory.get_input_coders(transform_proto)
@@ -824,7 +920,8 @@ def _create_pardo_operation(
         factory.descriptor.pcollections[pcoll_id].windowing_strategy_id)
     serialized_fn = pickler.dumps(dofn_data[:-1] + (windowing,))
 
-  if pardo_proto and (pardo_proto.timer_specs or pardo_proto.state_specs):
+  if pardo_proto and (pardo_proto.timer_specs or pardo_proto.state_specs
+                      or pardo_proto.splittable):
     main_input_coder = None
     timer_inputs = {}
     for tag, pcoll_id in transform_proto.inputs.items():
@@ -835,15 +932,19 @@ def _create_pardo_operation(
       else:
         # Must be the main input
         assert main_input_coder is None
+        main_input_tag = tag
         main_input_coder = factory.get_windowed_coder(pcoll_id)
     assert main_input_coder is not None
 
-    user_state_context = FnApiUserStateContext(
-        factory.state_handler,
-        transform_id,
-        main_input_coder.key_coder(),
-        main_input_coder.window_coder,
-        timer_specs=pardo_proto.timer_specs)
+    if pardo_proto.timer_specs or pardo_proto.state_specs:
+      user_state_context = FnApiUserStateContext(
+          factory.state_handler,
+          transform_id,
+          main_input_coder.key_coder(),
+          main_input_coder.window_coder,
+          timer_specs=pardo_proto.timer_specs)
+    else:
+      user_state_context = None
   else:
     user_state_context = None
     timer_inputs = None
@@ -856,8 +957,8 @@ def _create_pardo_operation(
       side_inputs=None,  # Fn API uses proto definitions and the Fn State API
       output_coders=[output_coders[tag] for tag in output_tags])
 
-  return factory.augment_oldstyle_op(
-      operations.DoOperation(
+  result = factory.augment_oldstyle_op(
+      operation_cls(
           transform_proto.unique_name,
           spec,
           factory.counter_factory,
@@ -868,6 +969,11 @@ def _create_pardo_operation(
       transform_proto.unique_name,
       consumers,
       output_tags)
+  if pardo_proto and pardo_proto.splittable:
+    result.input_info = (
+        transform_id, main_input_tag, main_input_coder,
+        transform_proto.outputs.keys())
+  return result
 
 
 def _create_simple_pardo_operation(

--- a/sdks/python/apache_beam/runners/worker/operations.pxd
+++ b/sdks/python/apache_beam/runners/worker/operations.pxd
@@ -45,6 +45,7 @@ cdef class Operation(object):
   cdef object consumers
   cdef readonly counter_factory
   cdef public metrics_container
+  cdef public execution_context
   # Public for access by Fn harness operations.
   # TODO(robertwb): Cythonize FnHarness.
   cdef public list receivers
@@ -89,6 +90,7 @@ cdef class DoOperation(Operation):
   cdef object user_state_context
   cdef public dict timer_inputs
   cdef dict timer_specs
+  cdef public object input_info
 
 
 cdef class CombineOperation(Operation):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -272,10 +272,11 @@ class SdkWorker(object):
         instruction_id,
         request.process_bundle_descriptor_reference) as bundle_processor:
       with self.maybe_profile(instruction_id):
-        bundle_processor.process_bundle(instruction_id)
+        delayed_applications = bundle_processor.process_bundle(instruction_id)
       return beam_fn_api_pb2.InstructionResponse(
           instruction_id=instruction_id,
           process_bundle=beam_fn_api_pb2.ProcessBundleResponse(
+              residual_roots=delayed_applications,
               metrics=bundle_processor.metrics(),
               monitoring_infos=bundle_processor.monitoring_infos()))
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1029,6 +1029,14 @@ class ParDo(PTransformWithSideInputs):
         "expected instance of ParDo, but got %s" % self.__class__
     picked_pardo_fn_data = pickler.dumps(self._pardo_fn_data())
     state_specs, timer_specs = userstate.get_dofn_specs(self.fn)
+    from apache_beam.runners.common import DoFnSignature
+    is_splittable = DoFnSignature(self.fn).is_splittable_dofn()
+    if is_splittable:
+      restriction_coder = (
+          DoFnSignature(self.fn).get_restriction_provider().restriction_coder())
+      restriction_coder_id = context.coders.get_id(restriction_coder)
+    else:
+      restriction_coder_id = None
     return (
         common_urns.primitives.PAR_DO.urn,
         beam_runner_api_pb2.ParDoPayload(
@@ -1037,6 +1045,8 @@ class ParDo(PTransformWithSideInputs):
                 spec=beam_runner_api_pb2.FunctionSpec(
                     urn=python_urns.PICKLED_DOFN_INFO,
                     payload=picked_pardo_fn_data)),
+            splittable=is_splittable,
+            restriction_coder_id=restriction_coder_id,
             state_specs={spec.name: spec.to_runner_api(context)
                          for spec in state_specs},
             timer_specs={spec.name: spec.to_runner_api(context)


### PR DESCRIPTION
This adds the basic ability for a (splittable) DoFn to request that it be called back for further processing.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

