### PR TITLE
Minor tweaks to Dockerized Jenkins README

### DIFF
--- a/.test-infra/dockerized-jenkins/README.md
+++ b/.test-infra/dockerized-jenkins/README.md
@@ -23,8 +23,8 @@ Setting up a local Jenkins instance is useful for testing Jenkins job changes
 without affecting the production instance. Using Docker makes the setup very
 straightforward.
 
-As of now, this setup allows you to test Job DSL scripts. Imported Beam jobs
-will not succeed due to some tools (like gcloud) and credentials missing.
+As of now, this setup allows you to test Job DSL scripts. **Imported Beam jobs
+will not succeed due to some tools (like gcloud) and credentials missing.**
 
 ## Jenkins on Docker
 
@@ -94,7 +94,7 @@ http://127.0.0.1:8080. And map jenkins_home of running container to JENKINS_HOME
 on your OS file system.
 
 You can setup your Jenkins instance to look like the Apache Beam Jenkins using
-[these steps](#beam-config). (Running Beam Job DSL groovy scripts)
+[these steps](#running-beam-job-dsl-groovy-scripts). (Running Beam Job DSL groovy scripts)
 
 ### Forking your Jenkins instance
 
@@ -118,13 +118,13 @@ docker run -p 127.0.0.1:8080:8080 -v ${JENKINS_HOME}:/var/jenkins_home jenkins/j
       Jenkins instance will only be available via localhost and not your machine
       hostname.
 
-### Running Beam Job DSL groovy scripts {#beam-config}
+### Running Beam Job DSL groovy scripts
 
 On Beam we configure Jenkins jobs via groovy job dsl scripts. If you want to run
 those on your docker instance of Jenkins, you will need to do some setup on top
 of installing default plugins:
 
-1.  Install following plugins
+1.  Make sure the following plugins are installed (Managee Jenkins -> Manage Plugins)
     1.  Environment Injector
     1.  GitHub pull request build (ghprb)
     1.  Groovy
@@ -140,7 +140,7 @@ of installing default plugins:
     1.  Go to Manage Jenkins -> Configure Global Security
     1.  Unmark "Enable script security for Job DSL scripts"
 1.  Set up Job DSL jobs import job. (Seed job)
-    1.  Refer to seedjobconfig.xml for parameters.
+    1.  Refer to [seedjobconfig.xml](./seedjobconfig.xml) for parameters.
     1.  Go to Jenkins -> New Item -> Freestyle project
     1.  Build step: Process Job DSLs
 

--- a/.test-infra/dockerized-jenkins/README.md
+++ b/.test-infra/dockerized-jenkins/README.md
@@ -124,7 +124,7 @@ On Beam we configure Jenkins jobs via groovy job dsl scripts. If you want to run
 those on your docker instance of Jenkins, you will need to do some setup on top
 of installing default plugins:
 
-1.  Make sure the following plugins are installed (Managee Jenkins -> Manage Plugins)
+1.  Make sure the following plugins are installed (Manage Jenkins -> Manage Plugins)
     1.  Environment Injector
     1.  GitHub pull request build (ghprb)
     1.  Groovy


### PR DESCRIPTION
* Emphasized that the jobs themselves _will not work_ in the Dockerized Jenkins. Apparently several people (including myself) have missed that fact and attempted to run a Dockerized Jenkins to replicate the CI environment.
* Fixed anchor link
* Added link to seedjobconfig.xml
* Added directions for finding plugins

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

