### PR TITLE
[BEAM-5644] Plugable Planners

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlCli.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlCli.java
@@ -39,11 +39,11 @@ public class BeamSqlCli {
 
   public BeamSqlCli metaStore(MetaStore metaStore, boolean autoLoadUdfUdaf) {
     this.metaStore = metaStore;
-    this.env = BeamSqlEnv.withTableProvider(metaStore);
-    if (autoLoadUdfUdaf) {
-      env.loadUdfUdafFromProvider();
-    }
-
+    this.env =
+        BeamSqlEnv.builder()
+            .setInitializeTableProvider(metaStore)
+            .loadUdfUdafFromProvider()
+            .build();
     return this;
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
@@ -17,11 +17,16 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.SQLException;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
@@ -36,10 +41,8 @@ import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.schema.Function;
 import org.apache.calcite.sql.SqlExecutableStatement;
-import org.apache.calcite.sql.parser.SqlParseException;
-import org.apache.calcite.tools.RelConversionException;
-import org.apache.calcite.tools.ValidationException;
 
 /**
  * Contains the metadata of tables/UDF functions, and exposes APIs to
@@ -49,11 +52,15 @@ import org.apache.calcite.tools.ValidationException;
 @Experimental
 public class BeamSqlEnv {
   final JdbcConnection connection;
-  final BeamQueryPlanner planner;
+  final QueryPlanner planner;
 
-  private BeamSqlEnv(TableProvider tableProvider) {
-    connection = JdbcDriver.connect(tableProvider);
-    planner = new BeamQueryPlanner(connection);
+  private BeamSqlEnv(JdbcConnection connection, QueryPlanner planner) {
+    this.connection = connection;
+    this.planner = planner;
+  }
+
+  public static BeamSqlEnvBuilder builder() {
+    return new BeamSqlEnvBuilder();
   }
 
   public static BeamSqlEnv readOnly(String tableType, Map<String, BeamSqlTable> tables) {
@@ -61,7 +68,7 @@ public class BeamSqlEnv {
   }
 
   public static BeamSqlEnv withTableProvider(TableProvider tableProvider) {
-    return new BeamSqlEnv(tableProvider);
+    return builder().setInitializeTableProvider(tableProvider).build();
   }
 
   public static BeamSqlEnv inMemory(TableProvider... tableProviders) {
@@ -73,94 +80,17 @@ public class BeamSqlEnv {
     return withTableProvider(inMemoryMetaStore);
   }
 
-  private void registerBuiltinUdf(Map<String, List<Method>> methods) {
-    for (Map.Entry<String, List<Method>> entry : methods.entrySet()) {
-      for (Method method : entry.getValue()) {
-        connection.getCurrentSchemaPlus().add(entry.getKey(), UdfImpl.create(method));
-      }
-    }
-  }
-
-  public void addSchema(String name, TableProvider tableProvider) {
-    connection.setSchema(name, tableProvider);
-  }
-
-  public void setCurrentSchema(String name) {
-    try {
-      connection.setSchema(name);
-    } catch (SQLException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  /** Register a UDF function which can be used in SQL expression. */
-  public void registerUdf(String functionName, Class<?> clazz, String method) {
-    connection.getCurrentSchemaPlus().add(functionName, UdfImpl.create(clazz, method));
-  }
-
-  /** Register a UDF function which can be used in SQL expression. */
-  public void registerUdf(String functionName, Class<? extends BeamSqlUdf> clazz) {
-    registerUdf(functionName, clazz, BeamSqlUdf.UDF_METHOD);
-  }
-
-  /**
-   * Register {@link SerializableFunction} as a UDF function which can be used in SQL expression.
-   * Note, {@link SerializableFunction} must have a constructor without arguments.
-   */
-  public void registerUdf(String functionName, SerializableFunction sfn) {
-    registerUdf(functionName, sfn.getClass(), "apply");
-  }
-
-  /**
-   * Register a UDAF function which can be used in GROUP-BY expression. See {@link
-   * org.apache.beam.sdk.transforms.Combine.CombineFn} on how to implement a UDAF.
-   */
-  public void registerUdaf(String functionName, Combine.CombineFn combineFn) {
-    connection.getCurrentSchemaPlus().add(functionName, new UdafImpl(combineFn));
-  }
-
-  /** Load all UDF/UDAF from {@link UdfUdafProvider}. */
-  public void loadUdfUdafFromProvider() {
-    ServiceLoader.<UdfUdafProvider>load(UdfUdafProvider.class)
-        .forEach(
-            ins -> {
-              ins.getBeamSqlUdfs().forEach((udfName, udfClass) -> registerUdf(udfName, udfClass));
-              ins.getSerializableFunctionUdfs()
-                  .forEach((udfName, udfFn) -> registerUdf(udfName, udfFn));
-              ins.getUdafs().forEach((udafName, udafFn) -> registerUdaf(udafName, udafFn));
-            });
-  }
-
-  public void loadBeamBuiltinFunctions() {
-    for (BeamBuiltinFunctionProvider provider :
-        ServiceLoader.load(BeamBuiltinFunctionProvider.class)) {
-      registerBuiltinUdf(provider.getBuiltinMethods());
-    }
-  }
-
   public BeamRelNode parseQuery(String query) throws ParseException {
-    try {
-      return planner.convertToBeamRel(query);
-    } catch (ValidationException | RelConversionException | SqlParseException e) {
-      throw new ParseException(String.format("Unable to parse query %s", query), e);
-    }
+    return planner.convertToBeamRel(query);
   }
 
   public boolean isDdl(String sqlStatement) throws ParseException {
-    try {
-      return planner.parse(sqlStatement) instanceof SqlExecutableStatement;
-    } catch (SqlParseException e) {
-      throw new ParseException("Unable to parse statement", e);
-    }
+    return planner.parse(sqlStatement) instanceof SqlExecutableStatement;
   }
 
   public void executeDdl(String sqlStatement) throws ParseException {
-    try {
-      SqlExecutableStatement ddl = (SqlExecutableStatement) planner.parse(sqlStatement);
-      ddl.execute(getContext());
-    } catch (SqlParseException e) {
-      throw new ParseException("Unable to parse DDL statement", e);
-    }
+    SqlExecutableStatement ddl = (SqlExecutableStatement) planner.parse(sqlStatement);
+    ddl.execute(getContext());
   }
 
   public CalcitePrepare.Context getContext() {
@@ -174,8 +104,158 @@ public class BeamSqlEnv {
   public String explain(String sqlString) throws ParseException {
     try {
       return RelOptUtil.toString(planner.convertToBeamRel(sqlString));
-    } catch (ValidationException | RelConversionException | SqlParseException e) {
+    } catch (Exception e) {
       throw new ParseException("Unable to parse statement", e);
+    }
+  }
+
+  /** BeamSqlEnv's Builder. */
+  public static class BeamSqlEnvBuilder {
+    private String queryPlannerClassName =
+        "org.apache.beam.sdk.extensions.sql.impl.CalciteQueryPlanner";
+
+    private TableProvider initialTableProvider;
+    private String currentSchemaName;
+    private Map<String, TableProvider> schemaMap = new HashMap<>();
+    private Set<Map.Entry<String, Function>> functionSet = new HashSet<>();
+
+    public BeamSqlEnvBuilder setInitializeTableProvider(TableProvider tableProvider) {
+      initialTableProvider = tableProvider;
+      return this;
+    }
+
+    public BeamSqlEnvBuilder registerBuiltinUdf(Map<String, List<Method>> methods) {
+      for (Map.Entry<String, List<Method>> entry : methods.entrySet()) {
+        for (Method method : entry.getValue()) {
+          functionSet.add(new SimpleEntry<>(entry.getKey(), UdfImpl.create(method)));
+        }
+      }
+      return this;
+    }
+
+    public BeamSqlEnvBuilder addSchema(String name, TableProvider tableProvider) {
+      if (schemaMap.containsKey(name)) {
+        throw new RuntimeException("Schema " + name + " is registered twice.");
+      }
+
+      schemaMap.put(name, tableProvider);
+      return this;
+    }
+
+    public BeamSqlEnvBuilder setCurrentSchema(String name) {
+      currentSchemaName = name;
+      return this;
+    }
+
+    /** Register a UDF function which can be used in SQL expression. */
+    public BeamSqlEnvBuilder registerUdf(String functionName, Class<?> clazz, String method) {
+      functionSet.add(new SimpleEntry<>(functionName, UdfImpl.create(clazz, method)));
+
+      return this;
+    }
+
+    /** Register a UDF function which can be used in SQL expression. */
+    public BeamSqlEnvBuilder registerUdf(String functionName, Class<? extends BeamSqlUdf> clazz) {
+      return registerUdf(functionName, clazz, BeamSqlUdf.UDF_METHOD);
+    }
+
+    public BeamSqlEnvBuilder registerUdf(String functionName, SerializableFunction sfn) {
+      return registerUdf(functionName, sfn.getClass(), "apply");
+    }
+
+    /**
+     * Register a UDAF function which can be used in GROUP-BY expression. See {@link
+     * org.apache.beam.sdk.transforms.Combine.CombineFn} on how to implement a UDAF.
+     */
+    public BeamSqlEnvBuilder registerUdaf(String functionName, Combine.CombineFn combineFn) {
+      functionSet.add(new SimpleEntry<>(functionName, new UdafImpl(combineFn)));
+      return this;
+    }
+
+    /** Load all UDF/UDAF from {@link UdfUdafProvider}. */
+    public BeamSqlEnvBuilder loadUdfUdafFromProvider() {
+      ServiceLoader.<UdfUdafProvider>load(UdfUdafProvider.class)
+          .forEach(
+              ins -> {
+                ins.getBeamSqlUdfs().forEach((udfName, udfClass) -> registerUdf(udfName, udfClass));
+                ins.getSerializableFunctionUdfs()
+                    .forEach((udfName, udfFn) -> registerUdf(udfName, udfFn));
+                ins.getUdafs().forEach((udafName, udafFn) -> registerUdaf(udafName, udafFn));
+              });
+
+      return this;
+    }
+
+    public BeamSqlEnvBuilder loadBeamBuiltinFunctions() {
+      for (BeamBuiltinFunctionProvider provider :
+          ServiceLoader.load(BeamBuiltinFunctionProvider.class)) {
+        registerBuiltinUdf(provider.getBuiltinMethods());
+      }
+
+      return this;
+    }
+
+    public BeamSqlEnvBuilder setQueryPlannerClassName(String name) {
+      queryPlannerClassName = name;
+      return this;
+    }
+
+    /**
+     * Build function to create an instance of BeamSqlEnv based on preset fields.
+     *
+     * @return BeamSqlEnv.
+     */
+    public BeamSqlEnv build() {
+      // This check is to retain backward compatible because most of BeamSqlEnv are initialized by
+      // withTableProvider API.
+      if (initialTableProvider == null) {
+        throw new RuntimeException("initialTableProvider must be set in BeamSqlEnvBuilder.");
+      }
+
+      JdbcConnection jdbcConnection = JdbcDriver.connect(initialTableProvider);
+
+      // set schema
+      for (Map.Entry<String, TableProvider> schemaEntry : schemaMap.entrySet()) {
+        jdbcConnection.setSchema(schemaEntry.getKey(), schemaEntry.getValue());
+      }
+
+      // reset default schema
+      if (currentSchemaName != null) {
+        try {
+          jdbcConnection.setSchema(currentSchemaName);
+        } catch (SQLException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      // add UDF
+      for (Map.Entry<String, Function> functionEntry : functionSet) {
+        jdbcConnection.getCurrentSchemaPlus().add(functionEntry.getKey(), functionEntry.getValue());
+      }
+
+      QueryPlanner planner;
+
+      if (queryPlannerClassName.equals(
+          "org.apache.beam.sdk.extensions.sql.impl.CalciteQueryPlanner")) {
+        planner = new CalciteQueryPlanner(jdbcConnection);
+      } else {
+        try {
+          planner =
+              (QueryPlanner)
+                  Class.forName(queryPlannerClassName)
+                      .getConstructor(JdbcConnection.class)
+                      .newInstance(jdbcConnection);
+        } catch (NoSuchMethodException
+            | ClassNotFoundException
+            | InstantiationException
+            | IllegalAccessException
+            | InvocationTargetException e) {
+          throw new RuntimeException(
+              String.format("Cannot construct query planner %s", queryPlannerClassName), e);
+        }
+      }
+
+      return new BeamSqlEnv(jdbcConnection, planner);
     }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlPipelineOptions.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlPipelineOptions.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl;
+
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/** Options used to configure BeamSQL. */
+public interface BeamSqlPipelineOptions extends PipelineOptions {
+
+  @Description("QueryPlanner class name.")
+  @Default.String("org.apache.beam.sdk.extensions.sql.impl.CalciteQueryPlanner")
+  String getPlannerName();
+
+  void setPlannerName(String className);
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlPipelineOptionsRegistrar.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlPipelineOptionsRegistrar.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl;
+
+import com.google.auto.service.AutoService;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsRegistrar;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+
+/** {@link AutoService} registrar for {@link BeamSqlPipelineOptions}. */
+@AutoService(PipelineOptionsRegistrar.class)
+public class BeamSqlPipelineOptionsRegistrar implements PipelineOptionsRegistrar {
+
+  @Override
+  public Iterable<Class<? extends PipelineOptions>> getPipelineOptions() {
+    return ImmutableList.of(BeamSqlPipelineOptions.class);
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/QueryPlanner.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/QueryPlanner.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl;
+
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamRelNode;
+import org.apache.calcite.sql.SqlNode;
+
+/**
+ * An interface that planners should implement to convert sql statement to {@link BeamRelNode} or
+ * {@link SqlNode}.
+ */
+public interface QueryPlanner {
+  /** It parses and validate the input query, then convert into a {@link BeamRelNode} tree. */
+  BeamRelNode convertToBeamRel(String sqlStatement) throws ParseException, SqlConversionException;
+
+  /** Parse input SQL query, and return a {@link SqlNode} as grammar tree. */
+  SqlNode parse(String sqlStatement) throws ParseException;
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/SqlConversionException.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/SqlConversionException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl;
+
+/** Exception thrown when BeamSQL cannot convert sql to BeamRelNode. */
+public class SqlConversionException extends RuntimeException {
+
+  public SqlConversionException(Throwable cause) {
+    super(cause);
+  }
+
+  public SqlConversionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
@@ -167,9 +167,11 @@ public class BeamDDLTest {
     TestTableProvider rootProvider = new TestTableProvider();
     TestTableProvider testProvider = new TestTableProvider();
 
-    BeamSqlEnv env = BeamSqlEnv.withTableProvider(rootProvider);
-    env.addSchema("test", testProvider);
-
+    BeamSqlEnv env =
+        BeamSqlEnv.builder()
+            .setInitializeTableProvider(rootProvider)
+            .addSchema("test", testProvider)
+            .build();
     assertNull(testProvider.getTables().get("person"));
     env.executeDdl("CREATE EXTERNAL TABLE test.person (id INT) TYPE text");
 


### PR DESCRIPTION
1. Add `BeamSqlEnvBuilder` as the only entry point to build a `BeamSqlEnv`.

2. Add pipeline option for BeamSQL to enable configurable planner.

3. Add `QueryPlanner` interface. Rename `BeamQueryPlanner` to `CalciteQueryPlanner` and implement `QueryPlanner` interface.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

