### PR TITLE
Use BeamDeprecationWarning in BQ client code.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -139,6 +139,7 @@ from apache_beam.transforms import DoFn
 from apache_beam.transforms import ParDo
 from apache_beam.transforms import PTransform
 from apache_beam.transforms.display import DisplayDataItem
+from apache_beam.utils.annotations import deprecated
 
 __all__ = [
     'TableRowJsonCoder',
@@ -149,52 +150,39 @@ __all__ = [
     ]
 
 
+@deprecated(since='2.11.0', current="bigquery_tools.parse_table_reference")
 def _parse_table_reference(table, dataset=None, project=None):
-  import warnings
-  warnings.warn("This function is deprecated and will be permanently moved "
-                "to the bigquery_tools module in a future version of beam")
-  return bigquery_tools._parse_table_reference(table, dataset, project)
+  return bigquery_tools.parse_table_reference(table, dataset, project)
 
 
+@deprecated(since='2.11.0',
+            current="bigquery_tools.parse_table_schema_from_json")
 def parse_table_schema_from_json(schema_string):
-  import warnings
-  warnings.warn("This function is deprecated and will be permanently moved "
-                "to the bigquery_tools module in a future version of beam")
   return bigquery_tools.parse_table_schema_from_json(schema_string)
 
 
+@deprecated(since='2.11.0', current="bigquery_tools.default_encoder")
 def default_encoder(obj):
-  import warnings
-  warnings.warn("This function is deprecated and will be permanently moved "
-                "to the bigquery_tools module in a future version of beam")
   return bigquery_tools.default_encoder(obj)
 
 
+@deprecated(since='2.11.0', current="bigquery_tools.RowAsDictJsonCoder")
 def RowAsDictJsonCoder(*args, **kwargs):
-  import warnings
-  warnings.warn("This class is deprecated and will be permanently moved "
-                "to the bigquery_tools module in a future version of beam")
   return bigquery_tools.RowAsDictJsonCoder(*args, **kwargs)
 
 
+@deprecated(since='2.11.0', current="bigquery_tools.BigQueryReader")
 def BigQueryReader(*args, **kwargs):
-  import warnings
-  warnings.warn("This class is deprecated and will be permanently moved "
-                "to the bigquery_tools module in a future version of beam")
   return bigquery_tools.BigQueryReader(*args, **kwargs)
 
 
+@deprecated(since='2.11.0', current="bigquery_tools.BigQueryWriter")
 def BigQueryWriter(*args, **kwargs):
-  import warnings
-  warnings.warn("This class is deprecated and will be permanently moved "
-                "to the bigquery_tools module in a future version of beam")
   return bigquery_tools.BigQueryWriter(*args, **kwargs)
 
 
+@deprecated(since='2.11.0', current="bigquery_tools.BigQueryWrapper")
 def BigQueryWrapper(*args, **kwargs):
-  import warnings
-  warnings.warn("This class is deprecated and will be permanently moved "
-                "to the bigquery_tools module in a future version of beam")
   return bigquery_tools.BigQueryWrapper(*args, **kwargs)
 
 
@@ -337,7 +325,7 @@ class BigQuerySource(dataflow_io.NativeSource):
     elif table is None and query is None:
       raise ValueError('A BigQuery table or a query must be specified')
     elif table is not None:
-      self.table_reference = bigquery_tools._parse_table_reference(
+      self.table_reference = bigquery_tools.parse_table_reference(
           table, dataset, project)
       self.query = None
       self.use_legacy_sql = True
@@ -464,7 +452,7 @@ bigquery_v2_messages.TableSchema` object.
           'Google Cloud IO not available, '
           'please install apache_beam[gcp]')
 
-    self.table_reference = bigquery_tools._parse_table_reference(
+    self.table_reference = bigquery_tools.parse_table_reference(
         table, dataset, project)
     # Transform the table schema into a bigquery.TableSchema instance.
     if isinstance(schema, (str, unicode)):
@@ -698,7 +686,7 @@ bigquery_v2_messages.TableSchema`
         insert.
       test_client: Override the default bigquery client used for testing.
     """
-    self.table_reference = bigquery_tools._parse_table_reference(
+    self.table_reference = bigquery_tools.parse_table_reference(
         table, dataset, project)
     self.create_disposition = BigQueryDisposition.validate_create(
         create_disposition)

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -108,7 +108,7 @@ def parse_table_schema_from_json(schema_string):
   return bigquery.TableSchema(fields=fields)
 
 
-def _parse_table_reference(table, dataset=None, project=None):
+def parse_table_reference(table, dataset=None, project=None):
   """Parses a table reference into a (project, dataset, table) tuple.
 
   Args:
@@ -202,7 +202,7 @@ class BigQueryWrapper(object):
     return '%s_%d' % (self._row_id_prefix, self._unique_row_id)
 
   def _get_temp_table(self, project_id):
-    return _parse_table_reference(
+    return parse_table_reference(
         table=BigQueryWrapper.TEMP_TABLE + self._temporary_table_suffix,
         dataset=BigQueryWrapper.TEMP_DATASET + self._temporary_table_suffix,
         project=project_id)

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -127,8 +127,7 @@ def parse_table_reference(table, dataset=None, project=None):
       argument.
 
   Returns:
-    A bigquery.TableReference object. The object has the following attributes:
-    projectId, datasetId, and tableId.
+    A bigquery.TableReference object.
 
   Raises:
     ValueError: if the table reference as a string does not match the expected


### PR DESCRIPTION
Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

