### PR TITLE
Reduce internal functions availble on beam package.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/graphx/user.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/user.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
@@ -60,7 +59,7 @@ func EncodeFn(fn reflectx.Func) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ref, err := EncodeUserFn(u)
+	ref, err := encodeUserFn(u)
 	if err != nil {
 		return "", err
 	}
@@ -74,33 +73,11 @@ func DecodeFn(data string) (reflectx.Func, error) {
 	if err := protox.DecodeBase64(data, &ref); err != nil {
 		return nil, err
 	}
-	fn, err := DecodeUserFn(&ref)
+	fn, err := decodeUserFn(&ref)
 	if err != nil {
 		return nil, err
 	}
-	return fn.Fn, nil
-}
-
-// EncodeGraphFn encodes a *graph.Fn as a string.
-func EncodeGraphFn(u *graph.Fn) (string, error) {
-	ref, err := encodeFn(u)
-	if err != nil {
-		return "", err
-	}
-	return protox.EncodeBase64(ref)
-}
-
-// DecodeGraphFn decodes an encoded *graph.Fn.
-func DecodeGraphFn(data string) (*graph.Fn, error) {
-	var ref v1.Fn
-	if err := protox.DecodeBase64(data, &ref); err != nil {
-		return nil, err
-	}
-	fn, err := decodeFn(&ref)
-	if err != nil {
-		return nil, err
-	}
-	return fn, nil
+	return reflectx.MakeFunc(fn), nil
 }
 
 // EncodeCoder encodes a coder as a string. Any custom coder function

--- a/sdks/go/pkg/beam/encoding.go
+++ b/sdks/go/pkg/beam/encoding.go
@@ -23,18 +23,6 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
 
-// EncodeType encodes a type as a string. Unless registered, the decoded type
-// is only guaranteed to the isomorphic to the input and with no methods.
-func EncodeType(t reflect.Type) (string, error) {
-	return graphx.EncodeType(t)
-}
-
-// DecodeType decodes a type. Unless registered, the decoded type
-// is only guaranteed to the isomorphic to the input and with no methods.
-func DecodeType(data string) (reflect.Type, error) {
-	return graphx.DecodeType(data)
-}
-
 // EncodedType is a serialization wrapper around a type for convenience.
 type EncodedType struct {
 	// T is the type to preserve across serialization.
@@ -43,7 +31,7 @@ type EncodedType struct {
 
 // MarshalJSON returns the JSON encoding this value.
 func (w EncodedType) MarshalJSON() ([]byte, error) {
-	str, err := EncodeType(w.T)
+	str, err := graphx.EncodeType(w.T)
 	if err != nil {
 		return nil, err
 	}
@@ -56,26 +44,12 @@ func (w *EncodedType) UnmarshalJSON(buf []byte) error {
 	if err := json.Unmarshal(buf, &s); err != nil {
 		return err
 	}
-	t, err := DecodeType(s)
+	t, err := graphx.DecodeType(s)
 	if err != nil {
 		return err
 	}
 	w.T = t
 	return nil
-}
-
-// EncodeFunc encodes a function and parameter types as a string. The function
-// symbol must be resolvable via the runtime.GlobalSymbolResolver. The types must
-// be encodable.
-func EncodeFunc(fn reflectx.Func) (string, error) {
-	return graphx.EncodeFn(fn)
-}
-
-// DecodeFunc encodes a function as a string. The function symbol must be
-// resolvable via the runtime.GlobalSymbolResolver. The parameter types must
-// be encodable.
-func DecodeFunc(data string) (reflectx.Func, error) {
-	return graphx.DecodeFn(data)
 }
 
 // EncodedFunc is a serialization wrapper around a function for convenience.
@@ -86,7 +60,7 @@ type EncodedFunc struct {
 
 // MarshalJSON returns the JSON encoding this value.
 func (w EncodedFunc) MarshalJSON() ([]byte, error) {
-	str, err := EncodeFunc(w.Fn)
+	str, err := graphx.EncodeFn(w.Fn)
 	if err != nil {
 		return nil, err
 	}
@@ -99,19 +73,12 @@ func (w *EncodedFunc) UnmarshalJSON(buf []byte) error {
 	if err := json.Unmarshal(buf, &s); err != nil {
 		return err
 	}
-	fn, err := DecodeFunc(s)
+	fn, err := graphx.DecodeFn(s)
 	if err != nil {
 		return err
 	}
 	w.Fn = fn
 	return nil
-}
-
-// EncodeCoder encodes a coder as a string. Any custom coder function
-// symbol must be resolvable via the runtime.GlobalSymbolResolver. The types must
-// be encodable.
-func EncodeCoder(c Coder) (string, error) {
-	return graphx.EncodeCoder(c.coder)
 }
 
 // DecodeCoder decodes a coder. Any custom coder function symbol must be
@@ -132,7 +99,7 @@ type EncodedCoder struct {
 
 // MarshalJSON returns the JSON encoding this value.
 func (w EncodedCoder) MarshalJSON() ([]byte, error) {
-	str, err := EncodeCoder(w.Coder)
+	str, err := graphx.EncodeCoder(w.Coder.coder)
 	if err != nil {
 		return nil, err
 	}
@@ -145,10 +112,10 @@ func (w *EncodedCoder) UnmarshalJSON(buf []byte) error {
 	if err := json.Unmarshal(buf, &s); err != nil {
 		return err
 	}
-	c, err := DecodeCoder(s)
+	c, err := graphx.DecodeCoder(s)
 	if err != nil {
 		return err
 	}
-	w.Coder = c
+	w.Coder = Coder{coder: c}
 	return nil
 }

--- a/sdks/go/pkg/beam/util.go
+++ b/sdks/go/pkg/beam/util.go
@@ -112,11 +112,3 @@ func Must(a PCollection, err error) PCollection {
 	}
 	return a
 }
-
-// Must2 returns the input, but panics if err != nil.
-func Must2(a, b PCollection, err error) (PCollection, PCollection) {
-	if err != nil {
-		panic(err)
-	}
-	return a, b
-}


### PR DESCRIPTION
FYI this is a breaking change against the Go SDK. It removes some functions from the beam package surface, because there were no clear path to using them, and having too many functions on the package surface hurts eventual usability of the docs.

* beam.Must2 had no uses in the SDK. Keeping Must and MustN since they are used by the SDK.
* beam.EncodeCoder, and beam.DecodeCoder
* beam.EncodeFunc, and beam.DecodeFunc
* beam.EncodeType, and beam.DecodeType
* These were all mostly externalizations of internal functions, used internally to the transport types.

There's a small change to the graphx.decodeUserFn semantics in that it now returns the raw anonymous function instead of wrapping it immeadiately. This allows for an allocation optimization for certain user defined coder shapes, avoiding a []byte -> interface{} -> []byte conversion and allocation that it entails. 

MustN functions, if they're used by the beam package must be in the beam package or duplicated in some utility package because of depending on beam.PCollection in the signature.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

