### PR TITLE
[BEAM-3061] Done notifications for BigtableIO.Write

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.annotation.Nullable;
@@ -53,6 +54,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -62,6 +64,7 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.base.MoreObjects.ToStringHelper;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,6 +132,33 @@ import org.slf4j.LoggerFactory;
  *         .withProjectId("project")
  *         .withInstanceId("instance")
  *         .withTableId("table"));
+ * }</pre>
+ *
+ * <p>Optionally, BigtableIO.write() may be configured to emit {@link BigtableWriteResult} elements
+ * after each group of inputs is written to Bigtable. These can be used to then trigger user code
+ * after writes have completed. See {@link org.apache.beam.sdk.transforms.Wait} for details on the
+ * windowing requirements of the signal and input PCollections.
+ *
+ * <pre>{@code
+ * // See Wait.on
+ * PCollection<KV<ByteString, Iterable<Mutation>>> data = ...;
+ *
+ * PCollection<BigtableWriteResult> writeResults =
+ *     data.apply("write",
+ *         BigtableIO.write()
+ *             .withProjectId("project")
+ *             .withInstanceId("instance")
+ *             .withTableId("table"))
+ *             .withWriteResults();
+ *
+ * // The windowing of `moreData` must be compatible with `data`, see {@link org.apache.beam.sdk.transforms.Wait#on}
+ * // for details.
+ * PCollection<...> moreData = ...;
+ *
+ * moreData
+ *     .apply("wait for writes", Wait.on(writeResults))
+ *     .apply("do something", ParDo.of(...))
+ *
  * }</pre>
  *
  * <h3>Experimental</h3>
@@ -660,118 +690,180 @@ public class BigtableIO {
       return toBuilder().setBigtableConfig(config.withBigtableService(bigtableService)).build();
     }
 
+    /**
+     * Returns a {@link BigtableIO.WriteWithResults} that will emit a {@link BigtableWriteResult}
+     * for each batch of rows written.
+     */
+    @Experimental
+    public WriteWithResults withWriteResults() {
+      return new WriteWithResults(getBigtableConfig());
+    }
+
     @Override
     public PDone expand(PCollection<KV<ByteString, Iterable<Mutation>>> input) {
-      getBigtableConfig().validate();
-
-      input.apply(ParDo.of(new BigtableWriterFn(getBigtableConfig())));
+      input.apply(withWriteResults());
       return PDone.in(input.getPipeline());
     }
 
     @Override
     public void validate(PipelineOptions options) {
-      validateTableExists(getBigtableConfig(), options);
+      withWriteResults().validate(options);
     }
 
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
-      super.populateDisplayData(builder);
-      getBigtableConfig().populateDisplayData(builder);
+      withWriteResults().populateDisplayData(builder);
     }
 
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(Write.class).add("config", getBigtableConfig()).toString();
     }
+  }
 
-    private class BigtableWriterFn extends DoFn<KV<ByteString, Iterable<Mutation>>, Void> {
+  /**
+   * A {@link PTransform} that writes to Google Cloud Bigtable and emits a {@link
+   * BigtableWriteResult} for each batch written. See the class-level Javadoc on {@link BigtableIO}
+   * for more information.
+   *
+   * @see BigtableIO
+   */
+  @Experimental(Experimental.Kind.SOURCE_SINK)
+  public static class WriteWithResults
+      extends PTransform<
+          PCollection<KV<ByteString, Iterable<Mutation>>>, PCollection<BigtableWriteResult>> {
 
-      public BigtableWriterFn(BigtableConfig bigtableConfig) {
-        this.config = bigtableConfig;
-        this.failures = new ConcurrentLinkedQueue<>();
+    private final BigtableConfig bigtableConfig;
+
+    WriteWithResults(BigtableConfig bigtableConfig) {
+      this.bigtableConfig = bigtableConfig;
+    }
+
+    @Override
+    public PCollection<BigtableWriteResult> expand(
+        PCollection<KV<ByteString, Iterable<Mutation>>> input) {
+      bigtableConfig.validate();
+
+      return input.apply(ParDo.of(new BigtableWriterFn(bigtableConfig)));
+    }
+
+    @Override
+    public void validate(PipelineOptions options) {
+      validateTableExists(bigtableConfig, options);
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      bigtableConfig.populateDisplayData(builder);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(WriteWithResults.class)
+          .add("config", bigtableConfig)
+          .toString();
+    }
+  }
+
+  private static class BigtableWriterFn
+      extends DoFn<KV<ByteString, Iterable<Mutation>>, BigtableWriteResult> {
+
+    BigtableWriterFn(BigtableConfig bigtableConfig) {
+      this.config = bigtableConfig;
+      this.failures = new ConcurrentLinkedQueue<>();
+    }
+
+    @StartBundle
+    public void startBundle(StartBundleContext c) throws IOException {
+      if (bigtableWriter == null) {
+        bigtableWriter =
+            config
+                .getBigtableService(c.getPipelineOptions())
+                .openForWriting(config.getTableId().get());
+      }
+      recordsWritten = 0;
+      this.seenWindows = Maps.newHashMapWithExpectedSize(1);
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c, BoundedWindow window) throws Exception {
+      checkForFailures();
+      bigtableWriter
+          .writeRecord(c.element())
+          .whenComplete(
+              (mutationResult, exception) -> {
+                if (exception != null) {
+                  failures.add(new BigtableWriteException(c.element(), exception));
+                }
+              });
+      ++recordsWritten;
+      seenWindows.compute(window, (key, count) -> (count != null ? count : 0) + 1);
+    }
+
+    @FinishBundle
+    public void finishBundle(FinishBundleContext c) throws Exception {
+      bigtableWriter.flush();
+      checkForFailures();
+      LOG.debug("Wrote {} records", recordsWritten);
+
+      for (Map.Entry<BoundedWindow, Long> entry : seenWindows.entrySet()) {
+        c.output(
+            BigtableWriteResult.create(entry.getValue()),
+            entry.getKey().maxTimestamp(),
+            entry.getKey());
+      }
+    }
+
+    @Teardown
+    public void tearDown() throws Exception {
+      if (bigtableWriter != null) {
+        bigtableWriter.close();
+        bigtableWriter = null;
+      }
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      config.populateDisplayData(builder);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    private final BigtableConfig config;
+    private BigtableService.Writer bigtableWriter;
+    private long recordsWritten;
+    private final ConcurrentLinkedQueue<BigtableWriteException> failures;
+    private Map<BoundedWindow, Long> seenWindows;
+
+    /** If any write has asynchronously failed, fail the bundle with a useful error. */
+    private void checkForFailures() throws IOException {
+      // Note that this function is never called by multiple threads and is the only place that
+      // we remove from failures, so this code is safe.
+      if (failures.isEmpty()) {
+        return;
       }
 
-      @StartBundle
-      public void startBundle(StartBundleContext c) throws IOException {
-        if (bigtableWriter == null) {
-          bigtableWriter =
-              config
-                  .getBigtableService(c.getPipelineOptions())
-                  .openForWriting(config.getTableId().get());
+      StringBuilder logEntry = new StringBuilder();
+      int i = 0;
+      List<BigtableWriteException> suppressed = Lists.newArrayList();
+      for (; i < 10 && !failures.isEmpty(); ++i) {
+        BigtableWriteException exc = failures.remove();
+        logEntry.append("\n").append(exc.getMessage());
+        if (exc.getCause() != null) {
+          logEntry.append(": ").append(exc.getCause().getMessage());
         }
-        recordsWritten = 0;
+        suppressed.add(exc);
       }
-
-      @ProcessElement
-      public void processElement(ProcessContext c) throws Exception {
-        checkForFailures();
-        bigtableWriter
-            .writeRecord(c.element())
-            .whenComplete(
-                (mutationResult, exception) -> {
-                  if (exception != null) {
-                    failures.add(new BigtableWriteException(c.element(), exception));
-                  }
-                });
-        ++recordsWritten;
+      String message =
+          String.format(
+              "At least %d errors occurred writing to Bigtable. First %d errors: %s",
+              i + failures.size(), i, logEntry.toString());
+      LOG.error(message);
+      IOException exception = new IOException(message);
+      for (BigtableWriteException e : suppressed) {
+        exception.addSuppressed(e);
       }
-
-      @FinishBundle
-      public void finishBundle() throws Exception {
-        bigtableWriter.flush();
-        checkForFailures();
-        LOG.debug("Wrote {} records", recordsWritten);
-      }
-
-      @Teardown
-      public void tearDown() throws Exception {
-        if (bigtableWriter != null) {
-          bigtableWriter.close();
-          bigtableWriter = null;
-        }
-      }
-
-      @Override
-      public void populateDisplayData(DisplayData.Builder builder) {
-        builder.delegate(Write.this);
-      }
-
-      ///////////////////////////////////////////////////////////////////////////////
-      private final BigtableConfig config;
-      private BigtableService.Writer bigtableWriter;
-      private long recordsWritten;
-      private final ConcurrentLinkedQueue<BigtableWriteException> failures;
-
-      /** If any write has asynchronously failed, fail the bundle with a useful error. */
-      private void checkForFailures() throws IOException {
-        // Note that this function is never called by multiple threads and is the only place that
-        // we remove from failures, so this code is safe.
-        if (failures.isEmpty()) {
-          return;
-        }
-
-        StringBuilder logEntry = new StringBuilder();
-        int i = 0;
-        List<BigtableWriteException> suppressed = Lists.newArrayList();
-        for (; i < 10 && !failures.isEmpty(); ++i) {
-          BigtableWriteException exc = failures.remove();
-          logEntry.append("\n").append(exc.getMessage());
-          if (exc.getCause() != null) {
-            logEntry.append(": ").append(exc.getCause().getMessage());
-          }
-          suppressed.add(exc);
-        }
-        String message =
-            String.format(
-                "At least %d errors occurred writing to Bigtable. First %d errors: %s",
-                i + failures.size(), i, logEntry.toString());
-        LOG.error(message);
-        IOException exception = new IOException(message);
-        for (BigtableWriteException e : suppressed) {
-          exception.addSuppressed(e);
-        }
-        throw exception;
-      }
+      throw exception;
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableWriteResult.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableWriteResult.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigtable;
+
+import com.google.auto.value.AutoValue;
+import org.apache.beam.sdk.coders.DefaultCoder;
+
+/**
+ * The result of writing a batch of rows to Bigtable. Rows are written to bigtable in batches (based
+ * on the runner-chosen bundle size). Once each batch finishes, a single {@link BigtableWriteResult}
+ * is emitted.
+ */
+@DefaultCoder(BigtableWriteResultCoder.class)
+@AutoValue
+public abstract class BigtableWriteResult {
+  public static BigtableWriteResult create(long rowsWritten) {
+    return new AutoValue_BigtableWriteResult(rowsWritten);
+  }
+
+  /** The number of rows written in this batch. */
+  public abstract long getRowsWritten();
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableWriteResultCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableWriteResultCoder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigtable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.CoderProvider;
+import org.apache.beam.sdk.coders.CoderProviders;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/** A coder for {@link BigtableWriteResult}. */
+public class BigtableWriteResultCoder extends AtomicCoder<BigtableWriteResult> {
+  private static final Coder<Long> LONG_CODER = VarLongCoder.of();
+  private static final BigtableWriteResultCoder INSTANCE = new BigtableWriteResultCoder();
+
+  public static CoderProvider getCoderProvider() {
+    return CoderProviders.forCoder(
+        TypeDescriptor.of(BigtableWriteResult.class), BigtableWriteResultCoder.of());
+  }
+
+  public static BigtableWriteResultCoder of() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void encode(BigtableWriteResult value, OutputStream outStream)
+      throws CoderException, IOException {
+    LONG_CODER.encode(value.getRowsWritten(), outStream);
+  }
+
+  @Override
+  public BigtableWriteResult decode(InputStream inStream) throws CoderException, IOException {
+    return BigtableWriteResult.create(LONG_CODER.decode(inStream));
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -76,6 +76,8 @@ import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.extensions.protobuf.ByteStringCoder;
@@ -91,10 +93,19 @@ import org.apache.beam.sdk.testing.ExpectedLogs;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipeline.PipelineRunMissingException;
+import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.Wait;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayDataEvaluator;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -104,6 +115,8 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableLis
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -297,11 +310,12 @@ public class BigtableIOTest {
 
   @Test
   public void testWriteValidationFailsMissingInstanceId() {
-    BigtableIO.Write write =
+    BigtableIO.WriteWithResults write =
         BigtableIO.write()
             .withTableId("table")
             .withProjectId("project")
-            .withBigtableOptions(new BigtableOptions.Builder().build());
+            .withBigtableOptions(new BigtableOptions.Builder().build())
+            .withWriteResults();
 
     thrown.expect(IllegalArgumentException.class);
 
@@ -310,11 +324,12 @@ public class BigtableIOTest {
 
   @Test
   public void testWriteValidationFailsMissingProjectId() {
-    BigtableIO.Write write =
+    BigtableIO.WriteWithResults write =
         BigtableIO.write()
             .withTableId("table")
             .withInstanceId("instance")
-            .withBigtableOptions(new BigtableOptions.Builder().build());
+            .withBigtableOptions(new BigtableOptions.Builder().build())
+            .withWriteResults();
 
     thrown.expect(IllegalArgumentException.class);
 
@@ -323,10 +338,11 @@ public class BigtableIOTest {
 
   @Test
   public void testWriteValidationFailsMissingInstanceIdAndProjectId() {
-    BigtableIO.Write write =
+    BigtableIO.WriteWithResults write =
         BigtableIO.write()
             .withTableId("table")
-            .withBigtableOptions(new BigtableOptions.Builder().build());
+            .withBigtableOptions(new BigtableOptions.Builder().build())
+            .withWriteResults();
 
     thrown.expect(IllegalArgumentException.class);
 
@@ -335,7 +351,7 @@ public class BigtableIOTest {
 
   @Test
   public void testWriteValidationFailsMissingOptionsAndInstanceAndProject() {
-    BigtableIO.Write write = BigtableIO.write().withTableId("table");
+    BigtableIO.WriteWithResults write = BigtableIO.write().withTableId("table").withWriteResults();
 
     thrown.expect(IllegalArgumentException.class);
 
@@ -1157,6 +1173,125 @@ public class BigtableIOTest {
     Map<ByteString, ByteString> rows = service.getTable(table);
     assertEquals(1, rows.size());
     assertEquals(ByteString.copyFromUtf8(value), rows.get(ByteString.copyFromUtf8(key)));
+  }
+
+  /** Tests that at least one result is emitted per element written in the global window. */
+  @Test
+  public void testWritingEmitsResultsWhenDoneInGlobalWindow() throws Exception {
+    final String table = "table";
+    final String key = "key";
+    final String value = "value";
+
+    service.createTable(table);
+
+    PCollection<BigtableWriteResult> results =
+        p.apply("single row", Create.of(makeWrite(key, value)).withCoder(bigtableCoder))
+            .apply("write", defaultWrite.withTableId(table).withWriteResults());
+    PAssert.that(results)
+        .inWindow(GlobalWindow.INSTANCE)
+        .containsInAnyOrder(BigtableWriteResult.create(1));
+
+    p.run();
+  }
+
+  /**
+   * Tests that the outputs of the Bigtable writer are correctly windowed, and can be used in a
+   * Wait.on transform as the trigger.
+   */
+  @Test
+  public void testWritingAndWaitingOnResults() throws Exception {
+    final String table = "table";
+    final String key = "key";
+    final String value = "value";
+
+    service.createTable(table);
+
+    Instant elementTimestamp = Instant.parse("2019-06-10T00:00:00");
+    Duration windowDuration = Duration.standardMinutes(1);
+
+    TestStream<KV<ByteString, Iterable<Mutation>>> writeInputs =
+        TestStream.create(bigtableCoder)
+            .advanceWatermarkTo(elementTimestamp)
+            .addElements(makeWrite(key, value))
+            .advanceWatermarkToInfinity();
+
+    TestStream<String> testInputs =
+        TestStream.create(StringUtf8Coder.of())
+            .advanceWatermarkTo(elementTimestamp)
+            .addElements("done")
+            .advanceWatermarkToInfinity();
+
+    PCollection<BigtableWriteResult> writes =
+        p.apply("rows", writeInputs)
+            .apply(
+                "window rows",
+                Window.<KV<ByteString, Iterable<Mutation>>>into(FixedWindows.of(windowDuration))
+                    .withAllowedLateness(Duration.ZERO))
+            .apply("write", defaultWrite.withTableId(table).withWriteResults());
+
+    PCollection<String> inputs =
+        p.apply("inputs", testInputs)
+            .apply("window inputs", Window.into(FixedWindows.of(windowDuration)))
+            .apply("wait", Wait.on(writes));
+
+    BoundedWindow expectedWindow = new IntervalWindow(elementTimestamp, windowDuration);
+
+    PAssert.that(inputs).inWindow(expectedWindow).containsInAnyOrder("done");
+
+    p.run();
+  }
+
+  /**
+   * A DoFn used to generate N outputs, where N is the input. Used to generate bundles of >= 1
+   * element.
+   */
+  private static class WriteGeneratorDoFn
+      extends DoFn<Integer, KV<ByteString, Iterable<Mutation>>> {
+    @ProcessElement
+    public void processElement(ProcessContext ctx) {
+      for (int i = 0; i < ctx.element(); i++) {
+        ctx.output(makeWrite("key", "value"));
+      }
+    }
+  }
+
+  /** Tests that at least one result is emitted per element written in each window. */
+  @Test
+  public void testWritingEmitsResultsWhenDoneInFixedWindow() throws Exception {
+    final String table = "table";
+    final String key = "key";
+    final String value = "value";
+
+    service.createTable(table);
+
+    Instant elementTimestamp = Instant.parse("2019-06-10T00:00:00");
+    Duration windowDuration = Duration.standardMinutes(1);
+
+    TestStream<Integer> input =
+        TestStream.create(VarIntCoder.of())
+            .advanceWatermarkTo(elementTimestamp)
+            .addElements(1)
+            .advanceWatermarkTo(elementTimestamp.plus(windowDuration))
+            .addElements(2)
+            .advanceWatermarkToInfinity();
+
+    BoundedWindow expectedFirstWindow = new IntervalWindow(elementTimestamp, windowDuration);
+    BoundedWindow expectedSecondWindow =
+        new IntervalWindow(elementTimestamp.plus(windowDuration), windowDuration);
+
+    PCollection<BigtableWriteResult> results =
+        p.apply("rows", input)
+            .apply("window", Window.into(FixedWindows.of(windowDuration)))
+            .apply("expand", ParDo.of(new WriteGeneratorDoFn()))
+            .apply("write", defaultWrite.withTableId(table).withWriteResults());
+    PAssert.that(results)
+        .inWindow(expectedFirstWindow)
+        .containsInAnyOrder(BigtableWriteResult.create(1));
+    PAssert.that(results)
+        .inWindow(expectedSecondWindow)
+        .containsInAnyOrder(BigtableWriteResult.create(2));
+
+    p.run();
   }
 
   /** Tests that when writing to a non-existent table, the write fails. */


### PR DESCRIPTION
This adds support for "done" notification in `BigtableIO.write()`. For each bundle+window that is written, a single "Void" is output by the PTransform. Doing so allows flows to effectively wait for all writes to finish.  Note that windowing is preserved, and pipeline writers can choose to deal with early firings, etc as they desire. A common use-case of this is to wait for all writes to finish, and then do something else, this can be accomplished using the built-in `Wait.on` transform with the output of the write, like so:

```
val writeResults = mutations.apply(
  "WriteToBigtable",
  BigtableIO.write()...
)

val collectionToProcessAfterWrites = Create.of("derp")
collectionToProcessAfterWrites
  .apply(Wait.on(writeResults))
  .apply(ParDo.of(someFn))
```

An important point to note here is this only ensures writes have been applied **to a single cluster**, it does not ensure that all writes **have replicated to all clusters**.

I had also made a previous PR a few months ago (https://github.com/apache/beam/pull/3997), this is an enhancement of that.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

