### PR TITLE
[BEAM-6652] Restrict map usage.

### DIFF
--- a/sdks/go/pkg/beam/core/typex/class.go
+++ b/sdks/go/pkg/beam/core/typex/class.go
@@ -122,8 +122,16 @@ func isConcrete(t reflect.Type, visited map[uintptr]bool) bool {
 		return false // no unserializable types
 
 	case reflect.Map:
-		return isConcrete(t.Elem(), visited) && isConcrete(t.Key(), visited)
-
+		// TODO(BEAM-6652): 2019.02.11
+		// Maps have random default iteration order, and the "default coder"
+		// doesn't ensure a specific encoding order for key/value pairs in maps.
+		// To ensure correctness we're better off restricting map usage from
+		// casual users, until the default coder handles the random iteration
+		// order properly.
+		// Power users can continue to handle map coding themselves, though
+		// it remains their responsibility to encode them consistently.
+		// return isConcrete(t.Elem(), visited) && isConcrete(t.Key(), visited)
+		return false
 	case reflect.Array, reflect.Slice, reflect.Ptr:
 		return isConcrete(t.Elem(), visited)
 

--- a/sdks/go/pkg/beam/core/typex/class_test.go
+++ b/sdks/go/pkg/beam/core/typex/class_test.go
@@ -51,7 +51,7 @@ func TestClassOf(t *testing.T) {
 		}{}), Concrete},
 		{reflect.TypeOf(struct{ A []int }{}), Concrete},
 		{reflect.TypeOf(reflect.Value{}), Concrete}, // ok: private fields
-		{reflect.TypeOf(map[string]int{}), Concrete},
+		{reflect.TypeOf(map[string]int{}), Invalid},
 		{reflect.TypeOf(map[string]func(){}), Invalid},
 		{reflect.TypeOf(map[error]int{}), Invalid},
 		{reflect.TypeOf([4]int{}), Concrete},
@@ -73,8 +73,8 @@ func TestClassOf(t *testing.T) {
 		// Recursive types.
 		{reflect.TypeOf(RecursivePtrTest{}), Concrete},
 		{reflect.TypeOf(RecursiveSliceTest{}), Concrete},
-		{reflect.TypeOf(RecursiveMapTest{}), Concrete},
 		{reflect.TypeOf(RecursivePtrArrayTest{}), Concrete},
+		{reflect.TypeOf(RecursiveMapTest{}), Invalid},
 		{reflect.TypeOf(RecursiveBadTest{}), Invalid},
 
 		{reflect.TypeOf([]X{}), Container},


### PR DESCRIPTION
Maps make terrible keys, since they aren't currently guaranteed to be coded in the same order for the same set of values by the default encoder. Until the default coder handles maps consistently (that is, maps with the same key,value pair are hashed equivalently for lifting and shuffling), their use should be restricted to ensure beam computes correctly.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

