### PR TITLE
[BEAM-6719] Allow multiple Joins in the same pipeline

### DIFF
--- a/sdks/java/extensions/join-library/src/main/java/org/apache/beam/sdk/extensions/joinlibrary/Join.java
+++ b/sdks/java/extensions/join-library/src/main/java/org/apache/beam/sdk/extensions/joinlibrary/Join.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.extensions.joinlibrary;
 
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -28,441 +30,439 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
 
-import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Utility class with different versions of joins. All methods join two collections of key/value
  * pairs (KV).
  */
 public class Join {
 
-    /**
-     * PTransform representing an inner join of two collections of KV elements.
-     *
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     */
-    public static class InnerJoin<K, V1, V2> extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
+  /**
+   * PTransform representing an inner join of two collections of KV elements.
+   *
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   */
+  public static class InnerJoin<K, V1, V2>
+      extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
 
-        private transient PCollection<KV<K, V2>> rightCollection;
+    private transient PCollection<KV<K, V2>> rightCollection;
 
-        private InnerJoin(PCollection<KV<K, V2>> rightCollection) {
-            this.rightCollection = rightCollection;
-        }
-
-        public static <K, V1, V2> InnerJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection) {
-            return new InnerJoin<>(rightCollection);
-        }
-
-        @Override
-        public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
-            checkNotNull(leftCollection);
-            checkNotNull(rightCollection);
-
-            final TupleTag<V1> v1Tuple = new TupleTag<>();
-            final TupleTag<V2> v2Tuple = new TupleTag<>();
-
-            PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
-                    KeyedPCollectionTuple.of(v1Tuple, leftCollection)
-                                         .and(v2Tuple, rightCollection)
-                                         .apply("CoGBK", CoGroupByKey.create());
-
-            return coGbkResultCollection
-                    .apply(
-                            "Join",
-                            ParDo.of(
-                                    new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
-                                        @ProcessElement
-                                        public void processElement(ProcessContext c) {
-                                            KV<K, CoGbkResult> e = c.element();
-
-                                            Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
-                                            Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
-
-                                            for (V1 leftValue : leftValuesIterable) {
-                                                for (V2 rightValue : rightValuesIterable) {
-                                                    c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
-                                                }
-                                            }
-                                        }
-                                    }))
-                    .setCoder(
-                            KvCoder.of(
-                                    ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
-                                    KvCoder.of(
-                                            ((KvCoder) leftCollection.getCoder()).getValueCoder(),
-                                            ((KvCoder) rightCollection.getCoder()).getValueCoder())));
-        }
-
+    private InnerJoin(PCollection<KV<K, V2>> rightCollection) {
+      this.rightCollection = rightCollection;
     }
 
-    /**
-     * PTransform representing a left outer join of two collections of KV elements.
-     *
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     */
-    public static class LeftOuterJoin<K, V1, V2> extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
-
-        private transient PCollection<KV<K, V2>> rightCollection;
-        private V2 nullValue;
-
-        private LeftOuterJoin(PCollection<KV<K, V2>> rightCollection, V2 nullValue) {
-            this.rightCollection = rightCollection;
-            this.nullValue = nullValue;
-        }
-
-        public static <K, V1, V2> LeftOuterJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection, V2 nullValue) {
-            return new LeftOuterJoin<>(rightCollection, nullValue);
-        }
-
-        @Override
-        public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
-            checkNotNull(leftCollection);
-            checkNotNull(rightCollection);
-            checkNotNull(nullValue);
-            final TupleTag<V1> v1Tuple = new TupleTag<>();
-            final TupleTag<V2> v2Tuple = new TupleTag<>();
-
-            PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
-                    KeyedPCollectionTuple.of(v1Tuple, leftCollection)
-                                         .and(v2Tuple, rightCollection)
-                                         .apply("CoGBK", CoGroupByKey.create());
-
-            return coGbkResultCollection
-                    .apply(
-                            "Join",
-                            ParDo.of(
-                                    new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
-                                        @ProcessElement
-                                        public void processElement(ProcessContext c) {
-                                            KV<K, CoGbkResult> e = c.element();
-
-                                            Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
-                                            Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
-
-                                            for (V1 leftValue : leftValuesIterable) {
-                                                if (rightValuesIterable.iterator().hasNext()) {
-                                                    for (V2 rightValue : rightValuesIterable) {
-                                                        c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
-                                                    }
-                                                } else {
-                                                    c.output(KV.of(e.getKey(), KV.of(leftValue, nullValue)));
-                                                }
-                                            }
-                                        }
-                                    }))
-                    .setCoder(
-                            KvCoder.of(
-                                    ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
-                                    KvCoder.of(
-                                            ((KvCoder) leftCollection.getCoder()).getValueCoder(),
-                                            ((KvCoder) rightCollection.getCoder()).getValueCoder())));
-        }
-
+    public static <K, V1, V2> InnerJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection) {
+      return new InnerJoin<>(rightCollection);
     }
 
-    /**
-     * PTransform representing a right outer join of two collections of KV elements.
-     *
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     */
-    public static class RightOuterJoin<K, V1, V2> extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
+    @Override
+    public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
+      checkNotNull(leftCollection);
+      checkNotNull(rightCollection);
 
-        private transient PCollection<KV<K, V2>> rightCollection;
-        private V1 nullValue;
+      final TupleTag<V1> v1Tuple = new TupleTag<>();
+      final TupleTag<V2> v2Tuple = new TupleTag<>();
 
-        private RightOuterJoin(PCollection<KV<K, V2>> rightCollection, V1 nullValue) {
-            this.rightCollection = rightCollection;
-            this.nullValue = nullValue;
-        }
+      PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
+          KeyedPCollectionTuple.of(v1Tuple, leftCollection)
+              .and(v2Tuple, rightCollection)
+              .apply("CoGBK", CoGroupByKey.create());
 
-        public static <K, V1, V2> RightOuterJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection, V1 nullValue) {
-            return new RightOuterJoin<>(rightCollection, nullValue);
-        }
+      return coGbkResultCollection
+          .apply(
+              "Join",
+              ParDo.of(
+                  new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
+                    @ProcessElement
+                    public void processElement(ProcessContext c) {
+                      KV<K, CoGbkResult> e = c.element();
 
-        @Override
-        public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
-            checkNotNull(leftCollection);
-            checkNotNull(rightCollection);
-            checkNotNull(nullValue);
+                      Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
+                      Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
 
-            final TupleTag<V1> v1Tuple = new TupleTag<>();
-            final TupleTag<V2> v2Tuple = new TupleTag<>();
+                      for (V1 leftValue : leftValuesIterable) {
+                        for (V2 rightValue : rightValuesIterable) {
+                          c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
+                        }
+                      }
+                    }
+                  }))
+          .setCoder(
+              KvCoder.of(
+                  ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
+                  KvCoder.of(
+                      ((KvCoder) leftCollection.getCoder()).getValueCoder(),
+                      ((KvCoder) rightCollection.getCoder()).getValueCoder())));
+    }
+  }
 
-            PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
-                    KeyedPCollectionTuple.of(v1Tuple, leftCollection)
-                                         .and(v2Tuple, rightCollection)
-                                         .apply("CoGBK", CoGroupByKey.create());
+  /**
+   * PTransform representing a left outer join of two collections of KV elements.
+   *
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   */
+  public static class LeftOuterJoin<K, V1, V2>
+      extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
 
-            return coGbkResultCollection
-                    .apply(
-                            "Join",
-                            ParDo.of(
-                                    new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
-                                        @ProcessElement
-                                        public void processElement(ProcessContext c) {
-                                            KV<K, CoGbkResult> e = c.element();
+    private transient PCollection<KV<K, V2>> rightCollection;
+    private V2 nullValue;
 
-                                            Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
-                                            Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
-
-                                            for (V2 rightValue : rightValuesIterable) {
-                                                if (leftValuesIterable.iterator().hasNext()) {
-                                                    for (V1 leftValue : leftValuesIterable) {
-                                                        c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
-                                                    }
-                                                } else {
-                                                    c.output(KV.of(e.getKey(), KV.of(nullValue, rightValue)));
-                                                }
-                                            }
-                                        }
-                                    }))
-                    .setCoder(
-                            KvCoder.of(
-                                    ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
-                                    KvCoder.of(
-                                            ((KvCoder) leftCollection.getCoder()).getValueCoder(),
-                                            ((KvCoder) rightCollection.getCoder()).getValueCoder())));
-        }
-
+    private LeftOuterJoin(PCollection<KV<K, V2>> rightCollection, V2 nullValue) {
+      this.rightCollection = rightCollection;
+      this.nullValue = nullValue;
     }
 
-    /**
-     * PTransform representing a full outer join of two collections of KV elements.
-     *
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     */
-    public static class FullOuterJoin<K, V1, V2> extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
-
-        private transient PCollection<KV<K, V2>> rightCollection;
-        private V1 leftNullValue;
-        private V2 rightNullValue;
-
-        private FullOuterJoin(PCollection<KV<K, V2>> rightCollection, V1 leftNullValue, V2 rightNullValue) {
-            this.rightCollection = rightCollection;
-            this.leftNullValue = leftNullValue;
-            this.rightNullValue = rightNullValue;
-        }
-
-        public static <K, V1, V2> FullOuterJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection, V1 leftNullValue, V2 rightNullValue) {
-            return new FullOuterJoin<>(rightCollection, leftNullValue, rightNullValue);
-        }
-
-        @Override
-        public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
-            checkNotNull(leftCollection);
-            checkNotNull(rightCollection);
-            checkNotNull(leftNullValue);
-            checkNotNull(rightNullValue);
-
-
-            final TupleTag<V1> v1Tuple = new TupleTag<>();
-            final TupleTag<V2> v2Tuple = new TupleTag<>();
-
-            PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
-                    KeyedPCollectionTuple.of(v1Tuple, leftCollection)
-                                         .and(v2Tuple, rightCollection)
-                                         .apply("CoGBK", CoGroupByKey.create());
-
-            return coGbkResultCollection
-                    .apply(
-                            "Join",
-                            ParDo.of(
-                                    new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
-                                        @ProcessElement
-                                        public void processElement(ProcessContext c) {
-                                            KV<K, CoGbkResult> e = c.element();
-
-                                            Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
-                                            Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
-                                            if (leftValuesIterable.iterator().hasNext()
-                                                    && rightValuesIterable.iterator().hasNext()) {
-                                                for (V2 rightValue : rightValuesIterable) {
-                                                    for (V1 leftValue : leftValuesIterable) {
-                                                        c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
-                                                    }
-                                                }
-                                            } else if (leftValuesIterable.iterator().hasNext()
-                                                    && !rightValuesIterable.iterator().hasNext()) {
-                                                for (V1 leftValue : leftValuesIterable) {
-                                                    c.output(KV.of(e.getKey(), KV.of(leftValue, rightNullValue)));
-                                                }
-                                            } else if (!leftValuesIterable.iterator().hasNext()
-                                                    && rightValuesIterable.iterator().hasNext()) {
-                                                for (V2 rightValue : rightValuesIterable) {
-                                                    c.output(KV.of(e.getKey(), KV.of(leftNullValue, rightValue)));
-                                                }
-                                            }
-                                        }
-                                    }))
-                    .setCoder(
-                            KvCoder.of(
-                                    ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
-                                    KvCoder.of(
-                                            ((KvCoder) leftCollection.getCoder()).getValueCoder(),
-                                            ((KvCoder) rightCollection.getCoder()).getValueCoder())));
-        }
-
+    public static <K, V1, V2> LeftOuterJoin<K, V1, V2> with(
+        PCollection<KV<K, V2>> rightCollection, V2 nullValue) {
+      return new LeftOuterJoin<>(rightCollection, nullValue);
     }
 
+    @Override
+    public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
+      checkNotNull(leftCollection);
+      checkNotNull(rightCollection);
+      checkNotNull(nullValue);
+      final TupleTag<V1> v1Tuple = new TupleTag<>();
+      final TupleTag<V2> v2Tuple = new TupleTag<>();
 
-    /**
-     * Inner join of two collections of KV elements.
-     *
-     * @param leftCollection  Left side collection to join.
-     * @param rightCollection Right side collection to join.
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-     * V1 and Value is type V2.
-     */
-    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> innerJoin(
-            final PCollection<KV<K, V1>> leftCollection, final PCollection<KV<K, V2>> rightCollection) {
-        return innerJoin("InnerJoin", leftCollection, rightCollection);
+      PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
+          KeyedPCollectionTuple.of(v1Tuple, leftCollection)
+              .and(v2Tuple, rightCollection)
+              .apply("CoGBK", CoGroupByKey.create());
+
+      return coGbkResultCollection
+          .apply(
+              "Join",
+              ParDo.of(
+                  new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
+                    @ProcessElement
+                    public void processElement(ProcessContext c) {
+                      KV<K, CoGbkResult> e = c.element();
+
+                      Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
+                      Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
+
+                      for (V1 leftValue : leftValuesIterable) {
+                        if (rightValuesIterable.iterator().hasNext()) {
+                          for (V2 rightValue : rightValuesIterable) {
+                            c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
+                          }
+                        } else {
+                          c.output(KV.of(e.getKey(), KV.of(leftValue, nullValue)));
+                        }
+                      }
+                    }
+                  }))
+          .setCoder(
+              KvCoder.of(
+                  ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
+                  KvCoder.of(
+                      ((KvCoder) leftCollection.getCoder()).getValueCoder(),
+                      ((KvCoder) rightCollection.getCoder()).getValueCoder())));
+    }
+  }
+
+  /**
+   * PTransform representing a right outer join of two collections of KV elements.
+   *
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   */
+  public static class RightOuterJoin<K, V1, V2>
+      extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
+
+    private transient PCollection<KV<K, V2>> rightCollection;
+    private V1 nullValue;
+
+    private RightOuterJoin(PCollection<KV<K, V2>> rightCollection, V1 nullValue) {
+      this.rightCollection = rightCollection;
+      this.nullValue = nullValue;
     }
 
-    /**
-     * Inner join of two collections of KV elements.
-     *
-     * @param name            Name of the PTransform.
-     * @param leftCollection  Left side collection to join.
-     * @param rightCollection Right side collection to join.
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-     * V1 and Value is type V2.
-     */
-    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> innerJoin(
-            final String name,
-            final PCollection<KV<K, V1>> leftCollection, final PCollection<KV<K, V2>> rightCollection) {
-        return leftCollection.apply(name, InnerJoin.with(rightCollection));
+    public static <K, V1, V2> RightOuterJoin<K, V1, V2> with(
+        PCollection<KV<K, V2>> rightCollection, V1 nullValue) {
+      return new RightOuterJoin<>(rightCollection, nullValue);
     }
 
+    @Override
+    public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
+      checkNotNull(leftCollection);
+      checkNotNull(rightCollection);
+      checkNotNull(nullValue);
 
-    /**
-     * Left Outer Join of two collections of KV elements.
-     *
-     * @param name            Name of the PTransform.
-     * @param leftCollection  Left side collection to join.
-     * @param rightCollection Right side collection to join.
-     * @param nullValue       Value to use as null value when right side do not match left side.
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-     * V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
-     */
-    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> leftOuterJoin(
-            final String name,
-            final PCollection<KV<K, V1>> leftCollection,
-            final PCollection<KV<K, V2>> rightCollection,
-            final V2 nullValue) {
-        return leftCollection.apply(name, LeftOuterJoin.with(rightCollection, nullValue));
+      final TupleTag<V1> v1Tuple = new TupleTag<>();
+      final TupleTag<V2> v2Tuple = new TupleTag<>();
+
+      PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
+          KeyedPCollectionTuple.of(v1Tuple, leftCollection)
+              .and(v2Tuple, rightCollection)
+              .apply("CoGBK", CoGroupByKey.create());
+
+      return coGbkResultCollection
+          .apply(
+              "Join",
+              ParDo.of(
+                  new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
+                    @ProcessElement
+                    public void processElement(ProcessContext c) {
+                      KV<K, CoGbkResult> e = c.element();
+
+                      Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
+                      Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
+
+                      for (V2 rightValue : rightValuesIterable) {
+                        if (leftValuesIterable.iterator().hasNext()) {
+                          for (V1 leftValue : leftValuesIterable) {
+                            c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
+                          }
+                        } else {
+                          c.output(KV.of(e.getKey(), KV.of(nullValue, rightValue)));
+                        }
+                      }
+                    }
+                  }))
+          .setCoder(
+              KvCoder.of(
+                  ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
+                  KvCoder.of(
+                      ((KvCoder) leftCollection.getCoder()).getValueCoder(),
+                      ((KvCoder) rightCollection.getCoder()).getValueCoder())));
+    }
+  }
+
+  /**
+   * PTransform representing a full outer join of two collections of KV elements.
+   *
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   */
+  public static class FullOuterJoin<K, V1, V2>
+      extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
+
+    private transient PCollection<KV<K, V2>> rightCollection;
+    private V1 leftNullValue;
+    private V2 rightNullValue;
+
+    private FullOuterJoin(
+        PCollection<KV<K, V2>> rightCollection, V1 leftNullValue, V2 rightNullValue) {
+      this.rightCollection = rightCollection;
+      this.leftNullValue = leftNullValue;
+      this.rightNullValue = rightNullValue;
     }
 
-    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> leftOuterJoin(
-            final PCollection<KV<K, V1>> leftCollection,
-            final PCollection<KV<K, V2>> rightCollection,
-            final V2 nullValue) {
-        return leftOuterJoin("LeftOuterJoin", leftCollection, rightCollection, nullValue);
+    public static <K, V1, V2> FullOuterJoin<K, V1, V2> with(
+        PCollection<KV<K, V2>> rightCollection, V1 leftNullValue, V2 rightNullValue) {
+      return new FullOuterJoin<>(rightCollection, leftNullValue, rightNullValue);
     }
 
-    /**
-     * Right Outer Join of two collections of KV elements.
-     *
-     * @param name            Name of the PTransform.
-     * @param leftCollection  Left side collection to join.
-     * @param rightCollection Right side collection to join.
-     * @param nullValue       Value to use as null value when left side do not match right side.
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-     * V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
-     */
-    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> rightOuterJoin(
-            final String name,
-            final PCollection<KV<K, V1>> leftCollection,
-            final PCollection<KV<K, V2>> rightCollection,
-            final V1 nullValue) {
-        return leftCollection.apply(name, RightOuterJoin.with(rightCollection, nullValue));
+    @Override
+    public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
+      checkNotNull(leftCollection);
+      checkNotNull(rightCollection);
+      checkNotNull(leftNullValue);
+      checkNotNull(rightNullValue);
 
+      final TupleTag<V1> v1Tuple = new TupleTag<>();
+      final TupleTag<V2> v2Tuple = new TupleTag<>();
+
+      PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
+          KeyedPCollectionTuple.of(v1Tuple, leftCollection)
+              .and(v2Tuple, rightCollection)
+              .apply("CoGBK", CoGroupByKey.create());
+
+      return coGbkResultCollection
+          .apply(
+              "Join",
+              ParDo.of(
+                  new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
+                    @ProcessElement
+                    public void processElement(ProcessContext c) {
+                      KV<K, CoGbkResult> e = c.element();
+
+                      Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
+                      Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
+                      if (leftValuesIterable.iterator().hasNext()
+                          && rightValuesIterable.iterator().hasNext()) {
+                        for (V2 rightValue : rightValuesIterable) {
+                          for (V1 leftValue : leftValuesIterable) {
+                            c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
+                          }
+                        }
+                      } else if (leftValuesIterable.iterator().hasNext()
+                          && !rightValuesIterable.iterator().hasNext()) {
+                        for (V1 leftValue : leftValuesIterable) {
+                          c.output(KV.of(e.getKey(), KV.of(leftValue, rightNullValue)));
+                        }
+                      } else if (!leftValuesIterable.iterator().hasNext()
+                          && rightValuesIterable.iterator().hasNext()) {
+                        for (V2 rightValue : rightValuesIterable) {
+                          c.output(KV.of(e.getKey(), KV.of(leftNullValue, rightValue)));
+                        }
+                      }
+                    }
+                  }))
+          .setCoder(
+              KvCoder.of(
+                  ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
+                  KvCoder.of(
+                      ((KvCoder) leftCollection.getCoder()).getValueCoder(),
+                      ((KvCoder) rightCollection.getCoder()).getValueCoder())));
     }
+  }
 
-    /**
-     * Right Outer Join of two collections of KV elements.
-     *
-     * @param leftCollection  Left side collection to join.
-     * @param rightCollection Right side collection to join.
-     * @param nullValue       Value to use as null value when left side do not match right side.
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-     * V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
-     */
-    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> rightOuterJoin(
-            final PCollection<KV<K, V1>> leftCollection,
-            final PCollection<KV<K, V2>> rightCollection,
-            final V1 nullValue) {
-        return rightOuterJoin("RightOuterJoin", leftCollection, rightCollection, nullValue);
+  /**
+   * Inner join of two collections of KV elements.
+   *
+   * @param leftCollection Left side collection to join.
+   * @param rightCollection Right side collection to join.
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+   *     V1 and Value is type V2.
+   */
+  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> innerJoin(
+      final PCollection<KV<K, V1>> leftCollection, final PCollection<KV<K, V2>> rightCollection) {
+    return innerJoin("InnerJoin", leftCollection, rightCollection);
+  }
 
-    }
+  /**
+   * Inner join of two collections of KV elements.
+   *
+   * @param name Name of the PTransform.
+   * @param leftCollection Left side collection to join.
+   * @param rightCollection Right side collection to join.
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+   *     V1 and Value is type V2.
+   */
+  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> innerJoin(
+      final String name,
+      final PCollection<KV<K, V1>> leftCollection,
+      final PCollection<KV<K, V2>> rightCollection) {
+    return leftCollection.apply(name, InnerJoin.with(rightCollection));
+  }
 
-    /**
-     * Full Outer Join of two collections of KV elements.
-     *
-     * @param name            Name of the PTransform.
-     * @param leftCollection  Left side collection to join.
-     * @param rightCollection Right side collection to join.
-     * @param leftNullValue   Value to use as null value when left side do not match right side.
-     * @param rightNullValue  Value to use as null value when right side do not match right side.
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-     * V1 and Value is type V2. Values that should be null or empty is replaced with
-     * leftNullValue/rightNullValue.
-     */
-    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> fullOuterJoin(
-            final String name,
-            final PCollection<KV<K, V1>> leftCollection,
-            final PCollection<KV<K, V2>> rightCollection,
-            final V1 leftNullValue,
-            final V2 rightNullValue) {
-        return leftCollection.apply(name, FullOuterJoin.with(rightCollection, leftNullValue, rightNullValue));
+  /**
+   * Left Outer Join of two collections of KV elements.
+   *
+   * @param name Name of the PTransform.
+   * @param leftCollection Left side collection to join.
+   * @param rightCollection Right side collection to join.
+   * @param nullValue Value to use as null value when right side do not match left side.
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+   *     V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
+   */
+  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> leftOuterJoin(
+      final String name,
+      final PCollection<KV<K, V1>> leftCollection,
+      final PCollection<KV<K, V2>> rightCollection,
+      final V2 nullValue) {
+    return leftCollection.apply(name, LeftOuterJoin.with(rightCollection, nullValue));
+  }
 
-    }
+  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> leftOuterJoin(
+      final PCollection<KV<K, V1>> leftCollection,
+      final PCollection<KV<K, V2>> rightCollection,
+      final V2 nullValue) {
+    return leftOuterJoin("LeftOuterJoin", leftCollection, rightCollection, nullValue);
+  }
 
-    /**
-     * Full Outer Join of two collections of KV elements.
-     *
-     * @param leftCollection  Left side collection to join.
-     * @param rightCollection Right side collection to join.
-     * @param leftNullValue   Value to use as null value when left side do not match right side.
-     * @param rightNullValue  Value to use as null value when right side do not match right side.
-     * @param <K>             Type of the key for both collections
-     * @param <V1>            Type of the values for the left collection.
-     * @param <V2>            Type of the values for the right collection.
-     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-     * V1 and Value is type V2. Values that should be null or empty is replaced with
-     * leftNullValue/rightNullValue.
-     */
-    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> fullOuterJoin(
-            final PCollection<KV<K, V1>> leftCollection,
-            final PCollection<KV<K, V2>> rightCollection,
-            final V1 leftNullValue,
-            final V2 rightNullValue) {
-        return fullOuterJoin("FullOuterJoin", leftCollection, rightCollection, leftNullValue, rightNullValue);
+  /**
+   * Right Outer Join of two collections of KV elements.
+   *
+   * @param name Name of the PTransform.
+   * @param leftCollection Left side collection to join.
+   * @param rightCollection Right side collection to join.
+   * @param nullValue Value to use as null value when left side do not match right side.
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+   *     V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
+   */
+  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> rightOuterJoin(
+      final String name,
+      final PCollection<KV<K, V1>> leftCollection,
+      final PCollection<KV<K, V2>> rightCollection,
+      final V1 nullValue) {
+    return leftCollection.apply(name, RightOuterJoin.with(rightCollection, nullValue));
+  }
 
-    }
+  /**
+   * Right Outer Join of two collections of KV elements.
+   *
+   * @param leftCollection Left side collection to join.
+   * @param rightCollection Right side collection to join.
+   * @param nullValue Value to use as null value when left side do not match right side.
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+   *     V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
+   */
+  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> rightOuterJoin(
+      final PCollection<KV<K, V1>> leftCollection,
+      final PCollection<KV<K, V2>> rightCollection,
+      final V1 nullValue) {
+    return rightOuterJoin("RightOuterJoin", leftCollection, rightCollection, nullValue);
+  }
+
+  /**
+   * Full Outer Join of two collections of KV elements.
+   *
+   * @param name Name of the PTransform.
+   * @param leftCollection Left side collection to join.
+   * @param rightCollection Right side collection to join.
+   * @param leftNullValue Value to use as null value when left side do not match right side.
+   * @param rightNullValue Value to use as null value when right side do not match right side.
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+   *     V1 and Value is type V2. Values that should be null or empty is replaced with
+   *     leftNullValue/rightNullValue.
+   */
+  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> fullOuterJoin(
+      final String name,
+      final PCollection<KV<K, V1>> leftCollection,
+      final PCollection<KV<K, V2>> rightCollection,
+      final V1 leftNullValue,
+      final V2 rightNullValue) {
+    return leftCollection.apply(
+        name, FullOuterJoin.with(rightCollection, leftNullValue, rightNullValue));
+  }
+
+  /**
+   * Full Outer Join of two collections of KV elements.
+   *
+   * @param leftCollection Left side collection to join.
+   * @param rightCollection Right side collection to join.
+   * @param leftNullValue Value to use as null value when left side do not match right side.
+   * @param rightNullValue Value to use as null value when right side do not match right side.
+   * @param <K> Type of the key for both collections
+   * @param <V1> Type of the values for the left collection.
+   * @param <V2> Type of the values for the right collection.
+   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+   *     V1 and Value is type V2. Values that should be null or empty is replaced with
+   *     leftNullValue/rightNullValue.
+   */
+  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> fullOuterJoin(
+      final PCollection<KV<K, V1>> leftCollection,
+      final PCollection<KV<K, V2>> rightCollection,
+      final V1 leftNullValue,
+      final V2 rightNullValue) {
+    return fullOuterJoin(
+        "FullOuterJoin", leftCollection, rightCollection, leftNullValue, rightNullValue);
+  }
 }

--- a/sdks/java/extensions/join-library/src/main/java/org/apache/beam/sdk/extensions/joinlibrary/Join.java
+++ b/sdks/java/extensions/join-library/src/main/java/org/apache/beam/sdk/extensions/joinlibrary/Join.java
@@ -17,10 +17,9 @@
  */
 package org.apache.beam.sdk.extensions.joinlibrary;
 
-import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkNotNull;
-
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.transforms.join.CoGroupByKey;
@@ -29,249 +28,441 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
 
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Utility class with different versions of joins. All methods join two collections of key/value
  * pairs (KV).
  */
 public class Join {
 
-  /**
-   * Inner join of two collections of KV elements.
-   *
-   * @param leftCollection Left side collection to join.
-   * @param rightCollection Right side collection to join.
-   * @param <K> Type of the key for both collections
-   * @param <V1> Type of the values for the left collection.
-   * @param <V2> Type of the values for the right collection.
-   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-   *     V1 and Value is type V2.
-   */
-  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> innerJoin(
-      final PCollection<KV<K, V1>> leftCollection, final PCollection<KV<K, V2>> rightCollection) {
-    checkNotNull(leftCollection);
-    checkNotNull(rightCollection);
+    /**
+     * PTransform representing an inner join of two collections of KV elements.
+     *
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     */
+    public static class InnerJoin<K, V1, V2> extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
 
-    final TupleTag<V1> v1Tuple = new TupleTag<>();
-    final TupleTag<V2> v2Tuple = new TupleTag<>();
+        private transient PCollection<KV<K, V2>> rightCollection;
 
-    PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
-        KeyedPCollectionTuple.of(v1Tuple, leftCollection)
-            .and(v2Tuple, rightCollection)
-            .apply("CoGBK", CoGroupByKey.create());
+        private InnerJoin(PCollection<KV<K, V2>> rightCollection) {
+            this.rightCollection = rightCollection;
+        }
 
-    return coGbkResultCollection
-        .apply(
-            "Join",
-            ParDo.of(
-                new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext c) {
-                    KV<K, CoGbkResult> e = c.element();
+        public static <K, V1, V2> InnerJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection) {
+            return new InnerJoin<>(rightCollection);
+        }
 
-                    Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
-                    Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
+        @Override
+        public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
+            checkNotNull(leftCollection);
+            checkNotNull(rightCollection);
 
-                    for (V1 leftValue : leftValuesIterable) {
-                      for (V2 rightValue : rightValuesIterable) {
-                        c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
-                      }
-                    }
-                  }
-                }))
-        .setCoder(
-            KvCoder.of(
-                ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
-                KvCoder.of(
-                    ((KvCoder) leftCollection.getCoder()).getValueCoder(),
-                    ((KvCoder) rightCollection.getCoder()).getValueCoder())));
-  }
+            final TupleTag<V1> v1Tuple = new TupleTag<>();
+            final TupleTag<V2> v2Tuple = new TupleTag<>();
 
-  /**
-   * Left Outer Join of two collections of KV elements.
-   *
-   * @param leftCollection Left side collection to join.
-   * @param rightCollection Right side collection to join.
-   * @param nullValue Value to use as null value when right side do not match left side.
-   * @param <K> Type of the key for both collections
-   * @param <V1> Type of the values for the left collection.
-   * @param <V2> Type of the values for the right collection.
-   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-   *     V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
-   */
-  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> leftOuterJoin(
-      final PCollection<KV<K, V1>> leftCollection,
-      final PCollection<KV<K, V2>> rightCollection,
-      final V2 nullValue) {
-    checkNotNull(leftCollection);
-    checkNotNull(rightCollection);
-    checkNotNull(nullValue);
+            PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
+                    KeyedPCollectionTuple.of(v1Tuple, leftCollection)
+                                         .and(v2Tuple, rightCollection)
+                                         .apply("CoGBK", CoGroupByKey.create());
 
-    final TupleTag<V1> v1Tuple = new TupleTag<>();
-    final TupleTag<V2> v2Tuple = new TupleTag<>();
+            return coGbkResultCollection
+                    .apply(
+                            "Join",
+                            ParDo.of(
+                                    new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
+                                        @ProcessElement
+                                        public void processElement(ProcessContext c) {
+                                            KV<K, CoGbkResult> e = c.element();
 
-    PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
-        KeyedPCollectionTuple.of(v1Tuple, leftCollection)
-            .and(v2Tuple, rightCollection)
-            .apply("CoGBK", CoGroupByKey.create());
+                                            Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
+                                            Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
 
-    return coGbkResultCollection
-        .apply(
-            "Join",
-            ParDo.of(
-                new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext c) {
-                    KV<K, CoGbkResult> e = c.element();
+                                            for (V1 leftValue : leftValuesIterable) {
+                                                for (V2 rightValue : rightValuesIterable) {
+                                                    c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
+                                                }
+                                            }
+                                        }
+                                    }))
+                    .setCoder(
+                            KvCoder.of(
+                                    ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
+                                    KvCoder.of(
+                                            ((KvCoder) leftCollection.getCoder()).getValueCoder(),
+                                            ((KvCoder) rightCollection.getCoder()).getValueCoder())));
+        }
 
-                    Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
-                    Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
+    }
 
-                    for (V1 leftValue : leftValuesIterable) {
-                      if (rightValuesIterable.iterator().hasNext()) {
-                        for (V2 rightValue : rightValuesIterable) {
-                          c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
-                        }
-                      } else {
-                        c.output(KV.of(e.getKey(), KV.of(leftValue, nullValue)));
-                      }
-                    }
-                  }
-                }))
-        .setCoder(
-            KvCoder.of(
-                ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
-                KvCoder.of(
-                    ((KvCoder) leftCollection.getCoder()).getValueCoder(),
-                    ((KvCoder) rightCollection.getCoder()).getValueCoder())));
-  }
+    /**
+     * PTransform representing a left outer join of two collections of KV elements.
+     *
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     */
+    public static class LeftOuterJoin<K, V1, V2> extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
 
-  /**
-   * Right Outer Join of two collections of KV elements.
-   *
-   * @param leftCollection Left side collection to join.
-   * @param rightCollection Right side collection to join.
-   * @param nullValue Value to use as null value when left side do not match right side.
-   * @param <K> Type of the key for both collections
-   * @param <V1> Type of the values for the left collection.
-   * @param <V2> Type of the values for the right collection.
-   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-   *     V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
-   */
-  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> rightOuterJoin(
-      final PCollection<KV<K, V1>> leftCollection,
-      final PCollection<KV<K, V2>> rightCollection,
-      final V1 nullValue) {
-    checkNotNull(leftCollection);
-    checkNotNull(rightCollection);
-    checkNotNull(nullValue);
+        private transient PCollection<KV<K, V2>> rightCollection;
+        private V2 nullValue;
 
-    final TupleTag<V1> v1Tuple = new TupleTag<>();
-    final TupleTag<V2> v2Tuple = new TupleTag<>();
+        private LeftOuterJoin(PCollection<KV<K, V2>> rightCollection, V2 nullValue) {
+            this.rightCollection = rightCollection;
+            this.nullValue = nullValue;
+        }
 
-    PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
-        KeyedPCollectionTuple.of(v1Tuple, leftCollection)
-            .and(v2Tuple, rightCollection)
-            .apply("CoGBK", CoGroupByKey.create());
+        public static <K, V1, V2> LeftOuterJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection, V2 nullValue) {
+            return new LeftOuterJoin<>(rightCollection, nullValue);
+        }
 
-    return coGbkResultCollection
-        .apply(
-            "Join",
-            ParDo.of(
-                new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext c) {
-                    KV<K, CoGbkResult> e = c.element();
+        @Override
+        public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
+            checkNotNull(leftCollection);
+            checkNotNull(rightCollection);
+            checkNotNull(nullValue);
+            final TupleTag<V1> v1Tuple = new TupleTag<>();
+            final TupleTag<V2> v2Tuple = new TupleTag<>();
 
-                    Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
-                    Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
+            PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
+                    KeyedPCollectionTuple.of(v1Tuple, leftCollection)
+                                         .and(v2Tuple, rightCollection)
+                                         .apply("CoGBK", CoGroupByKey.create());
 
-                    for (V2 rightValue : rightValuesIterable) {
-                      if (leftValuesIterable.iterator().hasNext()) {
-                        for (V1 leftValue : leftValuesIterable) {
-                          c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
-                        }
-                      } else {
-                        c.output(KV.of(e.getKey(), KV.of(nullValue, rightValue)));
-                      }
-                    }
-                  }
-                }))
-        .setCoder(
-            KvCoder.of(
-                ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
-                KvCoder.of(
-                    ((KvCoder) leftCollection.getCoder()).getValueCoder(),
-                    ((KvCoder) rightCollection.getCoder()).getValueCoder())));
-  }
+            return coGbkResultCollection
+                    .apply(
+                            "Join",
+                            ParDo.of(
+                                    new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
+                                        @ProcessElement
+                                        public void processElement(ProcessContext c) {
+                                            KV<K, CoGbkResult> e = c.element();
 
-  /**
-   * Full Outer Join of two collections of KV elements.
-   *
-   * @param leftCollection Left side collection to join.
-   * @param rightCollection Right side collection to join.
-   * @param leftNullValue Value to use as null value when left side do not match right side.
-   * @param rightNullValue Value to use as null value when right side do not match right side.
-   * @param <K> Type of the key for both collections
-   * @param <V1> Type of the values for the left collection.
-   * @param <V2> Type of the values for the right collection.
-   * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
-   *     V1 and Value is type V2. Values that should be null or empty is replaced with
-   *     leftNullValue/rightNullValue.
-   */
-  public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> fullOuterJoin(
-      final PCollection<KV<K, V1>> leftCollection,
-      final PCollection<KV<K, V2>> rightCollection,
-      final V1 leftNullValue,
-      final V2 rightNullValue) {
-    checkNotNull(leftCollection);
-    checkNotNull(rightCollection);
-    checkNotNull(leftNullValue);
-    checkNotNull(rightNullValue);
+                                            Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
+                                            Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
 
-    final TupleTag<V1> v1Tuple = new TupleTag<>();
-    final TupleTag<V2> v2Tuple = new TupleTag<>();
+                                            for (V1 leftValue : leftValuesIterable) {
+                                                if (rightValuesIterable.iterator().hasNext()) {
+                                                    for (V2 rightValue : rightValuesIterable) {
+                                                        c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
+                                                    }
+                                                } else {
+                                                    c.output(KV.of(e.getKey(), KV.of(leftValue, nullValue)));
+                                                }
+                                            }
+                                        }
+                                    }))
+                    .setCoder(
+                            KvCoder.of(
+                                    ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
+                                    KvCoder.of(
+                                            ((KvCoder) leftCollection.getCoder()).getValueCoder(),
+                                            ((KvCoder) rightCollection.getCoder()).getValueCoder())));
+        }
 
-    PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
-        KeyedPCollectionTuple.of(v1Tuple, leftCollection)
-            .and(v2Tuple, rightCollection)
-            .apply("CoGBK", CoGroupByKey.create());
+    }
 
-    return coGbkResultCollection
-        .apply(
-            "Join",
-            ParDo.of(
-                new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext c) {
-                    KV<K, CoGbkResult> e = c.element();
+    /**
+     * PTransform representing a right outer join of two collections of KV elements.
+     *
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     */
+    public static class RightOuterJoin<K, V1, V2> extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
 
-                    Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
-                    Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
-                    if (leftValuesIterable.iterator().hasNext()
-                        && rightValuesIterable.iterator().hasNext()) {
-                      for (V2 rightValue : rightValuesIterable) {
-                        for (V1 leftValue : leftValuesIterable) {
-                          c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
-                        }
-                      }
-                    } else if (leftValuesIterable.iterator().hasNext()
-                        && !rightValuesIterable.iterator().hasNext()) {
-                      for (V1 leftValue : leftValuesIterable) {
-                        c.output(KV.of(e.getKey(), KV.of(leftValue, rightNullValue)));
-                      }
-                    } else if (!leftValuesIterable.iterator().hasNext()
-                        && rightValuesIterable.iterator().hasNext()) {
-                      for (V2 rightValue : rightValuesIterable) {
-                        c.output(KV.of(e.getKey(), KV.of(leftNullValue, rightValue)));
-                      }
-                    }
-                  }
-                }))
-        .setCoder(
-            KvCoder.of(
-                ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
-                KvCoder.of(
-                    ((KvCoder) leftCollection.getCoder()).getValueCoder(),
-                    ((KvCoder) rightCollection.getCoder()).getValueCoder())));
-  }
+        private transient PCollection<KV<K, V2>> rightCollection;
+        private V1 nullValue;
+
+        private RightOuterJoin(PCollection<KV<K, V2>> rightCollection, V1 nullValue) {
+            this.rightCollection = rightCollection;
+            this.nullValue = nullValue;
+        }
+
+        public static <K, V1, V2> RightOuterJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection, V1 nullValue) {
+            return new RightOuterJoin<>(rightCollection, nullValue);
+        }
+
+        @Override
+        public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
+            checkNotNull(leftCollection);
+            checkNotNull(rightCollection);
+            checkNotNull(nullValue);
+
+            final TupleTag<V1> v1Tuple = new TupleTag<>();
+            final TupleTag<V2> v2Tuple = new TupleTag<>();
+
+            PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
+                    KeyedPCollectionTuple.of(v1Tuple, leftCollection)
+                                         .and(v2Tuple, rightCollection)
+                                         .apply("CoGBK", CoGroupByKey.create());
+
+            return coGbkResultCollection
+                    .apply(
+                            "Join",
+                            ParDo.of(
+                                    new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
+                                        @ProcessElement
+                                        public void processElement(ProcessContext c) {
+                                            KV<K, CoGbkResult> e = c.element();
+
+                                            Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
+                                            Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
+
+                                            for (V2 rightValue : rightValuesIterable) {
+                                                if (leftValuesIterable.iterator().hasNext()) {
+                                                    for (V1 leftValue : leftValuesIterable) {
+                                                        c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
+                                                    }
+                                                } else {
+                                                    c.output(KV.of(e.getKey(), KV.of(nullValue, rightValue)));
+                                                }
+                                            }
+                                        }
+                                    }))
+                    .setCoder(
+                            KvCoder.of(
+                                    ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
+                                    KvCoder.of(
+                                            ((KvCoder) leftCollection.getCoder()).getValueCoder(),
+                                            ((KvCoder) rightCollection.getCoder()).getValueCoder())));
+        }
+
+    }
+
+    /**
+     * PTransform representing a full outer join of two collections of KV elements.
+     *
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     */
+    public static class FullOuterJoin<K, V1, V2> extends PTransform<PCollection<KV<K, V1>>, PCollection<KV<K, KV<V1, V2>>>> {
+
+        private transient PCollection<KV<K, V2>> rightCollection;
+        private V1 leftNullValue;
+        private V2 rightNullValue;
+
+        private FullOuterJoin(PCollection<KV<K, V2>> rightCollection, V1 leftNullValue, V2 rightNullValue) {
+            this.rightCollection = rightCollection;
+            this.leftNullValue = leftNullValue;
+            this.rightNullValue = rightNullValue;
+        }
+
+        public static <K, V1, V2> FullOuterJoin<K, V1, V2> with(PCollection<KV<K, V2>> rightCollection, V1 leftNullValue, V2 rightNullValue) {
+            return new FullOuterJoin<>(rightCollection, leftNullValue, rightNullValue);
+        }
+
+        @Override
+        public PCollection<KV<K, KV<V1, V2>>> expand(PCollection<KV<K, V1>> leftCollection) {
+            checkNotNull(leftCollection);
+            checkNotNull(rightCollection);
+            checkNotNull(leftNullValue);
+            checkNotNull(rightNullValue);
+
+
+            final TupleTag<V1> v1Tuple = new TupleTag<>();
+            final TupleTag<V2> v2Tuple = new TupleTag<>();
+
+            PCollection<KV<K, CoGbkResult>> coGbkResultCollection =
+                    KeyedPCollectionTuple.of(v1Tuple, leftCollection)
+                                         .and(v2Tuple, rightCollection)
+                                         .apply("CoGBK", CoGroupByKey.create());
+
+            return coGbkResultCollection
+                    .apply(
+                            "Join",
+                            ParDo.of(
+                                    new DoFn<KV<K, CoGbkResult>, KV<K, KV<V1, V2>>>() {
+                                        @ProcessElement
+                                        public void processElement(ProcessContext c) {
+                                            KV<K, CoGbkResult> e = c.element();
+
+                                            Iterable<V1> leftValuesIterable = e.getValue().getAll(v1Tuple);
+                                            Iterable<V2> rightValuesIterable = e.getValue().getAll(v2Tuple);
+                                            if (leftValuesIterable.iterator().hasNext()
+                                                    && rightValuesIterable.iterator().hasNext()) {
+                                                for (V2 rightValue : rightValuesIterable) {
+                                                    for (V1 leftValue : leftValuesIterable) {
+                                                        c.output(KV.of(e.getKey(), KV.of(leftValue, rightValue)));
+                                                    }
+                                                }
+                                            } else if (leftValuesIterable.iterator().hasNext()
+                                                    && !rightValuesIterable.iterator().hasNext()) {
+                                                for (V1 leftValue : leftValuesIterable) {
+                                                    c.output(KV.of(e.getKey(), KV.of(leftValue, rightNullValue)));
+                                                }
+                                            } else if (!leftValuesIterable.iterator().hasNext()
+                                                    && rightValuesIterable.iterator().hasNext()) {
+                                                for (V2 rightValue : rightValuesIterable) {
+                                                    c.output(KV.of(e.getKey(), KV.of(leftNullValue, rightValue)));
+                                                }
+                                            }
+                                        }
+                                    }))
+                    .setCoder(
+                            KvCoder.of(
+                                    ((KvCoder) leftCollection.getCoder()).getKeyCoder(),
+                                    KvCoder.of(
+                                            ((KvCoder) leftCollection.getCoder()).getValueCoder(),
+                                            ((KvCoder) rightCollection.getCoder()).getValueCoder())));
+        }
+
+    }
+
+
+    /**
+     * Inner join of two collections of KV elements.
+     *
+     * @param leftCollection  Left side collection to join.
+     * @param rightCollection Right side collection to join.
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+     * V1 and Value is type V2.
+     */
+    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> innerJoin(
+            final PCollection<KV<K, V1>> leftCollection, final PCollection<KV<K, V2>> rightCollection) {
+        return innerJoin("InnerJoin", leftCollection, rightCollection);
+    }
+
+    /**
+     * Inner join of two collections of KV elements.
+     *
+     * @param name            Name of the PTransform.
+     * @param leftCollection  Left side collection to join.
+     * @param rightCollection Right side collection to join.
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+     * V1 and Value is type V2.
+     */
+    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> innerJoin(
+            final String name,
+            final PCollection<KV<K, V1>> leftCollection, final PCollection<KV<K, V2>> rightCollection) {
+        return leftCollection.apply(name, InnerJoin.with(rightCollection));
+    }
+
+
+    /**
+     * Left Outer Join of two collections of KV elements.
+     *
+     * @param name            Name of the PTransform.
+     * @param leftCollection  Left side collection to join.
+     * @param rightCollection Right side collection to join.
+     * @param nullValue       Value to use as null value when right side do not match left side.
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+     * V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
+     */
+    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> leftOuterJoin(
+            final String name,
+            final PCollection<KV<K, V1>> leftCollection,
+            final PCollection<KV<K, V2>> rightCollection,
+            final V2 nullValue) {
+        return leftCollection.apply(name, LeftOuterJoin.with(rightCollection, nullValue));
+    }
+
+    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> leftOuterJoin(
+            final PCollection<KV<K, V1>> leftCollection,
+            final PCollection<KV<K, V2>> rightCollection,
+            final V2 nullValue) {
+        return leftOuterJoin("LeftOuterJoin", leftCollection, rightCollection, nullValue);
+    }
+
+    /**
+     * Right Outer Join of two collections of KV elements.
+     *
+     * @param name            Name of the PTransform.
+     * @param leftCollection  Left side collection to join.
+     * @param rightCollection Right side collection to join.
+     * @param nullValue       Value to use as null value when left side do not match right side.
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+     * V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
+     */
+    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> rightOuterJoin(
+            final String name,
+            final PCollection<KV<K, V1>> leftCollection,
+            final PCollection<KV<K, V2>> rightCollection,
+            final V1 nullValue) {
+        return leftCollection.apply(name, RightOuterJoin.with(rightCollection, nullValue));
+
+    }
+
+    /**
+     * Right Outer Join of two collections of KV elements.
+     *
+     * @param leftCollection  Left side collection to join.
+     * @param rightCollection Right side collection to join.
+     * @param nullValue       Value to use as null value when left side do not match right side.
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+     * V1 and Value is type V2. Values that should be null or empty is replaced with nullValue.
+     */
+    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> rightOuterJoin(
+            final PCollection<KV<K, V1>> leftCollection,
+            final PCollection<KV<K, V2>> rightCollection,
+            final V1 nullValue) {
+        return rightOuterJoin("RightOuterJoin", leftCollection, rightCollection, nullValue);
+
+    }
+
+    /**
+     * Full Outer Join of two collections of KV elements.
+     *
+     * @param name            Name of the PTransform.
+     * @param leftCollection  Left side collection to join.
+     * @param rightCollection Right side collection to join.
+     * @param leftNullValue   Value to use as null value when left side do not match right side.
+     * @param rightNullValue  Value to use as null value when right side do not match right side.
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+     * V1 and Value is type V2. Values that should be null or empty is replaced with
+     * leftNullValue/rightNullValue.
+     */
+    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> fullOuterJoin(
+            final String name,
+            final PCollection<KV<K, V1>> leftCollection,
+            final PCollection<KV<K, V2>> rightCollection,
+            final V1 leftNullValue,
+            final V2 rightNullValue) {
+        return leftCollection.apply(name, FullOuterJoin.with(rightCollection, leftNullValue, rightNullValue));
+
+    }
+
+    /**
+     * Full Outer Join of two collections of KV elements.
+     *
+     * @param leftCollection  Left side collection to join.
+     * @param rightCollection Right side collection to join.
+     * @param leftNullValue   Value to use as null value when left side do not match right side.
+     * @param rightNullValue  Value to use as null value when right side do not match right side.
+     * @param <K>             Type of the key for both collections
+     * @param <V1>            Type of the values for the left collection.
+     * @param <V2>            Type of the values for the right collection.
+     * @return A joined collection of KV where Key is the key and value is a KV where Key is of type
+     * V1 and Value is type V2. Values that should be null or empty is replaced with
+     * leftNullValue/rightNullValue.
+     */
+    public static <K, V1, V2> PCollection<KV<K, KV<V1, V2>>> fullOuterJoin(
+            final PCollection<KV<K, V1>> leftCollection,
+            final PCollection<KV<K, V2>> rightCollection,
+            final V1 leftNullValue,
+            final V2 rightNullValue) {
+        return fullOuterJoin("FullOuterJoin", leftCollection, rightCollection, leftNullValue, rightNullValue);
+
+    }
 }

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/InnerJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/InnerJoinTest.java
@@ -76,7 +76,8 @@ public class InnerJoinTest {
 
     rightListOfKv.add(KV.of("Key2", "bar"));
     rightListOfKv.add(KV.of("Key2", "gazonk"));
-    PCollection<KV<String, String>> rightCollection = p.apply("CreateRight", Create.of(rightListOfKv));
+    PCollection<KV<String, String>> rightCollection =
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.innerJoin(leftCollection, rightCollection);
@@ -95,7 +96,8 @@ public class InnerJoinTest {
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
     rightListOfKv.add(KV.of("Key2", "bar"));
-    PCollection<KV<String, String>> rightCollection = p.apply("CreateRight", Create.of(rightListOfKv));
+    PCollection<KV<String, String>> rightCollection =
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.innerJoin(leftCollection, rightCollection);
@@ -114,7 +116,7 @@ public class InnerJoinTest {
 
     rightListOfKv.add(KV.of("Key3", "bar"));
     PCollection<KV<String, String>> rightCollection =
-            p.apply("CreateRight", Create.of(rightListOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.innerJoin(leftCollection, rightCollection);
@@ -130,12 +132,14 @@ public class InnerJoinTest {
 
     rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-            p.apply("CreateRight", Create.of(rightListOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
 
-    PCollection<KV<String, KV<Long, String>>> output1 = Join.innerJoin("Join1", leftCollection, rightCollection);
-    PCollection<KV<String, KV<Long, String>>> output2 = Join.innerJoin("Join2", leftCollection, rightCollection);
+    PCollection<KV<String, KV<Long, String>>> output1 =
+        Join.innerJoin("Join1", leftCollection, rightCollection);
+    PCollection<KV<String, KV<Long, String>>> output2 =
+        Join.innerJoin("Join2", leftCollection, rightCollection);
     PAssert.that(output1).containsInAnyOrder(expectedResult);
     PAssert.that(output2).containsInAnyOrder(expectedResult);
 

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/InnerJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/InnerJoinTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 /** This test Inner Join functionality. */
 public class InnerJoinTest {
   private List<KV<String, Long>> leftListOfKv;
-  private List<KV<String, String>> listRightOfKv;
+  private List<KV<String, String>> rightListOfKv;
   private List<KV<String, KV<Long, String>>> expectedResult;
 
   @Rule public final transient TestPipeline p = TestPipeline.create();
@@ -43,7 +43,7 @@ public class InnerJoinTest {
   public void setup() {
 
     leftListOfKv = new ArrayList<>();
-    listRightOfKv = new ArrayList<>();
+    rightListOfKv = new ArrayList<>();
 
     expectedResult = new ArrayList<>();
   }
@@ -54,10 +54,10 @@ public class InnerJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key1", "foo"));
-    listRightOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key1", "foo"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.innerJoin(leftCollection, rightCollection);
@@ -74,10 +74,9 @@ public class InnerJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key2", "bar"));
-    listRightOfKv.add(KV.of("Key2", "gazonk"));
-    PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key2", "gazonk"));
+    PCollection<KV<String, String>> rightCollection = p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.innerJoin(leftCollection, rightCollection);
@@ -95,9 +94,8 @@ public class InnerJoinTest {
     leftListOfKv.add(KV.of("Key2", 6L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key2", "bar"));
-    PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    PCollection<KV<String, String>> rightCollection = p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.innerJoin(leftCollection, rightCollection);
@@ -114,14 +112,35 @@ public class InnerJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key3", "bar"));
+    rightListOfKv.add(KV.of("Key3", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+            p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.innerJoin(leftCollection, rightCollection);
 
     PAssert.that(output).containsInAnyOrder(expectedResult);
+    p.run();
+  }
+
+  @Test
+  public void testMultipleJoinsInSamePipeline() {
+    leftListOfKv.add(KV.of("Key2", 4L));
+    PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
+
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    PCollection<KV<String, String>> rightCollection =
+            p.apply("CreateRight", Create.of(rightListOfKv));
+
+    expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
+
+    PCollection<KV<String, KV<Long, String>>> output1 =
+            Join.innerJoin("Join1", leftCollection, rightCollection);
+    PCollection<KV<String, KV<Long, String>>> output2 =
+            Join.innerJoin("Join2", leftCollection, rightCollection);
+    PAssert.that(output1).containsInAnyOrder(expectedResult);
+    PAssert.that(output2).containsInAnyOrder(expectedResult);
+
     p.run();
   }
 
@@ -131,7 +150,7 @@ public class InnerJoinTest {
     Join.innerJoin(
         null,
         p.apply(
-            Create.of(listRightOfKv)
+            Create.of(rightListOfKv)
                 .withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))));
   }
 

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/InnerJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/InnerJoinTest.java
@@ -134,10 +134,8 @@ public class InnerJoinTest {
 
     expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
 
-    PCollection<KV<String, KV<Long, String>>> output1 =
-            Join.innerJoin("Join1", leftCollection, rightCollection);
-    PCollection<KV<String, KV<Long, String>>> output2 =
-            Join.innerJoin("Join2", leftCollection, rightCollection);
+    PCollection<KV<String, KV<Long, String>>> output1 = Join.innerJoin("Join1", leftCollection, rightCollection);
+    PCollection<KV<String, KV<Long, String>>> output2 = Join.innerJoin("Join2", leftCollection, rightCollection);
     PAssert.that(output1).containsInAnyOrder(expectedResult);
     PAssert.that(output2).containsInAnyOrder(expectedResult);
 

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterFullJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterFullJoinTest.java
@@ -139,9 +139,9 @@ public class OuterFullJoinTest {
     expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
 
     PCollection<KV<String, KV<Long, String>>> output1 =
-            Join.fullOuterJoin("Join1", leftCollection, rightCollection,-1L, "");
+        Join.fullOuterJoin("Join1", leftCollection, rightCollection,-1L, "");
     PCollection<KV<String, KV<Long, String>>> output2 =
-            Join.fullOuterJoin("Join2", leftCollection, rightCollection, -1L, "");
+        Join.fullOuterJoin("Join2", leftCollection, rightCollection, -1L, "");
     PAssert.that(output1).containsInAnyOrder(expectedResult);
     PAssert.that(output2).containsInAnyOrder(expectedResult);
 

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterFullJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterFullJoinTest.java
@@ -134,12 +134,12 @@ public class OuterFullJoinTest {
 
     rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-            p.apply("CreateRight", Create.of(rightListOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
 
     PCollection<KV<String, KV<Long, String>>> output1 =
-        Join.fullOuterJoin("Join1", leftCollection, rightCollection,-1L, "");
+        Join.fullOuterJoin("Join1", leftCollection, rightCollection, -1L, "");
     PCollection<KV<String, KV<Long, String>>> output2 =
         Join.fullOuterJoin("Join2", leftCollection, rightCollection, -1L, "");
     PAssert.that(output1).containsInAnyOrder(expectedResult);

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterFullJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterFullJoinTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 /** This test Outer Full Join functionality. */
 public class OuterFullJoinTest {
   private List<KV<String, Long>> leftListOfKv;
-  private List<KV<String, String>> listRightOfKv;
+  private List<KV<String, String>> rightListOfKv;
   private List<KV<String, KV<Long, String>>> expectedResult;
 
   @Rule public final transient TestPipeline p = TestPipeline.create();
@@ -43,7 +43,7 @@ public class OuterFullJoinTest {
   public void setup() {
 
     leftListOfKv = new ArrayList<>();
-    listRightOfKv = new ArrayList<>();
+    rightListOfKv = new ArrayList<>();
 
     expectedResult = new ArrayList<>();
   }
@@ -54,10 +54,10 @@ public class OuterFullJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key1", "foo"));
-    listRightOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key1", "foo"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.fullOuterJoin(leftCollection, rightCollection, -1L, "");
@@ -74,10 +74,10 @@ public class OuterFullJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key2", "bar"));
-    listRightOfKv.add(KV.of("Key2", "gazonk"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key2", "gazonk"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.fullOuterJoin(leftCollection, rightCollection, -1L, "");
@@ -95,9 +95,9 @@ public class OuterFullJoinTest {
     leftListOfKv.add(KV.of("Key2", 6L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.fullOuterJoin(leftCollection, rightCollection, -1L, "");
@@ -114,9 +114,9 @@ public class OuterFullJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key3", "bar"));
+    rightListOfKv.add(KV.of("Key3", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.fullOuterJoin(leftCollection, rightCollection, -1L, "");
@@ -127,13 +127,34 @@ public class OuterFullJoinTest {
     p.run();
   }
 
+  @Test
+  public void testMultipleJoinsInSamePipeline() {
+    leftListOfKv.add(KV.of("Key2", 4L));
+    PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
+
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    PCollection<KV<String, String>> rightCollection =
+            p.apply("CreateRight", Create.of(rightListOfKv));
+
+    expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
+
+    PCollection<KV<String, KV<Long, String>>> output1 =
+            Join.fullOuterJoin("Join1", leftCollection, rightCollection,-1L, "");
+    PCollection<KV<String, KV<Long, String>>> output2 =
+            Join.fullOuterJoin("Join2", leftCollection, rightCollection, -1L, "");
+    PAssert.that(output1).containsInAnyOrder(expectedResult);
+    PAssert.that(output2).containsInAnyOrder(expectedResult);
+
+    p.run();
+  }
+
   @Test(expected = NullPointerException.class)
   public void testJoinLeftCollectionNull() {
     p.enableAbandonedNodeEnforcement(false);
     Join.fullOuterJoin(
         null,
         p.apply(
-            Create.of(listRightOfKv)
+            Create.of(rightListOfKv)
                 .withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))),
         "",
         "");

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterLeftJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterLeftJoinTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 /** This test Outer Left Join functionality. */
 public class OuterLeftJoinTest {
   private List<KV<String, Long>> leftListOfKv;
-  private List<KV<String, String>> listRightOfKv;
+  private List<KV<String, String>> rightListOfKv;
   private List<KV<String, KV<Long, String>>> expectedResult;
 
   @Rule public final transient TestPipeline p = TestPipeline.create();
@@ -43,7 +43,7 @@ public class OuterLeftJoinTest {
   public void setup() {
 
     leftListOfKv = new ArrayList<>();
-    listRightOfKv = new ArrayList<>();
+    rightListOfKv = new ArrayList<>();
 
     expectedResult = new ArrayList<>();
   }
@@ -54,10 +54,10 @@ public class OuterLeftJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key1", "foo"));
-    listRightOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key1", "foo"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.leftOuterJoin(leftCollection, rightCollection, "");
@@ -74,10 +74,10 @@ public class OuterLeftJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key2", "bar"));
-    listRightOfKv.add(KV.of("Key2", "gazonk"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key2", "gazonk"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.leftOuterJoin(leftCollection, rightCollection, "");
@@ -95,9 +95,9 @@ public class OuterLeftJoinTest {
     leftListOfKv.add(KV.of("Key2", 6L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.leftOuterJoin(leftCollection, rightCollection, "");
@@ -114,9 +114,9 @@ public class OuterLeftJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key3", "bar"));
+    rightListOfKv.add(KV.of("Key3", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.leftOuterJoin(leftCollection, rightCollection, "");
@@ -126,13 +126,34 @@ public class OuterLeftJoinTest {
     p.run();
   }
 
+  @Test
+  public void testMultipleJoinsInSamePipeline() {
+    leftListOfKv.add(KV.of("Key2", 4L));
+    PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
+
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    PCollection<KV<String, String>> rightCollection =
+            p.apply("CreateRight", Create.of(rightListOfKv));
+
+    expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
+
+    PCollection<KV<String, KV<Long, String>>> output1 =
+            Join.leftOuterJoin("Join1", leftCollection, rightCollection,"");
+    PCollection<KV<String, KV<Long, String>>> output2 =
+            Join.leftOuterJoin("Join2", leftCollection, rightCollection,"");
+    PAssert.that(output1).containsInAnyOrder(expectedResult);
+    PAssert.that(output2).containsInAnyOrder(expectedResult);
+
+    p.run();
+  }
+
   @Test(expected = NullPointerException.class)
   public void testJoinLeftCollectionNull() {
     p.enableAbandonedNodeEnforcement(false);
     Join.leftOuterJoin(
         null,
         p.apply(
-            Create.of(listRightOfKv)
+            Create.of(rightListOfKv)
                 .withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))),
         "");
   }

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterLeftJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterLeftJoinTest.java
@@ -137,10 +137,8 @@ public class OuterLeftJoinTest {
 
     expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
 
-    PCollection<KV<String, KV<Long, String>>> output1 =
-            Join.leftOuterJoin("Join1", leftCollection, rightCollection,"");
-    PCollection<KV<String, KV<Long, String>>> output2 =
-            Join.leftOuterJoin("Join2", leftCollection, rightCollection,"");
+    PCollection<KV<String, KV<Long, String>>> output1 = Join.leftOuterJoin("Join1", leftCollection, rightCollection,"");
+    PCollection<KV<String, KV<Long, String>>> output2 = Join.leftOuterJoin("Join2", leftCollection, rightCollection,"");
     PAssert.that(output1).containsInAnyOrder(expectedResult);
     PAssert.that(output2).containsInAnyOrder(expectedResult);
 

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterLeftJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterLeftJoinTest.java
@@ -133,12 +133,14 @@ public class OuterLeftJoinTest {
 
     rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-            p.apply("CreateRight", Create.of(rightListOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
 
-    PCollection<KV<String, KV<Long, String>>> output1 = Join.leftOuterJoin("Join1", leftCollection, rightCollection,"");
-    PCollection<KV<String, KV<Long, String>>> output2 = Join.leftOuterJoin("Join2", leftCollection, rightCollection,"");
+    PCollection<KV<String, KV<Long, String>>> output1 =
+        Join.leftOuterJoin("Join1", leftCollection, rightCollection, "");
+    PCollection<KV<String, KV<Long, String>>> output2 =
+        Join.leftOuterJoin("Join2", leftCollection, rightCollection, "");
     PAssert.that(output1).containsInAnyOrder(expectedResult);
     PAssert.that(output2).containsInAnyOrder(expectedResult);
 

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterRightJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterRightJoinTest.java
@@ -133,12 +133,15 @@ public class OuterRightJoinTest {
 
     rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-            p.apply("CreateRight", Create.of(rightListOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
 
-    PCollection<KV<String, KV<Long, String>>> output1 = Join.rightOuterJoin("Join1", leftCollection, rightCollection,-1L);
-    PCollection<KV<String, KV<Long, String>>> output2 = Join.rightOuterJoin("Join2", leftCollection, rightCollection,-1L);
+    PCollection<KV<String, KV<Long, String>>> output1 =
+        Join.rightOuterJoin("Join1", leftCollection, rightCollection, -1L);
+    PCollection<KV<String, KV<Long, String>>> output2 =
+        Join.rightOuterJoin("Join2", leftCollection, rightCollection, -1L);
+
     PAssert.that(output1).containsInAnyOrder(expectedResult);
     PAssert.that(output2).containsInAnyOrder(expectedResult);
 

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterRightJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterRightJoinTest.java
@@ -137,10 +137,8 @@ public class OuterRightJoinTest {
 
     expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
 
-    PCollection<KV<String, KV<Long, String>>> output1 =
-            Join.rightOuterJoin("Join1", leftCollection, rightCollection,-1L);
-    PCollection<KV<String, KV<Long, String>>> output2 =
-            Join.rightOuterJoin("Join2", leftCollection, rightCollection,-1L);
+    PCollection<KV<String, KV<Long, String>>> output1 = Join.rightOuterJoin("Join1", leftCollection, rightCollection,-1L);
+    PCollection<KV<String, KV<Long, String>>> output2 = Join.rightOuterJoin("Join2", leftCollection, rightCollection,-1L);
     PAssert.that(output1).containsInAnyOrder(expectedResult);
     PAssert.that(output2).containsInAnyOrder(expectedResult);
 

--- a/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterRightJoinTest.java
+++ b/sdks/java/extensions/join-library/src/test/java/org/apache/beam/sdk/extensions/joinlibrary/OuterRightJoinTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 /** This test Outer Right Join functionality. */
 public class OuterRightJoinTest {
   private List<KV<String, Long>> leftListOfKv;
-  private List<KV<String, String>> listRightOfKv;
+  private List<KV<String, String>> rightListOfKv;
   private List<KV<String, KV<Long, String>>> expectedResult;
 
   @Rule public final transient TestPipeline p = TestPipeline.create();
@@ -43,7 +43,7 @@ public class OuterRightJoinTest {
   public void setup() {
 
     leftListOfKv = new ArrayList<>();
-    listRightOfKv = new ArrayList<>();
+    rightListOfKv = new ArrayList<>();
 
     expectedResult = new ArrayList<>();
   }
@@ -54,10 +54,10 @@ public class OuterRightJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key1", "foo"));
-    listRightOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key1", "foo"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.rightOuterJoin(leftCollection, rightCollection, -1L);
@@ -74,10 +74,10 @@ public class OuterRightJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key2", "bar"));
-    listRightOfKv.add(KV.of("Key2", "gazonk"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key2", "gazonk"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.rightOuterJoin(leftCollection, rightCollection, -1L);
@@ -95,9 +95,9 @@ public class OuterRightJoinTest {
     leftListOfKv.add(KV.of("Key2", 6L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key2", "bar"));
+    rightListOfKv.add(KV.of("Key2", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.rightOuterJoin(leftCollection, rightCollection, -1L);
@@ -114,9 +114,9 @@ public class OuterRightJoinTest {
     leftListOfKv.add(KV.of("Key2", 4L));
     PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
 
-    listRightOfKv.add(KV.of("Key3", "bar"));
+    rightListOfKv.add(KV.of("Key3", "bar"));
     PCollection<KV<String, String>> rightCollection =
-        p.apply("CreateRight", Create.of(listRightOfKv));
+        p.apply("CreateRight", Create.of(rightListOfKv));
 
     PCollection<KV<String, KV<Long, String>>> output =
         Join.rightOuterJoin(leftCollection, rightCollection, -1L);
@@ -126,13 +126,34 @@ public class OuterRightJoinTest {
     p.run();
   }
 
+  @Test
+  public void testMultipleJoinsInSamePipeline() {
+    leftListOfKv.add(KV.of("Key2", 4L));
+    PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));
+
+    rightListOfKv.add(KV.of("Key2", "bar"));
+    PCollection<KV<String, String>> rightCollection =
+            p.apply("CreateRight", Create.of(rightListOfKv));
+
+    expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));
+
+    PCollection<KV<String, KV<Long, String>>> output1 =
+            Join.rightOuterJoin("Join1", leftCollection, rightCollection,-1L);
+    PCollection<KV<String, KV<Long, String>>> output2 =
+            Join.rightOuterJoin("Join2", leftCollection, rightCollection,-1L);
+    PAssert.that(output1).containsInAnyOrder(expectedResult);
+    PAssert.that(output2).containsInAnyOrder(expectedResult);
+
+    p.run();
+  }
+
   @Test(expected = NullPointerException.class)
   public void testJoinLeftCollectionNull() {
     p.enableAbandonedNodeEnforcement(false);
     Join.rightOuterJoin(
         null,
         p.apply(
-            Create.of(listRightOfKv)
+            Create.of(rightListOfKv)
                 .withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))),
         "");
   }


### PR DESCRIPTION
This change wraps the joins from the joinlibrary extension in individual PTransforms. I also provide overloaded methods which allow to name the corresponding nodes in the graph.

The background of this change is that currently it is not possible to have multiple joins in the same pipeline without wrapping them in individual PTransforms as this would generate name clashes.

Consider the following test case:

```
 @Test
  public void testMultipleJoinsInSamePipeline() {
    leftListOfKv.add(KV.of("Key2", 4L));
    PCollection<KV<String, Long>> leftCollection = p.apply("CreateLeft", Create.of(leftListOfKv));

    rightListOfKv.add(KV.of("Key2", "bar"));
    PCollection<KV<String, String>> rightCollection =
            p.apply("CreateRight", Create.of(rightListOfKv));

    expectedResult.add(KV.of("Key2", KV.of(4L, "bar")));

    PCollection<KV<String, KV<Long, String>>> output1 =
            Join.innerJoin(leftCollection, rightCollection);
    PCollection<KV<String, KV<Long, String>>> output2 =
            Join.innerJoin(leftCollection, rightCollection);
    PAssert.that(output1).containsInAnyOrder(expectedResult);
    PAssert.that(output2).containsInAnyOrder(expectedResult);

    p.run();
  }
```

With the change contained in this PR, the same code would still fail but there is now an overloaded call to `Join.innerJoin` so that the corresponding nodes in the execution graph receive different names (see test case below).

The change is backwards compatible. Two other side benefits are:

 * The naming of the transformation is slightly more intuitive in case you want to debug / look at the execution graph it's now easier  to see which steps correspond to the join.
 * It also allows using the `PTransform` directly writing something like `myCollection1.apply(InnerJoin.with(myCollection2))` which some people might find more intuitive.

 * [x]  [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 * [x]  Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 * [ ]  If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

