### PR TITLE
Remove EXPERIMENTAL_BEAM_PY3 and add a warning for Python 3 execution

### DIFF
--- a/sdks/python/apache_beam/__init__.py
+++ b/sdks/python/apache_beam/__init__.py
@@ -74,16 +74,22 @@ has some examples.
 
 from __future__ import absolute_import
 
-import sys
+import logging
 import os
+import sys
 
 
-if not ((sys.version_info[0] == 2 and sys.version_info[1] == 7) or
-        (sys.version_info[0] == 3 and
-         os.environ.get('BEAM_EXPERIMENTAL_PY3', False))):
+if sys.version_info[0] == 3:
+  logging.warning(
+      'Running the Apache Beam SDK on Python 3 is not yet fully supported. '
+      'You may encounter buggy behavior or missing features.')
+elif sys.version_info[0] == 2 and sys.version_info[1] == 7:
+  pass
+else:
   raise RuntimeError(
-      'The Apache Beam SDK for Python is supported only on Python 2.7. '
-      'It is not supported on Python ['+ str(sys.version_info) + '].')
+      'The Apache Beam SDK for Python is only supported on Python 2.7 or '
+      'Python 3. It is not supported on Python [' +
+      str(sys.version_info) + '].')
 
 # pylint: disable=wrong-import-position
 import apache_beam.internal.pickler

--- a/sdks/python/container/py3/Dockerfile
+++ b/sdks/python/container/py3/Dockerfile
@@ -43,7 +43,6 @@ RUN \
     rm -rf /root/.cache/pip
 
 
-ENV BEAM_EXPERIMENTAL_PY3=1
 COPY target/apache-beam.tar.gz /opt/apache/beam/tars/
 RUN pip install /opt/apache/beam/tars/apache-beam.tar.gz[gcp] && \
     # Remove pip cache.

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -20,8 +20,10 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
 import os
 import platform
+import sys
 import warnings
 from distutils.version import StrictVersion
 
@@ -164,9 +166,14 @@ def generate_protos_first(original_cmd):
     return original_cmd
 
 
-python_requires = '>=2.7'
-if os.environ.get('BEAM_EXPERIMENTAL_PY3') is None:
-  python_requires += ',<3.0'
+# TODO(BEAM-6583): audit Python 3.x version compatibility and refine this
+# requirement range if necessary.
+python_requires = '>=2.7<=3.7'
+
+if sys.version_info[0] == 3:
+  logging.warning(
+      'Python 3 support for the Apache Beam SDK is not yet fully supported. '
+      'You may encounter buggy behavior or missing features.')
 
 setuptools.setup(
     name=PACKAGE_NAME,

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -55,7 +55,6 @@ commands =
 
 [testenv:py3]
 setenv =
-  BEAM_EXPERIMENTAL_PY3=1
   RUN_SKIPPED_PY3_TESTS=0
 commands =
   python --version
@@ -91,7 +90,6 @@ commands =
 
 [testenv:py3-gcp]
 setenv =
-  BEAM_EXPERIMENTAL_PY3=1
   RUN_SKIPPED_PY3_TESTS=0
 extras = test,gcp
 modules =
@@ -138,8 +136,6 @@ deps =
   future==0.16.0
   isort==4.2.15
   flake8==3.5.0
-setenv =
-    BEAM_EXPERIMENTAL_PY3=1
 commands =
   pylint --version
   pip --version


### PR DESCRIPTION
This change replaces our guard against Python 3 execution with a warning.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

