### PR TITLE
[BEAM-6582] Upgrades gcsio dependency to 1.9.13

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -336,7 +336,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // Maven artifacts.
     def generated_grpc_beta_version = "0.19.0"
     def generated_grpc_ga_version = "1.18.0"
-    def google_cloud_bigdataoss_version = "1.9.12"
+    def google_cloud_bigdataoss_version = "1.9.13"
     def bigtable_version = "1.4.0"
     def google_clients_version = "1.27.0"
     def google_auth_version = "0.10.0"


### PR DESCRIPTION
We upgraded to 1.9.12 few days back but GCS client library team found a bug related to directory inference and recommended upgrading to 1.9.13 instead.

https://github.com/GoogleCloudPlatform/bigdata-interop/commit/52f5055d37f20a04303b146e9063e7ccc876ec17

