### PR TITLE
[BEAM-5959] KMS support for BigQuery

### DIFF
--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -111,13 +111,11 @@ task integrationTestKms(type: Test) {
   def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
   def gcpTempRoot = project.findProperty('gcpTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
   def dataflowKmsKey = project.findProperty('dataflowKmsKey') ?: "projects/apache-beam-testing/locations/global/keyRings/beam-it/cryptoKeys/test"
-  def kmsKey = project.findProperty('kmsKey') ?: dataflowKmsKey
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=DirectRunner",
           "--project=${gcpProject}",
           "--tempRoot=${gcpTempRoot}",
           "--dataflowKmsKey=${dataflowKmsKey}",
-          "--kmsKey=${kmsKey}",
   ])
 
   // Disable Gradle cache: these ITs interact with live service that should always be considered "out of date"

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -129,6 +129,7 @@ class BatchLoads<DestinationT>
   private Duration triggeringFrequency;
   private ValueProvider<String> customGcsTempLocation;
   private ValueProvider<String> loadJobProjectId;
+  private String kmsKey;
 
   // The maximum number of times to retry failed load or copy jobs.
   private int maxRetryJobs = DEFAULT_MAX_RETRY_JOBS;
@@ -141,7 +142,8 @@ class BatchLoads<DestinationT>
       Coder<DestinationT> destinationCoder,
       ValueProvider<String> customGcsTempLocation,
       @Nullable ValueProvider<String> loadJobProjectId,
-      boolean ignoreUnknownValues) {
+      boolean ignoreUnknownValues,
+      @Nullable String kmsKey) {
     bigQueryServices = new BigQueryServicesImpl();
     this.writeDisposition = writeDisposition;
     this.createDisposition = createDisposition;
@@ -157,6 +159,7 @@ class BatchLoads<DestinationT>
     this.customGcsTempLocation = customGcsTempLocation;
     this.loadJobProjectId = loadJobProjectId;
     this.ignoreUnknownValues = ignoreUnknownValues;
+    this.kmsKey = kmsKey;
   }
 
   void setTestServices(BigQueryServices bigQueryServices) {
@@ -319,7 +322,8 @@ class BatchLoads<DestinationT>
                         loadJobIdPrefixView,
                         writeDisposition,
                         createDisposition,
-                        maxRetryJobs))
+                        maxRetryJobs,
+                        kmsKey))
                 .withSideInputs(loadJobIdPrefixView));
     writeSinglePartition(partitions.get(singlePartitionTag), loadJobIdPrefixView);
     return writeResult(p);
@@ -381,7 +385,8 @@ class BatchLoads<DestinationT>
                         loadJobIdPrefixView,
                         writeDisposition,
                         createDisposition,
-                        maxRetryJobs))
+                        maxRetryJobs,
+                        kmsKey))
                 .withSideInputs(loadJobIdPrefixView));
     writeSinglePartition(partitions.get(singlePartitionTag), loadJobIdPrefixView);
     return writeResult(p);
@@ -554,7 +559,8 @@ class BatchLoads<DestinationT>
                 dynamicDestinations,
                 loadJobProjectId,
                 maxRetryJobs,
-                ignoreUnknownValues));
+                ignoreUnknownValues,
+                kmsKey));
   }
 
   // In the case where the files fit into a single load job, there's no need to write temporary
@@ -586,7 +592,8 @@ class BatchLoads<DestinationT>
                 dynamicDestinations,
                 loadJobProjectId,
                 maxRetryJobs,
-                ignoreUnknownValues));
+                ignoreUnknownValues,
+                kmsKey));
   }
 
   private WriteResult writeResult(Pipeline p) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
@@ -36,6 +36,7 @@ public class StreamingInserts<DestinationT>
   private boolean extendedErrorInfo;
   private final boolean skipInvalidRows;
   private final boolean ignoreUnknownValues;
+  private final String kmsKey;
 
   /** Constructor. */
   public StreamingInserts(
@@ -48,7 +49,8 @@ public class StreamingInserts<DestinationT>
         InsertRetryPolicy.alwaysRetry(),
         false,
         false,
-        false);
+        false,
+        null);
   }
 
   /** Constructor. */
@@ -59,7 +61,8 @@ public class StreamingInserts<DestinationT>
       InsertRetryPolicy retryPolicy,
       boolean extendedErrorInfo,
       boolean skipInvalidRows,
-      boolean ignoreUnknownValues) {
+      boolean ignoreUnknownValues,
+      String kmsKey) {
     this.createDisposition = createDisposition;
     this.dynamicDestinations = dynamicDestinations;
     this.bigQueryServices = bigQueryServices;
@@ -67,6 +70,7 @@ public class StreamingInserts<DestinationT>
     this.extendedErrorInfo = extendedErrorInfo;
     this.skipInvalidRows = skipInvalidRows;
     this.ignoreUnknownValues = ignoreUnknownValues;
+    this.kmsKey = kmsKey;
   }
 
   /** Specify a retry policy for failed inserts. */
@@ -78,7 +82,8 @@ public class StreamingInserts<DestinationT>
         retryPolicy,
         extendedErrorInfo,
         skipInvalidRows,
-        ignoreUnknownValues);
+        ignoreUnknownValues,
+        kmsKey);
   }
 
   /** Specify whether to use extended error info or not. */
@@ -90,7 +95,8 @@ public class StreamingInserts<DestinationT>
         retryPolicy,
         extendedErrorInfo,
         skipInvalidRows,
-        ignoreUnknownValues);
+        ignoreUnknownValues,
+        kmsKey);
   }
 
   StreamingInserts<DestinationT> withSkipInvalidRows(boolean skipInvalidRows) {
@@ -101,7 +107,8 @@ public class StreamingInserts<DestinationT>
         retryPolicy,
         extendedErrorInfo,
         skipInvalidRows,
-        ignoreUnknownValues);
+        ignoreUnknownValues,
+        kmsKey);
   }
 
   StreamingInserts<DestinationT> withIgnoreUnknownValues(boolean ignoreUnknownValues) {
@@ -112,7 +119,20 @@ public class StreamingInserts<DestinationT>
         retryPolicy,
         extendedErrorInfo,
         skipInvalidRows,
-        ignoreUnknownValues);
+        ignoreUnknownValues,
+        kmsKey);
+  }
+
+  StreamingInserts<DestinationT> withKmsKey(String kmsKey) {
+    return new StreamingInserts<>(
+        createDisposition,
+        dynamicDestinations,
+        bigQueryServices,
+        retryPolicy,
+        extendedErrorInfo,
+        skipInvalidRows,
+        ignoreUnknownValues,
+        kmsKey);
   }
 
   StreamingInserts<DestinationT> withTestServices(BigQueryServices bigQueryServices) {
@@ -123,7 +143,8 @@ public class StreamingInserts<DestinationT>
         retryPolicy,
         extendedErrorInfo,
         skipInvalidRows,
-        ignoreUnknownValues);
+        ignoreUnknownValues,
+        kmsKey);
   }
 
   @Override
@@ -132,7 +153,8 @@ public class StreamingInserts<DestinationT>
         input.apply(
             "CreateTables",
             new CreateTables<>(createDisposition, dynamicDestinations)
-                .withTestServices(bigQueryServices));
+                .withTestServices(bigQueryServices)
+                .withKmsKey(kmsKey));
 
     return writes.apply(
         new StreamingWriteTables()

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
@@ -133,6 +133,10 @@ public class BigQueryIOReadTest implements Serializable {
     checkReadQueryObjectWithValidate(read, query, true);
   }
 
+  private void checkTypedReadQueryObject(BigQueryIO.TypedRead read, String query, String kmsKey) {
+    checkTypedReadQueryObjectWithValidate(read, query, kmsKey, true);
+  }
+
   private void checkReadTableObjectWithValidate(
       BigQueryIO.Read read, String project, String dataset, String table, boolean validate) {
     assertEquals(project, read.getTable().getProjectId());
@@ -146,6 +150,14 @@ public class BigQueryIOReadTest implements Serializable {
       BigQueryIO.Read read, String query, boolean validate) {
     assertNull(read.getTable());
     assertEquals(query, read.getQuery().get());
+    assertEquals(validate, read.getValidate());
+  }
+
+  private void checkTypedReadQueryObjectWithValidate(
+      BigQueryIO.TypedRead read, String query, String kmsKey, boolean validate) {
+    assertNull(read.getTable());
+    assertEquals(query, read.getQuery().get());
+    assertEquals(kmsKey, read.getKmsKey());
     assertEquals(validate, read.getValidate());
   }
 
@@ -200,6 +212,13 @@ public class BigQueryIOReadTest implements Serializable {
             .setTableId("sometable");
     BigQueryIO.Read read = BigQueryIO.read().from(table);
     checkReadTableObject(read, "foo.com:project", "somedataset", "sometable");
+  }
+
+  @Test
+  public void testBuildQueryBasedTypedReadSource() {
+    BigQueryIO.TypedRead read =
+        BigQueryIO.readTableRows().fromQuery("foo_query").withKmsKey("kms_key");
+    checkTypedReadQueryObject(read, "foo_query", "kms_key");
   }
 
   @Test
@@ -620,6 +639,7 @@ public class BigQueryIOReadTest implements Serializable {
             TableRowJsonCoder.of(),
             BigQueryIO.TableRowParser.INSTANCE,
             QueryPriority.BATCH,
+            null,
             null);
 
     fakeJobService.expectDryRunQuery(
@@ -688,6 +708,7 @@ public class BigQueryIOReadTest implements Serializable {
             TableRowJsonCoder.of(),
             BigQueryIO.TableRowParser.INSTANCE,
             QueryPriority.BATCH,
+            null,
             null);
     options.setTempLocation(testFolder.getRoot().getAbsolutePath());
 
@@ -778,6 +799,7 @@ public class BigQueryIOReadTest implements Serializable {
             TableRowJsonCoder.of(),
             BigQueryIO.TableRowParser.INSTANCE,
             QueryPriority.BATCH,
+            null,
             null);
 
     options.setTempLocation(testFolder.getRoot().getAbsolutePath());

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -1235,7 +1235,8 @@ public class BigQueryIOWriteTest implements Serializable {
             new IdentityDynamicTables(),
             null,
             4,
-            false);
+            false,
+            null);
 
     PCollection<KV<TableDestination, String>> writeTablesOutput =
         writeTablesInput.apply(writeTables);
@@ -1317,7 +1318,8 @@ public class BigQueryIOWriteTest implements Serializable {
             jobIdTokenView,
             BigQueryIO.Write.WriteDisposition.WRITE_EMPTY,
             BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED,
-            3);
+            3,
+            "kms_key");
 
     DoFnTester<Iterable<KV<TableDestination, String>>, Void> tester = DoFnTester.of(writeRename);
     tester.setSideInput(jobIdTokenView, GlobalWindow.INSTANCE, jobIdToken);
@@ -1329,6 +1331,7 @@ public class BigQueryIOWriteTest implements Serializable {
       TableReference tableReference = tableDestination.getTableReference();
       Table table = checkNotNull(fakeDatasetService.getTable(tableReference));
       assertEquals(tableReference.getTableId() + "_desc", tableDestination.getTableDescription());
+      assertEquals("kms_key", table.getEncryptionConfiguration().getKmsKeyName());
 
       Collection<TableRow> expectedRows = expectedRowsPerTable.get(tableDestination);
       assertThat(

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryKmsKeyIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryKmsKeyIT.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableSchema;
+import java.security.SecureRandom;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.Method;
+import org.apache.beam.sdk.io.gcp.testing.BigqueryClient;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration tests for BigQuery operations that can use KMS keys, for use with DirectRunner.
+ *
+ * <p>Verification of KMS key usage is done on outputs, but not on any temporary files or tables
+ * used.
+ */
+@RunWith(JUnit4.class)
+public class BigQueryKmsKeyIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BigQueryKmsKeyIT.class);
+
+  private static final BigqueryClient BQ_CLIENT = new BigqueryClient("BigQueryKmsKeyIT");
+  private static final String BIG_QUERY_DATASET_ID =
+      "bq_query_to_table_" + System.currentTimeMillis() + "_" + (new SecureRandom().nextInt(32));
+  private static final TableSchema OUTPUT_SCHEMA =
+      new TableSchema()
+          .setFields(ImmutableList.of(new TableFieldSchema().setName("fruit").setType("STRING")));
+
+  private static TestPipelineOptions options;
+  private static String project;
+  private static String kmsKey =
+      "projects/apache-beam-testing/locations/global/keyRings/beam-it/cryptoKeys/test";
+
+  @BeforeClass
+  public static void setupTestEnvironment() throws Exception {
+    options = TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+    project = options.as(GcpOptions.class).getProject();
+    BQ_CLIENT.createNewDataset(project, BIG_QUERY_DATASET_ID);
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    LOG.info("Start to clean up tables and datasets.");
+    BQ_CLIENT.deleteDataset(project, BIG_QUERY_DATASET_ID);
+  }
+
+  /**
+   * Tests query job and table creation with KMS key settings.
+   *
+   * <p>Verifies table creation with KMS key.
+   */
+  private void testQueryAndWrite(Method method) throws Exception {
+    String outputTableId = "testQueryAndWrite_" + method.name();
+    String outputTableSpec = project + ":" + BIG_QUERY_DATASET_ID + "." + outputTableId;
+
+    options.setTempLocation(options.getTempRoot() + "/bq_it_temp");
+    Pipeline p = Pipeline.create(options);
+    // Reading triggers BQ query and extract jobs. Writing triggers either a load job or performs a
+    // streaming insert (depending on method).
+    p.apply(
+            BigQueryIO.readTableRows()
+                .fromQuery("SELECT * FROM (SELECT \"foo\" as fruit)")
+                .withKmsKey(kmsKey))
+        .apply(
+            BigQueryIO.writeTableRows()
+                .to(outputTableSpec)
+                .withSchema(OUTPUT_SCHEMA)
+                .withMethod(method)
+                .withKmsKey(kmsKey));
+    p.run().waitUntilFinish();
+
+    Table table = BQ_CLIENT.getTableResource(project, BIG_QUERY_DATASET_ID, outputTableId);
+    assertNotNull(String.format("table not found: %s", outputTableId), table);
+    assertNotNull(
+        "output table has no EncryptionConfiguration", table.getEncryptionConfiguration());
+    assertEquals(table.getEncryptionConfiguration().getKmsKeyName(), kmsKey);
+  }
+
+  @Test
+  public void testWithFileLoads() throws Exception {
+    testQueryAndWrite(Method.FILE_LOADS);
+  }
+
+  @Test
+  public void testWithStreamingInserts() throws Exception {
+    testQueryAndWrite(Method.STREAMING_INSERTS);
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
@@ -407,7 +407,8 @@ public class FakeJobService implements JobService, Serializable {
         new Table()
             .setTableReference(destination)
             .setSchema(schema)
-            .setTimePartitioning(partitioning));
+            .setTimePartitioning(partitioning)
+            .setEncryptionConfiguration(copy.getDestinationEncryptionConfiguration()));
     datasetService.insertAll(destination, allRows, null);
     return new JobStatus().setState("DONE");
   }


### PR DESCRIPTION
Adds withKmsKey() methods to reads and writes. Affects tables created
tables by: streaming writes, batched writes, query temporary tables,
table copies (for very large batched writes).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

