### PR TITLE
[BEAM-6567] Added Kinesis support to SyntheticDataPublisher

### DIFF
--- a/sdks/java/testing/load-tests/build.gradle
+++ b/sdks/java/testing/load-tests/build.gradle
@@ -63,6 +63,7 @@ dependencies {
   shadow project(path: ":beam-sdks-java-test-utils", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-io-google-cloud-platform", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-io-kafka", configuration: "shadow")
+  shadow project(path: ":beam-sdks-java-io-kinesis", configuration: "shadow")
 
   gradleRun project(path: project.path, configuration: "shadow")
   gradleRun project(path: runnerDependency, configuration: "shadow")

--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/SyntheticDataPublisher.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/SyntheticDataPublisher.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.loadtests;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.beam.sdk.util.CoderUtils.encodeToByteArray;
 
+import com.amazonaws.regions.Regions;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.io.kafka.KafkaIO;
+import org.apache.beam.sdk.io.kinesis.KinesisIO;
 import org.apache.beam.sdk.io.synthetic.SyntheticBoundedSource;
 import org.apache.beam.sdk.io.synthetic.SyntheticOptions;
 import org.apache.beam.sdk.io.synthetic.SyntheticSourceOptions;
@@ -47,7 +49,8 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 /**
- * Pipeline that generates synthetic data and publishes it in PubSub topic.
+ * Pipeline that generates synthetic data and publishes it in a PubSub or Kafka topic or in a
+ * Kinesis stream.
  *
  * <p>To run it manually, use the following command:
  *
@@ -56,12 +59,17 @@ import org.apache.kafka.common.serialization.StringSerializer;
  *    --pubSubTopic=TOPIC_NAME
  *    --kafkaBootstrapServerAddress=SERVER_ADDRESS
  *    --kafkaTopic=KAFKA_TOPIC_NAME
- *    --sourceOptions={"numRecords":1000,...}'
+ *    --sourceOptions={"numRecords":1000,...}
+ *    --kinesisStreamName=KINESIS_STREAM_NAME
+ *    --kinesisPartitionKey=KINESIS_PARTITION_KEY
+ *    --kinesisAwsKey=KINESIS_AWS_KEY
+ *    --kinesisAwsSecret=KINESIS_AWS_SECRET
+ *    --kinesisAwsRegion=KINESIS_AWS_REGION'
  *    -PloadTest.mainClass="org.apache.beam.sdk.loadtests.SyntheticDataPublisher"
  *  </pre>
  *
- * <p>If parameters related to a specific sink are provided (Kafka or PubSub), the pipeline writes
- * to the sink. Writing to both sinks is also acceptable.
+ * <p>If parameters related to a specific sink are provided (Kafka, PubSub or Kinesis), the pipeline
+ * writes to the sink. Writing to more than one sink is also acceptable.
  */
 public class SyntheticDataPublisher {
 
@@ -93,6 +101,31 @@ public class SyntheticDataPublisher {
     String getKafkaTopic();
 
     void setKafkaTopic(String topic);
+
+    @Description("Kinesis partition key")
+    String getKinesisPartitionKey();
+
+    void setKinesisPartitionKey(String partitionKey);
+
+    @Description("Kinesis partition name")
+    String getKinesisStreamName();
+
+    void setKinesisStreamName(String kinesisStreamName);
+
+    @Description("AWS secret for Kinesis")
+    String getKinesisAwsSecret();
+
+    void setKinesisAwsSecret(String kinesisAwsSecret);
+
+    @Description("AWS key for Kinesis")
+    String getKinesisAwsKey();
+
+    void setKinesisAwsKey(String kinesisAwsKey);
+
+    @Description("AWS region for Kinesis")
+    String getKinesisAwsRegion();
+
+    void setKinesisAwsRegion(String kinesisAwsRegion);
   }
 
   public static void main(String[] args) throws IOException {
@@ -111,7 +144,18 @@ public class SyntheticDataPublisher {
     if (options.getPubSubTopic() != null) {
       writeToPubSub(syntheticData);
     }
+    if (allKinesisOptionsConfigured()) {
+      writeToKinesis(syntheticData);
+    }
     pipeline.run().waitUntilFinish();
+  }
+
+  private static boolean allKinesisOptionsConfigured() {
+    return options.getKinesisAwsKey() != null
+        && options.getKinesisAwsRegion() != null
+        && options.getKinesisAwsSecret() != null
+        && options.getKinesisPartitionKey() != null
+        && options.getKinesisStreamName() != null;
   }
 
   private static void writeToPubSub(PCollection<KV<byte[], byte[]>> collection) {
@@ -132,11 +176,32 @@ public class SyntheticDataPublisher {
                 .values());
   }
 
+  private static void writeToKinesis(PCollection<KV<byte[], byte[]>> collection) {
+    collection
+        .apply("Map to byte array for Kinesis", MapElements.via(new MapKVToByteArray()))
+        .apply(
+            "Write to Kinesis",
+            KinesisIO.write()
+                .withStreamName(options.getKinesisStreamName())
+                .withPartitionKey(options.getKinesisPartitionKey())
+                .withAWSClientsProvider(
+                    options.getKinesisAwsKey(),
+                    options.getKinesisAwsSecret(),
+                    Regions.fromName(options.getKinesisAwsRegion())));
+  }
+
   private static class MapKVToString extends SimpleFunction<KV<byte[], byte[]>, String> {
     @Override
     public String apply(KV<byte[], byte[]> input) {
       return String.format(
           "{%s,%s}", Arrays.toString(input.getKey()), Arrays.toString(input.getValue()));
+    }
+  }
+
+  private static class MapKVToByteArray extends SimpleFunction<KV<byte[], byte[]>, byte[]> {
+    @Override
+    public byte[] apply(KV<byte[], byte[]> input) {
+      return encodeInputElement(input);
     }
   }
 


### PR DESCRIPTION
Added another option of synthetic data publication. KinesisIO is supported by appropriate command line options.



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

