### PR TITLE
[BEAM-6512] Run GrpcDataServiceTest clients on the main thread

### DIFF
--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/data/GrpcDataServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/data/GrpcDataServiceTest.java
@@ -79,6 +79,7 @@ public class GrpcDataServiceTest {
                 () -> {
                   ManagedChannel channel =
                       InProcessChannelBuilder.forName(server.getApiServiceDescriptor().getUrl())
+                          .directExecutor()
                           .build();
                   StreamObserver<Elements> outboundObserver =
                       BeamFnDataGrpc.newStub(channel)

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/data/GrpcDataServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/data/GrpcDataServiceTest.java
@@ -18,18 +18,15 @@
 package org.apache.beam.runners.fnexecution.data;
 
 import static org.apache.beam.sdk.util.CoderUtils.encodeToByteArray;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.Elements;
@@ -53,10 +50,14 @@ import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.stub.StreamObserver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Tests for {@link GrpcDataService}. */
 @RunWith(JUnit4.class)
 public class GrpcDataServiceTest {
+  private static final Logger LOG = LoggerFactory.getLogger(GrpcDataServiceTest.class);
+
   private static final BeamFnApi.Target TARGET =
       BeamFnApi.Target.newBuilder().setPrimitiveTransformReference("888").setName("test").build();
   private static final Coder<WindowedValue<String>> CODER =
@@ -65,28 +66,23 @@ public class GrpcDataServiceTest {
   @Test
   public void testMessageReceivedBySingleClientWhenThereAreMultipleClients() throws Exception {
     final LinkedBlockingQueue<Elements> clientInboundElements = new LinkedBlockingQueue<>();
-    ExecutorService executorService = Executors.newCachedThreadPool();
-    final CountDownLatch waitForInboundElements = new CountDownLatch(1);
     GrpcDataService service =
         GrpcDataService.create(
             Executors.newCachedThreadPool(), OutboundObserverFactory.serverDirect());
+
     try (GrpcFnServer<GrpcDataService> server =
         GrpcFnServer.allocatePortAndCreateFor(service, InProcessServerFactory.create())) {
-      Collection<Future<Void>> clientFutures = new ArrayList<>();
+
+      final Collection<StreamObserver> openObservers = new ArrayList<>(3);
+
       for (int i = 0; i < 3; ++i) {
-        clientFutures.add(
-            executorService.submit(
-                () -> {
-                  ManagedChannel channel =
-                      InProcessChannelBuilder.forName(server.getApiServiceDescriptor().getUrl())
-                          .build();
-                  StreamObserver<Elements> outboundObserver =
-                      BeamFnDataGrpc.newStub(channel)
-                          .data(TestStreams.withOnNext(clientInboundElements::add).build());
-                  waitForInboundElements.await();
-                  outboundObserver.onCompleted();
-                  return null;
-                }));
+        ManagedChannel channel =
+            InProcessChannelBuilder.forName(server.getApiServiceDescriptor().getUrl())
+                .directExecutor()
+                .build();
+        openObservers.add(
+            BeamFnDataGrpc.newStub(channel)
+                .data(TestStreams.withOnNext(clientInboundElements::add).build()));
       }
 
       for (int i = 0; i < 3; ++i) {
@@ -98,44 +94,36 @@ public class GrpcDataServiceTest {
         consumer.accept(WindowedValue.valueInGlobalWindow("C" + i));
         consumer.close();
       }
-      waitForInboundElements.countDown();
-      for (Future<Void> clientFuture : clientFutures) {
-        clientFuture.get();
-      }
-      assertThat(
-          clientInboundElements,
-          containsInAnyOrder(elementsWithData("0"), elementsWithData("1"), elementsWithData("2")));
+
+      openObservers.stream().forEach(StreamObserver::onCompleted);
     }
+
+    assertThat(
+        clientInboundElements,
+        containsInAnyOrder(elementsWithData("0"), elementsWithData("1"), elementsWithData("2")));
   }
 
   @Test
   public void testMultipleClientsSendMessagesAreDirectedToProperConsumers() throws Exception {
     final LinkedBlockingQueue<BeamFnApi.Elements> clientInboundElements =
         new LinkedBlockingQueue<>();
-    ExecutorService executorService = Executors.newCachedThreadPool();
-    final CountDownLatch waitForInboundElements = new CountDownLatch(1);
     GrpcDataService service =
         GrpcDataService.create(
             Executors.newCachedThreadPool(), OutboundObserverFactory.serverDirect());
     try (GrpcFnServer<GrpcDataService> server =
         GrpcFnServer.allocatePortAndCreateFor(service, InProcessServerFactory.create())) {
-      Collection<Future<Void>> clientFutures = new ArrayList<>();
+      final Collection<StreamObserver<Elements>> openObservers = new ArrayList<>(3);
       for (int i = 0; i < 3; ++i) {
         final String instructionReference = Integer.toString(i);
-        clientFutures.add(
-            executorService.submit(
-                () -> {
-                  ManagedChannel channel =
-                      InProcessChannelBuilder.forName(server.getApiServiceDescriptor().getUrl())
-                          .build();
-                  StreamObserver<Elements> outboundObserver =
-                      BeamFnDataGrpc.newStub(channel)
-                          .data(TestStreams.withOnNext(clientInboundElements::add).build());
-                  outboundObserver.onNext(elementsWithData(instructionReference));
-                  waitForInboundElements.await();
-                  outboundObserver.onCompleted();
-                  return null;
-                }));
+        ManagedChannel channel =
+            InProcessChannelBuilder.forName(server.getApiServiceDescriptor().getUrl())
+                .directExecutor()
+                .build();
+        StreamObserver<Elements> outboundObserver =
+            BeamFnDataGrpc.newStub(channel)
+                .data(TestStreams.withOnNext(clientInboundElements::add).build());
+        outboundObserver.onNext(elementsWithData(instructionReference));
+        openObservers.add(outboundObserver);
       }
 
       List<Collection<WindowedValue<String>>> serverInboundValues = new ArrayList<>();
@@ -150,10 +138,7 @@ public class GrpcDataServiceTest {
       for (InboundDataClient readFuture : readFutures) {
         readFuture.awaitCompletion();
       }
-      waitForInboundElements.countDown();
-      for (Future<Void> clientFuture : clientFutures) {
-        clientFuture.get();
-      }
+      openObservers.stream().forEach(StreamObserver::onCompleted);
       for (int i = 0; i < 3; ++i) {
         assertThat(
             serverInboundValues.get(i),


### PR DESCRIPTION
Run gRPC clients on the main thread in GrpcDataServiceTest. Prevents a possible race condition where clients did not add data to `clientInboundElements` until _after_ the assertion was already called.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

