### PR TITLE
[BEAM-6602] Preparatory PR for integrating schemas into BigQuery: Push TableRow conversion to end of pipeline

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -515,11 +515,10 @@ class BatchLoads<DestinationT, ElementT>
                           @Element KV<DestinationT, ElementT> element,
                           OutputReceiver<KV<ShardedKey<DestinationT>, ElementT>> o) {
                         DestinationT destination = element.getKey();
-                        ElementT tableRow = element.getValue();
                         o.output(
                             KV.of(
                                 ShardedKey.of(destination, ++shardNumber % numFileShards),
-                                tableRow));
+                                element.getValue()));
                       }
                     }))
             .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), elementCoder));

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -46,6 +46,7 @@ import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.Values;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.WithKeys;
@@ -74,8 +75,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** PTransform that uses BigQuery batch-load jobs to write a PCollection to BigQuery. */
-class BatchLoads<DestinationT>
-    extends PTransform<PCollection<KV<DestinationT, TableRow>>, WriteResult> {
+class BatchLoads<DestinationT, ElementT>
+    extends PTransform<PCollection<KV<DestinationT, ElementT>>, WriteResult> {
   static final Logger LOG = LoggerFactory.getLogger(BatchLoads.class);
 
   // The maximum number of file writers to keep open in a single bundle at a time, since file
@@ -129,6 +130,8 @@ class BatchLoads<DestinationT>
   private Duration triggeringFrequency;
   private ValueProvider<String> customGcsTempLocation;
   private ValueProvider<String> loadJobProjectId;
+  private final Coder<ElementT> elementCoder;
+  private final SerializableFunction<ElementT, TableRow> toRowFunction;
   private String kmsKey;
 
   // The maximum number of times to retry failed load or copy jobs.
@@ -143,6 +146,8 @@ class BatchLoads<DestinationT>
       ValueProvider<String> customGcsTempLocation,
       @Nullable ValueProvider<String> loadJobProjectId,
       boolean ignoreUnknownValues,
+      Coder<ElementT> elementCoder,
+      SerializableFunction<ElementT, TableRow> toRowFunction,
       @Nullable String kmsKey) {
     bigQueryServices = new BigQueryServicesImpl();
     this.writeDisposition = writeDisposition;
@@ -159,6 +164,8 @@ class BatchLoads<DestinationT>
     this.customGcsTempLocation = customGcsTempLocation;
     this.loadJobProjectId = loadJobProjectId;
     this.ignoreUnknownValues = ignoreUnknownValues;
+    this.elementCoder = elementCoder;
+    this.toRowFunction = toRowFunction;
     this.kmsKey = kmsKey;
   }
 
@@ -237,7 +244,7 @@ class BatchLoads<DestinationT>
   }
 
   // Expand the pipeline when the user has requested periodically-triggered file writes.
-  private WriteResult expandTriggered(PCollection<KV<DestinationT, TableRow>> input) {
+  private WriteResult expandTriggered(PCollection<KV<DestinationT, ElementT>> input) {
     checkArgument(numFileShards > 0);
     Pipeline p = input.getPipeline();
     final PCollectionView<String> loadJobIdPrefixView = createLoadJobIdPrefixView(p);
@@ -249,10 +256,10 @@ class BatchLoads<DestinationT>
     // Instead we ensure that the files are written if a threshold number of records are ready.
     // We use only the user-supplied trigger on the actual BigQuery load. This allows us to
     // offload the data to the filesystem.
-    PCollection<KV<DestinationT, TableRow>> inputInGlobalWindow =
+    PCollection<KV<DestinationT, ElementT>> inputInGlobalWindow =
         input.apply(
             "rewindowIntoGlobal",
-            Window.<KV<DestinationT, TableRow>>into(new GlobalWindows())
+            Window.<KV<DestinationT, ElementT>>into(new GlobalWindows())
                 .triggering(
                     Repeatedly.forever(
                         AfterFirst.of(
@@ -330,15 +337,15 @@ class BatchLoads<DestinationT>
   }
 
   // Expand the pipeline when the user has not requested periodically-triggered file writes.
-  public WriteResult expandUntriggered(PCollection<KV<DestinationT, TableRow>> input) {
+  public WriteResult expandUntriggered(PCollection<KV<DestinationT, ElementT>> input) {
     Pipeline p = input.getPipeline();
     final PCollectionView<String> loadJobIdPrefixView = createLoadJobIdPrefixView(p);
     final PCollectionView<String> tempFilePrefixView =
         createTempFilePrefixView(p, loadJobIdPrefixView);
-    PCollection<KV<DestinationT, TableRow>> inputInGlobalWindow =
+    PCollection<KV<DestinationT, ElementT>> inputInGlobalWindow =
         input.apply(
             "rewindowIntoGlobal",
-            Window.<KV<DestinationT, TableRow>>into(new GlobalWindows())
+            Window.<KV<DestinationT, ElementT>>into(new GlobalWindows())
                 .triggering(DefaultTrigger.of())
                 .discardingFiredPanes());
     PCollection<WriteBundlesToFiles.Result<DestinationT>> results =
@@ -445,27 +452,31 @@ class BatchLoads<DestinationT>
   // Writes input data to dynamically-sharded, per-bundle files. Returns a PCollection of filename,
   // file byte size, and table destination.
   PCollection<WriteBundlesToFiles.Result<DestinationT>> writeDynamicallyShardedFiles(
-      PCollection<KV<DestinationT, TableRow>> input, PCollectionView<String> tempFilePrefix) {
+      PCollection<KV<DestinationT, ElementT>> input, PCollectionView<String> tempFilePrefix) {
     TupleTag<WriteBundlesToFiles.Result<DestinationT>> writtenFilesTag =
         new TupleTag<WriteBundlesToFiles.Result<DestinationT>>("writtenFiles") {};
-    TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag =
-        new TupleTag<KV<ShardedKey<DestinationT>, TableRow>>("unwrittenRecords") {};
+    TupleTag<KV<ShardedKey<DestinationT>, ElementT>> unwrittedRecordsTag =
+        new TupleTag<KV<ShardedKey<DestinationT>, ElementT>>("unwrittenRecords") {};
     PCollectionTuple writeBundlesTuple =
         input.apply(
             "WriteBundlesToFiles",
             ParDo.of(
                     new WriteBundlesToFiles<>(
-                        tempFilePrefix, unwrittedRecordsTag, maxNumWritersPerBundle, maxFileSize))
+                        tempFilePrefix,
+                        unwrittedRecordsTag,
+                        maxNumWritersPerBundle,
+                        maxFileSize,
+                        toRowFunction))
                 .withSideInputs(tempFilePrefix)
                 .withOutputTags(writtenFilesTag, TupleTagList.of(unwrittedRecordsTag)));
     PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFiles =
         writeBundlesTuple
             .get(writtenFilesTag)
             .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
-    PCollection<KV<ShardedKey<DestinationT>, TableRow>> unwrittenRecords =
+    PCollection<KV<ShardedKey<DestinationT>, ElementT>> unwrittenRecords =
         writeBundlesTuple
             .get(unwrittedRecordsTag)
-            .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()));
+            .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), elementCoder));
 
     // If the bundles contain too many output tables to be written inline to files (due to memory
     // limits), any unwritten records will be spilled to the unwrittenRecordsTag PCollection.
@@ -484,14 +495,14 @@ class BatchLoads<DestinationT>
   // Writes input data to statically-sharded files. Returns a PCollection of filename,
   // file byte size, and table destination.
   PCollection<WriteBundlesToFiles.Result<DestinationT>> writeShardedFiles(
-      PCollection<KV<DestinationT, TableRow>> input, PCollectionView<String> tempFilePrefix) {
+      PCollection<KV<DestinationT, ElementT>> input, PCollectionView<String> tempFilePrefix) {
     checkState(numFileShards > 0);
-    PCollection<KV<ShardedKey<DestinationT>, TableRow>> shardedRecords =
+    PCollection<KV<ShardedKey<DestinationT>, ElementT>> shardedRecords =
         input
             .apply(
                 "AddShard",
                 ParDo.of(
-                    new DoFn<KV<DestinationT, TableRow>, KV<ShardedKey<DestinationT>, TableRow>>() {
+                    new DoFn<KV<DestinationT, ElementT>, KV<ShardedKey<DestinationT>, ElementT>>() {
                       int shardNumber;
 
                       @Setup
@@ -500,28 +511,32 @@ class BatchLoads<DestinationT>
                       }
 
                       @ProcessElement
-                      public void processElement(ProcessContext c) {
-                        DestinationT destination = c.element().getKey();
-                        TableRow tableRow = c.element().getValue();
-                        c.output(
+                      public void processElement(
+                          @Element KV<DestinationT, ElementT> element,
+                          OutputReceiver<KV<ShardedKey<DestinationT>, ElementT>> o) {
+                        DestinationT destination = element.getKey();
+                        ElementT tableRow = element.getValue();
+                        o.output(
                             KV.of(
                                 ShardedKey.of(destination, ++shardNumber % numFileShards),
                                 tableRow));
                       }
                     }))
-            .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()));
+            .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), elementCoder));
 
     return writeShardedRecords(shardedRecords, tempFilePrefix);
   }
 
   private PCollection<Result<DestinationT>> writeShardedRecords(
-      PCollection<KV<ShardedKey<DestinationT>, TableRow>> shardedRecords,
+      PCollection<KV<ShardedKey<DestinationT>, ElementT>> shardedRecords,
       PCollectionView<String> tempFilePrefix) {
     return shardedRecords
         .apply("GroupByDestination", GroupByKey.create())
         .apply(
             "WriteGroupedRecords",
-            ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(tempFilePrefix, maxFileSize))
+            ParDo.of(
+                    new WriteGroupedRecordsToFiles<DestinationT, ElementT>(
+                        tempFilePrefix, maxFileSize, toRowFunction))
                 .withSideInputs(tempFilePrefix))
         .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
   }
@@ -603,7 +618,7 @@ class BatchLoads<DestinationT>
   }
 
   @Override
-  public WriteResult expand(PCollection<KV<DestinationT, TableRow>> input) {
+  public WriteResult expand(PCollection<KV<DestinationT, ElementT>> input) {
     return (triggeringFrequency != null) ? expandTriggered(input) : expandUntriggered(input);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryCoderProviderRegistrar.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryCoderProviderRegistrar.java
@@ -32,7 +32,6 @@ public class BigQueryCoderProviderRegistrar implements CoderProviderRegistrar {
   @Override
   public List<CoderProvider> getCoderProviders() {
     return ImmutableList.of(
-        CoderProviders.forCoder(TypeDescriptor.of(TableRow.class), TableRowJsonCoder.of()),
-        CoderProviders.forCoder(TypeDescriptor.of(TableRowInfo.class), TableRowInfoCoder.of()));
+        CoderProviders.forCoder(TypeDescriptor.of(TableRow.class), TableRowJsonCoder.of()));
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1030,7 +1030,7 @@ public class BigQueryIO {
    * function must be provided to convert each input element into a {@link TableRow} using {@link
    * Write#withFormatFunction(SerializableFunction)}.
    *
-   * <p>In BigQuery, each table has an enlcosing dataset. The dataset being written must already
+   * <p>In BigQuery, each table has an enclosing dataset. The dataset being written must already
    * exist.
    *
    * <p>By default, tables will be created if they do not exist, which corresponds to a {@link

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -77,6 +77,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -1029,7 +1030,7 @@ public class BigQueryIO {
    * function must be provided to convert each input element into a {@link TableRow} using {@link
    * Write#withFormatFunction(SerializableFunction)}.
    *
-   * <p>In BigQuery, each table has an encosing dataset. The dataset being written must already
+   * <p>In BigQuery, each table has an enlcosing dataset. The dataset being written must already
    * exist.
    *
    * <p>By default, tables will be created if they do not exist, which corresponds to a {@link
@@ -1068,6 +1069,7 @@ public class BigQueryIO {
         .setIgnoreUnknownValues(false)
         .setMaxFilesPerPartition(BatchLoads.DEFAULT_MAX_FILES_PER_PARTITION)
         .setMaxBytesPerPartition(BatchLoads.DEFAULT_MAX_BYTES_PER_PARTITION)
+        .setOptimizeWrites(false)
         .build();
   }
 
@@ -1187,6 +1189,8 @@ public class BigQueryIO {
     @Nullable
     abstract String getKmsKey();
 
+    abstract Boolean getOptimizeWrites();
+
     abstract Builder<T> toBuilder();
 
     @AutoValue.Builder
@@ -1243,6 +1247,8 @@ public class BigQueryIO {
       abstract Builder<T> setIgnoreUnknownValues(Boolean ignoreUnknownValues);
 
       abstract Builder<T> setKmsKey(String kmsKey);
+
+      abstract Builder<T> setOptimizeWrites(Boolean optimizeWrites);
 
       abstract Write<T> build();
     }
@@ -1554,6 +1560,15 @@ public class BigQueryIO {
       return toBuilder().setKmsKey(kmsKey).build();
     }
 
+    /**
+     * If true, enables new codepaths that are expected to use less resources while writing to
+     * BigQuery.
+     */
+    @Experimental
+    public Write<T> withOptimizedWrites() {
+      return toBuilder().setOptimizeWrites(true).build();
+    }
+
     @VisibleForTesting
     /** This method is for test usage only */
     public Write<T> withTestServices(BigQueryServices testServices) {
@@ -1737,13 +1752,43 @@ public class BigQueryIO {
         throw new RuntimeException(e);
       }
 
-      PCollection<KV<DestinationT, TableRow>> rowsWithDestination =
-          input
-              .apply("PrepareWrite", new PrepareWrite<>(dynamicDestinations, getFormatFunction()))
-              .setCoder(KvCoder.of(destinationCoder, TableRowJsonCoder.of()));
-
       Method method = resolveMethod(input);
+      if (getOptimizeWrites()) {
+        PCollection<KV<DestinationT, T>> rowsWithDestination =
+            input
+                .apply(
+                    "PrepareWrite",
+                    new PrepareWrite<>(dynamicDestinations, SerializableFunctions.identity()))
+                .setCoder(KvCoder.of(destinationCoder, input.getCoder()));
+        return continueExpandTyped(
+            rowsWithDestination,
+            input.getCoder(),
+            destinationCoder,
+            dynamicDestinations,
+            getFormatFunction(),
+            method);
+      } else {
+        PCollection<KV<DestinationT, TableRow>> rowsWithDestination =
+            input
+                .apply("PrepareWrite", new PrepareWrite<>(dynamicDestinations, getFormatFunction()))
+                .setCoder(KvCoder.of(destinationCoder, TableRowJsonCoder.of()));
+        return continueExpandTyped(
+            rowsWithDestination,
+            TableRowJsonCoder.of(),
+            destinationCoder,
+            dynamicDestinations,
+            SerializableFunctions.identity(),
+            method);
+      }
+    }
 
+    private <DestinationT, ElementT> WriteResult continueExpandTyped(
+        PCollection<KV<DestinationT, ElementT>> input,
+        Coder<ElementT> elementCoder,
+        Coder<DestinationT> destinationCoder,
+        DynamicDestinations<T, DestinationT> dynamicDestinations,
+        SerializableFunction<ElementT, TableRow> toRowFunction,
+        Method method) {
       if (method == Method.STREAMING_INSERTS) {
         checkArgument(
             getWriteDisposition() != WriteDisposition.WRITE_TRUNCATE,
@@ -1751,21 +1796,22 @@ public class BigQueryIO {
         InsertRetryPolicy retryPolicy =
             MoreObjects.firstNonNull(getFailedInsertRetryPolicy(), InsertRetryPolicy.alwaysRetry());
 
-        StreamingInserts<DestinationT> streamingInserts =
-            new StreamingInserts<>(getCreateDisposition(), dynamicDestinations)
+        StreamingInserts<DestinationT, ElementT> streamingInserts =
+            new StreamingInserts<>(
+                    getCreateDisposition(), dynamicDestinations, elementCoder, toRowFunction)
                 .withInsertRetryPolicy(retryPolicy)
                 .withTestServices(getBigQueryServices())
                 .withExtendedErrorInfo(getExtendedErrorInfo())
                 .withSkipInvalidRows(getSkipInvalidRows())
                 .withIgnoreUnknownValues(getIgnoreUnknownValues())
                 .withKmsKey(getKmsKey());
-        return rowsWithDestination.apply(streamingInserts);
+        return input.apply(streamingInserts);
       } else {
         checkArgument(
             getFailedInsertRetryPolicy() == null,
             "Record-insert retry policies are not supported when using BigQuery load jobs.");
 
-        BatchLoads<DestinationT> batchLoads =
+        BatchLoads<DestinationT, ElementT> batchLoads =
             new BatchLoads<>(
                 getWriteDisposition(),
                 getCreateDisposition(),
@@ -1775,6 +1821,8 @@ public class BigQueryIO {
                 getCustomGcsTempLocation(),
                 getLoadJobProjectId(),
                 getIgnoreUnknownValues(),
+                elementCoder,
+                toRowFunction,
                 getKmsKey());
         batchLoads.setTestServices(getBigQueryServices());
         if (getMaxFilesPerBundle() != null) {
@@ -1793,7 +1841,7 @@ public class BigQueryIO {
         }
         batchLoads.setTriggeringFrequency(getTriggeringFrequency());
         batchLoads.setNumFileShards(getNumFileShards());
-        return rowsWithDestination.apply(batchLoads);
+        return input.apply(batchLoads);
       }
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1562,7 +1562,7 @@ public class BigQueryIO {
 
     /**
      * If true, enables new codepaths that are expected to use less resources while writing to
-     * BigQuery.
+     * BigQuery. Not enabled by default in order to maintain backwards compatibility.
      */
     @Experimental
     public Write<T> withOptimizedWrites() {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTables.java
@@ -22,7 +22,6 @@ import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Precondi
 import com.google.api.services.bigquery.model.EncryptionConfiguration;
 import com.google.api.services.bigquery.model.Table;
 import com.google.api.services.bigquery.model.TableReference;
-import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import java.util.Collections;
 import java.util.List;
@@ -46,9 +45,9 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
  * Creates any tables needed before performing streaming writes to the tables. This is a side-effect
  * {@link DoFn}, and returns the original collection unchanged.
  */
-public class CreateTables<DestinationT>
+public class CreateTables<DestinationT, ElementT>
     extends PTransform<
-        PCollection<KV<DestinationT, TableRow>>, PCollection<KV<TableDestination, TableRow>>> {
+        PCollection<KV<DestinationT, ElementT>>, PCollection<KV<TableDestination, ElementT>>> {
   private final CreateDisposition createDisposition;
   private final BigQueryServices bqServices;
   private final DynamicDestinations<?, DestinationT> dynamicDestinations;
@@ -79,17 +78,17 @@ public class CreateTables<DestinationT>
     this.kmsKey = kmsKey;
   }
 
-  CreateTables<DestinationT> withTestServices(BigQueryServices bqServices) {
+  CreateTables<DestinationT, ElementT> withKmsKey(String kmsKey) {
     return new CreateTables<>(createDisposition, bqServices, dynamicDestinations, kmsKey);
   }
 
-  CreateTables<DestinationT> withKmsKey(String kmsKey) {
+  CreateTables<DestinationT, ElementT> withTestServices(BigQueryServices bqServices) {
     return new CreateTables<>(createDisposition, bqServices, dynamicDestinations, kmsKey);
   }
 
   @Override
-  public PCollection<KV<TableDestination, TableRow>> expand(
-      PCollection<KV<DestinationT, TableRow>> input) {
+  public PCollection<KV<TableDestination, ElementT>> expand(
+      PCollection<KV<DestinationT, ElementT>> input) {
     List<PCollectionView<?>> sideInputs = Lists.newArrayList();
     sideInputs.addAll(dynamicDestinations.getSideInputs());
 
@@ -97,7 +96,7 @@ public class CreateTables<DestinationT>
   }
 
   private class CreateTablesFn
-      extends DoFn<KV<DestinationT, TableRow>, KV<TableDestination, TableRow>> {
+      extends DoFn<KV<DestinationT, ElementT>, KV<TableDestination, ElementT>> {
     private Map<DestinationT, TableDestination> destinations;
 
     @StartBundle

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/GenerateShardedTable.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/GenerateShardedTable.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import com.google.api.services.bigquery.model.TableRow;
 import java.io.IOException;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -29,8 +28,8 @@ import org.apache.beam.sdk.values.ShardedKey;
  * Given a write to a specific table, assign that to one of the {@link
  * GenerateShardedTable#numShards} keys assigned to that table.
  */
-class GenerateShardedTable
-    extends DoFn<KV<TableDestination, TableRow>, KV<ShardedKey<String>, TableRow>> {
+class GenerateShardedTable<ElementT>
+    extends DoFn<KV<TableDestination, ElementT>, KV<ShardedKey<String>, ElementT>> {
   private final int numShards;
 
   GenerateShardedTable(int numShards) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PrepareWrite.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PrepareWrite.java
@@ -73,13 +73,13 @@ public class PrepareWrite<InputT, DestinationT, OutputT>
                             + "but %s returned null on element %s",
                         dynamicDestinations,
                         element);
-                    OutputT tableRow = formatFunction.apply(element);
+                    OutputT outputValue = formatFunction.apply(element);
                     checkArgument(
-                        tableRow != null,
+                        outputValue != null,
                         "formatFunction may not return null, but %s returned null on element %s",
                         formatFunction,
                         element);
-                    context.output(KV.of(tableDestination, tableRow));
+                    context.output(KV.of(tableDestination, outputValue));
                   }
                 })
             .withSideInputs(dynamicDestinations.getSideInputs()));

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PrepareWrite.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PrepareWrite.java
@@ -26,52 +26,59 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
+import org.joda.time.Instant;
 
 /**
  * Prepare an input {@link PCollection} for writing to BigQuery. Use the table function to determine
  * which tables each element is written to, and format the element into a {@link TableRow} using the
  * user-supplied format function.
  */
-public class PrepareWrite<T, DestinationT>
-    extends PTransform<PCollection<T>, PCollection<KV<DestinationT, TableRow>>> {
-  private DynamicDestinations<T, DestinationT> dynamicDestinations;
-  private SerializableFunction<T, TableRow> formatFunction;
+public class PrepareWrite<InputT, DestinationT, OutputT>
+    extends PTransform<PCollection<InputT>, PCollection<KV<DestinationT, OutputT>>> {
+  private DynamicDestinations<InputT, DestinationT> dynamicDestinations;
+  private SerializableFunction<InputT, OutputT> formatFunction;
 
   public PrepareWrite(
-      DynamicDestinations<T, DestinationT> dynamicDestinations,
-      SerializableFunction<T, TableRow> formatFunction) {
+      DynamicDestinations<InputT, DestinationT> dynamicDestinations,
+      SerializableFunction<InputT, OutputT> formatFunction) {
     this.dynamicDestinations = dynamicDestinations;
     this.formatFunction = formatFunction;
   }
 
   @Override
-  public PCollection<KV<DestinationT, TableRow>> expand(PCollection<T> input) {
+  public PCollection<KV<DestinationT, OutputT>> expand(PCollection<InputT> input) {
     return input.apply(
         ParDo.of(
-                new DoFn<T, KV<DestinationT, TableRow>>() {
+                new DoFn<InputT, KV<DestinationT, OutputT>>() {
                   @ProcessElement
-                  public void processElement(ProcessContext context, BoundedWindow window)
+                  public void processElement(
+                      ProcessContext context,
+                      @Element InputT element,
+                      @Timestamp Instant timestamp,
+                      BoundedWindow window,
+                      PaneInfo pane)
                       throws IOException {
                     dynamicDestinations.setSideInputAccessorFromProcessContext(context);
-                    ValueInSingleWindow<T> element =
-                        ValueInSingleWindow.of(
-                            context.element(), context.timestamp(), window, context.pane());
-                    DestinationT tableDestination = dynamicDestinations.getDestination(element);
+                    ValueInSingleWindow<InputT> windowedElement =
+                        ValueInSingleWindow.of(element, timestamp, window, pane);
+                    DestinationT tableDestination =
+                        dynamicDestinations.getDestination(windowedElement);
                     checkArgument(
                         tableDestination != null,
                         "DynamicDestinations.getDestination() may not return null, "
                             + "but %s returned null on element %s",
                         dynamicDestinations,
                         element);
-                    TableRow tableRow = formatFunction.apply(context.element());
+                    OutputT tableRow = formatFunction.apply(element);
                     checkArgument(
                         tableRow != null,
                         "formatFunction may not return null, but %s returned null on element %s",
                         formatFunction,
-                        context.element());
+                        element);
                     context.output(KV.of(tableDestination, tableRow));
                   }
                 })

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
@@ -18,8 +18,10 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import com.google.api.services.bigquery.model.TableRow;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 
@@ -27,8 +29,8 @@ import org.apache.beam.sdk.values.PCollection;
  * PTransform that performs streaming BigQuery write. To increase consistency, it leverages
  * BigQuery's best effort de-dup mechanism.
  */
-public class StreamingInserts<DestinationT>
-    extends PTransform<PCollection<KV<DestinationT, TableRow>>, WriteResult> {
+public class StreamingInserts<DestinationT, ElementT>
+    extends PTransform<PCollection<KV<DestinationT, ElementT>>, WriteResult> {
   private BigQueryServices bigQueryServices;
   private final CreateDisposition createDisposition;
   private final DynamicDestinations<?, DestinationT> dynamicDestinations;
@@ -37,11 +39,15 @@ public class StreamingInserts<DestinationT>
   private final boolean skipInvalidRows;
   private final boolean ignoreUnknownValues;
   private final String kmsKey;
+  private final Coder<ElementT> elementCoder;
+  private final SerializableFunction<ElementT, TableRow> toTableRow;
 
   /** Constructor. */
   public StreamingInserts(
       CreateDisposition createDisposition,
-      DynamicDestinations<?, DestinationT> dynamicDestinations) {
+      DynamicDestinations<?, DestinationT> dynamicDestinations,
+      Coder<ElementT> elementCoder,
+      SerializableFunction<ElementT, TableRow> toTableRow) {
     this(
         createDisposition,
         dynamicDestinations,
@@ -50,6 +56,8 @@ public class StreamingInserts<DestinationT>
         false,
         false,
         false,
+        elementCoder,
+        toTableRow,
         null);
   }
 
@@ -62,6 +70,8 @@ public class StreamingInserts<DestinationT>
       boolean extendedErrorInfo,
       boolean skipInvalidRows,
       boolean ignoreUnknownValues,
+      Coder<ElementT> elementCoder,
+      SerializableFunction<ElementT, TableRow> toTableRow,
       String kmsKey) {
     this.createDisposition = createDisposition;
     this.dynamicDestinations = dynamicDestinations;
@@ -70,11 +80,14 @@ public class StreamingInserts<DestinationT>
     this.extendedErrorInfo = extendedErrorInfo;
     this.skipInvalidRows = skipInvalidRows;
     this.ignoreUnknownValues = ignoreUnknownValues;
+    this.elementCoder = elementCoder;
+    this.toTableRow = toTableRow;
     this.kmsKey = kmsKey;
   }
 
   /** Specify a retry policy for failed inserts. */
-  public StreamingInserts<DestinationT> withInsertRetryPolicy(InsertRetryPolicy retryPolicy) {
+  public StreamingInserts<DestinationT, ElementT> withInsertRetryPolicy(
+      InsertRetryPolicy retryPolicy) {
     return new StreamingInserts<>(
         createDisposition,
         dynamicDestinations,
@@ -83,11 +96,13 @@ public class StreamingInserts<DestinationT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        elementCoder,
+        toTableRow,
         kmsKey);
   }
 
   /** Specify whether to use extended error info or not. */
-  public StreamingInserts<DestinationT> withExtendedErrorInfo(boolean extendedErrorInfo) {
+  public StreamingInserts<DestinationT, ElementT> withExtendedErrorInfo(boolean extendedErrorInfo) {
     return new StreamingInserts<>(
         createDisposition,
         dynamicDestinations,
@@ -96,10 +111,12 @@ public class StreamingInserts<DestinationT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        elementCoder,
+        toTableRow,
         kmsKey);
   }
 
-  StreamingInserts<DestinationT> withSkipInvalidRows(boolean skipInvalidRows) {
+  StreamingInserts<DestinationT, ElementT> withSkipInvalidRows(boolean skipInvalidRows) {
     return new StreamingInserts<>(
         createDisposition,
         dynamicDestinations,
@@ -108,10 +125,12 @@ public class StreamingInserts<DestinationT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        elementCoder,
+        toTableRow,
         kmsKey);
   }
 
-  StreamingInserts<DestinationT> withIgnoreUnknownValues(boolean ignoreUnknownValues) {
+  StreamingInserts<DestinationT, ElementT> withIgnoreUnknownValues(boolean ignoreUnknownValues) {
     return new StreamingInserts<>(
         createDisposition,
         dynamicDestinations,
@@ -120,10 +139,12 @@ public class StreamingInserts<DestinationT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        elementCoder,
+        toTableRow,
         kmsKey);
   }
 
-  StreamingInserts<DestinationT> withKmsKey(String kmsKey) {
+  StreamingInserts<DestinationT, ElementT> withKmsKey(String kmsKey) {
     return new StreamingInserts<>(
         createDisposition,
         dynamicDestinations,
@@ -132,10 +153,12 @@ public class StreamingInserts<DestinationT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        elementCoder,
+        toTableRow,
         kmsKey);
   }
 
-  StreamingInserts<DestinationT> withTestServices(BigQueryServices bigQueryServices) {
+  StreamingInserts<DestinationT, ElementT> withTestServices(BigQueryServices bigQueryServices) {
     return new StreamingInserts<>(
         createDisposition,
         dynamicDestinations,
@@ -144,24 +167,28 @@ public class StreamingInserts<DestinationT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        elementCoder,
+        toTableRow,
         kmsKey);
-  }
+ }
 
   @Override
-  public WriteResult expand(PCollection<KV<DestinationT, TableRow>> input) {
-    PCollection<KV<TableDestination, TableRow>> writes =
+  public WriteResult expand(PCollection<KV<DestinationT, ElementT>> input) {
+    PCollection<KV<TableDestination, ElementT>> writes =
         input.apply(
             "CreateTables",
-            new CreateTables<>(createDisposition, dynamicDestinations)
+            new CreateTables<DestinationT, ElementT>(createDisposition, dynamicDestinations)
                 .withTestServices(bigQueryServices)
                 .withKmsKey(kmsKey));
 
     return writes.apply(
-        new StreamingWriteTables()
+        new StreamingWriteTables<ElementT>()
             .withTestServices(bigQueryServices)
             .withInsertRetryPolicy(retryPolicy)
             .withExtendedErrorInfo(extendedErrorInfo)
             .withSkipInvalidRows(skipInvalidRows)
-            .withIgnoreUnknownValues(ignoreUnknownValues));
+            .withIgnoreUnknownValues(ignoreUnknownValues)
+            .withElementCoder(elementCoder)
+            .withToTableRow(toTableRow));
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
@@ -170,7 +170,7 @@ public class StreamingInserts<DestinationT, ElementT>
         elementCoder,
         toTableRow,
         kmsKey);
- }
+  }
 
   @Override
   public WriteResult expand(PCollection<KV<DestinationT, ElementT>> input) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
@@ -19,12 +19,14 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 
 import com.google.api.services.bigquery.model.TableRow;
 import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.ShardedKeyCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
@@ -43,17 +45,26 @@ import org.apache.beam.sdk.values.TupleTagList;
  * <p>This transform assumes that all destination tables already exist by the time it sees a write
  * for that table.
  */
-public class StreamingWriteTables
-    extends PTransform<PCollection<KV<TableDestination, TableRow>>, WriteResult> {
+public class StreamingWriteTables<ElementT>
+    extends PTransform<PCollection<KV<TableDestination, ElementT>>, WriteResult> {
   private BigQueryServices bigQueryServices;
   private InsertRetryPolicy retryPolicy;
   private boolean extendedErrorInfo;
   private static final String FAILED_INSERTS_TAG_ID = "failedInserts";
   private final boolean skipInvalidRows;
   private final boolean ignoreUnknownValues;
+  private final Coder<ElementT> elementCoder;
+  private final SerializableFunction<ElementT, TableRow> toTableRow;
 
   public StreamingWriteTables() {
-    this(new BigQueryServicesImpl(), InsertRetryPolicy.alwaysRetry(), false, false, false);
+    this(
+        new BigQueryServicesImpl(),
+        InsertRetryPolicy.alwaysRetry(),
+        false,
+        false,
+        false,
+        null,
+        null);
   }
 
   private StreamingWriteTables(
@@ -61,41 +72,98 @@ public class StreamingWriteTables
       InsertRetryPolicy retryPolicy,
       boolean extendedErrorInfo,
       boolean skipInvalidRows,
-      boolean ignoreUnknownValues) {
+      boolean ignoreUnknownValues,
+      Coder<ElementT> elementCoder,
+      SerializableFunction<ElementT, TableRow> toTableRow) {
     this.bigQueryServices = bigQueryServices;
     this.retryPolicy = retryPolicy;
     this.extendedErrorInfo = extendedErrorInfo;
     this.skipInvalidRows = skipInvalidRows;
     this.ignoreUnknownValues = ignoreUnknownValues;
+    this.elementCoder = elementCoder;
+    this.toTableRow = toTableRow;
   }
 
-  StreamingWriteTables withTestServices(BigQueryServices bigQueryServices) {
-    return new StreamingWriteTables(
-        bigQueryServices, retryPolicy, extendedErrorInfo, skipInvalidRows, ignoreUnknownValues);
+  StreamingWriteTables<ElementT> withTestServices(BigQueryServices bigQueryServices) {
+    return new StreamingWriteTables<>(
+        bigQueryServices,
+        retryPolicy,
+        extendedErrorInfo,
+        skipInvalidRows,
+        ignoreUnknownValues,
+        elementCoder,
+        toTableRow);
   }
 
-  StreamingWriteTables withInsertRetryPolicy(InsertRetryPolicy retryPolicy) {
-    return new StreamingWriteTables(
-        bigQueryServices, retryPolicy, extendedErrorInfo, skipInvalidRows, ignoreUnknownValues);
+  StreamingWriteTables<ElementT> withInsertRetryPolicy(InsertRetryPolicy retryPolicy) {
+    return new StreamingWriteTables<>(
+        bigQueryServices,
+        retryPolicy,
+        extendedErrorInfo,
+        skipInvalidRows,
+        ignoreUnknownValues,
+        elementCoder,
+        toTableRow);
   }
 
-  StreamingWriteTables withExtendedErrorInfo(boolean extendedErrorInfo) {
-    return new StreamingWriteTables(
-        bigQueryServices, retryPolicy, extendedErrorInfo, skipInvalidRows, ignoreUnknownValues);
+  StreamingWriteTables<ElementT> withExtendedErrorInfo(boolean extendedErrorInfo) {
+    return new StreamingWriteTables<>(
+        bigQueryServices,
+        retryPolicy,
+        extendedErrorInfo,
+        skipInvalidRows,
+        ignoreUnknownValues,
+        elementCoder,
+        toTableRow);
   }
 
-  StreamingWriteTables withSkipInvalidRows(boolean skipInvalidRows) {
-    return new StreamingWriteTables(
-        bigQueryServices, retryPolicy, extendedErrorInfo, skipInvalidRows, ignoreUnknownValues);
+  StreamingWriteTables<ElementT> withSkipInvalidRows(boolean skipInvalidRows) {
+    return new StreamingWriteTables<>(
+        bigQueryServices,
+        retryPolicy,
+        extendedErrorInfo,
+        skipInvalidRows,
+        ignoreUnknownValues,
+        elementCoder,
+        toTableRow);
   }
 
-  StreamingWriteTables withIgnoreUnknownValues(boolean ignoreUnknownValues) {
-    return new StreamingWriteTables(
-        bigQueryServices, retryPolicy, extendedErrorInfo, skipInvalidRows, ignoreUnknownValues);
+  StreamingWriteTables<ElementT> withIgnoreUnknownValues(boolean ignoreUnknownValues) {
+    return new StreamingWriteTables<>(
+        bigQueryServices,
+        retryPolicy,
+        extendedErrorInfo,
+        skipInvalidRows,
+        ignoreUnknownValues,
+        elementCoder,
+        toTableRow);
+  }
+
+  StreamingWriteTables<ElementT> withElementCoder(Coder<ElementT> elementCoder) {
+    return new StreamingWriteTables<>(
+        bigQueryServices,
+        retryPolicy,
+        extendedErrorInfo,
+        skipInvalidRows,
+        ignoreUnknownValues,
+        elementCoder,
+        toTableRow);
+  }
+
+  StreamingWriteTables<ElementT> withToTableRow(
+      SerializableFunction<ElementT, TableRow> toTableRow) {
+    return new StreamingWriteTables<>(
+        bigQueryServices,
+        retryPolicy,
+        extendedErrorInfo,
+        skipInvalidRows,
+        ignoreUnknownValues,
+        elementCoder,
+        toTableRow);
   }
 
   @Override
-  public WriteResult expand(PCollection<KV<TableDestination, TableRow>> input) {
+  public WriteResult expand(PCollection<KV<TableDestination, ElementT>> input) {
     if (extendedErrorInfo) {
       TupleTag<BigQueryInsertError> failedInsertsTag = new TupleTag<>(FAILED_INSERTS_TAG_ID);
       PCollection<BigQueryInsertError> failedInserts =
@@ -118,7 +186,7 @@ public class StreamingWriteTables
   }
 
   private <T> PCollection<T> writeAndGetErrors(
-      PCollection<KV<TableDestination, TableRow>> input,
+      PCollection<KV<TableDestination, ElementT>> input,
       TupleTag<T> failedInsertsTag,
       AtomicCoder<T> coder,
       ErrorContainer<T> errorContainer) {
@@ -134,12 +202,14 @@ public class StreamingWriteTables
     // We create 50 keys per BigQuery table to generate output on. This is few enough that we
     // get good batching into BigQuery's insert calls, and enough that we can max out the
     // streaming insert quota.
-    PCollection<KV<ShardedKey<String>, TableRowInfo>> tagged =
+    PCollection<KV<ShardedKey<String>, TableRowInfo<ElementT>>> tagged =
         input
-            .apply("ShardTableWrites", ParDo.of(new GenerateShardedTable(50)))
-            .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowJsonCoder.of()))
-            .apply("TagWithUniqueIds", ParDo.of(new TagWithUniqueIds()))
-            .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowInfoCoder.of()));
+            .apply("ShardTableWrites", ParDo.of(new GenerateShardedTable<>(50)))
+            .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), elementCoder))
+            .apply("TagWithUniqueIds", ParDo.of(new TagWithUniqueIds<>()))
+            .setCoder(
+                KvCoder.of(
+                    ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowInfoCoder.of(elementCoder)));
 
     TupleTag<Void> mainOutputTag = new TupleTag<>("mainOutput");
 
@@ -154,7 +224,7 @@ public class StreamingWriteTables
             // correctly.
             .apply(
                 "GlobalWindow",
-                Window.<KV<ShardedKey<String>, TableRowInfo>>into(new GlobalWindows())
+                Window.<KV<ShardedKey<String>, TableRowInfo<ElementT>>>into(new GlobalWindows())
                     .triggering(DefaultTrigger.of())
                     .discardingFiredPanes())
             .apply(
@@ -166,7 +236,8 @@ public class StreamingWriteTables
                             failedInsertsTag,
                             errorContainer,
                             skipInvalidRows,
-                            ignoreUnknownValues))
+                            ignoreUnknownValues,
+                            toTableRow))
                     .withOutputTags(mainOutputTag, TupleTagList.of(failedInsertsTag)));
     PCollection<T> failedInserts = tuple.get(failedInsertsTag);
     failedInserts.setCoder(coder);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
@@ -60,11 +60,11 @@ public class StreamingWriteTables<ElementT>
     this(
         new BigQueryServicesImpl(),
         InsertRetryPolicy.alwaysRetry(),
-        false,
-        false,
-        false,
-        null,
-        null);
+        false, // extendedErrorInfo
+        false, // skipInvalidRows
+        false, // ignoreUnknownValues
+        null, // elementCoder
+        null); // toTableRow
   }
 
   private StreamingWriteTables(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowInfo.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowInfo.java
@@ -20,12 +20,12 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import com.google.api.services.bigquery.model.TableRow;
 
 /** Encapsulates a {@link TableRow} along with a unique insertion id. */
-class TableRowInfo {
-  TableRowInfo(TableRow tableRow, String uniqueId) {
+class TableRowInfo<ElementT> {
+  TableRowInfo(ElementT tableRow, String uniqueId) {
     this.tableRow = tableRow;
     this.uniqueId = uniqueId;
   }
 
-  final TableRow tableRow;
+  final ElementT tableRow;
   final String uniqueId;
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowInfoCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowInfoCoder.java
@@ -21,42 +21,47 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
 
 /** Defines a coder for {@link TableRowInfo} objects. */
 @VisibleForTesting
-class TableRowInfoCoder extends AtomicCoder<TableRowInfo> {
-  private static final TableRowInfoCoder INSTANCE = new TableRowInfoCoder();
+class TableRowInfoCoder<ElementT> extends AtomicCoder<TableRowInfo<ElementT>> {
+  private final Coder<ElementT> elementCoder;
 
-  public static TableRowInfoCoder of() {
-    return INSTANCE;
+  private TableRowInfoCoder(Coder<ElementT> elementCoder) {
+    this.elementCoder = elementCoder;
+  }
+
+  public static <ElementT> TableRowInfoCoder of(Coder<ElementT> elementCoder) {
+    return new TableRowInfoCoder(elementCoder);
   }
 
   @Override
-  public void encode(TableRowInfo value, OutputStream outStream) throws IOException {
+  public void encode(TableRowInfo<ElementT> value, OutputStream outStream) throws IOException {
     encode(value, outStream, Context.NESTED);
   }
 
   @Override
-  public void encode(TableRowInfo value, OutputStream outStream, Context context)
+  public void encode(TableRowInfo<ElementT> value, OutputStream outStream, Context context)
       throws IOException {
     if (value == null) {
       throw new CoderException("cannot encode a null value");
     }
-    tableRowCoder.encode(value.tableRow, outStream);
+    elementCoder.encode(value.tableRow, outStream);
     idCoder.encode(value.uniqueId, outStream, context);
   }
 
   @Override
-  public TableRowInfo decode(InputStream inStream) throws IOException {
+  public TableRowInfo<ElementT> decode(InputStream inStream) throws IOException {
     return decode(inStream, Context.NESTED);
   }
 
   @Override
-  public TableRowInfo decode(InputStream inStream, Context context) throws IOException {
-    return new TableRowInfo(tableRowCoder.decode(inStream), idCoder.decode(inStream, context));
+  public TableRowInfo<ElementT> decode(InputStream inStream, Context context) throws IOException {
+    return new TableRowInfo<>(elementCoder.decode(inStream), idCoder.decode(inStream, context));
   }
 
   @Override
@@ -64,6 +69,5 @@ class TableRowInfoCoder extends AtomicCoder<TableRowInfo> {
     throw new NonDeterministicException(this, "TableRows are not deterministic.");
   }
 
-  TableRowJsonCoder tableRowCoder = TableRowJsonCoder.of();
   StringUtf8Coder idCoder = StringUtf8Coder.of();
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TagWithUniqueIds.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TagWithUniqueIds.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import com.google.api.services.bigquery.model.TableRow;
 import java.io.IOException;
 import java.util.UUID;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -33,8 +32,8 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleF
  * sequential number.
  */
 @VisibleForTesting
-class TagWithUniqueIds
-    extends DoFn<KV<ShardedKey<String>, TableRow>, KV<ShardedKey<String>, TableRowInfo>> {
+class TagWithUniqueIds<ElementT>
+    extends DoFn<KV<ShardedKey<String>, ElementT>, KV<ShardedKey<String>, TableRowInfo>> {
   private transient String randomUUID;
   private transient long sequenceNo = 0L;
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteGroupedRecordsToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteGroupedRecordsToFiles.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 
 import com.google.api.services.bigquery.model.TableRow;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.ShardedKey;
@@ -28,41 +29,50 @@ import org.apache.beam.sdk.values.ShardedKey;
  * all the elements in the {@link Iterable} are destined to the same table, they are all written to
  * the same file. Ensures that only one {@link TableRowWriter} is active per bundle.
  */
-class WriteGroupedRecordsToFiles<DestinationT>
+class WriteGroupedRecordsToFiles<DestinationT, ElementT>
     extends DoFn<
-        KV<ShardedKey<DestinationT>, Iterable<TableRow>>,
+        KV<ShardedKey<DestinationT>, Iterable<ElementT>>,
         WriteBundlesToFiles.Result<DestinationT>> {
 
   private final PCollectionView<String> tempFilePrefix;
   private final long maxFileSize;
+  private final SerializableFunction<ElementT, TableRow> toRowFunction;
 
-  WriteGroupedRecordsToFiles(PCollectionView<String> tempFilePrefix, long maxFileSize) {
+  WriteGroupedRecordsToFiles(
+      PCollectionView<String> tempFilePrefix,
+      long maxFileSize,
+      SerializableFunction<ElementT, TableRow> toRowFunction) {
     this.tempFilePrefix = tempFilePrefix;
     this.maxFileSize = maxFileSize;
+    this.toRowFunction = toRowFunction;
   }
 
   @ProcessElement
-  public void processElement(ProcessContext c) throws Exception {
+  public void processElement(
+      ProcessContext c,
+      @Element KV<ShardedKey<DestinationT>, Iterable<ElementT>> element,
+      OutputReceiver<WriteBundlesToFiles.Result<DestinationT>> o)
+      throws Exception {
     String tempFilePrefix = c.sideInput(this.tempFilePrefix);
     TableRowWriter writer = new TableRowWriter(tempFilePrefix);
     try {
-      for (TableRow tableRow : c.element().getValue()) {
+      for (ElementT tableRow : element.getValue()) {
         if (writer.getByteSize() > maxFileSize) {
           writer.close();
           writer = new TableRowWriter(tempFilePrefix);
           TableRowWriter.Result result = writer.getResult();
-          c.output(
+          o.output(
               new WriteBundlesToFiles.Result<>(
                   result.resourceId.toString(), result.byteSize, c.element().getKey().getKey()));
         }
-        writer.write(tableRow);
+        writer.write(toRowFunction.apply(tableRow));
       }
     } finally {
       writer.close();
     }
 
     TableRowWriter.Result result = writer.getResult();
-    c.output(
+    o.output(
         new WriteBundlesToFiles.Result<>(
             result.resourceId.toString(), result.byteSize, c.element().getKey().getKey()));
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryCoderProviderRegistrarTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryCoderProviderRegistrarTest.java
@@ -30,9 +30,4 @@ public class BigQueryCoderProviderRegistrarTest {
   public void testTableRowCoderIsRegistered() throws Exception {
     CoderRegistry.createDefault().getCoder(TableRow.class);
   }
-
-  @Test
-  public void testTableRowInfoCoderIsRegistered() throws Exception {
-    CoderRegistry.createDefault().getCoder(TableRowInfo.class);
-  }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpersTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpersTest.java
@@ -134,14 +134,16 @@ public class BigQueryHelpersTest {
 
   @Test
   public void testTableRowInfoCoderSerializable() {
-    CoderProperties.coderSerializable(TableRowInfoCoder.of());
+    CoderProperties.coderSerializable(TableRowInfoCoder.of(TableRowJsonCoder.of()));
   }
 
   @Test
   public void testComplexCoderSerializable() {
     CoderProperties.coderSerializable(
         WindowedValue.getFullCoder(
-            KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowInfoCoder.of()),
+            KvCoder.of(
+                ShardedKeyCoder.of(StringUtf8Coder.of()),
+                TableRowInfoCoder.of(TableRowJsonCoder.of())),
             IntervalWindow.getCoder()));
   }
 


### PR DESCRIPTION
This sets the stage for using schemas in BigQueryIO. This also has the advantage of being more efficient in the scenario where the user provides a PCollection<T> and a format function T -> TableRow. TableRow is encoded as JSON, so shuffling these objects is expensive. The user's T is often a more efficient object, so shuffling those objects is preferable.