### PR TITLE
[BEAM-6493] Add wordcount example in kotlin

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -18,7 +18,9 @@
 
 import groovy.json.JsonOutput
 
-plugins { id 'org.apache.beam.module' }
+plugins { id 'org.apache.beam.module'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.21'
+}
 applyJavaNature(exportJavadoc: false)
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
@@ -86,6 +88,7 @@ dependencies {
   sparkRunnerPreCommit project(path: ":beam-sdks-java-io-hadoop-file-system", configuration: "shadow")
   sparkRunnerPreCommit library.java.spark_streaming
   sparkRunnerPreCommit library.java.spark_core
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 /*
@@ -124,5 +127,18 @@ task preCommit() {
   for (String runner : preCommitRunners) {
     dependsOn runner + "PreCommit"
   }
+}
+repositories {
+    mavenCentral()
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 

--- a/examples/java/src/main/java/org/apache/beam/examples/DebuggingWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/DebuggingWordCount.java
@@ -20,7 +20,6 @@ package org.apache.beam.examples;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
-
 import org.apache.beam.examples.java.WordCount;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;

--- a/examples/java/src/main/java/org/apache/beam/examples/DebuggingWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/DebuggingWordCount.java
@@ -20,6 +20,8 @@ package org.apache.beam.examples;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import org.apache.beam.examples.java.WordCount;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.metrics.Counter;

--- a/examples/java/src/main/java/org/apache/beam/examples/MinimalWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/MinimalWordCount.java
@@ -18,7 +18,6 @@
 package org.apache.beam.examples;
 
 import java.util.Arrays;
-
 import org.apache.beam.examples.java.WordCount;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;

--- a/examples/java/src/main/java/org/apache/beam/examples/MinimalWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/MinimalWordCount.java
@@ -18,6 +18,8 @@
 package org.apache.beam.examples;
 
 import java.util.Arrays;
+
+import org.apache.beam.examples.java.WordCount;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.options.PipelineOptions;

--- a/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.examples.common.ExampleBigQueryTableOptions;
 import org.apache.beam.examples.common.ExampleOptions;
 import org.apache.beam.examples.common.WriteOneFilePerWindow;
+import org.apache.beam.examples.java.WordCount;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.TextIO;

--- a/examples/java/src/main/java/org/apache/beam/examples/java/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/java/WordCount.java
@@ -15,8 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.examples;
+package org.apache.beam.examples.java;
 
+import org.apache.beam.examples.DebuggingWordCount;
+import org.apache.beam.examples.MinimalWordCount;
 import org.apache.beam.examples.common.ExampleUtils;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;

--- a/examples/java/src/main/java/org/apache/beam/examples/java/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/java/WordCount.java
@@ -85,112 +85,116 @@ import org.apache.beam.sdk.values.PCollection;
  */
 public class WordCount {
 
-  /**
-   * Concept #2: You can make your pipeline assembly code less verbose by defining your DoFns
-   * statically out-of-line. This DoFn tokenizes lines of text into individual words; we pass it to
-   * a ParDo in the pipeline.
-   */
-  static class ExtractWordsFn extends DoFn<String, String> {
-    private final Counter emptyLines = Metrics.counter(ExtractWordsFn.class, "emptyLines");
-    private final Distribution lineLenDist =
-        Metrics.distribution(ExtractWordsFn.class, "lineLenDistro");
+    /**
+     * Concept #2: You can make your pipeline assembly code less verbose by defining your DoFns
+     * statically out-of-line. This DoFn tokenizes lines of text into individual words; we pass it to
+     * a ParDo in the pipeline.
+     */
+    public static class ExtractWordsFn extends DoFn<String, String> {
+        private final Counter emptyLines = Metrics.counter(ExtractWordsFn.class, "emptyLines");
+        private final Distribution lineLenDist =
+                Metrics.distribution(ExtractWordsFn.class, "lineLenDistro");
 
-    @ProcessElement
-    public void processElement(@Element String element, OutputReceiver<String> receiver) {
-      lineLenDist.update(element.length());
-      if (element.trim().isEmpty()) {
-        emptyLines.inc();
-      }
+        @ProcessElement
+        public void processElement(@Element String element, OutputReceiver<String> receiver) {
+            lineLenDist.update(element.length());
+            if (element.trim().isEmpty()) {
+                emptyLines.inc();
+            }
 
-      // Split the line into words.
-      String[] words = element.split(ExampleUtils.TOKENIZER_PATTERN, -1);
+            // Split the line into words.
+            String[] words = element.split(ExampleUtils.TOKENIZER_PATTERN, -1);
 
-      // Output each word encountered into the output PCollection.
-      for (String word : words) {
-        if (!word.isEmpty()) {
-          receiver.output(word);
+            // Output each word encountered into the output PCollection.
+            for (String word : words) {
+                if (!word.isEmpty()) {
+                    receiver.output(word);
+                }
+            }
         }
-      }
     }
-  }
-
-  /** A SimpleFunction that converts a Word and Count into a printable string. */
-  public static class FormatAsTextFn extends SimpleFunction<KV<String, Long>, String> {
-    @Override
-    public String apply(KV<String, Long> input) {
-      return input.getKey() + ": " + input.getValue();
-    }
-  }
-
-  /**
-   * A PTransform that converts a PCollection containing lines of text into a PCollection of
-   * formatted word counts.
-   *
-   * <p>Concept #3: This is a custom composite transform that bundles two transforms (ParDo and
-   * Count) as a reusable PTransform subclass. Using composite transforms allows for easy reuse,
-   * modular testing, and an improved monitoring experience.
-   */
-  public static class CountWords
-      extends PTransform<PCollection<String>, PCollection<KV<String, Long>>> {
-    @Override
-    public PCollection<KV<String, Long>> expand(PCollection<String> lines) {
-
-      // Convert lines of text into individual words.
-      PCollection<String> words = lines.apply(ParDo.of(new ExtractWordsFn()));
-
-      // Count the number of times each word occurs.
-      PCollection<KV<String, Long>> wordCounts = words.apply(Count.perElement());
-
-      return wordCounts;
-    }
-  }
-
-  /**
-   * Options supported by {@link WordCount}.
-   *
-   * <p>Concept #4: Defining your own configuration options. Here, you can add your own arguments to
-   * be processed by the command-line parser, and specify default values for them. You can then
-   * access the options values in your pipeline code.
-   *
-   * <p>Inherits standard configuration options.
-   */
-  public interface WordCountOptions extends PipelineOptions {
 
     /**
-     * By default, this example reads from a public dataset containing the text of King Lear. Set
-     * this option to choose a different input file or glob.
+     * A SimpleFunction that converts a Word and Count into a printable string.
      */
-    @Description("Path of the file to read from")
-    @Default.String("gs://apache-beam-samples/shakespeare/kinglear.txt")
-    String getInputFile();
+    public static class FormatAsTextFn extends SimpleFunction<KV<String, Long>, String> {
+        @Override
+        public String apply(KV<String, Long> input) {
+            return input.getKey() + ": " + input.getValue();
+        }
+    }
 
-    void setInputFile(String value);
+    /**
+     * A PTransform that converts a PCollection containing lines of text into a PCollection of
+     * formatted word counts.
+     *
+     * <p>Concept #3: This is a custom composite transform that bundles two transforms (ParDo and
+     * Count) as a reusable PTransform subclass. Using composite transforms allows for easy reuse,
+     * modular testing, and an improved monitoring experience.
+     */
+    public static class CountWords
+            extends PTransform<PCollection<String>, PCollection<KV<String, Long>>> {
+        @Override
+        public PCollection<KV<String, Long>> expand(PCollection<String> lines) {
 
-    /** Set this required option to specify where to write the output. */
-    @Description("Path of the file to write to")
-    @Required
-    String getOutput();
+            // Convert lines of text into individual words.
+            PCollection<String> words = lines.apply(ParDo.of(new ExtractWordsFn()));
 
-    void setOutput(String value);
-  }
+            // Count the number of times each word occurs.
+            PCollection<KV<String, Long>> wordCounts = words.apply(Count.perElement());
 
-  static void runWordCount(WordCountOptions options) {
-    Pipeline p = Pipeline.create(options);
+            return wordCounts;
+        }
+    }
 
-    // Concepts #2 and #3: Our pipeline applies the composite CountWords transform, and passes the
-    // static FormatAsTextFn() to the ParDo transform.
-    p.apply("ReadLines", TextIO.read().from(options.getInputFile()))
-        .apply(new CountWords())
-        .apply(MapElements.via(new FormatAsTextFn()))
-        .apply("WriteCounts", TextIO.write().to(options.getOutput()));
+    /**
+     * Options supported by {@link WordCount}.
+     *
+     * <p>Concept #4: Defining your own configuration options. Here, you can add your own arguments to
+     * be processed by the command-line parser, and specify default values for them. You can then
+     * access the options values in your pipeline code.
+     *
+     * <p>Inherits standard configuration options.
+     */
+    public interface WordCountOptions extends PipelineOptions {
 
-    p.run().waitUntilFinish();
-  }
+        /**
+         * By default, this example reads from a public dataset containing the text of King Lear. Set
+         * this option to choose a different input file or glob.
+         */
+        @Description("Path of the file to read from")
+        @Default.String("gs://apache-beam-samples/shakespeare/kinglear.txt")
+        String getInputFile();
 
-  public static void main(String[] args) {
-    WordCountOptions options =
-        PipelineOptionsFactory.fromArgs(args).withValidation().as(WordCountOptions.class);
+        void setInputFile(String value);
 
-    runWordCount(options);
-  }
+        /**
+         * Set this required option to specify where to write the output.
+         */
+        @Description("Path of the file to write to")
+        @Required
+        String getOutput();
+
+        void setOutput(String value);
+    }
+
+    static void runWordCount(WordCountOptions options) {
+        Pipeline p = Pipeline.create(options);
+
+        // Concepts #2 and #3: Our pipeline applies the composite CountWords transform, and passes the
+        // static FormatAsTextFn() to the ParDo transform.
+        p.apply("ReadLines", TextIO.read().from(options.getInputFile()))
+                .apply(new CountWords())
+                .apply(MapElements.via(new FormatAsTextFn()))
+                .apply("WriteCounts", TextIO.write().to(options.getOutput()));
+
+        p.run().waitUntilFinish();
+    }
+
+    public static void main(String[] args) {
+        WordCountOptions options =
+                PipelineOptionsFactory.fromArgs(args).withValidation().as(WordCountOptions.class);
+
+        runWordCount(options);
+    }
 }

--- a/examples/java/src/main/java/org/apache/beam/examples/java/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/java/WordCount.java
@@ -178,7 +178,7 @@ public class WordCount {
         void setOutput(String value);
     }
 
-    static void runWordCount(WordCountOptions options) {
+    public static void runWordCount(WordCountOptions options) {
         Pipeline p = Pipeline.create(options);
 
         // Concepts #2 and #3: Our pipeline applies the composite CountWords transform, and passes the

--- a/examples/java/src/main/java/org/apache/beam/examples/java/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/java/WordCount.java
@@ -85,116 +85,112 @@ import org.apache.beam.sdk.values.PCollection;
  */
 public class WordCount {
 
-    /**
-     * Concept #2: You can make your pipeline assembly code less verbose by defining your DoFns
-     * statically out-of-line. This DoFn tokenizes lines of text into individual words; we pass it to
-     * a ParDo in the pipeline.
-     */
-    public static class ExtractWordsFn extends DoFn<String, String> {
-        private final Counter emptyLines = Metrics.counter(ExtractWordsFn.class, "emptyLines");
-        private final Distribution lineLenDist =
-                Metrics.distribution(ExtractWordsFn.class, "lineLenDistro");
+  /**
+   * Concept #2: You can make your pipeline assembly code less verbose by defining your DoFns
+   * statically out-of-line. This DoFn tokenizes lines of text into individual words; we pass it to
+   * a ParDo in the pipeline.
+   */
+  public static class ExtractWordsFn extends DoFn<String, String> {
+    private final Counter emptyLines = Metrics.counter(ExtractWordsFn.class, "emptyLines");
+    private final Distribution lineLenDist =
+        Metrics.distribution(ExtractWordsFn.class, "lineLenDistro");
 
-        @ProcessElement
-        public void processElement(@Element String element, OutputReceiver<String> receiver) {
-            lineLenDist.update(element.length());
-            if (element.trim().isEmpty()) {
-                emptyLines.inc();
-            }
+    @ProcessElement
+    public void processElement(@Element String element, OutputReceiver<String> receiver) {
+      lineLenDist.update(element.length());
+      if (element.trim().isEmpty()) {
+        emptyLines.inc();
+      }
 
-            // Split the line into words.
-            String[] words = element.split(ExampleUtils.TOKENIZER_PATTERN, -1);
+      // Split the line into words.
+      String[] words = element.split(ExampleUtils.TOKENIZER_PATTERN, -1);
 
-            // Output each word encountered into the output PCollection.
-            for (String word : words) {
-                if (!word.isEmpty()) {
-                    receiver.output(word);
-                }
-            }
+      // Output each word encountered into the output PCollection.
+      for (String word : words) {
+        if (!word.isEmpty()) {
+          receiver.output(word);
         }
+      }
     }
+  }
+
+  /** A SimpleFunction that converts a Word and Count into a printable string. */
+  public static class FormatAsTextFn extends SimpleFunction<KV<String, Long>, String> {
+    @Override
+    public String apply(KV<String, Long> input) {
+      return input.getKey() + ": " + input.getValue();
+    }
+  }
+
+  /**
+   * A PTransform that converts a PCollection containing lines of text into a PCollection of
+   * formatted word counts.
+   *
+   * <p>Concept #3: This is a custom composite transform that bundles two transforms (ParDo and
+   * Count) as a reusable PTransform subclass. Using composite transforms allows for easy reuse,
+   * modular testing, and an improved monitoring experience.
+   */
+  public static class CountWords
+      extends PTransform<PCollection<String>, PCollection<KV<String, Long>>> {
+    @Override
+    public PCollection<KV<String, Long>> expand(PCollection<String> lines) {
+
+      // Convert lines of text into individual words.
+      PCollection<String> words = lines.apply(ParDo.of(new ExtractWordsFn()));
+
+      // Count the number of times each word occurs.
+      PCollection<KV<String, Long>> wordCounts = words.apply(Count.perElement());
+
+      return wordCounts;
+    }
+  }
+
+  /**
+   * Options supported by {@link WordCount}.
+   *
+   * <p>Concept #4: Defining your own configuration options. Here, you can add your own arguments to
+   * be processed by the command-line parser, and specify default values for them. You can then
+   * access the options values in your pipeline code.
+   *
+   * <p>Inherits standard configuration options.
+   */
+  public interface WordCountOptions extends PipelineOptions {
 
     /**
-     * A SimpleFunction that converts a Word and Count into a printable string.
+     * By default, this example reads from a public dataset containing the text of King Lear. Set
+     * this option to choose a different input file or glob.
      */
-    public static class FormatAsTextFn extends SimpleFunction<KV<String, Long>, String> {
-        @Override
-        public String apply(KV<String, Long> input) {
-            return input.getKey() + ": " + input.getValue();
-        }
-    }
+    @Description("Path of the file to read from")
+    @Default.String("gs://apache-beam-samples/shakespeare/kinglear.txt")
+    String getInputFile();
 
-    /**
-     * A PTransform that converts a PCollection containing lines of text into a PCollection of
-     * formatted word counts.
-     *
-     * <p>Concept #3: This is a custom composite transform that bundles two transforms (ParDo and
-     * Count) as a reusable PTransform subclass. Using composite transforms allows for easy reuse,
-     * modular testing, and an improved monitoring experience.
-     */
-    public static class CountWords
-            extends PTransform<PCollection<String>, PCollection<KV<String, Long>>> {
-        @Override
-        public PCollection<KV<String, Long>> expand(PCollection<String> lines) {
+    void setInputFile(String value);
 
-            // Convert lines of text into individual words.
-            PCollection<String> words = lines.apply(ParDo.of(new ExtractWordsFn()));
+    /** Set this required option to specify where to write the output. */
+    @Description("Path of the file to write to")
+    @Required
+    String getOutput();
 
-            // Count the number of times each word occurs.
-            PCollection<KV<String, Long>> wordCounts = words.apply(Count.perElement());
+    void setOutput(String value);
+  }
 
-            return wordCounts;
-        }
-    }
+  public static void runWordCount(WordCountOptions options) {
+    Pipeline p = Pipeline.create(options);
 
-    /**
-     * Options supported by {@link WordCount}.
-     *
-     * <p>Concept #4: Defining your own configuration options. Here, you can add your own arguments to
-     * be processed by the command-line parser, and specify default values for them. You can then
-     * access the options values in your pipeline code.
-     *
-     * <p>Inherits standard configuration options.
-     */
-    public interface WordCountOptions extends PipelineOptions {
+    // Concepts #2 and #3: Our pipeline applies the composite CountWords transform, and passes the
+    // static FormatAsTextFn() to the ParDo transform.
+    p.apply("ReadLines", TextIO.read().from(options.getInputFile()))
+        .apply(new CountWords())
+        .apply(MapElements.via(new FormatAsTextFn()))
+        .apply("WriteCounts", TextIO.write().to(options.getOutput()));
 
-        /**
-         * By default, this example reads from a public dataset containing the text of King Lear. Set
-         * this option to choose a different input file or glob.
-         */
-        @Description("Path of the file to read from")
-        @Default.String("gs://apache-beam-samples/shakespeare/kinglear.txt")
-        String getInputFile();
+    p.run().waitUntilFinish();
+  }
 
-        void setInputFile(String value);
+  public static void main(String[] args) {
+    WordCountOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(WordCountOptions.class);
 
-        /**
-         * Set this required option to specify where to write the output.
-         */
-        @Description("Path of the file to write to")
-        @Required
-        String getOutput();
-
-        void setOutput(String value);
-    }
-
-    public static void runWordCount(WordCountOptions options) {
-        Pipeline p = Pipeline.create(options);
-
-        // Concepts #2 and #3: Our pipeline applies the composite CountWords transform, and passes the
-        // static FormatAsTextFn() to the ParDo transform.
-        p.apply("ReadLines", TextIO.read().from(options.getInputFile()))
-                .apply(new CountWords())
-                .apply(MapElements.via(new FormatAsTextFn()))
-                .apply("WriteCounts", TextIO.write().to(options.getOutput()));
-
-        p.run().waitUntilFinish();
-    }
-
-    public static void main(String[] args) {
-        WordCountOptions options =
-                PipelineOptionsFactory.fromArgs(args).withValidation().as(WordCountOptions.class);
-
-        runWordCount(options);
-    }
+    runWordCount(options);
+  }
 }

--- a/examples/java/src/main/java/org/apache/beam/examples/kotlin/WordCount.kt
+++ b/examples/java/src/main/java/org/apache/beam/examples/kotlin/WordCount.kt
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.examples.kotlin
 
 import org.apache.beam.examples.DebuggingWordCount

--- a/examples/java/src/main/java/org/apache/beam/examples/kotlin/WordCount.kt
+++ b/examples/java/src/main/java/org/apache/beam/examples/kotlin/WordCount.kt
@@ -1,0 +1,168 @@
+package org.apache.beam.examples.kotlin
+
+import org.apache.beam.examples.DebuggingWordCount
+import org.apache.beam.examples.MinimalWordCount
+import org.apache.beam.examples.common.ExampleUtils
+import org.apache.beam.sdk.Pipeline
+import org.apache.beam.sdk.io.TextIO
+import org.apache.beam.sdk.metrics.Metrics
+import org.apache.beam.sdk.options.*
+import org.apache.beam.sdk.transforms.*
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
+import org.apache.beam.sdk.values.PDone
+
+/**
+ * An example that counts words in Shakespeare and includes Beam best practices.
+ *
+ *
+ * This class, [WordCount], is the second in a series of four successively more detailed
+ * 'word count' examples. You may first want to take a look at [MinimalWordCount]. After
+ * you've looked at this example, then see the [DebuggingWordCount] pipeline, for introduction
+ * of additional concepts.
+ *
+ *
+ * For a detailed walkthrough of this example, see [
+ * https://beam.apache.org/get-started/wordcount-example/ ](https://beam.apache.org/get-started/wordcount-example/)
+ *
+ *
+ * Basic concepts, also in the MinimalWordCount example: Reading text files; counting a
+ * PCollection; writing to text files
+ *
+ *
+ * New Concepts:
+ *
+ * <pre>
+ * 1. Executing a Pipeline both locally and using the selected runner
+ * 2. Using ParDo with static DoFns defined out-of-line
+ * 3. Building a composite transform
+ * 4. Defining your own pipeline options
+</pre> *
+ *
+ *
+ * Concept #1: you can execute this pipeline either locally or using by selecting another runner.
+ * These are now command-line options and not hard-coded as they were in the MinimalWordCount
+ * example.
+ *
+ *
+ * To change the runner, specify:
+ *
+ * <pre>`--runner=YOUR_SELECTED_RUNNER
+`</pre> *
+ *
+ *
+ * To execute this pipeline, specify a local output file (if using the `DirectRunner`) or
+ * output prefix on a supported distributed file system.
+ *
+ * <pre>`--output=[YOUR_LOCAL_FILE | YOUR_OUTPUT_PREFIX]
+`</pre> *
+ *
+ *
+ * The input file defaults to a public data set containing the text of of King Lear, by William
+ * Shakespeare. You can override it and choose your own input with `--inputFile`.
+ */
+object WordCount {
+
+    /**
+     * Concept #2: You can make your pipeline assembly code less verbose by defining your DoFns
+     * statically out-of-line. This DoFn tokenizes lines of text into individual words; we pass it to
+     * a ParDo in the pipeline.
+     */
+    internal class ExtractWordsFn : DoFn<String, String>() {
+        private val emptyLines = Metrics.counter(ExtractWordsFn::class.java, "emptyLines")
+        private val lineLenDist = Metrics.distribution(ExtractWordsFn::class.java, "lineLenDistro")
+
+        @ProcessElement
+        fun processElement(@Element element: String, receiver: DoFn.OutputReceiver<String>) {
+            lineLenDist.update(element.length.toLong())
+            if (element.trim(' ').isEmpty()) {
+                emptyLines.inc()
+            }
+
+            // Split the line into words.
+            val words = element.split(ExampleUtils.TOKENIZER_PATTERN.toRegex()).toTypedArray()
+
+            // Output each word encountered into the output PCollection.
+            for (word in words) {
+                if (!word.isEmpty()) {
+                    receiver.output(word)
+                }
+            }
+        }
+    }
+
+    /** A SimpleFunction that converts a Word and Count into a printable string.  */
+    class FormatAsTextFn : SimpleFunction<KV<String, Long>, String>() {
+
+        override fun apply(input: KV<String, Long>) = "${input.key} : ${input.value}"
+
+    }
+
+    /**
+     * A PTransform that converts a PCollection containing lines of text into a PCollection of
+     * formatted word counts.
+     *
+     *
+     * Concept #3: This is a custom composite transform that bundles two transforms (ParDo and
+     * Count) as a reusable PTransform subclass. Using composite transforms allows for easy reuse,
+     * modular testing, and an improved monitoring experience.
+     */
+    class CountWords : PTransform<PCollection<String>, PCollection<KV<String, Long>>>() {
+        override fun expand(lines: PCollection<String>): PCollection<KV<String, Long>> {
+
+            // Convert lines of text into individual words.
+            val words = lines.apply(ParDo.of(ExtractWordsFn()))
+
+            // Count the number of times each word occurs.
+
+            return words.apply(Count.perElement())
+        }
+    }
+
+    /**
+     * Options supported by [WordCount].
+     *
+     *
+     * Concept #4: Defining your own configuration options. Here, you can add your own arguments to
+     * be processed by the command-line parser, and specify default values for them. You can then
+     * access the options values in your pipeline code.
+     *
+     *
+     * Inherits standard configuration options.
+     */
+    interface WordCountOptions : PipelineOptions {
+
+        /**
+         * By default, this example reads from a public dataset containing the text of King Lear. Set
+         * this option to choose a different input file or glob.
+         */
+        @get:Description("Path of the file to read from")
+        @get:Default.String("gs://apache-beam-samples/shakespeare/kinglear.txt")
+        var inputFile: String
+
+        /** Set this required option to specify where to write the output.  */
+        @get:Description("Path of the file to write to")
+        @get:Validation.Required
+        var output: String
+    }
+
+    private fun runWordCount(options: WordCountOptions) {
+        val p = Pipeline.create(options)
+
+        // Concepts #2 and #3: Our pipeline applies the composite CountWords transform, and passes the
+        // static FormatAsTextFn() to the ParDo transform.
+        p.apply("ReadLines", TextIO.read().from(options.inputFile))
+                .apply(CountWords())
+                .apply(MapElements.via(FormatAsTextFn()))
+                .apply<PDone>("WriteCounts", TextIO.write().to(options.output))
+
+        p.run().waitUntilFinish()
+    }
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val options = PipelineOptionsFactory.fromArgs(*args).withValidation().`as`(WordCountOptions::class.java)
+
+        runWordCount(options)
+    }
+}

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
@@ -18,7 +18,6 @@
 package org.apache.beam.examples;
 
 import java.util.Date;
-
 import org.apache.beam.examples.java.WordCount;
 import org.apache.beam.examples.java.WordCount.WordCountOptions;
 import org.apache.beam.sdk.io.FileSystems;

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
@@ -18,7 +18,9 @@
 package org.apache.beam.examples;
 
 import java.util.Date;
-import org.apache.beam.examples.WordCount.WordCountOptions;
+
+import org.apache.beam.examples.java.WordCount;
+import org.apache.beam.examples.java.WordCount.WordCountOptions;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.examples;
 
 import java.util.Arrays;
 import java.util.List;
+
 import org.apache.beam.examples.java.WordCount.CountWords;
 import org.apache.beam.examples.java.WordCount.ExtractWordsFn;
 import org.apache.beam.examples.java.WordCount.FormatAsTextFn;

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountTest.java
@@ -19,7 +19,6 @@ package org.apache.beam.examples;
 
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.beam.examples.java.WordCount.CountWords;
 import org.apache.beam.examples.java.WordCount.ExtractWordsFn;
 import org.apache.beam.examples.java.WordCount.FormatAsTextFn;

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountTest.java
@@ -19,9 +19,9 @@ package org.apache.beam.examples;
 
 import java.util.Arrays;
 import java.util.List;
-import org.apache.beam.examples.WordCount.CountWords;
-import org.apache.beam.examples.WordCount.ExtractWordsFn;
-import org.apache.beam.examples.WordCount.FormatAsTextFn;
+import org.apache.beam.examples.java.WordCount.CountWords;
+import org.apache.beam.examples.java.WordCount.ExtractWordsFn;
+import org.apache.beam.examples.java.WordCount.FormatAsTextFn;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;

--- a/sdks/java/io/hadoop-format/src/test/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIOSequenceFileTest.java
+++ b/sdks/java/io/hadoop-format/src/test/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIOSequenceFileTest.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.beam.examples.WordCount;
+import org.apache.beam.examples.java.WordCount;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;

--- a/website/src/documentation/runners/apex.md
+++ b/website/src/documentation/runners/apex.md
@@ -43,12 +43,12 @@ mvn package -Papex-runner
 
 Copy the resulting `target/word-count-beam-bundled-0.1.jar` to the cluster and submit the application using:
 ```
-java -cp word-count-beam-bundled-0.1.jar org.apache.beam.examples.WordCount --inputFile=/etc/profile --output=/tmp/counts --embeddedExecution=false --configFile=beam-runners-apex.properties --runner=ApexRunner
+java -cp word-count-beam-bundled-0.1.jar org.apache.beam.examples.java.WordCount --inputFile=/etc/profile --output=/tmp/counts --embeddedExecution=false --configFile=beam-runners-apex.properties --runner=ApexRunner
 ```
 
 If the build environment is setup as cluster client, it is possible to run the example directly:
 ```
-mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount -Dexec.args="--inputFile=/etc/profile --output=/tmp/counts --runner=ApexRunner --embeddedExecution=false --configFile=beam-runners-apex.properties" -Papex-runner
+mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount -Dexec.args="--inputFile=/etc/profile --output=/tmp/counts --runner=ApexRunner --embeddedExecution=false --configFile=beam-runners-apex.properties" -Papex-runner
 ```
 
 The application will run asynchronously. Check status with `yarn application -list -appStates ALL`

--- a/website/src/documentation/runners/flink.md
+++ b/website/src/documentation/runners/flink.md
@@ -156,7 +156,7 @@ The Beam Quickstart Maven project is setup to use the Maven Shade plugin to crea
 
 For actually running the pipeline you would use this command
 ```
-$ mvn exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
     -Pflink-runner \
     -Dexec.args="--runner=FlinkRunner \
       --inputFile=/path/to/pom.xml \

--- a/website/src/documentation/runners/jstorm.md
+++ b/website/src/documentation/runners/jstorm.md
@@ -45,13 +45,13 @@ You can add a dependency on the latest version of the JStorm runner by adding th
 
 To run against a Standalone cluster, you can package your program with all Beam dependencies into a fat jar, and then submit the topology with the following command.
 ```
-jstorm jar WordCount.jar org.apache.beam.examples.WordCount --runner=org.apache.beam.runners.jstorm.JStormRunner
+jstorm jar WordCount.jar org.apache.beam.examples.java.WordCount --runner=org.apache.beam.runners.jstorm.JStormRunner
 ```
 
 If you don't want to package a fat jar, you can upload the Beam dependencies onto all cluster nodes(`$JSTORM_HOME/lib/ext/beam`) first.
 When you submit a topology with argument `"--external-libs beam"`, JStorm will load the Beam dependencies automatically.
 ```
-jstorm jar WordCount.jar org.apache.beam.examples.WordCount --external-libs beam  --runner=org.apache.beam.runners.jstorm.JStormRunner
+jstorm jar WordCount.jar org.apache.beam.examples.java.WordCount --external-libs beam  --runner=org.apache.beam.runners.jstorm.JStormRunner
 ```
 
 To learn about deploying a JStorm cluster, please refer to [JStorm cluster deploy](http://jstorm.io/QuickStart/Deploy/index.html)

--- a/website/src/documentation/runners/mapreduce.md
+++ b/website/src/documentation/runners/mapreduce.md
@@ -40,7 +40,7 @@ You can add a dependency on the latest version of the Apache Hadoop MapReduce ru
 ## Deploying Apache Hadoop MapReduce with your application
 To execute in a local Hadoop environment, use this command:
 ```
-$ mvn exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
     -Pmapreduce-runner \
     -Dexec.args="--runner=MapReduceRunner \
       --inputFile=/path/to/pom.xml \
@@ -58,7 +58,7 @@ $ mvn package -Pflink-runner
 For actually running the pipeline you would use this command
 ```
 $ yarn jar word-count-beam-bundled-0.1.jar \
-    org.apache.beam.examples.WordCount \
+    org.apache.beam.examples.java.WordCount \
     --runner=MapReduceRunner \
     --inputFile=/path/to/pom.xml \
       --output=/path/to/counts \

--- a/website/src/documentation/runners/samza.md
+++ b/website/src/documentation/runners/samza.md
@@ -89,7 +89,7 @@ The Samza Runner is built on Samza version greater than 0.14.1.
 If you run your pipeline locally or deploy it to a standalone cluster with all the jars and resource files, no packaging is required. For example, the following command runs the WordCount example:
 
 ```
-$ mvn exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
     -Psamza-runner \
     -Dexec.args="--runner=SamzaRunner \
       --inputFile=/path/to/input \

--- a/website/src/get-started/quickstart-java.md
+++ b/website/src/get-started/quickstart-java.md
@@ -131,25 +131,25 @@ For Unix shells:
 
 {:.runner-direct}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--inputFile=pom.xml --output=counts" -Pdirect-runner
 ```
 
 {:.runner-apex}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--inputFile=pom.xml --output=counts --runner=ApexRunner" -Papex-runner
 ```
 
 {:.runner-flink-local}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--runner=FlinkRunner --inputFile=pom.xml --output=counts" -Pflink-runner
 ```
 
 {:.runner-flink-cluster}
 ```
-$ mvn package exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn package exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--runner=FlinkRunner --flinkMaster=<flink master> --filesToStage=target/word-count-beam-bundled-0.1.jar \
                   --inputFile=/path/to/quickstart/pom.xml --output=/tmp/counts" -Pflink-runner
 
@@ -158,7 +158,7 @@ You can monitor the running job by visiting the Flink dashboard at http://<flink
 
 {:.runner-spark}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--runner=SparkRunner --inputFile=pom.xml --output=counts" -Pspark-runner
 ```
 
@@ -166,7 +166,7 @@ $ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
 ```
 Make sure you complete the setup steps at {{ site.baseurl }}/documentation/runners/dataflow/#setup
 
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--runner=DataflowRunner --project=<your-gcp-project> \
                   --gcpTempLocation=gs://<your-gcs-bucket>/tmp \
                   --inputFile=gs://apache-beam-samples/shakespeare/* --output=gs://<your-gcs-bucket>/counts" \
@@ -175,13 +175,13 @@ $ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
 
 {:.runner-samza-local}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--inputFile=pom.xml --output=/tmp/counts --runner=SamzaRunner" -Psamza-runner
 ```
 
 {:.runner-nemo}
 ```
-$ mvn package -Pnemo-runner && java -cp target/word-count-beam-bundled-0.1.jar org.apache.beam.examples.WordCount \
+$ mvn package -Pnemo-runner && java -cp target/word-count-beam-bundled-0.1.jar org.apache.beam.examples.java.WordCount \
      --runner=NemoRunner --inputFile=`pwd`/pom.xml --output=counts
 ```
 
@@ -189,25 +189,25 @@ For Windows PowerShell:
 
 {:.runner-direct}
 ```
-PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
+PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.java.WordCount `
  -D exec.args="--inputFile=pom.xml --output=counts" -P direct-runner
 ```
 
 {:.runner-apex}
 ```
-PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
+PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.java.WordCount `
  -D exec.args="--inputFile=pom.xml --output=counts --runner=ApexRunner" -P apex-runner
 ```
 
 {:.runner-flink-local}
 ```
-PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
+PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.java.WordCount `
  -D exec.args="--runner=FlinkRunner --inputFile=pom.xml --output=counts" -P flink-runner
 ```
 
 {:.runner-flink-cluster}
 ```
-PS> mvn package exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
+PS> mvn package exec:java -D exec.mainClass=org.apache.beam.examples.java.WordCount `
  -D exec.args="--runner=FlinkRunner --flinkMaster=<flink master> --filesToStage=.\target\word-count-beam-bundled-0.1.jar `
                --inputFile=C:\path\to\quickstart\pom.xml --output=C:\tmp\counts" -P flink-runner
 
@@ -216,7 +216,7 @@ You can monitor the running job by visiting the Flink dashboard at http://<flink
 
 {:.runner-spark}
 ```
-PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
+PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.java.WordCount `
  -D exec.args="--runner=SparkRunner --inputFile=pom.xml --output=counts" -P spark-runner
 ```
 
@@ -224,7 +224,7 @@ PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
 ```
 Make sure you complete the setup steps at {{ site.baseurl }}/documentation/runners/dataflow/#setup
 
-PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
+PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.java.WordCount `
  -D exec.args="--runner=DataflowRunner --project=<your-gcp-project> `
                --gcpTempLocation=gs://<your-gcs-bucket>/tmp `
                --inputFile=gs://apache-beam-samples/shakespeare/* --output=gs://<your-gcs-bucket>/counts" `
@@ -233,14 +233,14 @@ PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
 
 {:.runner-samza-local}
 ```
-PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.WordCount `
+PS> mvn compile exec:java -D exec.mainClass=org.apache.beam.examples.java.WordCount `
      -D exec.args="--inputFile=pom.xml --output=/tmp/counts --runner=SamzaRunner" -P samza-runner
 ```
 
 {:.runner-nemo}
 ```
 PS> mvn package -P nemo-runner -DskipTests
-PS> java -cp target/word-count-beam-bundled-0.1.jar org.apache.beam.examples.WordCount `
+PS> java -cp target/word-count-beam-bundled-0.1.jar org.apache.beam.examples.java.WordCount `
       --runner=NemoRunner --inputFile=`pwd`/pom.xml --output=counts
 ```
 

--- a/website/src/get-started/wordcount-example.md
+++ b/website/src/get-started/wordcount-example.md
@@ -339,25 +339,25 @@ above section, [MinimalWordCount](#minimalwordcount-example).
 
 {:.runner-direct}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--inputFile=pom.xml --output=counts" -Pdirect-runner
 ```
 
 {:.runner-apex}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--inputFile=pom.xml --output=counts --runner=ApexRunner" -Papex-runner
 ```
 
 {:.runner-flink-local}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--runner=FlinkRunner --inputFile=pom.xml --output=counts" -Pflink-runner
 ```
 
 {:.runner-flink-cluster}
 ```
-$ mvn package exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn package exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--runner=FlinkRunner --flinkMaster=<flink master> --filesToStage=target/word-count-beam-bundled-0.1.jar \
                   --inputFile=/path/to/quickstart/pom.xml --output=/tmp/counts" -Pflink-runner
 
@@ -366,13 +366,13 @@ You can monitor the running job by visiting the Flink dashboard at http://<flink
 
 {:.runner-spark}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--runner=SparkRunner --inputFile=pom.xml --output=counts" -Pspark-runner
 ```
 
 {:.runner-dataflow}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--runner=DataflowRunner --gcpTempLocation=gs://YOUR_GCS_BUCKET/tmp \
                   --inputFile=gs://apache-beam-samples/shakespeare/* --output=gs://YOUR_GCS_BUCKET/counts" \
      -Pdataflow-runner
@@ -380,13 +380,13 @@ $ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
 
 {:.runner-samza-local}
 ```
-$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount \
+$ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.java.WordCount \
      -Dexec.args="--inputFile=pom.xml --output=counts --runner=SamzaRunner" -Psamza-runner
 ```
 
 {:.runner-nemo}
 ```
-$ mvn package -Pnemo-runner && java -cp target/word-count-beam-bundled-0.1.jar org.apache.beam.examples.WordCount \
+$ mvn package -Pnemo-runner && java -cp target/word-count-beam-bundled-0.1.jar org.apache.beam.examples.java.WordCount \
      --runner=NemoRunner --inputFile=`pwd`/pom.xml --output=counts
 ```
 


### PR DESCRIPTION
Signed-off-by: Harshit Dwivedi <harshithdwivedi@gmail.com>

Hi @kennknowles, as discussed in the [Jira ticket](https://issues.apache.org/jira/browse/BEAM-6493), I've added the Kotlin Sample for WordCount in the example folder.
Please have a look and let me know if the project structure looks good, if it does, I'll go ahead and refactor rest of the projects.

Here's what I had in mind for the structure : 

```
examples
    -java/src/main/org/apache/beam/examples
        -java (all the java samples go in this folder)
        -kotlin (all the kotlin samples go in this folder)

```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`). @kennknowles 
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

