### PR TITLE
[BEAM-3306] Encapsulate coder details.

### DIFF
--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -18,10 +18,12 @@ package beam
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/coderx"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/golang/protobuf/proto"
@@ -68,20 +70,56 @@ func (c Coder) String() string {
 	return c.coder.String()
 }
 
-// TODO(herohde) 4/4/2017: for convenience, we use the magic json coding
-// everywhere. To be replaced by Coder registry, sharing, etc.
+// NewElementEncoder returns a new encoding function for the given type.
+func NewElementEncoder(t reflect.Type) ElementEncoder {
+	c, err := inferCoder(typex.New(t))
+	if err != nil {
+		panic(err)
+	}
+	return &execEncoder{enc: exec.MakeElementEncoder(c)}
+}
 
-// TODO: select optimal coder based on type, notably handling int, string, etc.
+// execEncoder wraps an exec.ElementEncoder to implement the ElementDecoder interface
+// in this package.
+type execEncoder struct {
+	enc   exec.ElementEncoder
+	coder *coder.Coder
+}
 
-// TODO(herohde) 7/11/2017: figure out best way to let transformation use
-// coders (like passert). For now, we just allow them to grab in the internal
-// coder. Maybe it's cleaner to pull Encode/Decode into beam instead, if
-// adequate. The issue is that we would need non-windowed coding. Maybe focus on
-// coder registry and construction: then type -> coder might be adequate.
+func (e *execEncoder) Encode(element interface{}, w io.Writer) error {
+	return e.enc.Encode(exec.FullValue{Elm: element}, w)
+}
 
-// UnwrapCoder returns the internal coder.
-func UnwrapCoder(c Coder) *coder.Coder {
-	return c.coder
+func (e *execEncoder) String() string {
+	return e.coder.String()
+}
+
+// NewElementDecoder returns an ElementDecoder the given type.
+func NewElementDecoder(t reflect.Type) ElementDecoder {
+	c, err := inferCoder(typex.New(t))
+	if err != nil {
+		panic(err)
+	}
+	return &execDecoder{dec: exec.MakeElementDecoder(c)}
+}
+
+// execDecoder wraps an exec.ElementDecoder to implement the ElementDecoder interface
+// in this package.
+type execDecoder struct {
+	dec   exec.ElementDecoder
+	coder *coder.Coder
+}
+
+func (d *execDecoder) Decode(r io.Reader) (interface{}, error) {
+	fv, err := d.dec.Decode(r)
+	if err != nil {
+		return nil, err
+	}
+	return fv.Elm, nil
+}
+
+func (d *execDecoder) String() string {
+	return d.coder.String()
 }
 
 // NewCoder infers a Coder for any bound full type.
@@ -178,11 +216,6 @@ func inferCoders(list []FullType) ([]*coder.Coder, error) {
 	}
 	return ret, nil
 }
-
-// TODO(herohde) 4/5/2017: decide whether we want an Encoded form. For now,
-// we'll use exploded form coders only using typex.T. We might also need a
-// form that doesn't require LengthPrefix'ing to cut up the bytestream from
-// the FnHarness.
 
 // protoEnc marshals the supplied proto.Message.
 func protoEnc(in T) ([]byte, error) {

--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -19,6 +19,7 @@ package coder
 
 import (
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 
@@ -91,6 +92,16 @@ var (
 		Return:    []reflect.Type{typex.TType}, // T to be substituted
 		OptReturn: []reflect.Type{reflectx.Error}}
 )
+
+// ElementEncoder encapsulates being able to encode an element into a writer.
+type ElementEncoder interface {
+	Encode(element interface{}, w io.Writer) error
+}
+
+// ElementDecoder encapsulates being able to decode an element from a reader.
+type ElementDecoder interface {
+	Decode(r io.Reader) (interface{}, error)
+}
 
 func validateEncoder(t reflect.Type, encode interface{}) error {
 	// Check if it uses the real type in question.

--- a/sdks/go/pkg/beam/forward.go
+++ b/sdks/go/pkg/beam/forward.go
@@ -92,13 +92,18 @@ func RegisterInit(hook func()) {
 //  func(reflect.Type, []byte) (T, error)
 //
 // where T is the matching user type.
-//
 func RegisterCoder(t reflect.Type, encoder, decoder interface{}) {
 	runtime.RegisterType(t)
 	runtime.RegisterFunction(encoder)
 	runtime.RegisterFunction(decoder)
 	coder.RegisterCoder(t, encoder, decoder)
 }
+
+// ElementEncoder encapsulates being able to encode an element into a writer.
+type ElementEncoder = coder.ElementEncoder
+
+// ElementDecoder encapsulates being able to decode an element from a reader.
+type ElementDecoder = coder.ElementDecoder
 
 // Init is the hook that all user code must call after flags processing and
 // other static initialization, for now.

--- a/sdks/go/pkg/beam/testing/passert/passert.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/transforms/filter"
 )
@@ -61,26 +59,25 @@ func equals(s beam.Scope, actual, expected beam.PCollection) beam.PCollection {
 // because all values are held in memory at the same time.
 func Diff(s beam.Scope, a, b beam.PCollection) (left, both, right beam.PCollection) {
 	imp := beam.Impulse(s)
-	return beam.ParDo3(s, &diffFn{Coder: beam.EncodedCoder{Coder: a.Coder()}}, imp, beam.SideInput{Input: a}, beam.SideInput{Input: b})
-}
 
-// TODO(herohde) 7/11/2017: should there be a first-class way to obtain the coder,
-// such a a specially-typed parameter?
+	t := beam.ValidateNonCompositeType(a)
+	beam.ValidateNonCompositeType(b)
+	return beam.ParDo3(s, &diffFn{Type: beam.EncodedType{T: t.Type()}}, imp, beam.SideInput{Input: a}, beam.SideInput{Input: b})
+}
 
 // diffFn computes the symmetrical multi-set difference of 2 collections, under
 // coder equality. The Go values returned may be any of the coder-equal ones.
 type diffFn struct {
-	Coder beam.EncodedCoder `json:"coder"`
+	Type beam.EncodedType `json:"type"`
 }
 
 func (f *diffFn) ProcessElement(_ []byte, ls, rs func(*beam.T) bool, left, both, right func(t beam.T)) error {
-	c := beam.UnwrapCoder(f.Coder.Coder)
-
-	indexL, err := index(c, ls)
+	enc := beam.NewElementEncoder(f.Type.T)
+	indexL, err := index(enc, ls)
 	if err != nil {
 		return err
 	}
-	indexR, err := index(c, rs)
+	indexR, err := index(enc, rs)
 	if err != nil {
 		return err
 	}
@@ -130,15 +127,14 @@ type indexEntry struct {
 	value beam.T
 }
 
-func index(c *coder.Coder, iter func(*beam.T) bool) (map[string]indexEntry, error) {
+func index(enc beam.ElementEncoder, iter func(*beam.T) bool) (map[string]indexEntry, error) {
 	ret := make(map[string]indexEntry)
-	enc := exec.MakeElementEncoder(c)
 
 	var val beam.T
 	for iter(&val) {
 		var buf bytes.Buffer
-		if err := enc.Encode(exec.FullValue{Elm: val}, &buf); err != nil {
-			return nil, fmt.Errorf("value %v not encodable by %v", val, c)
+		if err := enc.Encode(val, &buf); err != nil {
+			return nil, fmt.Errorf("value %v not encodable with %v", val, enc)
 		}
 		encoded := buf.String()
 
@@ -147,9 +143,6 @@ func index(c *coder.Coder, iter func(*beam.T) bool) (map[string]indexEntry, erro
 	}
 	return ret, nil
 }
-
-// TODO(herohde) 7/11/2017: perhaps extract the coder helpers as more
-// general and polished utilities for working with coders in user code.
 
 // True asserts that all elements satisfy the given predicate.
 func True(s beam.Scope, col beam.PCollection, fn interface{}) beam.PCollection {

--- a/sdks/go/pkg/beam/transforms/top/top.go
+++ b/sdks/go/pkg/beam/transforms/top/top.go
@@ -21,11 +21,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
@@ -52,7 +52,7 @@ func Largest(s beam.Scope, col beam.PCollection, n int, less interface{}) beam.P
 	t := beam.ValidateNonCompositeType(col)
 	validate(t, n, less)
 
-	return beam.Combine(s, newCombineFn(less, n, t, false), col)
+	return beam.Combine(s, newCombineFn(less, n, t.Type(), false), col)
 }
 
 // LargestPerKey returns the largest N values for each key of a PCollection<KV<K,T>>.
@@ -65,7 +65,7 @@ func LargestPerKey(s beam.Scope, col beam.PCollection, n int, less interface{}) 
 	_, t := beam.ValidateKVType(col)
 	validate(t, n, less)
 
-	return beam.CombinePerKey(s, newCombineFn(less, n, t, false), col)
+	return beam.CombinePerKey(s, newCombineFn(less, n, t.Type(), false), col)
 }
 
 // Smallest returns the smallest N elements of a PCollection<T>. The order is
@@ -83,7 +83,7 @@ func Smallest(s beam.Scope, col beam.PCollection, n int, less interface{}) beam.
 	t := beam.ValidateNonCompositeType(col)
 	validate(t, n, less)
 
-	return beam.Combine(s, newCombineFn(less, n, t, true), col)
+	return beam.Combine(s, newCombineFn(less, n, t.Type(), true), col)
 }
 
 // SmallestPerKey returns the smallest N values for each key of a PCollection<KV<K,T>>.
@@ -96,7 +96,7 @@ func SmallestPerKey(s beam.Scope, col beam.PCollection, n int, less interface{})
 	_, t := beam.ValidateKVType(col)
 	validate(t, n, less)
 
-	return beam.Combine(s, newCombineFn(less, n, t, true), col)
+	return beam.Combine(s, newCombineFn(less, n, t.Type(), true), col)
 }
 
 func validate(t typex.FullType, n int, less interface{}) {
@@ -106,16 +106,21 @@ func validate(t typex.FullType, n int, less interface{}) {
 	funcx.MustSatisfy(less, funcx.Replace(sig, beam.TType, t.Type()))
 }
 
-func newCombineFn(less interface{}, n int, t typex.FullType, reversed bool) *combineFn {
-	coder := beam.NewCoder(t)
-	return &combineFn{Less: beam.EncodedFunc{Fn: reflectx.MakeFunc(less)}, N: n, Coder: beam.EncodedCoder{Coder: coder}, Reversed: reversed}
+func newCombineFn(less interface{}, n int, t reflect.Type, reversed bool) *combineFn {
+	fn := &combineFn{Less: beam.EncodedFunc{Fn: reflectx.MakeFunc(less)}, N: n, Type: beam.EncodedType{T: t}, Reversed: reversed}
+	// Running SetupFn at pipeline construction helps validate the
+	// combineFn, and simplify testing.
+	fn.SetupFn()
+	return fn
 }
 
 // TODO(herohde) 5/25/2017: use a heap instead of a sorted slice.
 
 type accum struct {
-	coder beam.Coder
-	data  [][]byte
+	enc beam.ElementEncoder
+	dec beam.ElementDecoder
+
+	data [][]byte
 	// list stores the elements of type A in order. It has at most size N.
 	list []interface{}
 }
@@ -131,28 +136,26 @@ func (a *accum) unmarshal() error {
 	if a.data == nil {
 		return nil
 	}
-	dec := exec.MakeElementDecoder(beam.UnwrapCoder(a.coder))
 	for _, val := range a.data {
-		fv, err := dec.Decode(bytes.NewBuffer(val))
+		element, err := a.dec.Decode(bytes.NewBuffer(val))
 		if err != nil {
 			return fmt.Errorf("top.accum: error unmarshal: %v", err)
 		}
-		a.list = append(a.list, fv.Elm)
+		a.list = append(a.list, element)
 	}
 	a.data = nil
 	return nil
 }
 
-// MarshalJSON uses the hook into the JSON encoder library to
+// MarshalJSON uses the hook into the JSON encoder library to encode the accumulator.
 func (a accum) MarshalJSON() ([]byte, error) {
-	if !a.coder.IsValid() {
-		return nil, fmt.Errorf("top.accum: element coder unspecified")
+	if a.enc == nil {
+		return nil, fmt.Errorf("top.accum: element encoder unspecified")
 	}
-	enc := exec.MakeElementEncoder(beam.UnwrapCoder(a.coder))
 	var values [][]byte
 	for _, value := range a.list {
 		var buf bytes.Buffer
-		if err := enc.Encode(exec.FullValue{Elm: value}, &buf); err != nil {
+		if err := a.enc.Encode(value, &buf); err != nil {
 			return nil, fmt.Errorf("top.accum: marshalling of %v failed: %v", value, err)
 		}
 		values = append(values, buf.Bytes())
@@ -171,14 +174,21 @@ type combineFn struct {
 	Reversed bool `json:"reversed"`
 	// N is the number of elements to keep.
 	N int `json:"n"`
-	// Coder is the element coder for the underlying type, A.
-	Coder beam.EncodedCoder `json:"coder"`
+	// Type is the element type A
+	Type beam.EncodedType `json:"type"`
 
+	enc  beam.ElementEncoder
+	dec  beam.ElementDecoder
 	less reflectx.Func2x1
 }
 
+func (f *combineFn) SetupFn() {
+	f.enc = beam.NewElementEncoder(f.Type.T)
+	f.dec = beam.NewElementDecoder(f.Type.T)
+}
+
 func (f *combineFn) CreateAccumulator() accum {
-	return accum{coder: f.Coder.Coder}
+	return accum{enc: f.enc, dec: f.dec}
 }
 
 func (f *combineFn) AddInput(a accum, val beam.T) accum {
@@ -187,8 +197,8 @@ func (f *combineFn) AddInput(a accum, val beam.T) accum {
 }
 
 func (f *combineFn) MergeAccumulators(a, b accum) accum {
-	a.coder = f.Coder.Coder
-	b.coder = f.Coder.Coder
+	a.enc, a.dec = f.enc, f.dec
+	b.enc, b.dec = f.enc, f.dec
 	if err := a.unmarshal(); err != nil {
 		panic(err)
 	}
@@ -225,5 +235,5 @@ func (f *combineFn) trim(ret []interface{}) accum {
 	if len(ret) > f.N {
 		ret = ret[:f.N]
 	}
-	return accum{coder: f.Coder.Coder, list: ret}
+	return accum{enc: f.enc, dec: f.dec, list: ret}
 }

--- a/sdks/go/pkg/beam/transforms/top/top_test.go
+++ b/sdks/go/pkg/beam/transforms/top/top_test.go
@@ -20,8 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
 
@@ -31,7 +29,7 @@ func TestCombineFn3String(t *testing.T) {
 	less := func(a, b string) bool {
 		return len(a) < len(b)
 	}
-	fn := newCombineFn(less, 3, typex.New(reflectx.String), false)
+	fn := newCombineFn(less, 3, reflectx.String, false)
 
 	tests := []struct {
 		Elms     []string
@@ -59,7 +57,7 @@ func TestCombineFn3RevString(t *testing.T) {
 	less := func(a, b string) bool {
 		return len(a) < len(b)
 	}
-	fn := newCombineFn(less, 3, typex.New(reflectx.String), true)
+	fn := newCombineFn(less, 3, reflectx.String, true)
 
 	tests := []struct {
 		Elms     []string
@@ -86,7 +84,7 @@ func TestCombineFnMerge(t *testing.T) {
 	less := func(a, b string) bool {
 		return len(a) < len(b)
 	}
-	fn := newCombineFn(less, 3, typex.New(reflectx.String), false)
+	fn := newCombineFn(less, 3, reflectx.String, false)
 	tests := []struct {
 		Elms     [][]string
 		Expected []string


### PR DESCRIPTION
This change encapsulates internal implementation details that most users should not need.

In particular: This CL removes needing to wrap values in the exec.FullValue type before encoding them. It also hides the internal coder.Coder abstraction.

Previously users needed to do the following to use a beam coder to encode an element of a given type:

	var t reflect.Type // from somewhere
	coder := beam.NewCoder(typex.New(t))
	enc := exec.MakeElementEncoder(beam.UnwrapCoder(coder))
	var buf bytes.Buffer
	err := enc.Encode(exec.FullValue{Elm: value}, &buf)
	...


This required users to access beam implementation details directly: coder.Coder, the typex package, the exec package & the FullValue type.

Following this PR:
 
	var t reflect.Type // from somewhere
	enc := beam.NewElementEncoder(t)
	var buf bytes.Buffer
	err := enc.Encode(value, &buf)
	...
 
which doesn't leak such details. Similarly for the Decoders.

This PR makes the breaking change of removing the beam.UnwrapCoder method. There is an open question of whether users will ever need to encode KVs, or CoGBKs or similar themselves, rather than via the framework, at which point we can revisit this.

TODO in a later PR: allow users to register coders that implement beam.ElementEncoder and beam.ElementDecoder.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

