### PR TITLE
Update starcgen for new types

### DIFF
--- a/sdks/go/pkg/beam/beam.shims.go
+++ b/sdks/go/pkg/beam/beam.shims.go
@@ -42,16 +42,14 @@ func init() {
 	runtime.RegisterFunction(swapKVFn)
 	runtime.RegisterType(reflect.TypeOf((*createFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*reflect.Type)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.X)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.Y)(nil)).Elem())
+	runtime.RegisterType(reflect.TypeOf((*reflectx.Func)(nil)).Elem())
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*createFn)(nil)).Elem(), wrapMakerCreateFn)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type,[]byte) (typex.T,error))(nil)).Elem(), funcMakerReflect۰TypeSliceofByteГTypex۰TError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte,func(typex.T)) (error))(nil)).Elem(), funcMakerSliceofByteEmitTypex۰TГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]typex.T,func(typex.T)) ())(nil)).Elem(), funcMakerSliceofTypex۰TEmitTypex۰TГ)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(string,reflect.Type,[]byte) (reflectx.Func))(nil)).Elem(), funcMakerStringReflect۰TypeSliceofByteГReflectx۰Func)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type,[]byte) (typex.T,error))(nil)).Elem(), funcMakerReflect۰TypeSliceOfByteГTypex۰TError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte,func(typex.T)) (error))(nil)).Elem(), funcMakerSliceOfByteEmitTypex۰TГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]typex.T,func(typex.T)) ())(nil)).Elem(), funcMakerSliceOfTypex۰TEmitTypex۰TГ)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(string,reflect.Type,[]byte) (reflectx.Func))(nil)).Elem(), funcMakerStringReflect۰TypeSliceOfByteГReflectx۰Func)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) (int,typex.T))(nil)).Elem(), funcMakerTypex۰TГIntTypex۰T)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) ([]byte,error))(nil)).Elem(), funcMakerTypex۰TГSliceofByteError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) ([]byte,error))(nil)).Elem(), funcMakerTypex۰TГSliceOfByteError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X,typex.Y) (typex.X))(nil)).Elem(), funcMakerTypex۰XTypex۰YГTypex۰X)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X,typex.Y) (typex.Y))(nil)).Elem(), funcMakerTypex۰XTypex۰YГTypex۰Y)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X,typex.Y) (typex.Y,typex.X))(nil)).Elem(), funcMakerTypex۰XTypex۰YГTypex۰YTypex۰X)
@@ -65,107 +63,107 @@ func wrapMakerCreateFn(fn interface{}) map[string]reflectx.Func {
 	}
 }
 
-type callerReflect۰TypeSliceofByteГTypex۰TError struct {
+type callerReflect۰TypeSliceOfByteГTypex۰TError struct {
 	fn func(reflect.Type,[]byte) (typex.T,error)
 }
 
-func funcMakerReflect۰TypeSliceofByteГTypex۰TError(fn interface{}) reflectx.Func {
+func funcMakerReflect۰TypeSliceOfByteГTypex۰TError(fn interface{}) reflectx.Func {
 	f := fn.(func(reflect.Type,[]byte) (typex.T,error))
-	return &callerReflect۰TypeSliceofByteГTypex۰TError{fn: f}
+	return &callerReflect۰TypeSliceOfByteГTypex۰TError{fn: f}
 }
 
-func (c *callerReflect۰TypeSliceofByteГTypex۰TError) Name() string {
+func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerReflect۰TypeSliceofByteГTypex۰TError) Type() reflect.Type {
+func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerReflect۰TypeSliceofByteГTypex۰TError) Call(args []interface{}) []interface{} {
+func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Call(args []interface{}) []interface{} {
 	out0, out1 := c.fn(args[0].(reflect.Type), args[1].([]byte))
 	return []interface{}{out0, out1}
 }
 
-func (c *callerReflect۰TypeSliceofByteГTypex۰TError) Call2x2(arg0, arg1 interface{}) (interface{}, interface{}) {
+func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Call2x2(arg0, arg1 interface{}) (interface{}, interface{}) {
 	return c.fn(arg0.(reflect.Type), arg1.([]byte))
 }
 
-type callerSliceofByteEmitTypex۰TГError struct {
+type callerSliceOfByteEmitTypex۰TГError struct {
 	fn func([]byte,func(typex.T)) (error)
 }
 
-func funcMakerSliceofByteEmitTypex۰TГError(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteEmitTypex۰TГError(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte,func(typex.T)) (error))
-	return &callerSliceofByteEmitTypex۰TГError{fn: f}
+	return &callerSliceOfByteEmitTypex۰TГError{fn: f}
 }
 
-func (c *callerSliceofByteEmitTypex۰TГError) Name() string {
+func (c *callerSliceOfByteEmitTypex۰TГError) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteEmitTypex۰TГError) Type() reflect.Type {
+func (c *callerSliceOfByteEmitTypex۰TГError) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteEmitTypex۰TГError) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteEmitTypex۰TГError) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].([]byte), args[1].(func(typex.T)))
 	return []interface{}{out0}
 }
 
-func (c *callerSliceofByteEmitTypex۰TГError) Call2x1(arg0, arg1 interface{}) (interface{}) {
+func (c *callerSliceOfByteEmitTypex۰TГError) Call2x1(arg0, arg1 interface{}) (interface{}) {
 	return c.fn(arg0.([]byte), arg1.(func(typex.T)))
 }
 
-type callerSliceofTypex۰TEmitTypex۰TГ struct {
+type callerSliceOfTypex۰TEmitTypex۰TГ struct {
 	fn func([]typex.T,func(typex.T)) ()
 }
 
-func funcMakerSliceofTypex۰TEmitTypex۰TГ(fn interface{}) reflectx.Func {
+func funcMakerSliceOfTypex۰TEmitTypex۰TГ(fn interface{}) reflectx.Func {
 	f := fn.(func([]typex.T,func(typex.T)) ())
-	return &callerSliceofTypex۰TEmitTypex۰TГ{fn: f}
+	return &callerSliceOfTypex۰TEmitTypex۰TГ{fn: f}
 }
 
-func (c *callerSliceofTypex۰TEmitTypex۰TГ) Name() string {
+func (c *callerSliceOfTypex۰TEmitTypex۰TГ) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofTypex۰TEmitTypex۰TГ) Type() reflect.Type {
+func (c *callerSliceOfTypex۰TEmitTypex۰TГ) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofTypex۰TEmitTypex۰TГ) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfTypex۰TEmitTypex۰TГ) Call(args []interface{}) []interface{} {
 	c.fn(args[0].([]typex.T), args[1].(func(typex.T)))
 	return []interface{}{}
 }
 
-func (c *callerSliceofTypex۰TEmitTypex۰TГ) Call2x0(arg0, arg1 interface{}) () {
+func (c *callerSliceOfTypex۰TEmitTypex۰TГ) Call2x0(arg0, arg1 interface{}) () {
 	c.fn(arg0.([]typex.T), arg1.(func(typex.T)))
 }
 
-type callerStringReflect۰TypeSliceofByteГReflectx۰Func struct {
+type callerStringReflect۰TypeSliceOfByteГReflectx۰Func struct {
 	fn func(string,reflect.Type,[]byte) (reflectx.Func)
 }
 
-func funcMakerStringReflect۰TypeSliceofByteГReflectx۰Func(fn interface{}) reflectx.Func {
+func funcMakerStringReflect۰TypeSliceOfByteГReflectx۰Func(fn interface{}) reflectx.Func {
 	f := fn.(func(string,reflect.Type,[]byte) (reflectx.Func))
-	return &callerStringReflect۰TypeSliceofByteГReflectx۰Func{fn: f}
+	return &callerStringReflect۰TypeSliceOfByteГReflectx۰Func{fn: f}
 }
 
-func (c *callerStringReflect۰TypeSliceofByteГReflectx۰Func) Name() string {
+func (c *callerStringReflect۰TypeSliceOfByteГReflectx۰Func) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerStringReflect۰TypeSliceofByteГReflectx۰Func) Type() reflect.Type {
+func (c *callerStringReflect۰TypeSliceOfByteГReflectx۰Func) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerStringReflect۰TypeSliceofByteГReflectx۰Func) Call(args []interface{}) []interface{} {
+func (c *callerStringReflect۰TypeSliceOfByteГReflectx۰Func) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].(string), args[1].(reflect.Type), args[2].([]byte))
 	return []interface{}{out0}
 }
 
-func (c *callerStringReflect۰TypeSliceofByteГReflectx۰Func) Call3x1(arg0, arg1, arg2 interface{}) (interface{}) {
+func (c *callerStringReflect۰TypeSliceOfByteГReflectx۰Func) Call3x1(arg0, arg1, arg2 interface{}) (interface{}) {
 	return c.fn(arg0.(string), arg1.(reflect.Type), arg2.([]byte))
 }
 
@@ -195,29 +193,29 @@ func (c *callerTypex۰TГIntTypex۰T) Call1x2(arg0 interface{}) (interface{}, in
 	return c.fn(arg0.(typex.T))
 }
 
-type callerTypex۰TГSliceofByteError struct {
+type callerTypex۰TГSliceOfByteError struct {
 	fn func(typex.T) ([]byte,error)
 }
 
-func funcMakerTypex۰TГSliceofByteError(fn interface{}) reflectx.Func {
+func funcMakerTypex۰TГSliceOfByteError(fn interface{}) reflectx.Func {
 	f := fn.(func(typex.T) ([]byte,error))
-	return &callerTypex۰TГSliceofByteError{fn: f}
+	return &callerTypex۰TГSliceOfByteError{fn: f}
 }
 
-func (c *callerTypex۰TГSliceofByteError) Name() string {
+func (c *callerTypex۰TГSliceOfByteError) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerTypex۰TГSliceofByteError) Type() reflect.Type {
+func (c *callerTypex۰TГSliceOfByteError) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerTypex۰TГSliceofByteError) Call(args []interface{}) []interface{} {
+func (c *callerTypex۰TГSliceOfByteError) Call(args []interface{}) []interface{} {
 	out0, out1 := c.fn(args[0].(typex.T))
 	return []interface{}{out0, out1}
 }
 
-func (c *callerTypex۰TГSliceofByteError) Call1x2(arg0 interface{}) (interface{}, interface{}) {
+func (c *callerTypex۰TГSliceOfByteError) Call1x2(arg0 interface{}) (interface{}, interface{}) {
 	return c.fn(arg0.(typex.T))
 }
 

--- a/sdks/go/pkg/beam/core/runtime/coderx/coderx.shims.go
+++ b/sdks/go/pkg/beam/core/runtime/coderx/coderx.shims.go
@@ -45,303 +45,302 @@ func init() {
 	runtime.RegisterFunction(encVarIntZ)
 	runtime.RegisterFunction(encVarUintZ)
 	runtime.RegisterType(reflect.TypeOf((*reflect.Type)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())
-	reflectx.RegisterFunc(reflect.TypeOf((*func(int32) ([]byte))(nil)).Elem(), funcMakerInt32ГSliceofByte)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(int64) ([]byte))(nil)).Elem(), funcMakerInt64ГSliceofByte)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type,[]byte) (typex.T,error))(nil)).Elem(), funcMakerReflect۰TypeSliceofByteГTypex۰TError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (int32))(nil)).Elem(), funcMakerSliceofByteГInt32)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (int64))(nil)).Elem(), funcMakerSliceofByteГInt64)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (typex.T))(nil)).Elem(), funcMakerSliceofByteГTypex۰T)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (uint32))(nil)).Elem(), funcMakerSliceofByteГUint32)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (uint64))(nil)).Elem(), funcMakerSliceofByteГUint64)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) ([]byte))(nil)).Elem(), funcMakerTypex۰TГSliceofByte)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(uint32) ([]byte))(nil)).Elem(), funcMakerUint32ГSliceofByte)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(uint64) ([]byte))(nil)).Elem(), funcMakerUint64ГSliceofByte)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(int32) ([]byte))(nil)).Elem(), funcMakerInt32ГSliceOfByte)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(int64) ([]byte))(nil)).Elem(), funcMakerInt64ГSliceOfByte)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type,[]byte) (typex.T,error))(nil)).Elem(), funcMakerReflect۰TypeSliceOfByteГTypex۰TError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (int32))(nil)).Elem(), funcMakerSliceOfByteГInt32)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (int64))(nil)).Elem(), funcMakerSliceOfByteГInt64)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (typex.T))(nil)).Elem(), funcMakerSliceOfByteГTypex۰T)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (uint32))(nil)).Elem(), funcMakerSliceOfByteГUint32)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte) (uint64))(nil)).Elem(), funcMakerSliceOfByteГUint64)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) ([]byte))(nil)).Elem(), funcMakerTypex۰TГSliceOfByte)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(uint32) ([]byte))(nil)).Elem(), funcMakerUint32ГSliceOfByte)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(uint64) ([]byte))(nil)).Elem(), funcMakerUint64ГSliceOfByte)
 }
 
-type callerInt32ГSliceofByte struct {
+type callerInt32ГSliceOfByte struct {
 	fn func(int32) ([]byte)
 }
 
-func funcMakerInt32ГSliceofByte(fn interface{}) reflectx.Func {
+func funcMakerInt32ГSliceOfByte(fn interface{}) reflectx.Func {
 	f := fn.(func(int32) ([]byte))
-	return &callerInt32ГSliceofByte{fn: f}
+	return &callerInt32ГSliceOfByte{fn: f}
 }
 
-func (c *callerInt32ГSliceofByte) Name() string {
+func (c *callerInt32ГSliceOfByte) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerInt32ГSliceofByte) Type() reflect.Type {
+func (c *callerInt32ГSliceOfByte) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerInt32ГSliceofByte) Call(args []interface{}) []interface{} {
+func (c *callerInt32ГSliceOfByte) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].(int32))
 	return []interface{}{out0}
 }
 
-func (c *callerInt32ГSliceofByte) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerInt32ГSliceOfByte) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.(int32))
 }
 
-type callerInt64ГSliceofByte struct {
+type callerInt64ГSliceOfByte struct {
 	fn func(int64) ([]byte)
 }
 
-func funcMakerInt64ГSliceofByte(fn interface{}) reflectx.Func {
+func funcMakerInt64ГSliceOfByte(fn interface{}) reflectx.Func {
 	f := fn.(func(int64) ([]byte))
-	return &callerInt64ГSliceofByte{fn: f}
+	return &callerInt64ГSliceOfByte{fn: f}
 }
 
-func (c *callerInt64ГSliceofByte) Name() string {
+func (c *callerInt64ГSliceOfByte) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerInt64ГSliceofByte) Type() reflect.Type {
+func (c *callerInt64ГSliceOfByte) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerInt64ГSliceofByte) Call(args []interface{}) []interface{} {
+func (c *callerInt64ГSliceOfByte) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].(int64))
 	return []interface{}{out0}
 }
 
-func (c *callerInt64ГSliceofByte) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerInt64ГSliceOfByte) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.(int64))
 }
 
-type callerReflect۰TypeSliceofByteГTypex۰TError struct {
+type callerReflect۰TypeSliceOfByteГTypex۰TError struct {
 	fn func(reflect.Type,[]byte) (typex.T,error)
 }
 
-func funcMakerReflect۰TypeSliceofByteГTypex۰TError(fn interface{}) reflectx.Func {
+func funcMakerReflect۰TypeSliceOfByteГTypex۰TError(fn interface{}) reflectx.Func {
 	f := fn.(func(reflect.Type,[]byte) (typex.T,error))
-	return &callerReflect۰TypeSliceofByteГTypex۰TError{fn: f}
+	return &callerReflect۰TypeSliceOfByteГTypex۰TError{fn: f}
 }
 
-func (c *callerReflect۰TypeSliceofByteГTypex۰TError) Name() string {
+func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerReflect۰TypeSliceofByteГTypex۰TError) Type() reflect.Type {
+func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerReflect۰TypeSliceofByteГTypex۰TError) Call(args []interface{}) []interface{} {
+func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Call(args []interface{}) []interface{} {
 	out0, out1 := c.fn(args[0].(reflect.Type), args[1].([]byte))
 	return []interface{}{out0, out1}
 }
 
-func (c *callerReflect۰TypeSliceofByteГTypex۰TError) Call2x2(arg0, arg1 interface{}) (interface{}, interface{}) {
+func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Call2x2(arg0, arg1 interface{}) (interface{}, interface{}) {
 	return c.fn(arg0.(reflect.Type), arg1.([]byte))
 }
 
-type callerSliceofByteГInt32 struct {
+type callerSliceOfByteГInt32 struct {
 	fn func([]byte) (int32)
 }
 
-func funcMakerSliceofByteГInt32(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteГInt32(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte) (int32))
-	return &callerSliceofByteГInt32{fn: f}
+	return &callerSliceOfByteГInt32{fn: f}
 }
 
-func (c *callerSliceofByteГInt32) Name() string {
+func (c *callerSliceOfByteГInt32) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteГInt32) Type() reflect.Type {
+func (c *callerSliceOfByteГInt32) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteГInt32) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteГInt32) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].([]byte))
 	return []interface{}{out0}
 }
 
-func (c *callerSliceofByteГInt32) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerSliceOfByteГInt32) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.([]byte))
 }
 
-type callerSliceofByteГInt64 struct {
+type callerSliceOfByteГInt64 struct {
 	fn func([]byte) (int64)
 }
 
-func funcMakerSliceofByteГInt64(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteГInt64(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte) (int64))
-	return &callerSliceofByteГInt64{fn: f}
+	return &callerSliceOfByteГInt64{fn: f}
 }
 
-func (c *callerSliceofByteГInt64) Name() string {
+func (c *callerSliceOfByteГInt64) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteГInt64) Type() reflect.Type {
+func (c *callerSliceOfByteГInt64) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteГInt64) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteГInt64) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].([]byte))
 	return []interface{}{out0}
 }
 
-func (c *callerSliceofByteГInt64) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerSliceOfByteГInt64) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.([]byte))
 }
 
-type callerSliceofByteГTypex۰T struct {
+type callerSliceOfByteГTypex۰T struct {
 	fn func([]byte) (typex.T)
 }
 
-func funcMakerSliceofByteГTypex۰T(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteГTypex۰T(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte) (typex.T))
-	return &callerSliceofByteГTypex۰T{fn: f}
+	return &callerSliceOfByteГTypex۰T{fn: f}
 }
 
-func (c *callerSliceofByteГTypex۰T) Name() string {
+func (c *callerSliceOfByteГTypex۰T) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteГTypex۰T) Type() reflect.Type {
+func (c *callerSliceOfByteГTypex۰T) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteГTypex۰T) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteГTypex۰T) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].([]byte))
 	return []interface{}{out0}
 }
 
-func (c *callerSliceofByteГTypex۰T) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerSliceOfByteГTypex۰T) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.([]byte))
 }
 
-type callerSliceofByteГUint32 struct {
+type callerSliceOfByteГUint32 struct {
 	fn func([]byte) (uint32)
 }
 
-func funcMakerSliceofByteГUint32(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteГUint32(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte) (uint32))
-	return &callerSliceofByteГUint32{fn: f}
+	return &callerSliceOfByteГUint32{fn: f}
 }
 
-func (c *callerSliceofByteГUint32) Name() string {
+func (c *callerSliceOfByteГUint32) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteГUint32) Type() reflect.Type {
+func (c *callerSliceOfByteГUint32) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteГUint32) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteГUint32) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].([]byte))
 	return []interface{}{out0}
 }
 
-func (c *callerSliceofByteГUint32) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerSliceOfByteГUint32) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.([]byte))
 }
 
-type callerSliceofByteГUint64 struct {
+type callerSliceOfByteГUint64 struct {
 	fn func([]byte) (uint64)
 }
 
-func funcMakerSliceofByteГUint64(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteГUint64(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte) (uint64))
-	return &callerSliceofByteГUint64{fn: f}
+	return &callerSliceOfByteГUint64{fn: f}
 }
 
-func (c *callerSliceofByteГUint64) Name() string {
+func (c *callerSliceOfByteГUint64) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteГUint64) Type() reflect.Type {
+func (c *callerSliceOfByteГUint64) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteГUint64) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteГUint64) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].([]byte))
 	return []interface{}{out0}
 }
 
-func (c *callerSliceofByteГUint64) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerSliceOfByteГUint64) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.([]byte))
 }
 
-type callerTypex۰TГSliceofByte struct {
+type callerTypex۰TГSliceOfByte struct {
 	fn func(typex.T) ([]byte)
 }
 
-func funcMakerTypex۰TГSliceofByte(fn interface{}) reflectx.Func {
+func funcMakerTypex۰TГSliceOfByte(fn interface{}) reflectx.Func {
 	f := fn.(func(typex.T) ([]byte))
-	return &callerTypex۰TГSliceofByte{fn: f}
+	return &callerTypex۰TГSliceOfByte{fn: f}
 }
 
-func (c *callerTypex۰TГSliceofByte) Name() string {
+func (c *callerTypex۰TГSliceOfByte) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerTypex۰TГSliceofByte) Type() reflect.Type {
+func (c *callerTypex۰TГSliceOfByte) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerTypex۰TГSliceofByte) Call(args []interface{}) []interface{} {
+func (c *callerTypex۰TГSliceOfByte) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].(typex.T))
 	return []interface{}{out0}
 }
 
-func (c *callerTypex۰TГSliceofByte) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerTypex۰TГSliceOfByte) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.(typex.T))
 }
 
-type callerUint32ГSliceofByte struct {
+type callerUint32ГSliceOfByte struct {
 	fn func(uint32) ([]byte)
 }
 
-func funcMakerUint32ГSliceofByte(fn interface{}) reflectx.Func {
+func funcMakerUint32ГSliceOfByte(fn interface{}) reflectx.Func {
 	f := fn.(func(uint32) ([]byte))
-	return &callerUint32ГSliceofByte{fn: f}
+	return &callerUint32ГSliceOfByte{fn: f}
 }
 
-func (c *callerUint32ГSliceofByte) Name() string {
+func (c *callerUint32ГSliceOfByte) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerUint32ГSliceofByte) Type() reflect.Type {
+func (c *callerUint32ГSliceOfByte) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerUint32ГSliceofByte) Call(args []interface{}) []interface{} {
+func (c *callerUint32ГSliceOfByte) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].(uint32))
 	return []interface{}{out0}
 }
 
-func (c *callerUint32ГSliceofByte) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerUint32ГSliceOfByte) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.(uint32))
 }
 
-type callerUint64ГSliceofByte struct {
+type callerUint64ГSliceOfByte struct {
 	fn func(uint64) ([]byte)
 }
 
-func funcMakerUint64ГSliceofByte(fn interface{}) reflectx.Func {
+func funcMakerUint64ГSliceOfByte(fn interface{}) reflectx.Func {
 	f := fn.(func(uint64) ([]byte))
-	return &callerUint64ГSliceofByte{fn: f}
+	return &callerUint64ГSliceOfByte{fn: f}
 }
 
-func (c *callerUint64ГSliceofByte) Name() string {
+func (c *callerUint64ГSliceOfByte) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerUint64ГSliceofByte) Type() reflect.Type {
+func (c *callerUint64ГSliceOfByte) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerUint64ГSliceofByte) Call(args []interface{}) []interface{} {
+func (c *callerUint64ГSliceOfByte) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].(uint64))
 	return []interface{}{out0}
 }
 
-func (c *callerUint64ГSliceofByte) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerUint64ГSliceOfByte) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.(uint64))
 }
 

--- a/sdks/go/pkg/beam/testing/passert/passert.shims.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.shims.go
@@ -38,9 +38,6 @@ func init() {
 	runtime.RegisterType(reflect.TypeOf((*failKVFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*hashFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*sumFn)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.X)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.Y)(nil)).Elem())
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*diffFn)(nil)).Elem(), wrapMakerDiffFn)
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*failFn)(nil)).Elem(), wrapMakerFailFn)
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*failGBKFn)(nil)).Elem(), wrapMakerFailGBKFn)
@@ -49,7 +46,7 @@ func init() {
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*sumFn)(nil)).Elem(), wrapMakerSumFn)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int,func(*int) bool) (error))(nil)).Elem(), funcMakerIntIterIntГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int,func(*string) bool) (error))(nil)).Elem(), funcMakerIntIterStringГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte,func(*typex.T) bool,func(*typex.T) bool,func(t typex.T),func(t typex.T),func(t typex.T)) (error))(nil)).Elem(), funcMakerSliceofByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte,func(*typex.T) bool,func(*typex.T) bool,func(t typex.T),func(t typex.T),func(t typex.T)) (error))(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X,func(*typex.Y) bool) (error))(nil)).Elem(), funcMakerTypex۰XIterTypex۰YГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X,typex.Y) (error))(nil)).Elem(), funcMakerTypex۰XTypex۰YГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X) (error))(nil)).Elem(), funcMakerTypex۰XГError)
@@ -154,29 +151,29 @@ func (c *callerIntIterStringГError) Call2x1(arg0, arg1 interface{}) (interface{
 	return c.fn(arg0.(int), arg1.(func(*string) bool))
 }
 
-type callerSliceofByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError struct {
+type callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError struct {
 	fn func([]byte,func(*typex.T) bool,func(*typex.T) bool,func(t typex.T),func(t typex.T),func(t typex.T)) (error)
 }
 
-func funcMakerSliceofByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte,func(*typex.T) bool,func(*typex.T) bool,func(t typex.T),func(t typex.T),func(t typex.T)) (error))
-	return &callerSliceofByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError{fn: f}
+	return &callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError{fn: f}
 }
 
-func (c *callerSliceofByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Name() string {
+func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Type() reflect.Type {
+func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].([]byte), args[1].(func(*typex.T) bool), args[2].(func(*typex.T) bool), args[3].(func(t typex.T)), args[4].(func(t typex.T)), args[5].(func(t typex.T)))
 	return []interface{}{out0}
 }
 
-func (c *callerSliceofByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Call6x1(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) (interface{}) {
+func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Call6x1(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) (interface{}) {
 	return c.fn(arg0.([]byte), arg1.(func(*typex.T) bool), arg2.(func(*typex.T) bool), arg3.(func(t typex.T)), arg4.(func(t typex.T)), arg5.(func(t typex.T)))
 }
 

--- a/sdks/go/pkg/beam/transforms/filter/filter.shims.go
+++ b/sdks/go/pkg/beam/transforms/filter/filter.shims.go
@@ -35,7 +35,6 @@ func init() {
 	runtime.RegisterFunction(keyFn)
 	runtime.RegisterFunction(mapFn)
 	runtime.RegisterType(reflect.TypeOf((*filterFn)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*filterFn)(nil)).Elem(), wrapMakerFilterFn)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T,func(typex.T)) ())(nil)).Elem(), funcMakerTypex۰TEmitTypex۰TГ)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T,func(*int) bool) (typex.T))(nil)).Elem(), funcMakerTypex۰TIterIntГTypex۰T)

--- a/sdks/go/pkg/beam/transforms/stats/stats.shims.go
+++ b/sdks/go/pkg/beam/transforms/stats/stats.shims.go
@@ -67,7 +67,6 @@ func init() {
 	runtime.RegisterFunction(sumUintFn)
 	runtime.RegisterType(reflect.TypeOf((*meanAccum)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*meanFn)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*meanFn)(nil)).Elem(), wrapMakerMeanFn)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(float32,float32) (float32))(nil)).Elem(), funcMakerFloat32Float32ГFloat32)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(float64,float64) (float64))(nil)).Elem(), funcMakerFloat64Float64ГFloat64)
@@ -78,7 +77,7 @@ func init() {
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int,int) (int))(nil)).Elem(), funcMakerIntIntГInt)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(meanAccum,typex.T) (meanAccum))(nil)).Elem(), funcMakerMeanAccumTypex۰TГMeanAccum)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(meanAccum) (float64))(nil)).Elem(), funcMakerMeanAccumГFloat64)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]meanAccum) (meanAccum))(nil)).Elem(), funcMakerSliceofMeanAccumГMeanAccum)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]meanAccum) (meanAccum))(nil)).Elem(), funcMakerSliceOfMeanAccumГMeanAccum)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) (typex.T,int))(nil)).Elem(), funcMakerTypex۰TГTypex۰TInt)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(uint16,uint16) (uint16))(nil)).Elem(), funcMakerUint16Uint16ГUint16)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(uint32,uint32) (uint32))(nil)).Elem(), funcMakerUint32Uint32ГUint32)
@@ -332,29 +331,29 @@ func (c *callerMeanAccumГFloat64) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.(meanAccum))
 }
 
-type callerSliceofMeanAccumГMeanAccum struct {
+type callerSliceOfMeanAccumГMeanAccum struct {
 	fn func([]meanAccum) (meanAccum)
 }
 
-func funcMakerSliceofMeanAccumГMeanAccum(fn interface{}) reflectx.Func {
+func funcMakerSliceOfMeanAccumГMeanAccum(fn interface{}) reflectx.Func {
 	f := fn.(func([]meanAccum) (meanAccum))
-	return &callerSliceofMeanAccumГMeanAccum{fn: f}
+	return &callerSliceOfMeanAccumГMeanAccum{fn: f}
 }
 
-func (c *callerSliceofMeanAccumГMeanAccum) Name() string {
+func (c *callerSliceOfMeanAccumГMeanAccum) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofMeanAccumГMeanAccum) Type() reflect.Type {
+func (c *callerSliceOfMeanAccumГMeanAccum) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofMeanAccumГMeanAccum) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfMeanAccumГMeanAccum) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].([]meanAccum))
 	return []interface{}{out0}
 }
 
-func (c *callerSliceofMeanAccumГMeanAccum) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerSliceOfMeanAccumГMeanAccum) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.([]meanAccum))
 }
 

--- a/sdks/go/pkg/beam/transforms/top/top.shims.go
+++ b/sdks/go/pkg/beam/transforms/top/top.shims.go
@@ -30,11 +30,10 @@ import (
 func init() {
 	runtime.RegisterType(reflect.TypeOf((*accum)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*combineFn)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*combineFn)(nil)).Elem(), wrapMakerCombineFn)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(accum,accum) (accum))(nil)).Elem(), funcMakerAccumAccumГAccum)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(accum,typex.T) (accum))(nil)).Elem(), funcMakerAccumTypex۰TГAccum)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(accum) ([]typex.T))(nil)).Elem(), funcMakerAccumГSliceofTypex۰T)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(accum) ([]typex.T))(nil)).Elem(), funcMakerAccumГSliceOfTypex۰T)
 	reflectx.RegisterFunc(reflect.TypeOf((*func() (accum))(nil)).Elem(), funcMakerГAccum)
 }
 
@@ -100,29 +99,29 @@ func (c *callerAccumTypex۰TГAccum) Call2x1(arg0, arg1 interface{}) (interface{
 	return c.fn(arg0.(accum), arg1.(typex.T))
 }
 
-type callerAccumГSliceofTypex۰T struct {
+type callerAccumГSliceOfTypex۰T struct {
 	fn func(accum) ([]typex.T)
 }
 
-func funcMakerAccumГSliceofTypex۰T(fn interface{}) reflectx.Func {
+func funcMakerAccumГSliceOfTypex۰T(fn interface{}) reflectx.Func {
 	f := fn.(func(accum) ([]typex.T))
-	return &callerAccumГSliceofTypex۰T{fn: f}
+	return &callerAccumГSliceOfTypex۰T{fn: f}
 }
 
-func (c *callerAccumГSliceofTypex۰T) Name() string {
+func (c *callerAccumГSliceOfTypex۰T) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerAccumГSliceofTypex۰T) Type() reflect.Type {
+func (c *callerAccumГSliceOfTypex۰T) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerAccumГSliceofTypex۰T) Call(args []interface{}) []interface{} {
+func (c *callerAccumГSliceOfTypex۰T) Call(args []interface{}) []interface{} {
 	out0 := c.fn(args[0].(accum))
 	return []interface{}{out0}
 }
 
-func (c *callerAccumГSliceofTypex۰T) Call1x1(arg0 interface{}) (interface{}) {
+func (c *callerAccumГSliceOfTypex۰T) Call1x1(arg0 interface{}) (interface{}) {
 	return c.fn(arg0.(accum))
 }
 

--- a/sdks/go/pkg/beam/util/shimx/generate.go
+++ b/sdks/go/pkg/beam/util/shimx/generate.go
@@ -176,14 +176,27 @@ type Wrap struct {
 // See https://golang.org/ref/spec#Identifiers for details.
 func Name(t string) string {
 	if strings.HasPrefix(t, "[]") {
-		return Name(t[2:] + "Slice")
+		return "SliceOf" + Name(t[2:])
+	}
+	if strings.HasPrefix(t, "map[") {
+		if i := strings.Index(t, "]"); i >= 0 {
+			// It should read MapOfKeyTypeName_ValueTypeName.
+			return "MapOf" + Name(t[4:i]) + "_" + Name(t[i+1:])
+		}
+	}
+	// Handle arrays.
+	if strings.HasPrefix(t, "[") {
+		if i := strings.Index(t, "]"); i >= 0 {
+			// It should read ArrayOfNTypeName.
+			return "ArrayOf" + t[1:i] + Name(t[i+1:])
+		}
+	}
+	if strings.HasPrefix(t, "*") {
+		return "Ꮨ" + Name(t[1:])
 	}
 
 	t = strings.Replace(t, "beam.", "typex.", -1)
 	t = strings.Replace(t, ".", "۰", -1) // For packages
-	t = strings.Replace(t, "*", "Ꮨ", -1) // For pointers
-	t = strings.Replace(t, "[", "_", -1) // For maps
-	t = strings.Replace(t, "]", "_", -1)
 	return strings.Title(t)
 }
 

--- a/sdks/go/pkg/beam/util/shimx/generate_test.go
+++ b/sdks/go/pkg/beam/util/shimx/generate_test.go
@@ -29,6 +29,7 @@ func TestTop_Sort(t *testing.T) {
 		Emitters:  []Emitter{{Name: "z"}, {Name: "a"}, {Name: "r"}},
 		Inputs:    []Input{{Name: "z"}, {Name: "a"}, {Name: "r"}},
 		Shims:     []Func{{Name: "z"}, {Name: "a"}, {Name: "r"}},
+		Wraps:     []Wrap{{Name: "z"}, {Name: "a", Methods: []Func{{Name: "z"}, {Name: "a"}, {Name: "r"}}}, {Name: "r"}},
 	}
 
 	top.sort()
@@ -49,6 +50,14 @@ func TestTop_Sort(t *testing.T) {
 	}
 	if !sort.SliceIsSorted(top.Shims, func(i, j int) bool { return top.Shims[i].Name < top.Shims[j].Name }) {
 		t.Errorf("top.Shims not sorted: got %v, want it sorted", top.Shims)
+	}
+	if !sort.SliceIsSorted(top.Wraps, func(i, j int) bool { return top.Wraps[i].Name < top.Wraps[j].Name }) {
+		t.Errorf("top.Wraps not sorted: got %v, want it sorted", top.Wraps)
+	}
+	for i, w := range top.Wraps {
+		if !sort.SliceIsSorted(w.Methods, func(i, j int) bool { return w.Methods[i].Name < w.Methods[j].Name }) {
+			t.Errorf("top.Wraps[%d] not sorted: got %v, want it sorted", i, w.Methods)
+		}
 	}
 }
 
@@ -89,9 +98,16 @@ func TestName(t *testing.T) {
 	}{
 		{"int", "Int"},
 		{"foo.MyInt", "Foo۰MyInt"},
-		{"[]beam.X", "Typex۰XSlice"},
-		{"map[int]beam.X", "Map_int_typex۰X"},
-		{"map[string]*beam.X", "Map_string_Ꮨtypex۰X"},
+		{"*foo.MyInt", "ᏘFoo۰MyInt"},
+		{"[]beam.X", "SliceOfTypex۰X"},
+		{"[4]beam.X", "ArrayOf4Typex۰X"},
+		{"[53][]beam.X", "ArrayOf53SliceOfTypex۰X"},
+		{"[][123]beam.X", "SliceOfArrayOf123Typex۰X"},
+		{"[][123]*beam.X", "SliceOfArrayOf123ᏘTypex۰X"},
+		{"*[][123]beam.X", "ᏘSliceOfArrayOf123Typex۰X"},
+		{"*[][123]*beam.X", "ᏘSliceOfArrayOf123ᏘTypex۰X"},
+		{"map[int]beam.X", "MapOfInt_Typex۰X"},
+		{"map[string]*beam.X", "MapOfString_ᏘTypex۰X"},
 	}
 	for _, test := range tests {
 		if got := Name(test.have); got != test.want {

--- a/sdks/go/pkg/beam/util/starcgenx/starcgenx.go
+++ b/sdks/go/pkg/beam/util/starcgenx/starcgenx.go
@@ -27,6 +27,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"strconv"
 	"strings"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/util/shimx"
@@ -316,13 +317,19 @@ func (e *Extractor) extractType(ot *types.TypeName) {
 		if t, ok := ot.Type().(*types.Named); ok {
 			ot = t.Obj()
 			name = types.TypeString(t, e.qualifier)
-
-			if pkg := t.Obj().Pkg(); pkg != nil {
-				e.imports[pkg.Path()] = struct{}{}
-			}
 		}
 	}
-	e.types[name] = struct{}{}
+	// Only register non-universe types (eg. avoid `error` and similar)
+	if pkg := ot.Pkg(); pkg != nil {
+		path := pkg.Path()
+		e.imports[pkg.Path()] = struct{}{}
+
+		// Do not add universal types to be registered.
+		if path == shimx.TypexImport {
+			return
+		}
+		e.types[name] = struct{}{}
+	}
 }
 
 // Examines the signature and extracts types of parameters and results for
@@ -593,10 +600,12 @@ func (e *Extractor) NameType(t types.Type) string {
 			return "Iter" + ipt.Name
 		}
 		return shimx.Name(e.sigKey(a))
-	case *types.Pointer:
-		return e.NameType(a.Elem())
 	case *types.Slice:
-		return "Sliceof" + e.NameType(a.Elem())
+		return "SliceOf" + e.NameType(a.Elem())
+	case *types.Map:
+		return "MapOf" + e.NameType(a.Key()) + "_" + e.NameType(a.Elem())
+	case *types.Array:
+		return "ArrayOf" + strconv.Itoa(int(a.Len())) + e.NameType(a.Elem())
 	default:
 		return shimx.Name(types.TypeString(t, e.qualifier))
 	}

--- a/sdks/go/pkg/beam/util/starcgenx/starcgenx_test.go
+++ b/sdks/go/pkg/beam/util/starcgenx/starcgenx_test.go
@@ -32,12 +32,10 @@ func TestExtractor(t *testing.T) {
 		ids      []string
 		expected []string
 		excluded []string
+		imports  []string
 	}{
 		{name: "pardo1", files: []string{pardo}, pkg: "pardo",
 			expected: []string{"runtime.RegisterFunction(MyIdent)", "runtime.RegisterFunction(MyDropVal)", "runtime.RegisterFunction(MyOtherDoFn)", "runtime.RegisterType(reflect.TypeOf((*foo)(nil)).Elem())", "funcMakerStringГString", "funcMakerIntStringГInt", "funcMakerFooГStringFoo"},
-		},
-		{name: "imports1", files: []string{imports}, pkg: "imports",
-			expected: []string{"runtime.RegisterFunction(MyImportedTypesDoFn)", "runtime.RegisterType(reflect.TypeOf((*rand.Rand)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*time.Time)(nil)).Elem())", "funcMakerRand۰RandГTime۰Time", "\"math/rand\"", "\"time\""},
 		},
 		{name: "emits1", files: []string{emits}, pkg: "emits",
 			expected: []string{"runtime.RegisterFunction(anotherFn)", "runtime.RegisterFunction(emitFn)", "runtime.RegisterType(reflect.TypeOf((*reInt)(nil)).Elem())", "funcMakerEmitIntIntГ", "emitMakerIntInt", "funcMakerIntIntEmitIntIntГError"},
@@ -47,11 +45,47 @@ func TestExtractor(t *testing.T) {
 		},
 		{name: "structs1", files: []string{structs}, pkg: "structs", ids: []string{"myDoFn"},
 			expected: []string{"runtime.RegisterType(reflect.TypeOf((*myDoFn)(nil)).Elem())", "funcMakerEmitIntГ", "emitMakerInt", "funcMakerValTypeValTypeEmitIntГ", "runtime.RegisterType(reflect.TypeOf((*valType)(nil)).Elem())", "reflectx.RegisterStructWrapper(reflect.TypeOf((*myDoFn)(nil)).Elem(), wrapMakerMyDoFn)"},
-			excluded: []string{"funcMakerStringГ", "emitMakerString", "nonPipelineType", "UnrelatedMethod1", "UnrelatedMethod2", "UnrelatedMethod3"},
+			excluded: []string{"funcMakerStringГ", "emitMakerString", "nonPipelineType", "UnrelatedMethod1", "UnrelatedMethod2", "UnrelatedMethod3", "nonLifecycleMethod"},
+		},
+		{name: "excludedtypes", files: []string{excludedtypes}, pkg: "excludedtypes", imports: []string{"github.com/apache/beam/sdks/go/pkg/beam"},
+			expected: []string{"runtime.RegisterFunction(ShouldExist)", "funcMakerTypex۰TГTypex۰XError"},
+			excluded: []string{"runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*beam.T)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*typex.X)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*beam.X)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*error)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*context.Context)(nil)).Elem())"},
+		},
+		{name: "newtypes", files: []string{newtypes}, pkg: "newtypes",
+			expected: []string{"runtime.RegisterFunction(included)", "runtime.RegisterFunction(users)", "funcMakerMapOfString_IntᏘIntГArrayOf4ᏘInt", "runtime.RegisterType(reflect.TypeOf((*myInterface)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*myType)(nil)).Elem())"},
+			excluded: []string{"runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*beam.T)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*typex.X)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*beam.X)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*error)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*context.Context)(nil)).Elem())"},
+		},
+		{name: "imports1", files: []string{imports}, pkg: "imports", imports: []string{"math/rand", "time"},
+			expected: []string{"runtime.RegisterFunction(MyImportedTypesDoFn)", "runtime.RegisterType(reflect.TypeOf((*rand.Rand)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*time.Time)(nil)).Elem())", "funcMakerᏘRand۰RandГTime۰Time", "\"math/rand\"", "\"time\""},
+		},
+		{name: "alias", files: []string{alias}, pkg: "alias", imports: []string{"io"},
+			expected: []string{"runtime.RegisterType(reflect.TypeOf((*io.Reader)(nil)).Elem())"},
+			excluded: []string{"runtime.RegisterType(reflect.TypeOf((*myType)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*error)(nil)).Elem())", "runtime.RegisterType(reflect.TypeOf((*myError)(nil)).Elem())"},
+		},
+		{name: "vars", files: []string{vars}, pkg: "vars", imports: []string{"strings"},
+			excluded: []string{"runtime.RegisterFunction(strings.MyTitle)", "runtime.RegisterFunction(anonFunction)"},
 		},
 	}
+
+	// Some environments (eg. Jenkins) doen't appear to be able to
+	// handle the imports in some tests. If a test would fail, for the
+	// environment, it shouldn't be run.
+	imp := importer.Default()
 	for _, test := range tests {
 		test := test
+
+		var skip bool
+		for _, p := range test.imports {
+			if _, err := imp.Import(p); err != nil {
+				t.Logf("unable to import %v", p)
+				skip = true
+			}
+		}
+		if skip {
+			t.Logf("skipping testcase %v", test.name)
+			continue
+		}
+
 		t.Run(test.name, func(t *testing.T) {
 			fset := token.NewFileSet()
 			var fs []*ast.File
@@ -64,7 +98,7 @@ func TestExtractor(t *testing.T) {
 			}
 			e := NewExtractor(test.pkg)
 			e.Ids = test.ids
-			if err := e.FromAsts(importer.Default(), fset, fs); err != nil {
+			if err := e.FromAsts(imp, fset, fs); err != nil {
 				t.Fatal(err)
 			}
 			data := e.Generate("test_shims.go")
@@ -117,6 +151,54 @@ func MyImportedTypesDoFn(r *rand.Rand) time.Time {
 }
 `
 
+const excludedtypes = `
+package excludedtypes
+
+import (
+	"github.com/apache/beam/sdks/go/pkg/beam"
+)
+
+func ShouldExist(v beam.T) (beam.X, error) {
+	return nil
+}
+`
+
+const newtypes = `
+package newtypes
+
+func included(k map[string]int, v *int) [4]*int {
+	return [4]*int{}
+}
+
+type myType struct{}
+type myInterface interface{}
+
+func users(k *myType, v [2]myInterface) {
+}
+`
+
+const alias = `
+package newtypes
+
+import (
+	"io"
+)
+
+type myType = io.Reader
+type myError = error
+`
+
+const vars = `
+package vars
+
+import (
+	"strings"
+)
+var myTitle = strings.Title
+
+var anonFunction = func(int) int {return 0}
+`
+
 const emits = `
 package emits
 
@@ -151,6 +233,8 @@ func (f *myDoFn) Setup(emit func(int)) {}
 func (f *myDoFn) StartBundle(emit func(int)) {}
 func (f *myDoFn) FinishBundle(emit func(int)) error {}
 func (f *myDoFn) Teardown(emit func(int)) {}
+
+func (f *myDoFn) NonLifecycleMethod() {}
 
 type nonPipelineType int
 

--- a/sdks/go/pkg/beam/x/debug/debug.shims.go
+++ b/sdks/go/pkg/beam/x/debug/debug.shims.go
@@ -39,9 +39,6 @@ func init() {
 	runtime.RegisterType(reflect.TypeOf((*printFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*printGBKFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*printKVFn)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.T)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.X)(nil)).Elem())
-	runtime.RegisterType(reflect.TypeOf((*typex.Y)(nil)).Elem())
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*headFn)(nil)).Elem(), wrapMakerHeadFn)
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*headKVFn)(nil)).Elem(), wrapMakerHeadKVFn)
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*printFn)(nil)).Elem(), wrapMakerPrintFn)
@@ -50,8 +47,8 @@ func init() {
 	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context,typex.T) (typex.T))(nil)).Elem(), funcMakerContext۰ContextTypex۰TГTypex۰T)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context,typex.X,func(*typex.Y) bool) (typex.X))(nil)).Elem(), funcMakerContext۰ContextTypex۰XIterTypex۰YГTypex۰X)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context,typex.X,typex.Y) (typex.X,typex.Y))(nil)).Elem(), funcMakerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte,func(*typex.T) bool,func(typex.T)) ())(nil)).Elem(), funcMakerSliceofByteIterTypex۰TEmitTypex۰TГ)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte,func(*typex.X, *typex.Y) bool,func(typex.X, typex.Y)) ())(nil)).Elem(), funcMakerSliceofByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte,func(*typex.T) bool,func(typex.T)) ())(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TEmitTypex۰TГ)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte,func(*typex.X, *typex.Y) bool,func(typex.X, typex.Y)) ())(nil)).Elem(), funcMakerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) ())(nil)).Elem(), funcMakerTypex۰TГ)
 	exec.RegisterEmitter(reflect.TypeOf((*func(typex.T) ())(nil)).Elem(), emitMakerTypex۰T)
 	exec.RegisterEmitter(reflect.TypeOf((*func(typex.X,typex.Y) ())(nil)).Elem(), emitMakerTypex۰XTypex۰Y)
@@ -173,55 +170,55 @@ func (c *callerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y) Call3x2(arg0,
 	return c.fn(arg0.(context.Context), arg1.(typex.X), arg2.(typex.Y))
 }
 
-type callerSliceofByteIterTypex۰TEmitTypex۰TГ struct {
+type callerSliceOfByteIterTypex۰TEmitTypex۰TГ struct {
 	fn func([]byte,func(*typex.T) bool,func(typex.T)) ()
 }
 
-func funcMakerSliceofByteIterTypex۰TEmitTypex۰TГ(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteIterTypex۰TEmitTypex۰TГ(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte,func(*typex.T) bool,func(typex.T)) ())
-	return &callerSliceofByteIterTypex۰TEmitTypex۰TГ{fn: f}
+	return &callerSliceOfByteIterTypex۰TEmitTypex۰TГ{fn: f}
 }
 
-func (c *callerSliceofByteIterTypex۰TEmitTypex۰TГ) Name() string {
+func (c *callerSliceOfByteIterTypex۰TEmitTypex۰TГ) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteIterTypex۰TEmitTypex۰TГ) Type() reflect.Type {
+func (c *callerSliceOfByteIterTypex۰TEmitTypex۰TГ) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteIterTypex۰TEmitTypex۰TГ) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteIterTypex۰TEmitTypex۰TГ) Call(args []interface{}) []interface{} {
 	c.fn(args[0].([]byte), args[1].(func(*typex.T) bool), args[2].(func(typex.T)))
 	return []interface{}{}
 }
 
-func (c *callerSliceofByteIterTypex۰TEmitTypex۰TГ) Call3x0(arg0, arg1, arg2 interface{}) () {
+func (c *callerSliceOfByteIterTypex۰TEmitTypex۰TГ) Call3x0(arg0, arg1, arg2 interface{}) () {
 	c.fn(arg0.([]byte), arg1.(func(*typex.T) bool), arg2.(func(typex.T)))
 }
 
-type callerSliceofByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ struct {
+type callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ struct {
 	fn func([]byte,func(*typex.X, *typex.Y) bool,func(typex.X, typex.Y)) ()
 }
 
-func funcMakerSliceofByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ(fn interface{}) reflectx.Func {
+func funcMakerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ(fn interface{}) reflectx.Func {
 	f := fn.(func([]byte,func(*typex.X, *typex.Y) bool,func(typex.X, typex.Y)) ())
-	return &callerSliceofByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ{fn: f}
+	return &callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ{fn: f}
 }
 
-func (c *callerSliceofByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Name() string {
+func (c *callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceofByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Type() reflect.Type {
+func (c *callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceofByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Call(args []interface{}) []interface{} {
+func (c *callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Call(args []interface{}) []interface{} {
 	c.fn(args[0].([]byte), args[1].(func(*typex.X, *typex.Y) bool), args[2].(func(typex.X, typex.Y)))
 	return []interface{}{}
 }
 
-func (c *callerSliceofByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Call3x0(arg0, arg1, arg2 interface{}) () {
+func (c *callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Call3x0(arg0, arg1, arg2 interface{}) () {
 	c.fn(arg0.([]byte), arg1.(func(*typex.X, *typex.Y) bool), arg2.(func(typex.X, typex.Y)))
 }
 


### PR DESCRIPTION
Updates the starcgen code generator to better handle Pointer, Map, and Array types.

* Slice suffix for function names is now a prefix to avoid collisions in ordering with Maps of Slice of Arrays or similar
* Filter out "universal" named types such as error.
* Filter out Beam internal types (beam.X/typex.X and similar)
* Improve test coverage for both the templates and the analyzer.
* Regenerate the beam shims with `go generate ./...`

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

