### PR TITLE
Improve visibility of large key commits in StreamingDataflowWorker

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowSystemMetrics.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowSystemMetrics.java
@@ -35,6 +35,7 @@ public class DataflowSystemMetrics {
     WINDMILL_SHUFFLE_BYTES_READ("WindmillShuffleBytesRead"),
     WINDMILL_STATE_BYTES_READ("WindmillStateBytesRead"),
     WINDMILL_STATE_BYTES_WRITTEN("WindmillStateBytesWritten"),
+    WINDMILL_MAX_WORK_ITEM_COMMIT_BYTES("WindmillMaxWorkItemCommitBytes"),
     JAVA_HARNESS_USED_MEMORY("dataflow_java_harness_used_memory"),
     JAVA_HARNESS_MAX_MEMORY("dataflow_java_harness_max_memory"),
     JAVA_HARNESS_RESTARTS("dataflow_java_harness_restarts"),

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -109,6 +109,7 @@ import org.apache.beam.runners.dataflow.worker.util.MemoryMonitor;
 import org.apache.beam.runners.dataflow.worker.util.common.worker.OutputObjectAndByteCounter;
 import org.apache.beam.runners.dataflow.worker.util.common.worker.ReadOperation;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItemCommitRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServerStub;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServerStub.CommitWorkStream;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServerStub.GetWorkStream;
@@ -174,7 +175,7 @@ public class StreamingDataflowWorker {
   // retrieving extra work from Windmill without working on it, leading to better
   // prioritization / utilization.
   static final int MAX_WORK_UNITS_QUEUED = 100;
-  static final long MAX_COMMIT_BYTES = 32 << 20;
+  static final long TARGET_COMMIT_BUNDLE_BYTES = 32 << 20;
   static final int MAX_COMMIT_QUEUE_BYTES = 500 << 20; // 500MB
   static final int NUM_COMMIT_STREAMS = 1;
   static final Duration COMMIT_STREAM_TIMEOUT = Duration.standardMinutes(1);
@@ -203,6 +204,35 @@ public class StreamingDataflowWorker {
       t = t.getCause();
     }
     return false;
+  }
+
+  private static class KeyCommitTooLargeException extends Exception {
+    public static KeyCommitTooLargeException causedBy(
+        String computationId, long byteLimit, WorkItemCommitRequest request) {
+      StringBuilder message = new StringBuilder();
+      message.append("Commit request for stage ");
+      message.append(computationId);
+      message.append(" and key ");
+      message.append(request.getKey().toStringUtf8());
+      if (request.getSerializedSize() > 0) {
+        message.append(
+            " has size "
+                + request.getSerializedSize()
+                + " which is more than the limit of "
+                + byteLimit);
+      } else {
+        message.append(" is larger than 2GB and cannot be processed");
+      }
+      message.append(
+          ". This may be caused by grouping a very "
+              + "large amount of data in a single window without using Combine,"
+              + " or by producing a large amount of data from a single input element.");
+      return new KeyCommitTooLargeException(message.toString());
+    }
+
+    private KeyCommitTooLargeException(String message) {
+      super(message);
+    }
   }
 
   private static MapTask parseMapTask(String input) throws IOException {
@@ -312,6 +342,7 @@ public class StreamingDataflowWorker {
     public Commit(
         Windmill.WorkItemCommitRequest request, ComputationState computationState, Work work) {
       this.request = request;
+      assert request.getSerializedSize() > 0;
       this.computationState = computationState;
       this.work = work;
     }
@@ -329,20 +360,7 @@ public class StreamingDataflowWorker {
     }
 
     public int getSize() {
-      int commitSize = request.getSerializedSize();
-      if (commitSize < 0) {
-        throw new IllegalStateException(
-            "Commit request for stage "
-                + computationState.getComputationId()
-                + " and key "
-                + request.getKey().toStringUtf8()
-                + " is larger than 2GB and cannot be processed."
-                + " This may be caused by grouping a very "
-                + "large amount of data in a single window without using Combine,"
-                + " or by producing a "
-                + "large amount of data from a single input element.");
-      }
-      return commitSize;
+      return request.getSerializedSize();
     }
   }
 
@@ -388,6 +406,7 @@ public class StreamingDataflowWorker {
   // Built-in cumulative counters.
   private final Counter<Long, Long> javaHarnessUsedMemory;
   private final Counter<Long, Long> javaHarnessMaxMemory;
+  private final Counter<Integer, Integer> windmillMaxObservedWorkItemCommitBytes;
   private Timer refreshActiveWorkTimer;
   private Timer statusPageTimer;
 
@@ -408,6 +427,8 @@ public class StreamingDataflowWorker {
 
   // Limit on bytes sinked (committed) in a work item.
   private final long maxSinkBytes; // = MAX_SINK_BYTES unless disabled in options.
+  // Possibly overridden by streaming engine config.
+  private int maxWorkItemCommitBytes = Integer.MAX_VALUE;
 
   private final EvictingQueue<String> pendingFailuresToReport =
       EvictingQueue.<String>create(MAX_FAILURES_TO_REPORT_IN_UPDATE);
@@ -559,6 +580,9 @@ public class StreamingDataflowWorker {
     this.javaHarnessMaxMemory =
         pendingCumulativeCounters.longSum(
             StreamingSystemCounterNames.JAVA_HARNESS_MAX_MEMORY.counterName());
+    this.windmillMaxObservedWorkItemCommitBytes =
+        pendingCumulativeCounters.intMax(
+            StreamingSystemCounterNames.WINDMILL_MAX_WORK_ITEM_COMMIT_BYTES.counterName());
     this.isDoneFuture = new CompletableFuture<>();
 
     this.threadFactory =
@@ -695,6 +719,11 @@ public class StreamingDataflowWorker {
   @VisibleForTesting
   public void setRetryLocallyDelayMs(int retryLocallyDelayMs) {
     this.retryLocallyDelayMs = retryLocallyDelayMs;
+  }
+
+  @VisibleForTesting
+  public void setMaxWorkItemCommitBytes(int maxWorkItemCommitBytes) {
+    this.maxWorkItemCommitBytes = maxWorkItemCommitBytes;
   }
 
   @VisibleForTesting
@@ -1247,7 +1276,25 @@ public class StreamingDataflowWorker {
 
       // Add the output to the commit queue.
       work.setState(State.COMMIT_QUEUED);
-      commitQueue.put(new Commit(outputBuilder.build(), computationState, work));
+
+      WorkItemCommitRequest commitRequest = outputBuilder.build();
+      int byteLimit = maxWorkItemCommitBytes;
+      int commitSize = commitRequest.getSerializedSize();
+      // Detect overflow of integer serialized size or if the byte limit was exceeded.
+      windmillMaxObservedWorkItemCommitBytes.addValue(
+          commitSize < 0 ? Integer.MAX_VALUE : commitSize);
+      if (commitSize < 0) {
+        throw KeyCommitTooLargeException.causedBy(computationId, byteLimit, commitRequest);
+      } else if (commitSize > byteLimit) {
+        // Once supported, we should communicate the desired truncation for the commit to the
+        // streaming engine. For now we report the error but attempt the commit so that it will be
+        // truncated by the streaming engine backend.
+        KeyCommitTooLargeException e =
+            KeyCommitTooLargeException.causedBy(computationId, byteLimit, commitRequest);
+        reportFailure(computationId, workItem, e);
+        LOG.error(e.toString());
+      }
+      commitQueue.put(new Commit(commitRequest, computationState, work));
 
       // Compute shuffle and state byte statistics these will be flushed asynchronously.
       long stateBytesWritten = outputBuilder.clearOutputMessages().build().getSerializedSize();
@@ -1278,25 +1325,23 @@ public class StreamingDataflowWorker {
 
       t = t instanceof UserCodeException ? t.getCause() : t;
 
+      boolean retryLocally = false;
       if (KeyTokenInvalidException.isKeyTokenInvalidException(t)) {
         LOG.debug(
             "Execution of work for {} for key {} failed due to token expiration. "
                 + "Will not retry locally.",
             computationId,
             key.toStringUtf8());
-        computationState.completeWork(key, workItem.getWorkToken());
       } else {
         LOG.error("Uncaught exception: ", t);
         LastExceptionDataProvider.reportException(t);
         LOG.debug("Failed work: {}", work);
-        boolean retryLocally;
         if (!reportFailure(computationId, workItem, t)) {
           LOG.error(
               "Execution of work for {} for key {} failed, and Windmill "
                   + "indicated not to retry locally.",
               computationId,
               key.toStringUtf8());
-          retryLocally = false;
         } else if (isOutOfMemoryError(t)) {
           File heapDump = memoryMonitor.tryToDumpHeap();
           LOG.error(
@@ -1305,7 +1350,6 @@ public class StreamingDataflowWorker {
               computationId,
               key.toStringUtf8(),
               heapDump == null ? "not written" : ("written to '" + heapDump + "'"));
-          retryLocally = false;
         } else {
           LOG.error(
               "Execution of work for {} for key {} failed. Will retry locally.",
@@ -1313,15 +1357,15 @@ public class StreamingDataflowWorker {
               key.toStringUtf8());
           retryLocally = true;
         }
-
-        if (retryLocally) {
-          // Try again after some delay and at the end of the queue to avoid a tight loop.
-          sleep(retryLocallyDelayMs);
-          workUnitExecutor.forceExecute(work);
-        } else {
-          // Consider the item invalid. It will eventually be retried by Windmill.
-          computationState.completeWork(key, workItem.getWorkToken());
-        }
+      }
+      if (retryLocally) {
+        // Try again after some delay and at the end of the queue to avoid a tight loop.
+        sleep(retryLocallyDelayMs);
+        workUnitExecutor.forceExecute(work);
+      } else {
+        // Consider the item invalid. It will eventually be retried by Windmill if it still needs
+        // to be processed.
+        computationState.completeWork(key, workItem.getWorkToken());
       }
     } finally {
       // Update total processing time counters. Updating in finally clause ensures that
@@ -1374,7 +1418,7 @@ public class StreamingDataflowWorker {
         // Send the request if we've exceeded the bytes or there is no more
         // pending work.  commitBytes is a long, so this cannot overflow.
         commitBytes += commit.getSize();
-        if (commitBytes >= MAX_COMMIT_BYTES) {
+        if (commitBytes >= TARGET_COMMIT_BUNDLE_BYTES) {
           break;
         }
         commit = commitQueue.poll();
@@ -1473,6 +1517,9 @@ public class StreamingDataflowWorker {
         Windmill.GetConfigRequest.newBuilder().addComputations(computation).build();
 
     Windmill.GetConfigResponse response = windmillServer.getConfig(request);
+    // The max work item commit bytes should be modified to be dynamic once it is available in
+    // the request.
+    setMaxWorkItemCommitBytes(180 << 20);
     for (Windmill.GetConfigResponse.SystemNameToComputationIdMapEntry entry :
         response.getSystemNameToComputationIdMapList()) {
       systemNameToComputationIdMap.put(entry.getSystemName(), entry.getComputationId());

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1554,7 +1554,7 @@ public class StreamingDataflowWorker {
     } else {
       workItem = workUnitClient.getGlobalStreamingConfigWorkItem();
     }
-    if (!workItem.isPresent() || workItem.get() == null) {
+    if (workItem == null || !workItem.isPresent() || workItem.get() == null) {
       return;
     }
     setMaxWorkItemCommitBytes(180 << 20);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1519,7 +1519,6 @@ public class StreamingDataflowWorker {
     Windmill.GetConfigResponse response = windmillServer.getConfig(request);
     // The max work item commit bytes should be modified to be dynamic once it is available in
     // the request.
-    setMaxWorkItemCommitBytes(180 << 20);
     for (Windmill.GetConfigResponse.SystemNameToComputationIdMapEntry entry :
         response.getSystemNameToComputationIdMapList()) {
       systemNameToComputationIdMap.put(entry.getSystemName(), entry.getComputationId());
@@ -1558,6 +1557,7 @@ public class StreamingDataflowWorker {
     if (!workItem.isPresent() || workItem.get() == null) {
       return;
     }
+    setMaxWorkItemCommitBytes(180 << 20);
     StreamingConfigTask config = workItem.get().getStreamingConfigTask();
     Preconditions.checkState(config != null);
     if (config.getUserStepToStateFamilyNameMap() != null) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -930,16 +930,16 @@ public class StreamingDataflowWorkerTest {
     KvCoder<String, String> kvCoder = KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
 
     List<ParallelInstruction> instructions =
-            Arrays.asList(
-                    makeSourceInstruction(kvCoder),
-                    makeDoFnInstruction(new LargeCommitFn(), 0, kvCoder),
-                    makeSinkInstruction(kvCoder, 1));
+        Arrays.asList(
+            makeSourceInstruction(kvCoder),
+            makeDoFnInstruction(new LargeCommitFn(), 0, kvCoder),
+            makeSinkInstruction(kvCoder, 1));
 
     FakeWindmillServer server = new FakeWindmillServer(errorCollector);
     server.setExpectedExceptionCount(1);
 
     StreamingDataflowWorker worker =
-            makeWorker(instructions, createTestingPipelineOptions(server), true /* publishCounters */);
+        makeWorker(instructions, createTestingPipelineOptions(server), true /* publishCounters */);
     worker.setMaxWorkItemCommitBytes(1000);
     worker.start();
 
@@ -964,7 +964,7 @@ public class StreamingDataflowWorkerTest {
 
     // We should see an exception reported for the large commit but not the small one.
     ArgumentCaptor<WorkItemStatus> workItemStatusCaptor =
-            ArgumentCaptor.forClass(WorkItemStatus.class);
+        ArgumentCaptor.forClass(WorkItemStatus.class);
     verify(mockWorkUnitClient, atLeast(2)).reportWorkItemStatus(workItemStatusCaptor.capture());
     List<WorkItemStatus> capturedStatuses = workItemStatusCaptor.getAllValues();
     boolean foundErrors = false;
@@ -984,18 +984,17 @@ public class StreamingDataflowWorkerTest {
     KvCoder<String, String> kvCoder = KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
 
     List<ParallelInstruction> instructions =
-            Arrays.asList(
-                    makeSourceInstruction(kvCoder),
-                    makeDoFnInstruction(new LargeCommitFn(), 0, kvCoder),
-                    makeSinkInstruction(kvCoder, 1));
+        Arrays.asList(
+            makeSourceInstruction(kvCoder),
+            makeDoFnInstruction(new LargeCommitFn(), 0, kvCoder),
+            makeSinkInstruction(kvCoder, 1));
 
     FakeWindmillServer server = new FakeWindmillServer(errorCollector);
     server.setExpectedExceptionCount(1);
 
     StreamingDataflowWorkerOptions options =
-            createTestingPipelineOptions(server, "--experiments=enable_streaming_engine");
-    StreamingDataflowWorker worker =
-            makeWorker(instructions, options, true /* publishCounters */);
+        createTestingPipelineOptions(server, "--experiments=enable_streaming_engine");
+    StreamingDataflowWorker worker = makeWorker(instructions, options, true /* publishCounters */);
     worker.setMaxWorkItemCommitBytes(1000);
     worker.start();
 
@@ -1020,7 +1019,7 @@ public class StreamingDataflowWorkerTest {
 
     // We should see an exception reported for the large commit but not the small one.
     ArgumentCaptor<WorkItemStatus> workItemStatusCaptor =
-            ArgumentCaptor.forClass(WorkItemStatus.class);
+        ArgumentCaptor.forClass(WorkItemStatus.class);
     verify(mockWorkUnitClient, atLeast(2)).reportWorkItemStatus(workItemStatusCaptor.capture());
     List<WorkItemStatus> capturedStatuses = workItemStatusCaptor.getAllValues();
     boolean foundErrors = false;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -930,16 +930,16 @@ public class StreamingDataflowWorkerTest {
     KvCoder<String, String> kvCoder = KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
 
     List<ParallelInstruction> instructions =
-        Arrays.asList(
-            makeSourceInstruction(kvCoder),
-            makeDoFnInstruction(new LargeCommitFn(), 0, kvCoder),
-            makeSinkInstruction(kvCoder, 1));
+            Arrays.asList(
+                    makeSourceInstruction(kvCoder),
+                    makeDoFnInstruction(new LargeCommitFn(), 0, kvCoder),
+                    makeSinkInstruction(kvCoder, 1));
 
     FakeWindmillServer server = new FakeWindmillServer(errorCollector);
     server.setExpectedExceptionCount(1);
 
     StreamingDataflowWorker worker =
-        makeWorker(instructions, createTestingPipelineOptions(server), true /* publishCounters */);
+            makeWorker(instructions, createTestingPipelineOptions(server), true /* publishCounters */);
     worker.setMaxWorkItemCommitBytes(1000);
     worker.start();
 
@@ -964,7 +964,63 @@ public class StreamingDataflowWorkerTest {
 
     // We should see an exception reported for the large commit but not the small one.
     ArgumentCaptor<WorkItemStatus> workItemStatusCaptor =
-        ArgumentCaptor.forClass(WorkItemStatus.class);
+            ArgumentCaptor.forClass(WorkItemStatus.class);
+    verify(mockWorkUnitClient, atLeast(2)).reportWorkItemStatus(workItemStatusCaptor.capture());
+    List<WorkItemStatus> capturedStatuses = workItemStatusCaptor.getAllValues();
+    boolean foundErrors = false;
+    for (WorkItemStatus status : capturedStatuses) {
+      if (!status.getErrors().isEmpty()) {
+        assertFalse(foundErrors);
+        foundErrors = true;
+        String errorMessage = status.getErrors().get(0).getMessage();
+        assertThat(errorMessage, Matchers.containsString("KeyCommitTooLargeException"));
+      }
+    }
+    assertTrue(foundErrors);
+  }
+
+  @Test
+  public void testKeyCommitTooLargeException_StreamingEngine() throws Exception {
+    KvCoder<String, String> kvCoder = KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
+
+    List<ParallelInstruction> instructions =
+            Arrays.asList(
+                    makeSourceInstruction(kvCoder),
+                    makeDoFnInstruction(new LargeCommitFn(), 0, kvCoder),
+                    makeSinkInstruction(kvCoder, 1));
+
+    FakeWindmillServer server = new FakeWindmillServer(errorCollector);
+    server.setExpectedExceptionCount(1);
+
+    StreamingDataflowWorkerOptions options =
+            createTestingPipelineOptions(server, "--experiments=enable_streaming_engine");
+    StreamingDataflowWorker worker =
+            makeWorker(instructions, options, true /* publishCounters */);
+    worker.setMaxWorkItemCommitBytes(1000);
+    worker.start();
+
+    server.addWorkToOffer(makeInput(1, 0, "large_key"));
+    server.addWorkToOffer(makeInput(2, 0, "key"));
+    server.waitForEmptyWorkQueue();
+
+    Map<Long, Windmill.WorkItemCommitRequest> result = server.waitForAndGetCommits(1);
+
+    assertEquals(2, result.size());
+    assertEquals(makeExpectedOutput(2, 0, "key", "key").build(), result.get(2L));
+    assertTrue(result.containsKey(1L));
+    assertEquals("large_key", result.get(1L).getKey().toStringUtf8());
+    assertTrue(result.get(1L).getSerializedSize() > 1000);
+
+    // Spam worker updates a few times.
+    int maxTries = 10;
+    while (--maxTries > 0) {
+      worker.reportPeriodicWorkerUpdates();
+      Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
+    }
+
+    // We should see an exception reported for the large commit but not the small one.
+    ArgumentCaptor<WorkItemStatus> workItemStatusCaptor =
+            ArgumentCaptor.forClass(WorkItemStatus.class);
     verify(mockWorkUnitClient, atLeast(2)).reportWorkItemStatus(workItemStatusCaptor.capture());
     List<WorkItemStatus> capturedStatuses = workItemStatusCaptor.getAllValues();
     boolean foundErrors = false;


### PR DESCRIPTION
Report an error for large commits and adding a counter for the maximum key commit
size.

This change also prepares for future backend support of dynamic commit
limits and worker initiated truncations. Note: this is PR/7681. I am taking this over while scwhittle is ooo.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

