### PR TITLE
[BEAM-6638] Python ExternalTransform output mismatched

### DIFF
--- a/runners/core-construction-java/build.gradle
+++ b/runners/core-construction-java/build.gradle
@@ -57,8 +57,15 @@ task runExpansionService (type: JavaExec) {
   args = [project.findProperty("constructionService.port") ?: "8097"]
 }
 
-task testExpansionService(type: Jar) {
+task runTestExpansionService (type: JavaExec) {
+  main = "org.apache.beam.runners.core.construction.TestExpansionService"
+  classpath = sourceSets.test.runtimeClasspath
+  args = [project.findProperty("constructionService.port") ?: "8097"]
+}
+
+task jarTestExpansionService(type: Jar) {
   dependsOn = [shadowJar, shadowTestJar]
+  appendix = "testExpansionService"
   manifest {
     attributes(
             'Main-Class': 'org.apache.beam.runners.core.construction.TestExpansionService'

--- a/runners/core-construction-java/build.gradle
+++ b/runners/core-construction-java/build.gradle
@@ -63,7 +63,7 @@ task runTestExpansionService (type: JavaExec) {
   args = [project.findProperty("constructionService.port") ?: "8097"]
 }
 
-task jarTestExpansionService(type: Jar) {
+task buildTestExpansionServiceJar(type: Jar) {
   dependsOn = [shadowJar, shadowTestJar]
   appendix = "testExpansionService"
   manifest {

--- a/sdks/python/apache_beam/examples/wordcount_xlang.py
+++ b/sdks/python/apache_beam/examples/wordcount_xlang.py
@@ -51,6 +51,9 @@ class WordExtractingDoFn(beam.DoFn):
       The processed element.
     """
     text_line = element.strip()
+    # Using bytes type to match input and output coders between Python
+    # and Java SDKs. Any element type can be used for crossing the language
+    # boundary if a matching coder implementation exists in both SDKs.
     words = [bytes(x) for x in re.findall(r'[\w\']+', text_line)]
     return words
 

--- a/sdks/python/apache_beam/examples/wordcount_xlang.py
+++ b/sdks/python/apache_beam/examples/wordcount_xlang.py
@@ -54,6 +54,8 @@ class WordExtractingDoFn(beam.DoFn):
     # Using bytes type to match input and output coders between Python
     # and Java SDKs. Any element type can be used for crossing the language
     # boundary if a matching coder implementation exists in both SDKs.
+    # TODO(BEAM-6587): Use strings once they're understood by the
+    # Java SDK.
     words = [bytes(x) for x in re.findall(r'[\w\']+', text_line)]
     return words
 

--- a/sdks/python/apache_beam/examples/wordcount_xlang.py
+++ b/sdks/python/apache_beam/examples/wordcount_xlang.py
@@ -1,0 +1,122 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A cross-language word-counting workflow."""
+
+from __future__ import absolute_import
+
+import argparse
+import logging
+import re
+import subprocess
+
+import grpc
+
+import apache_beam as beam
+from apache_beam.io import ReadFromText
+from apache_beam.io import WriteToText
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+
+EXPANSION_SERVICE_PORT = '8097'
+EXPANSION_SERVICE_ADDR = 'localhost:%s' % EXPANSION_SERVICE_PORT
+
+
+class WordExtractingDoFn(beam.DoFn):
+  """Parse each line of input text into words."""
+
+  def process(self, element):
+    """Returns an iterator over the words of this element.
+
+    The element is a line of text.  If the line is blank, note that, too.
+
+    Args:
+      element: the element being processed
+
+    Returns:
+      The processed element.
+    """
+    text_line = element.strip()
+    words = [bytes(x) for x in re.findall(r'[\w\']+', text_line)]
+    return words
+
+
+def run(pipeline_args, input_file, output_file):
+
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_options = PipelineOptions(pipeline_args)
+  pipeline_options.view_as(SetupOptions).save_main_session = True
+  p = beam.Pipeline(options=pipeline_options)
+
+  # Read the text file[pattern] into a PCollection.
+  lines = p | 'read' >> ReadFromText(input_file)
+
+  counts = (lines
+            | 'split' >> (beam.ParDo(WordExtractingDoFn())
+                          .with_output_types(bytes))
+            | 'count' >> beam.ExternalTransform(
+                'pytest:beam:transforms:count', None, EXPANSION_SERVICE_ADDR))
+
+  # Format the counts into a PCollection of strings.
+  def format_result(word_count):
+    (word, count) = word_count
+    return '%s: %d' % (word, count)
+
+  output = counts | 'format' >> beam.Map(format_result)
+
+  # Write the output using a "Write" transform that has side effects.
+  # pylint: disable=expression-not-assigned
+  output | 'write' >> WriteToText(output_file)
+
+  result = p.run()
+  result.wait_until_finish()
+
+
+def wait_for_ready():
+  with grpc.insecure_channel(EXPANSION_SERVICE_ADDR) as channel:
+    grpc.channel_ready_future(channel).result()
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--input',
+                      dest='input',
+                      default='gs://dataflow-samples/shakespeare/kinglear.txt',
+                      help='Input file to process.')
+  parser.add_argument('--output',
+                      dest='output',
+                      required=True,
+                      help='Output file to write results to.')
+  parser.add_argument('--expansion_service_jar',
+                      dest='expansion_service_jar',
+                      required=True,
+                      help='Jar file for expansion service')
+
+  known_args, pipeline_args = parser.parse_known_args()
+  try:
+    server = subprocess.Popen([
+        'java', '-jar', known_args.expansion_service_jar,
+        EXPANSION_SERVICE_PORT])
+    wait_for_ready()
+
+    run(pipeline_args, known_args.input, known_args.output)
+
+  finally:
+    server.kill()

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -203,7 +203,14 @@ class ExternalTransform(ptransform.PTransform):
                    for tag, pcoll in proto.outputs.items()})
       context.transforms.put_proto(id, new_proto)
 
-    return self._expanded_transform
+    return beam_runner_api_pb2.PTransform(
+        unique_name=full_label,
+        spec=self._expanded_transform.spec,
+        subtransforms=self._expanded_transform.subtransforms,
+        inputs=self._expanded_transform.inputs,
+        outputs={
+            tag: pcoll_renames.get(pcoll, pcoll)
+            for tag, pcoll in self._expanded_transform.outputs.items()})
 
 
 def memoize(func):

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -203,7 +203,7 @@ task portableWordCount {
 def portableWordCountTask(name, streaming, crossLanguage) {
   tasks.create(name) {
     dependsOn = ['installGcpTest']
-    mustRunAfter = [':beam-runners-flink_2.11-job-server-container:docker', ':beam-sdks-python-container:docker', ':beam-sdks-java-container:docker', ':beam-runners-core-construction-java:jarTestExpansionService']
+    mustRunAfter = [':beam-runners-flink_2.11-job-server-container:docker', ':beam-sdks-python-container:docker', ':beam-sdks-java-container:docker', ':beam-runners-core-construction-java:buildTestExpansionServiceJar']
     doLast {
       // TODO: Figure out GCS credentials and use real GCS input and output.
       def options = [
@@ -220,7 +220,7 @@ def portableWordCountTask(name, streaming, crossLanguage) {
         // workaround for local file output in docker container
         options += ["--environment_cache_millis=10000"]
       if (crossLanguage)
-        options += ["--expansion_service_jar=${project(":beam-runners-core-construction-java:").jarTestExpansionService.archivePath}"]
+        options += ["--expansion_service_jar=${project(":beam-runners-core-construction-java:").buildTestExpansionServiceJar.archivePath}"]
       if (project.hasProperty("jobEndpoint"))
         options += ["--job_endpoint=${project.property('jobEndpoint')}"]
       def wordcountMain = crossLanguage ? "apache_beam.examples.wordcount_xlang" : "apache_beam.examples.wordcount"
@@ -449,11 +449,11 @@ project.task('createProcessWorker') {
 project.task('crossLanguagePythonJava') {
   dependsOn 'setupVirtualenv'
   dependsOn ':beam-sdks-java-container:docker'
-  dependsOn ':beam-runners-core-construction-java:jarTestExpansionService'
+  dependsOn ':beam-runners-core-construction-java:buildTestExpansionServiceJar'
   doLast {
     exec {
       executable 'sh'
-      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.transforms.external_test --expansion_service_jar=${project(":beam-runners-core-construction-java:").jarTestExpansionService.archivePath}"
+      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.transforms.external_test --expansion_service_jar=${project(":beam-runners-core-construction-java:").buildTestExpansionServiceJar.archivePath}"
     }
   }
 }

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -118,8 +118,8 @@ task preCommit() {
 task portablePreCommit() {
   dependsOn ':beam-runners-flink_2.11-job-server-container:docker'
   dependsOn ':beam-sdks-python-container:docker'
-  dependsOn portableWordCountTask('portableWordCountBatch', false)
-  dependsOn portableWordCountTask('portableWordCountStreaming', true)
+  dependsOn portableWordCountTask('portableWordCountBatch', false, false)
+  dependsOn portableWordCountTask('portableWordCountStreaming', true, false)
 }
 
 
@@ -197,13 +197,13 @@ task directRunnerIT(dependsOn: 'installGcpTest') {
 //    ./gradlew :beam-sdks-python:portableWordCount -PjobEndpoint=localhost:8099
 //
 task portableWordCount {
-  dependsOn portableWordCountTask('portableWordCountExample', project.hasProperty("streaming"))
+  dependsOn portableWordCountTask('portableWordCountExample', project.hasProperty("streaming"), project.hasProperty("crossLanguage"))
 }
 
-def portableWordCountTask(name, streaming) {
+def portableWordCountTask(name, streaming, crossLanguage) {
   tasks.create(name) {
     dependsOn = ['installGcpTest']
-    mustRunAfter = [':beam-runners-flink_2.11-job-server-container:docker', ':beam-sdks-python-container:docker']
+    mustRunAfter = [':beam-runners-flink_2.11-job-server-container:docker', ':beam-sdks-python-container:docker', ':beam-sdks-java-container:docker', ':beam-runners-core-construction-java:jarTestExpansionService']
     doLast {
       // TODO: Figure out GCS credentials and use real GCS input and output.
       def options = [
@@ -219,11 +219,14 @@ def portableWordCountTask(name, streaming) {
       else
         // workaround for local file output in docker container
         options += ["--environment_cache_millis=10000"]
+      if (crossLanguage)
+        options += ["--expansion_service_jar=${project(":beam-runners-core-construction-java:").jarTestExpansionService.archivePath}"]
       if (project.hasProperty("jobEndpoint"))
         options += ["--job_endpoint=${project.property('jobEndpoint')}"]
+      def wordcountMain = crossLanguage ? "apache_beam.examples.wordcount_xlang" : "apache_beam.examples.wordcount"
       exec {
         executable 'sh'
-        args '-c', ". ${project.ext.envdir}/bin/activate && python -m apache_beam.examples.wordcount ${options.join(' ')}"
+        args '-c', ". ${project.ext.envdir}/bin/activate && python -m ${wordcountMain} ${options.join(' ')}"
         // TODO: Check that the output file is generated and runs.
       }
     }
@@ -446,11 +449,11 @@ project.task('createProcessWorker') {
 project.task('crossLanguagePythonJava') {
   dependsOn 'setupVirtualenv'
   dependsOn ':beam-sdks-java-container:docker'
-  dependsOn ':beam-runners-core-construction-java:testExpansionService'
+  dependsOn ':beam-runners-core-construction-java:jarTestExpansionService'
   doLast {
     exec {
       executable 'sh'
-      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.transforms.external_test --expansion_service_jar=${project(":beam-runners-core-construction-java:").testExpansionService.archivePath}"
+      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.transforms.external_test --expansion_service_jar=${project(":beam-runners-core-construction-java:").jarTestExpansionService.archivePath}"
     }
   }
 }


### PR DESCRIPTION
- fix PipelineValidator() issue
- add cross-language wordcount example
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

