### PR TITLE
[BEAM-6426] Use vendored guava class for kryo registration in Spark runner

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/BeamSparkRunnerRegistrator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/BeamSparkRunnerRegistrator.java
@@ -63,7 +63,9 @@ public class BeamSparkRunnerRegistrator implements KryoRegistrator {
     kryo.register(PaneInfo.class);
 
     try {
-      kryo.register(Class.forName("com.google.common.collect.HashBasedTable$Factory"));
+      kryo.register(
+          Class.forName(
+              "org.apache.beam.vendor.guava.v20_0.com.google.common.collect.HashBasedTable$Factory"));
       kryo.register(
           Class.forName("org.apache.beam.sdk.util.WindowedValue$TimestampedValueInGlobalWindow"));
     } catch (ClassNotFoundException e) {


### PR DESCRIPTION
It seems we missed this one. It is the last missed use after checking via grep.
R: @aromanenko-dev 