### PR TITLE
[BEAM-6805] Use assertEquals(x, y) instead of assertTrue(x.equals(y))

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/counters/CounterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/counters/CounterTest.java
@@ -49,10 +49,10 @@ public class CounterTest {
   @Test
   public void testCompatibility() {
     // Equal counters are compatible, of all kinds.
-    assertTrue(counters.longSum(name).equals(counters.longSum(name)));
-    assertTrue(counters.intSum(name).equals(counters.intSum(name)));
-    assertTrue(counters.doubleSum(name).equals(counters.doubleSum(name)));
-    assertTrue(counters.booleanOr(name).equals(counters.booleanOr(name)));
+    assertEquals(counters.longSum(name), counters.longSum(name));
+    assertEquals(counters.intSum(name), counters.intSum(name));
+    assertEquals(counters.doubleSum(name), counters.doubleSum(name));
+    assertEquals(counters.booleanOr(name), counters.booleanOr(name));
 
     // The name, kind, and type of the counter must match.
     assertFalse(counters.longSum(name).equals(counters.longSum(name2)));
@@ -60,7 +60,7 @@ public class CounterTest {
     assertFalse(counters.longSum(name).equals(counters.intSum(name)));
 
     // The value of the counters are ignored.
-    assertTrue(counters.longSum(name).addValue(666L).equals(counters.longSum(name).addValue(42L)));
+    assertEquals(counters.longSum(name).addValue(666L), counters.longSum(name).addValue(42L));
   }
 
   // Tests for SUM.
@@ -466,7 +466,7 @@ public class CounterTest {
     assertFalse(unstructured.equals(structuredCompatible));
 
     // structuredOriginal is only equal to structuredCompatible
-    assertTrue(structuredOriginal.equals(structuredCompatible));
+    assertEquals(structuredOriginal, structuredCompatible);
     assertFalse(structuredOriginal.equals(structuredSystem));
 
     // structuredSystem is equal to nothing

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleEntryTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleEntryTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +46,7 @@ public class ShuffleEntryTest {
   @SuppressWarnings("SelfEquals")
   public void equalsToItself() {
     ShuffleEntry entry = new ShuffleEntry(KEY, SKEY, VALUE);
-    assertTrue(entry.equals(entry));
+    assertEquals(entry, entry);
   }
 
   @Test
@@ -55,8 +54,8 @@ public class ShuffleEntryTest {
     ShuffleEntry entry0 = new ShuffleEntry(KEY, SKEY, VALUE);
     ShuffleEntry entry1 = new ShuffleEntry(KEY.clone(), SKEY.clone(), VALUE.clone());
 
-    assertTrue(entry0.equals(entry1));
-    assertTrue(entry1.equals(entry0));
+    assertEquals(entry0, entry1);
+    assertEquals(entry1, entry0);
     assertEquals(entry0.hashCode(), entry1.hashCode());
   }
 
@@ -65,8 +64,8 @@ public class ShuffleEntryTest {
     ShuffleEntry entry0 = new ShuffleEntry(null, null, null);
     ShuffleEntry entry1 = new ShuffleEntry(null, null, null);
 
-    assertTrue(entry0.equals(entry1));
-    assertTrue(entry1.equals(entry0));
+    assertEquals(entry0, entry1);
+    assertEquals(entry1, entry0);
     assertEquals(entry0.hashCode(), entry1.hashCode());
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/AvroCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/AvroCoderTest.java
@@ -19,8 +19,8 @@ package org.apache.beam.sdk.coders;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -31,7 +31,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -719,7 +718,7 @@ public class AvroCoderTest {
     coder.encode(size1, outStream1, context);
     coder.encode(size2, outStream2, context);
 
-    assertTrue(Arrays.equals(outStream1.toByteArray(), outStream2.toByteArray()));
+    assertArrayEquals(outStream1.toByteArray(), outStream2.toByteArray());
   }
 
   private static class TreeMapField {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/range/ByteKeyTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/range/ByteKeyTest.java
@@ -18,13 +18,13 @@
 package org.apache.beam.sdk.io.range;
 
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -159,8 +159,7 @@ public class ByteKeyTest {
   /** Tests {@link ByteKey#getBytes}. */
   @Test
   public void testGetBytes() {
-    assertTrue("[] equal after getBytes", Arrays.equals(new byte[] {}, ByteKey.EMPTY.getBytes()));
-    assertTrue(
-        "[00] equal after getBytes", Arrays.equals(new byte[] {0x00}, ByteKey.of(0x00).getBytes()));
+    assertArrayEquals("[] equal after getBytes", new byte[] {}, ByteKey.EMPTY.getBytes());
+    assertArrayEquals("[00] equal after getBytes", new byte[] {0x00}, ByteKey.of(0x00).getBytes());
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformTreeTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformTreeTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.runners;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -163,8 +164,8 @@ public class TransformTreeTest {
           }
         });
 
-    assertTrue(visited.equals(EnumSet.allOf(TransformsSeen.class)));
-    assertTrue(left.equals(EnumSet.of(TransformsSeen.SAMPLE)));
+    assertEquals(visited, EnumSet.allOf(TransformsSeen.class));
+    assertEquals(left, EnumSet.of(TransformsSeen.SAMPLE));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/OrderedCodeTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/OrderedCodeTest.java
@@ -17,13 +17,13 @@
  */
 package org.apache.beam.sdk.io.gcp.spanner;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.auto.value.AutoValue;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.io.BaseEncoding;
@@ -271,28 +271,28 @@ public class OrderedCodeTest {
     OrderedCode orderedCode = new OrderedCode();
     orderedCode.writeBytes(first);
     byte[] firstEncoded = orderedCode.getEncodedBytes();
-    assertTrue(Arrays.equals(orderedCode.readBytes(), first));
+    assertArrayEquals(orderedCode.readBytes(), first);
 
     orderedCode.writeBytes(first);
     orderedCode.writeBytes(second);
     orderedCode.writeBytes(last);
     byte[] allEncoded = orderedCode.getEncodedBytes();
-    assertTrue(Arrays.equals(orderedCode.readBytes(), first));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), second));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), last));
+    assertArrayEquals(orderedCode.readBytes(), first);
+    assertArrayEquals(orderedCode.readBytes(), second);
+    assertArrayEquals(orderedCode.readBytes(), last);
 
     orderedCode = new OrderedCode(firstEncoded);
     orderedCode.writeBytes(second);
     orderedCode.writeBytes(last);
-    assertTrue(Arrays.equals(orderedCode.getEncodedBytes(), allEncoded));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), first));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), second));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), last));
+    assertArrayEquals(orderedCode.getEncodedBytes(), allEncoded);
+    assertArrayEquals(orderedCode.readBytes(), first);
+    assertArrayEquals(orderedCode.readBytes(), second);
+    assertArrayEquals(orderedCode.readBytes(), last);
 
     orderedCode = new OrderedCode(allEncoded);
-    assertTrue(Arrays.equals(orderedCode.readBytes(), first));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), second));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), last));
+    assertArrayEquals(orderedCode.readBytes(), first);
+    assertArrayEquals(orderedCode.readBytes(), second);
+    assertArrayEquals(orderedCode.readBytes(), last);
   }
 
   @Test
@@ -303,28 +303,28 @@ public class OrderedCodeTest {
     OrderedCode orderedCode = new OrderedCode();
     orderedCode.writeBytesDecreasing(first);
     byte[] firstEncoded = orderedCode.getEncodedBytes();
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), first));
+    assertArrayEquals(orderedCode.readBytesDecreasing(), first);
 
     orderedCode.writeBytesDecreasing(first);
     orderedCode.writeBytesDecreasing(second);
     orderedCode.writeBytesDecreasing(last);
     byte[] allEncoded = orderedCode.getEncodedBytes();
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), first));
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), second));
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), last));
+    assertArrayEquals(orderedCode.readBytesDecreasing(), first);
+    assertArrayEquals(orderedCode.readBytesDecreasing(), second);
+    assertArrayEquals(orderedCode.readBytesDecreasing(), last);
 
     orderedCode = new OrderedCode(firstEncoded);
     orderedCode.writeBytesDecreasing(second);
     orderedCode.writeBytesDecreasing(last);
-    assertTrue(Arrays.equals(orderedCode.getEncodedBytes(), allEncoded));
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), first));
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), second));
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), last));
+    assertArrayEquals(orderedCode.getEncodedBytes(), allEncoded);
+    assertArrayEquals(orderedCode.readBytesDecreasing(), first);
+    assertArrayEquals(orderedCode.readBytesDecreasing(), second);
+    assertArrayEquals(orderedCode.readBytesDecreasing(), last);
 
     orderedCode = new OrderedCode(allEncoded);
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), first));
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), second));
-    assertTrue(Arrays.equals(orderedCode.readBytesDecreasing(), last));
+    assertArrayEquals(orderedCode.readBytesDecreasing(), first);
+    assertArrayEquals(orderedCode.readBytesDecreasing(), second);
+    assertArrayEquals(orderedCode.readBytesDecreasing(), last);
   }
 
   @Test
@@ -674,8 +674,8 @@ public class OrderedCodeTest {
 
     OrderedCode orderedCode = new OrderedCode();
     orderedCode.writeTrailingBytes(escapeChars);
-    assertTrue(Arrays.equals(orderedCode.getEncodedBytes(), escapeChars));
-    assertTrue(Arrays.equals(orderedCode.readTrailingBytes(), escapeChars));
+    assertArrayEquals(orderedCode.getEncodedBytes(), escapeChars);
+    assertArrayEquals(orderedCode.readTrailingBytes(), escapeChars);
     try {
       orderedCode.readInfinity();
       fail("Expected IllegalArgumentException.");
@@ -685,8 +685,8 @@ public class OrderedCodeTest {
 
     orderedCode = new OrderedCode();
     orderedCode.writeTrailingBytes(anotherArray);
-    assertTrue(Arrays.equals(orderedCode.getEncodedBytes(), anotherArray));
-    assertTrue(Arrays.equals(orderedCode.readTrailingBytes(), anotherArray));
+    assertArrayEquals(orderedCode.getEncodedBytes(), anotherArray);
+    assertArrayEquals(orderedCode.readTrailingBytes(), anotherArray);
   }
 
   @Test
@@ -719,10 +719,10 @@ public class OrderedCodeTest {
     orderedCode.writeSignedNumIncreasing(Long.MAX_VALUE);
     orderedCode.writeTrailingBytes(escapeChars);
     byte[] allEncoded = orderedCode.getEncodedBytes();
-    assertTrue(Arrays.equals(orderedCode.readBytes(), first));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), second));
+    assertArrayEquals(orderedCode.readBytes(), first);
+    assertArrayEquals(orderedCode.readBytes(), second);
     assertFalse(orderedCode.readInfinity());
-    assertTrue(Arrays.equals(orderedCode.readBytes(), last));
+    assertArrayEquals(orderedCode.readBytes(), last);
     assertTrue(orderedCode.readInfinity());
     assertEquals(0, orderedCode.readNumIncreasing());
     assertEquals(1, orderedCode.readNumIncreasing());
@@ -734,14 +734,14 @@ public class OrderedCodeTest {
     assertFalse(orderedCode.readInfinity());
     assertEquals(Long.MIN_VALUE, orderedCode.readSignedNumIncreasing());
     assertEquals(Long.MAX_VALUE, orderedCode.readSignedNumIncreasing());
-    assertTrue(Arrays.equals(orderedCode.getEncodedBytes(), escapeChars));
-    assertTrue(Arrays.equals(orderedCode.readTrailingBytes(), escapeChars));
+    assertArrayEquals(orderedCode.getEncodedBytes(), escapeChars);
+    assertArrayEquals(orderedCode.readTrailingBytes(), escapeChars);
 
     orderedCode = new OrderedCode(allEncoded);
-    assertTrue(Arrays.equals(orderedCode.readBytes(), first));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), second));
+    assertArrayEquals(orderedCode.readBytes(), first);
+    assertArrayEquals(orderedCode.readBytes(), second);
     assertFalse(orderedCode.readInfinity());
-    assertTrue(Arrays.equals(orderedCode.readBytes(), last));
+    assertArrayEquals(orderedCode.readBytes(), last);
     assertTrue(orderedCode.readInfinity());
     assertEquals(0, orderedCode.readNumIncreasing());
     assertEquals(1, orderedCode.readNumIncreasing());
@@ -753,8 +753,8 @@ public class OrderedCodeTest {
     assertFalse(orderedCode.readInfinity());
     assertEquals(Long.MIN_VALUE, orderedCode.readSignedNumIncreasing());
     assertEquals(Long.MAX_VALUE, orderedCode.readSignedNumIncreasing());
-    assertTrue(Arrays.equals(orderedCode.getEncodedBytes(), escapeChars));
-    assertTrue(Arrays.equals(orderedCode.readTrailingBytes(), escapeChars));
+    assertArrayEquals(orderedCode.getEncodedBytes(), escapeChars);
+    assertArrayEquals(orderedCode.readTrailingBytes(), escapeChars);
   }
 
   @Test
@@ -771,24 +771,19 @@ public class OrderedCodeTest {
     orderedCode.writeBytes(ffChar);
     orderedCode.writeBytes(nullChar);
     orderedCode.writeInfinity();
-    assertTrue(
-        Arrays.equals(
-            orderedCode.getEncodedBytes(),
-            Bytes.concat(
-                ffCharEncoded,
-                separatorEncoded,
-                nullCharEncoded,
-                separatorEncoded,
-                infinityEncoded)));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), ffChar));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), nullChar));
+    assertArrayEquals(
+        orderedCode.getEncodedBytes(),
+        Bytes.concat(
+            ffCharEncoded, separatorEncoded, nullCharEncoded, separatorEncoded, infinityEncoded));
+    assertArrayEquals(orderedCode.readBytes(), ffChar);
+    assertArrayEquals(orderedCode.readBytes(), nullChar);
     assertTrue(orderedCode.readInfinity());
 
     orderedCode = new OrderedCode(Bytes.concat(ffCharEncoded, separatorEncoded));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), ffChar));
+    assertArrayEquals(orderedCode.readBytes(), ffChar);
 
     orderedCode = new OrderedCode(Bytes.concat(nullCharEncoded, separatorEncoded));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), nullChar));
+    assertArrayEquals(orderedCode.readBytes(), nullChar);
 
     byte[] invalidEncodingForRead = {
       OrderedCode.ESCAPE2, OrderedCode.ESCAPE2, OrderedCode.ESCAPE1, OrderedCode.SEPARATOR
@@ -815,7 +810,7 @@ public class OrderedCodeTest {
     // First and only field of each type.
     orderedCode.writeBytes(bytes);
     assertTrue(orderedCode.hasRemainingEncodedBytes());
-    assertTrue(Arrays.equals(orderedCode.readBytes(), bytes));
+    assertArrayEquals(orderedCode.readBytes(), bytes);
     assertFalse(orderedCode.hasRemainingEncodedBytes());
 
     orderedCode.writeNumIncreasing(number);
@@ -835,15 +830,15 @@ public class OrderedCodeTest {
 
     orderedCode.writeTrailingBytes(bytes);
     assertTrue(orderedCode.hasRemainingEncodedBytes());
-    assertTrue(Arrays.equals(orderedCode.readTrailingBytes(), bytes));
+    assertArrayEquals(orderedCode.readTrailingBytes(), bytes);
     assertFalse(orderedCode.hasRemainingEncodedBytes());
 
     // Two fields of same type.
     orderedCode.writeBytes(bytes);
     orderedCode.writeBytes(bytes);
     assertTrue(orderedCode.hasRemainingEncodedBytes());
-    assertTrue(Arrays.equals(orderedCode.readBytes(), bytes));
-    assertTrue(Arrays.equals(orderedCode.readBytes(), bytes));
+    assertArrayEquals(orderedCode.readBytes(), bytes);
+    assertArrayEquals(orderedCode.readBytes(), bytes);
     assertFalse(orderedCode.hasRemainingEncodedBytes());
   }
 


### PR DESCRIPTION
This commit cleans up a few instances where we could be using assertEquals or assertArrayEquals to simplify test assertions instead of using assertTrue.