### PR TITLE
Windmill service cherry pick

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowSystemMetrics.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowSystemMetrics.java
@@ -33,11 +33,12 @@ public class DataflowSystemMetrics {
   /** System counters populated by streaming dataflow workers. */
   public enum StreamingSystemCounterNames {
     WINDMILL_SHUFFLE_BYTES_READ("WindmillShuffleBytesRead"),
-    WINDMILl_STATE_BYTES_READ("WindmillStateBytesRead"),
-    WINDMILl_STATE_BYTES_WRITTEN("WindmillStateBytesWritten"),
+    WINDMILL_STATE_BYTES_READ("WindmillStateBytesRead"),
+    WINDMILL_STATE_BYTES_WRITTEN("WindmillStateBytesWritten"),
     JAVA_HARNESS_USED_MEMORY("dataflow_java_harness_used_memory"),
     JAVA_HARNESS_MAX_MEMORY("dataflow_java_harness_max_memory"),
-    JAVA_HARNESS_RESTARTS("dataflow_java_harness_restarts");
+    JAVA_HARNESS_RESTARTS("dataflow_java_harness_restarts"),
+    WINDMILL_QUOTA_THROTTLING("dataflow_streaming_engine_throttled_msecs");
 
     private final String name;
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -533,7 +533,7 @@ public class StreamingDataflowWorker {
     this.workUnitClient = workUnitClient;
     this.options = options;
     this.sdkHarnessRegistry = sdkHarnessRegistry;
-    this.windmillServiceEnabled = StreamingDataflowWorkerOptions.streamingEngineEnabled(options);
+    this.windmillServiceEnabled = options.isEnableStreamingEngine();
     this.memoryMonitor = MemoryMonitor.fromOptions(options);
     this.statusPages = WorkerStatusPages.create(DEFAULT_STATUS_PORT, memoryMonitor);
     if (windmillServiceEnabled) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.dataflow.worker.options;
 
+import static org.apache.beam.runners.dataflow.DataflowRunner.hasExperiment;
+
 import java.io.IOException;
 import org.apache.beam.runners.dataflow.options.DataflowWorkerHarnessOptions;
 import org.apache.beam.runners.dataflow.worker.windmill.GrpcWindmillServer;
@@ -192,7 +194,7 @@ public interface StreamingDataflowWorkerOptions extends DataflowWorkerHarnessOpt
     public Boolean create(PipelineOptions options) {
       StreamingDataflowWorkerOptions streamingOptions =
           options.as(StreamingDataflowWorkerOptions.class);
-      return streamingEngineEnabled(streamingOptions)
+      return streamingOptions.isEnableStreamingEngine()
           && hasExperiment(streamingOptions, "windmill_service_streaming_rpcs")
           && !hasExperiment(streamingOptions, "windmill_service_disable_streaming_rpcs");
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.dataflow.worker.options;
 
-import static org.apache.beam.runners.dataflow.DataflowRunner.hasExperiment;
-
 import java.io.IOException;
 import org.apache.beam.runners.dataflow.options.DataflowWorkerHarnessOptions;
 import org.apache.beam.runners.dataflow.worker.windmill.GrpcWindmillServer;
@@ -100,18 +98,6 @@ public interface StreamingDataflowWorkerOptions extends DataflowWorkerHarnessOpt
 
   void setWindmillServiceStreamingRpcBatchLimit(int value);
 
-  /** Experiment to turn on the Streaming Engine experiment. */
-  public static final String STREAMING_ENGINE_EXPERIMENT = "enable_streaming_engine";
-
-  /** @deprecated Use STREAMING_ENGINE_EXPERIMENT instead. */
-  @Deprecated public static final String WINDMILL_SERVICE_EXPERIMENT = "enable_windmill_service";
-
-  /** Returns true if the job is running with streaming engine enabled. */
-  public static boolean streamingEngineEnabled(StreamingDataflowWorkerOptions options) {
-    return hasExperiment(options, STREAMING_ENGINE_EXPERIMENT)
-        || hasExperiment(options, WINDMILL_SERVICE_EXPERIMENT);
-  }
-
   /**
    * Factory for creating local Windmill address. Reads from system propery 'windmill.hostport' for
    * backwards compatibility.
@@ -186,7 +172,7 @@ public interface StreamingDataflowWorkerOptions extends DataflowWorkerHarnessOpt
       StreamingDataflowWorkerOptions streamingOptions =
           options.as(StreamingDataflowWorkerOptions.class);
       if (streamingOptions.getWindmillServiceEndpoint() != null
-          || streamingEngineEnabled(streamingOptions)
+          || streamingOptions.isEnableStreamingEngine()
           || streamingOptions.getLocalWindmillHostport().startsWith("grpc:")) {
         try {
           return new GrpcWindmillServer(streamingOptions);
@@ -219,11 +205,12 @@ public interface StreamingDataflowWorkerOptions extends DataflowWorkerHarnessOpt
     public Integer create(PipelineOptions options) {
       StreamingDataflowWorkerOptions streamingOptions =
           options.as(StreamingDataflowWorkerOptions.class);
-      if (streamingEngineEnabled(streamingOptions)
+      if (streamingOptions.isEnableStreamingEngine()
           && hasExperiment(streamingOptions, "windmill_service_streaming_rpc_batching")) {
         return Integer.MAX_VALUE;
       }
       return 1;
+
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -85,6 +85,7 @@ import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.vendor.grpc.v1p13p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.CallCredentials;
 import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.Channel;
+import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.Status;
 import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.StatusRuntimeException;
 import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.auth.MoreCallCredentials;
 import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.inprocess.InProcessChannelBuilder;
@@ -103,7 +104,10 @@ import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** gRPC client for communicating with Windmill Service or Windmill Appliance. */
+/** gRPC client for communicating with Windmill Service. */
+// Very likely real potential for bugs - https://issues.apache.org/jira/browse/BEAM-6562
+// Very likely real potential for bugs - https://issues.apache.org/jira/browse/BEAM-6564
+@SuppressFBWarnings({"JLM_JSR166_UTILCONCURRENT_MONITORENTER", "IS2_INCONSISTENT_SYNC"})
 public class GrpcWindmillServer extends WindmillServerStub {
   private static final Logger LOG = LoggerFactory.getLogger(GrpcWindmillServer.class);
 
@@ -134,6 +138,9 @@ public class GrpcWindmillServer extends WindmillServerStub {
   private ImmutableSet<HostAndPort> endpoints;
   private int logEveryNStreamFailures = 20;
   private Duration maxBackoff = MAX_BACKOFF;
+  private final ThrottleTimer getWorkThrottleTimer = new ThrottleTimer();
+  private final ThrottleTimer getDataThrottleTimer = new ThrottleTimer();
+  private final ThrottleTimer commitWorkThrottleTimer = new ThrottleTimer();
   Random rand = new Random();
 
   private final Set<AbstractWindmillStream<?, ?>> streamRegistry =
@@ -528,6 +535,13 @@ public class GrpcWindmillServer extends WindmillServerStub {
     }
   }
 
+  @Override
+  public long getAndResetThrottleTime() {
+    return getWorkThrottleTimer.getAndResetThrottleTime()
+        + getDataThrottleTimer.getAndResetThrottleTime()
+        + commitWorkThrottleTimer.getAndResetThrottleTime();
+  }
+
   private JobHeader makeHeader() {
     return JobHeader.newBuilder()
         .setJobId(options.getJobId())
@@ -586,7 +600,12 @@ public class GrpcWindmillServer extends WindmillServerStub {
     protected abstract void onNewStream();
     /** Returns whether there are any pending requests that should be retried on a stream break. */
     protected abstract boolean hasPendingRequests();
-
+    /**
+     * Called when the stream is throttled due to resource exhausted errors. Will be called for each
+     * resource exhausted error not just the first. onResponse() must stop throttling on reciept of
+     * the first good message.
+     */
+    protected abstract void startThrottleTimer();
     /** Send a request to the server. */
     protected final synchronized void send(RequestT request) {
       requestObserver.onNext(request);
@@ -684,6 +703,14 @@ public class GrpcWindmillServer extends WindmillServerStub {
                 errorCount.get(),
                 t.toString());
           }
+          // If the stream was stopped due to a resource exhausted error then we are throttled.
+          if (t instanceof StatusRuntimeException) {
+            StatusRuntimeException statusExc = (StatusRuntimeException) t;
+            if (statusExc.getStatus() != null
+                && statusExc.getStatus().getCode() == Status.Code.RESOURCE_EXHAUSTED) {
+              startThrottleTimer();
+            }
+          }
           try {
             long sleep = backoff.nextBackOffMillis();
             sleepUntil.set(Instant.now().getMillis() + sleep);
@@ -773,6 +800,7 @@ public class GrpcWindmillServer extends WindmillServerStub {
 
     @Override
     protected void onResponse(StreamingGetWorkResponseChunk chunk) {
+      getWorkThrottleTimer.stop();
       long id = chunk.getStreamId();
 
       WorkItemBuffer buffer = buffers.computeIfAbsent(id, (Long l) -> new WorkItemBuffer());
@@ -812,6 +840,11 @@ public class GrpcWindmillServer extends WindmillServerStub {
                   });
         }
       }
+    }
+
+    @Override
+    protected void startThrottleTimer() {
+      getWorkThrottleTimer.start();
     }
 
     private class WorkItemBuffer {
@@ -941,6 +974,7 @@ public class GrpcWindmillServer extends WindmillServerStub {
       Preconditions.checkArgument(chunk.getRequestIdCount() == chunk.getSerializedResponseCount());
       Preconditions.checkArgument(
           chunk.getRemainingBytesForResponse() == 0 || chunk.getRequestIdCount() == 1);
+      getDataThrottleTimer.stop();
 
       for (int i = 0; i < chunk.getRequestIdCount(); ++i) {
         AppendableInputStream responseStream = pending.get(chunk.getRequestId(i));
@@ -950,6 +984,11 @@ public class GrpcWindmillServer extends WindmillServerStub {
           responseStream.complete();
         }
       }
+    }
+
+    @Override
+    protected void startThrottleTimer() {
+      getDataThrottleTimer.start();
     }
 
     @Override
@@ -1177,6 +1216,8 @@ public class GrpcWindmillServer extends WindmillServerStub {
 
     @Override
     protected void onResponse(StreamingCommitResponse response) {
+      commitWorkThrottleTimer.stop();
+
       for (int i = 0; i < response.getRequestIdCount(); ++i) {
         long requestId = response.getRequestId(i);
         PendingRequest done = pending.remove(requestId);
@@ -1187,6 +1228,11 @@ public class GrpcWindmillServer extends WindmillServerStub {
               (i < response.getStatusCount()) ? response.getStatus(i) : CommitStatus.OK);
         }
       }
+    }
+
+    @Override
+    protected void startThrottleTimer() {
+      commitWorkThrottleTimer.start();
     }
 
     @Override
@@ -1410,6 +1456,55 @@ public class GrpcWindmillServer extends WindmillServerStub {
     @Override
     public void close() throws IOException {
       stream.close();
+    }
+  }
+
+  /**
+   * A stopwatch used to track the amount of time spent throttled due to Resource Exhausted errors.
+   * Throttle time is cumulative for all three rpcs types but not for all streams. So if GetWork and
+   * CommitWork are both blocked for x, totalTime will be 2x. However, if 2 GetWork streams are both
+   * blocked for x totalTime will be x. All methods are thread safe.
+   */
+  private static class ThrottleTimer {
+
+    // This is -1 if not currently being throttled or the time in
+    // milliseconds when throttling for this type started.
+    private long startTime = -1;
+    // This is the collected total throttle times since the last poll.  Throttle times are
+    // reported as a delta so this is cleared whenever it gets reported.
+    private long totalTime = 0;
+
+    /**
+     * Starts the timer if it has not been started and does nothing if it has already been started.
+     */
+    public synchronized void start() {
+      if (!throttled()) { // This timer is not started yet so start it now.
+        startTime = Instant.now().getMillis();
+      }
+    }
+
+    /** Stops the timer if it has been started and does nothing if it has not been started. */
+    public synchronized void stop() {
+      if (throttled()) { // This timer has been started already so stop it now.
+        totalTime += Instant.now().getMillis() - startTime;
+        startTime = -1;
+      }
+    }
+
+    /** Returns if the specified type is currently being throttled */
+    public synchronized boolean throttled() {
+      return startTime != -1;
+    }
+
+    /** Returns the combined total of all throttle times and resets those times to 0. */
+    public synchronized long getAndResetThrottleTime() {
+      if (throttled()) {
+        stop();
+        start();
+      }
+      long toReturn = totalTime;
+      totalTime = 0;
+      return toReturn;
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -77,6 +77,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingGetWor
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingGetWorkRequestExtension;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingGetWorkResponseChunk;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItemCommitRequest;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.BackOff;
 import org.apache.beam.sdk.util.BackOffUtils;
@@ -178,14 +179,14 @@ public class GrpcWindmillServer extends WindmillServerStub {
       if (experiments == null) {
         experiments = new ArrayList<>();
       }
-      experiments.add(StreamingDataflowWorkerOptions.STREAMING_ENGINE_EXPERIMENT);
+      experiments.add(GcpOptions.STREAMING_ENGINE_EXPERIMENT);
       options.setExperiments(experiments);
     }
     this.stubList.add(CloudWindmillServiceV1Alpha1Grpc.newStub(inProcessChannel(name)));
   }
 
   private boolean streamingEngineEnabled() {
-    return StreamingDataflowWorkerOptions.streamingEngineEnabled(this.options);
+    return options.isEnableStreamingEngine();
   }
 
   @Override

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -106,9 +106,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** gRPC client for communicating with Windmill Service. */
-// Very likely real potential for bugs - https://issues.apache.org/jira/browse/BEAM-6562
-// Very likely real potential for bugs - https://issues.apache.org/jira/browse/BEAM-6564
-@SuppressFBWarnings({"JLM_JSR166_UTILCONCURRENT_MONITORENTER", "IS2_INCONSISTENT_SYNC"})
 public class GrpcWindmillServer extends WindmillServerStub {
   private static final Logger LOG = LoggerFactory.getLogger(GrpcWindmillServer.class);
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillServerBase.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillServerBase.java
@@ -110,6 +110,12 @@ public class WindmillServerBase extends WindmillServerStub {
   }
 
   @Override
+  public long getAndResetThrottleTime() {
+    // Windmill appliance does not have throttling.
+    return 0;
+  }
+
+  @Override
   public GetWorkStream getWorkStream(Windmill.GetWorkRequest request, WorkItemReceiver receiver) {
     throw new UnsupportedOperationException();
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillServerStub.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillServerStub.java
@@ -91,6 +91,9 @@ public abstract class WindmillServerStub implements StatusDataProvider {
   /** Returns a stream allowing individual WorkItemCommitRequests to be streamed to Windmill. */
   public abstract CommitWorkStream commitWorkStream();
 
+  /** Returns the amount of time the server has been throttled and resets the time to 0. */
+  public abstract long getAndResetThrottleTime();
+
   @Override
   public void appendSummaryHtml(PrintWriter writer) {}
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -179,6 +179,11 @@ class FakeWindmillServer extends WindmillServerStub {
   }
 
   @Override
+  public long getAndResetThrottleTime() {
+    return (long) 0;
+  }
+
+  @Override
   public GetWorkStream getWorkStream(Windmill.GetWorkRequest request, WorkItemReceiver receiver) {
     throw new UnsupportedOperationException();
   }

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java
@@ -49,6 +49,7 @@ import org.apache.beam.sdk.extensions.gcp.storage.PathValidator;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.BackOffAdapter;
 import org.apache.beam.sdk.util.FluentBackoff;
@@ -125,6 +126,19 @@ public interface GcpOptions extends GoogleApiDebugOptions, PipelineOptions {
   Credentials getGcpCredential();
 
   void setGcpCredential(Credentials value);
+
+  /** Experiment to turn on the Streaming Engine experiment. */
+  String STREAMING_ENGINE_EXPERIMENT = "enable_streaming_engine";
+
+  /** @deprecated Use STREAMING_ENGINE_EXPERIMENT instead. */
+  @Deprecated String WINDMILL_SERVICE_EXPERIMENT = "enable_windmill_service";
+
+  @Description(
+      "If true will use Streaming Engine.  Defaults to false unless the experiments enable_streaming_engine or enable_windmill_service are set.")
+  @Default.InstanceFactory(EnableStreamingEngineFactory.class)
+  boolean isEnableStreamingEngine();
+
+  void setEnableStreamingEngine(boolean value);
 
   /**
    * Attempts to infer the default project based upon the environment this application is executing
@@ -213,6 +227,15 @@ public interface GcpOptions extends GoogleApiDebugOptions, PipelineOptions {
       } catch (IOException | GeneralSecurityException e) {
         throw new RuntimeException("Unable to obtain credential", e);
       }
+    }
+  }
+
+  /** EneableStreamingEngine defaults to false unless one of the two experiments is set. */
+  class EnableStreamingEngineFactory implements DefaultValueFactory<Boolean> {
+    @Override
+    public Boolean create(PipelineOptions options) {
+      return ExperimentalOptions.hasExperiment(options, STREAMING_ENGINE_EXPERIMENT)
+          || ExperimentalOptions.hasExperiment(options, WINDMILL_SERVICE_EXPERIMENT);
     }
   }
 

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -403,6 +403,10 @@ class GoogleCloudOptions(PipelineOptions):
                         'Experimental. '
                         'See https://cloud.google.com/dataflow/pipelines/'
                         'updating-a-pipeline')
+    parser.add_argument('--enable_streaming_engine',
+                        default=False,
+                        action='store_true',
+                        help='Enable Windmill Service for this Dataflow job. ')
 
   def validate(self, validator):
     errors = []

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -41,6 +41,7 @@ from apache_beam import pvalue
 from apache_beam.internal import pickler
 from apache_beam.internal.gcp import json_value
 from apache_beam.options.pipeline_options import DebugOptions
+from apache_beam.options.pipeline_options import GoogleCloudOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.pipeline_options import TestOptions
@@ -352,6 +353,25 @@ class DataflowRunner(PipelineRunner):
       if debug_options.experiments is not None:
         experiments = list(set(experiments + debug_options.experiments))
       debug_options.experiments = experiments
+
+    # Elevate "enable_streaming_engine" to pipeline option, but using the
+    # existing experiment.
+    google_cloud_options = options.view_as(GoogleCloudOptions)
+    if google_cloud_options.enable_streaming_engine:
+      if debug_options.experiments is None:
+        debug_options.experiments = []
+      if "enable_windmill_service" not in debug_options.experiments:
+        debug_options.experiments.append("enable_windmill_service")
+      if "enable_streaming_engine" not in debug_options.experiments:
+        debug_options.experiments.append("enable_streaming_engine")
+    else:
+      if debug_options.experiments is not None:
+        if ("enable_windmill_service" in debug_options.experiments
+            or "enable_streaming_engine" in debug_options.experiments):
+          raise ValueError("""Streaming engine both disabled and enabled:
+          enableStreamingEngine is set to false, but enable_windmill_service
+          and/or enable_streaming_engine are present. It is recommended you
+          only set enableStreamingEngine.""")
 
     self.job = apiclient.Job(options, self.proto_pipeline)
 


### PR DESCRIPTION
Cherry picks the windmill service quota reporting and the windmill service flag to version 2.10.0.  Original PRs are:
https://github.com/apache/beam/pull/7693/
https://github.com/apache/beam/pull/7664
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

