### PR TITLE
Use *FullValue instead of FullValue, to reduce unnecessary copying.

### DIFF
--- a/sdks/go/pkg/beam/beam.shims.go
+++ b/sdks/go/pkg/beam/beam.shims.go
@@ -304,6 +304,7 @@ type emitNative struct {
 	ctx context.Context
 	ws  []typex.Window
 	et  typex.EventTime
+	value exec.FullValue
 }
 
 func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
@@ -324,8 +325,8 @@ func emitMakerTypex۰T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex۰T(val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }

--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -87,7 +87,7 @@ type execEncoder struct {
 }
 
 func (e *execEncoder) Encode(element interface{}, w io.Writer) error {
-	return e.enc.Encode(exec.FullValue{Elm: element}, w)
+	return e.enc.Encode(&exec.FullValue{Elm: element}, w)
 }
 
 func (e *execEncoder) String() string {

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -39,14 +39,14 @@ import (
 // can be reused, even if an error is encountered. Concurrency-safe.
 type ElementEncoder interface {
 	// Encode serializes the given value to the writer.
-	Encode(FullValue, io.Writer) error
+	Encode(*FullValue, io.Writer) error
 }
 
 // EncodeElement is a convenience function for encoding a single element into a
 // byte slice.
 func EncodeElement(c ElementEncoder, val interface{}) ([]byte, error) {
 	var buf bytes.Buffer
-	if err := c.Encode(FullValue{Elm: val}, &buf); err != nil {
+	if err := c.Encode(&FullValue{Elm: val}, &buf); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
@@ -56,7 +56,7 @@ func EncodeElement(c ElementEncoder, val interface{}) ([]byte, error) {
 // can be reused, even if an error is encountered.  Concurrency-safe.
 type ElementDecoder interface {
 	// Decode deserializes a value from the given reader.
-	Decode(io.Reader) (FullValue, error)
+	Decode(io.Reader) (*FullValue, error)
 }
 
 // MakeElementEncoder returns a ElementCoder for the given coder. It panics
@@ -115,7 +115,7 @@ func MakeElementDecoder(c *coder.Coder) ElementDecoder {
 
 type bytesEncoder struct{}
 
-func (*bytesEncoder) Encode(val FullValue, w io.Writer) error {
+func (*bytesEncoder) Encode(val *FullValue, w io.Writer) error {
 	// Encoding: size (varint) + raw data
 	var data []byte
 	data, ok := val.Elm.([]byte)
@@ -133,23 +133,23 @@ func (*bytesEncoder) Encode(val FullValue, w io.Writer) error {
 
 type bytesDecoder struct{}
 
-func (*bytesDecoder) Decode(r io.Reader) (FullValue, error) {
+func (*bytesDecoder) Decode(r io.Reader) (*FullValue, error) {
 	// Encoding: size (varint) + raw data
 
 	size, err := coder.DecodeVarInt(r)
 	if err != nil {
-		return FullValue{}, err
+		return nil, err
 	}
 	data, err := ioutilx.ReadN(r, (int)(size))
 	if err != nil {
-		return FullValue{}, err
+		return nil, err
 	}
-	return FullValue{Elm: data}, nil
+	return &FullValue{Elm: data}, nil
 }
 
 type varIntEncoder struct{}
 
-func (*varIntEncoder) Encode(val FullValue, w io.Writer) error {
+func (*varIntEncoder) Encode(val *FullValue, w io.Writer) error {
 	// Encoding: beam varint
 
 	n := Convert(val.Elm, reflectx.Int32).(int32) // Convert needed?
@@ -158,14 +158,14 @@ func (*varIntEncoder) Encode(val FullValue, w io.Writer) error {
 
 type varIntDecoder struct{}
 
-func (*varIntDecoder) Decode(r io.Reader) (FullValue, error) {
+func (*varIntDecoder) Decode(r io.Reader) (*FullValue, error) {
 	// Encoding: beam varint
 
 	n, err := coder.DecodeVarInt(r)
 	if err != nil {
-		return FullValue{}, err
+		return nil, err
 	}
-	return FullValue{Elm: n}, nil
+	return &FullValue{Elm: n}, nil
 }
 
 type customEncoder struct {
@@ -173,7 +173,7 @@ type customEncoder struct {
 	enc Encoder
 }
 
-func (c *customEncoder) Encode(val FullValue, w io.Writer) error {
+func (c *customEncoder) Encode(val *FullValue, w io.Writer) error {
 	// (1) Call encode
 
 	data, err := c.enc.Encode(c.t, val.Elm)
@@ -196,32 +196,32 @@ type customDecoder struct {
 	dec Decoder
 }
 
-func (c *customDecoder) Decode(r io.Reader) (FullValue, error) {
+func (c *customDecoder) Decode(r io.Reader) (*FullValue, error) {
 	// (1) Read length-prefixed encoded data
 
 	size, err := coder.DecodeVarInt(r)
 	if err != nil {
-		return FullValue{}, err
+		return nil, err
 	}
 	data, err := ioutilx.ReadN(r, (int)(size))
 	if err != nil {
-		return FullValue{}, err
+		return nil, err
 	}
 
 	// (2) Call decode
 
 	val, err := c.dec.Decode(c.t, data)
 	if err != nil {
-		return FullValue{}, err
+		return nil, err
 	}
-	return FullValue{Elm: val}, err
+	return &FullValue{Elm: val}, err
 }
 
 type kvEncoder struct {
 	fst, snd ElementEncoder
 }
 
-func (c *kvEncoder) Encode(val FullValue, w io.Writer) error {
+func (c *kvEncoder) Encode(val *FullValue, w io.Writer) error {
 	if err := c.fst.Encode(convertIfNeeded(val.Elm), w); err != nil {
 		return err
 	}
@@ -232,16 +232,16 @@ type kvDecoder struct {
 	fst, snd ElementDecoder
 }
 
-func (c *kvDecoder) Decode(r io.Reader) (FullValue, error) {
+func (c *kvDecoder) Decode(r io.Reader) (*FullValue, error) {
 	key, err := c.fst.Decode(r)
 	if err != nil {
-		return FullValue{}, err
+		return nil, err
 	}
 	value, err := c.snd.Decode(r)
 	if err != nil {
-		return FullValue{}, err
+		return nil, err
 	}
-	return FullValue{Elm: key.Elm, Elm2: value.Elm}, nil
+	return &FullValue{Elm: key.Elm, Elm2: value.Elm}, nil
 
 }
 
@@ -398,9 +398,9 @@ func DecodeWindowedValueHeader(dec WindowDecoder, r io.Reader) ([]typex.Window, 
 	return ws, t, nil
 }
 
-func convertIfNeeded(v interface{}) FullValue {
-	if fv, ok := v.(FullValue); ok {
+func convertIfNeeded(v interface{}) *FullValue {
+	if fv, ok := v.(*FullValue); ok {
 		return fv
 	}
-	return FullValue{Elm: v}
+	return &FullValue{Elm: v}
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/cogbk.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/cogbk.go
@@ -51,17 +51,17 @@ func (n *Inject) StartBundle(ctx context.Context, id string, data DataContext) e
 	return n.Out.StartBundle(ctx, id, data)
 }
 
-func (n *Inject) ProcessElement(ctx context.Context, elm FullValue, values ...ReStream) error {
+func (n *Inject) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	// Transform: KV<K,V> to KV<K,KV<int,[]byte>>
 
 	var buf bytes.Buffer
-	if err := n.ValueEncoder.Encode(FullValue{Elm: elm.Elm2}, &buf); err != nil {
+	if err := n.ValueEncoder.Encode(&FullValue{Elm: elm.Elm2}, &buf); err != nil {
 		return err
 	}
 
-	v := FullValue{
+	v := &FullValue{
 		Elm: elm.Elm,
-		Elm2: FullValue{
+		Elm2: &FullValue{
 			Elm:  n.N,
 			Elm2: buf.Bytes(),
 		},
@@ -104,7 +104,7 @@ func (n *Expand) StartBundle(ctx context.Context, id string, data DataContext) e
 	return n.Out.StartBundle(ctx, id, data)
 }
 
-func (n *Expand) ProcessElement(ctx context.Context, elm FullValue, values ...ReStream) error {
+func (n *Expand) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	filtered := make([]ReStream, len(n.ValueDecoders))
 	for i, dec := range n.ValueDecoders {
 		filtered[i] = &filterReStream{n: i, dec: dec, real: values[0]}
@@ -149,11 +149,11 @@ func (f *filterStream) Close() error {
 	return f.real.Close()
 }
 
-func (f *filterStream) Read() (FullValue, error) {
+func (f *filterStream) Read() (*FullValue, error) {
 	for {
 		elm, err := f.real.Read()
 		if err != nil {
-			return FullValue{}, err
+			return nil, err
 		}
 
 		key := elm.Elm.(int)
@@ -167,7 +167,7 @@ func (f *filterStream) Read() (FullValue, error) {
 
 		v, err := f.dec.Decode(bytes.NewReader(value))
 		if err != nil {
-			return FullValue{}, fmt.Errorf("failed to decode union value '%v' for key %v: %v", value, key, err)
+			return nil, fmt.Errorf("failed to decode union value '%v' for key %v: %v", value, key, err)
 		}
 		v.Timestamp = elm.Timestamp
 		v.Windows = elm.Windows

--- a/sdks/go/pkg/beam/core/runtime/exec/combine_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/combine_test.go
@@ -345,7 +345,7 @@ func (n *simpleGBK) StartBundle(ctx context.Context, id string, data DataContext
 	return n.Out.StartBundle(ctx, id, data)
 }
 
-func (n *simpleGBK) ProcessElement(ctx context.Context, elm FullValue, _ ...ReStream) error {
+func (n *simpleGBK) ProcessElement(ctx context.Context, elm *FullValue, _ ...ReStream) error {
 	key := elm.Elm
 	value := elm.Elm2
 	keyHash, err := n.hasher.Hash(key)
@@ -368,7 +368,7 @@ func (n *simpleGBK) ProcessElement(ctx context.Context, elm FullValue, _ ...ReSt
 func (n *simpleGBK) FinishBundle(ctx context.Context) error {
 	for _, g := range n.m {
 		values := &FixedReStream{Buf: g.values}
-		if err := n.Out.ProcessElement(ctx, g.key, values); err != nil {
+		if err := n.Out.ProcessElement(ctx, &g.key, values); err != nil {
 			return err
 		}
 	}

--- a/sdks/go/pkg/beam/core/runtime/exec/datasink.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasink.go
@@ -61,7 +61,7 @@ func (n *DataSink) StartBundle(ctx context.Context, id string, data DataContext)
 	return nil
 }
 
-func (n *DataSink) ProcessElement(ctx context.Context, value FullValue, values ...ReStream) error {
+func (n *DataSink) ProcessElement(ctx context.Context, value *FullValue, values ...ReStream) error {
 	// Marshal the pieces into a temporary buffer since they must be transmitted on FnAPI as a single
 	// unit.
 	var b bytes.Buffer

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -108,7 +108,7 @@ func (n *DataSource) Process(ctx context.Context) error {
 					if err != nil {
 						return fmt.Errorf("stream value decode failed: %v", err)
 					}
-					buf = append(buf, value)
+					buf = append(buf, *value)
 				}
 			} else {
 				// Multi-chunked stream.
@@ -131,7 +131,7 @@ func (n *DataSource) Process(ctx context.Context) error {
 						if err != nil {
 							return fmt.Errorf("stream value decode failed: %v", err)
 						}
-						buf = append(buf, value)
+						buf = append(buf, *value)
 					}
 				}
 			}

--- a/sdks/go/pkg/beam/core/runtime/exec/discard.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/discard.go
@@ -36,7 +36,7 @@ func (d *Discard) StartBundle(ctx context.Context, id string, data DataContext) 
 	return nil
 }
 
-func (d *Discard) ProcessElement(ctx context.Context, value FullValue, values ...ReStream) error {
+func (d *Discard) ProcessElement(ctx context.Context, value *FullValue, values ...ReStream) error {
 	return nil
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/emit.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/emit.go
@@ -102,7 +102,7 @@ func (e *emitValue) Value() interface{} {
 }
 
 func (e *emitValue) invoke(args []reflect.Value) []reflect.Value {
-	value := FullValue{Windows: e.ws, Timestamp: e.et}
+	value := &FullValue{Windows: e.ws, Timestamp: e.et}
 	isKey := true
 	for i, t := range e.types {
 		switch {

--- a/sdks/go/pkg/beam/core/runtime/exec/flatten.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/flatten.go
@@ -52,7 +52,7 @@ func (m *Flatten) StartBundle(ctx context.Context, id string, data DataContext) 
 	return m.Out.StartBundle(ctx, id, data)
 }
 
-func (m *Flatten) ProcessElement(ctx context.Context, elm FullValue, values ...ReStream) error {
+func (m *Flatten) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	return m.Out.ProcessElement(ctx, elm, values...)
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
@@ -38,7 +38,7 @@ type FullValue struct {
 	Windows   []typex.Window
 }
 
-func (v FullValue) String() string {
+func (v *FullValue) String() string {
 	if v.Elm2 == nil {
 		return fmt.Sprintf("%v [@%v:%v]", v.Elm, v.Timestamp, v.Windows)
 	}
@@ -49,7 +49,7 @@ func (v FullValue) String() string {
 // prematurely closed.
 type Stream interface {
 	io.Closer
-	Read() (FullValue, error)
+	Read() (*FullValue, error)
 }
 
 // ReStream is re-iterable stream, i.e., a Stream factory.
@@ -80,13 +80,13 @@ func (s *FixedStream) Close() error {
 }
 
 // Read produces the next value in the stream.
-func (s *FixedStream) Read() (FullValue, error) {
+func (s *FixedStream) Read() (*FullValue, error) {
 	if s.Buf == nil || s.next == len(s.Buf) {
-		return FullValue{}, io.EOF
+		return nil, io.EOF
 	}
 	ret := s.Buf[s.next]
 	s.next++
-	return ret, nil
+	return &ret, nil
 }
 
 // TODO(herohde) 1/19/2018: type-specialize list and other conversions?
@@ -183,6 +183,6 @@ func ReadAll(rs ReStream) ([]FullValue, error) {
 			}
 			return nil, err
 		}
-		ret = append(ret, elm)
+		ret = append(ret, *elm)
 	}
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/multiplex.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/multiplex.go
@@ -40,7 +40,7 @@ func (m *Multiplex) StartBundle(ctx context.Context, id string, data DataContext
 	return MultiStartBundle(ctx, id, data, m.Out...)
 }
 
-func (m *Multiplex) ProcessElement(ctx context.Context, elm FullValue, values ...ReStream) error {
+func (m *Multiplex) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	for _, out := range m.Out {
 		if err := out.ProcessElement(ctx, elm, values...); err != nil {
 			return err

--- a/sdks/go/pkg/beam/core/runtime/exec/optimized/emitters.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/optimized/emitters.go
@@ -1044,9 +1044,10 @@ type emitNative struct {
 	n  exec.ElementProcessor
 	fn interface{}
 
-	ctx context.Context
-	ws  []typex.Window
-	et  typex.EventTime
+	ctx   context.Context
+	ws    []typex.Window
+	et    typex.EventTime
+	value exec.FullValue
 }
 
 func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
@@ -1067,8 +1068,8 @@ func emitMakerByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSlice(elm []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1080,8 +1081,8 @@ func emitMakerETByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSlice(t typex.EventTime, elm []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1093,8 +1094,8 @@ func emitMakerByteSliceByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceByteSlice(key []byte, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1106,8 +1107,8 @@ func emitMakerETByteSliceByteSlice(n exec.ElementProcessor) exec.ReusableEmitter
 }
 
 func (e *emitNative) invokeETByteSliceByteSlice(t typex.EventTime, key []byte, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1119,8 +1120,8 @@ func emitMakerByteSliceBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceBool(key []byte, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1132,8 +1133,8 @@ func emitMakerETByteSliceBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceBool(t typex.EventTime, key []byte, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1145,8 +1146,8 @@ func emitMakerByteSliceString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceString(key []byte, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1158,8 +1159,8 @@ func emitMakerETByteSliceString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceString(t typex.EventTime, key []byte, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1171,8 +1172,8 @@ func emitMakerByteSliceInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt(key []byte, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1184,8 +1185,8 @@ func emitMakerETByteSliceInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt(t typex.EventTime, key []byte, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1197,8 +1198,8 @@ func emitMakerByteSliceInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt8(key []byte, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1210,8 +1211,8 @@ func emitMakerETByteSliceInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt8(t typex.EventTime, key []byte, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1223,8 +1224,8 @@ func emitMakerByteSliceInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt16(key []byte, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1236,8 +1237,8 @@ func emitMakerETByteSliceInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt16(t typex.EventTime, key []byte, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1249,8 +1250,8 @@ func emitMakerByteSliceInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt32(key []byte, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1262,8 +1263,8 @@ func emitMakerETByteSliceInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt32(t typex.EventTime, key []byte, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1275,8 +1276,8 @@ func emitMakerByteSliceInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt64(key []byte, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1288,8 +1289,8 @@ func emitMakerETByteSliceInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt64(t typex.EventTime, key []byte, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1301,8 +1302,8 @@ func emitMakerByteSliceUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint(key []byte, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1314,8 +1315,8 @@ func emitMakerETByteSliceUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint(t typex.EventTime, key []byte, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1327,8 +1328,8 @@ func emitMakerByteSliceUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint8(key []byte, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1340,8 +1341,8 @@ func emitMakerETByteSliceUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint8(t typex.EventTime, key []byte, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1353,8 +1354,8 @@ func emitMakerByteSliceUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint16(key []byte, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1366,8 +1367,8 @@ func emitMakerETByteSliceUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint16(t typex.EventTime, key []byte, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1379,8 +1380,8 @@ func emitMakerByteSliceUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint32(key []byte, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1392,8 +1393,8 @@ func emitMakerETByteSliceUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint32(t typex.EventTime, key []byte, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1405,8 +1406,8 @@ func emitMakerByteSliceUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint64(key []byte, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1418,8 +1419,8 @@ func emitMakerETByteSliceUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint64(t typex.EventTime, key []byte, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1431,8 +1432,8 @@ func emitMakerByteSliceFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceFloat32(key []byte, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1444,8 +1445,8 @@ func emitMakerETByteSliceFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceFloat32(t typex.EventTime, key []byte, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1457,8 +1458,8 @@ func emitMakerByteSliceFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceFloat64(key []byte, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1470,8 +1471,8 @@ func emitMakerETByteSliceFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceFloat64(t typex.EventTime, key []byte, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1483,8 +1484,8 @@ func emitMakerByteSliceTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_T(key []byte, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1496,8 +1497,8 @@ func emitMakerETByteSliceTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_T(t typex.EventTime, key []byte, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1509,8 +1510,8 @@ func emitMakerByteSliceTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_U(key []byte, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1522,8 +1523,8 @@ func emitMakerETByteSliceTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_U(t typex.EventTime, key []byte, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1535,8 +1536,8 @@ func emitMakerByteSliceTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_V(key []byte, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1548,8 +1549,8 @@ func emitMakerETByteSliceTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_V(t typex.EventTime, key []byte, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1561,8 +1562,8 @@ func emitMakerByteSliceTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_W(key []byte, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1574,8 +1575,8 @@ func emitMakerETByteSliceTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_W(t typex.EventTime, key []byte, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1587,8 +1588,8 @@ func emitMakerByteSliceTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_X(key []byte, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1600,8 +1601,8 @@ func emitMakerETByteSliceTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_X(t typex.EventTime, key []byte, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1613,8 +1614,8 @@ func emitMakerByteSliceTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_Y(key []byte, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1626,8 +1627,8 @@ func emitMakerETByteSliceTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_Y(t typex.EventTime, key []byte, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1639,8 +1640,8 @@ func emitMakerByteSliceTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_Z(key []byte, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1652,8 +1653,8 @@ func emitMakerETByteSliceTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_Z(t typex.EventTime, key []byte, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1665,8 +1666,8 @@ func emitMakerBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBool(elm bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1678,8 +1679,8 @@ func emitMakerETBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBool(t typex.EventTime, elm bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1691,8 +1692,8 @@ func emitMakerBoolByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolByteSlice(key bool, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1704,8 +1705,8 @@ func emitMakerETBoolByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolByteSlice(t typex.EventTime, key bool, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1717,8 +1718,8 @@ func emitMakerBoolBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolBool(key bool, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1730,8 +1731,8 @@ func emitMakerETBoolBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolBool(t typex.EventTime, key bool, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1743,8 +1744,8 @@ func emitMakerBoolString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolString(key bool, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1756,8 +1757,8 @@ func emitMakerETBoolString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolString(t typex.EventTime, key bool, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1769,8 +1770,8 @@ func emitMakerBoolInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt(key bool, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1782,8 +1783,8 @@ func emitMakerETBoolInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt(t typex.EventTime, key bool, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1795,8 +1796,8 @@ func emitMakerBoolInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt8(key bool, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1808,8 +1809,8 @@ func emitMakerETBoolInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt8(t typex.EventTime, key bool, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1821,8 +1822,8 @@ func emitMakerBoolInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt16(key bool, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1834,8 +1835,8 @@ func emitMakerETBoolInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt16(t typex.EventTime, key bool, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1847,8 +1848,8 @@ func emitMakerBoolInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt32(key bool, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1860,8 +1861,8 @@ func emitMakerETBoolInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt32(t typex.EventTime, key bool, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1873,8 +1874,8 @@ func emitMakerBoolInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt64(key bool, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1886,8 +1887,8 @@ func emitMakerETBoolInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt64(t typex.EventTime, key bool, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1899,8 +1900,8 @@ func emitMakerBoolUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint(key bool, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1912,8 +1913,8 @@ func emitMakerETBoolUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint(t typex.EventTime, key bool, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1925,8 +1926,8 @@ func emitMakerBoolUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint8(key bool, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1938,8 +1939,8 @@ func emitMakerETBoolUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint8(t typex.EventTime, key bool, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1951,8 +1952,8 @@ func emitMakerBoolUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint16(key bool, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1964,8 +1965,8 @@ func emitMakerETBoolUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint16(t typex.EventTime, key bool, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1977,8 +1978,8 @@ func emitMakerBoolUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint32(key bool, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -1990,8 +1991,8 @@ func emitMakerETBoolUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint32(t typex.EventTime, key bool, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2003,8 +2004,8 @@ func emitMakerBoolUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint64(key bool, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2016,8 +2017,8 @@ func emitMakerETBoolUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint64(t typex.EventTime, key bool, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2029,8 +2030,8 @@ func emitMakerBoolFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolFloat32(key bool, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2042,8 +2043,8 @@ func emitMakerETBoolFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolFloat32(t typex.EventTime, key bool, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2055,8 +2056,8 @@ func emitMakerBoolFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolFloat64(key bool, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2068,8 +2069,8 @@ func emitMakerETBoolFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolFloat64(t typex.EventTime, key bool, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2081,8 +2082,8 @@ func emitMakerBoolTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_T(key bool, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2094,8 +2095,8 @@ func emitMakerETBoolTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_T(t typex.EventTime, key bool, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2107,8 +2108,8 @@ func emitMakerBoolTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_U(key bool, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2120,8 +2121,8 @@ func emitMakerETBoolTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_U(t typex.EventTime, key bool, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2133,8 +2134,8 @@ func emitMakerBoolTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_V(key bool, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2146,8 +2147,8 @@ func emitMakerETBoolTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_V(t typex.EventTime, key bool, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2159,8 +2160,8 @@ func emitMakerBoolTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_W(key bool, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2172,8 +2173,8 @@ func emitMakerETBoolTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_W(t typex.EventTime, key bool, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2185,8 +2186,8 @@ func emitMakerBoolTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_X(key bool, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2198,8 +2199,8 @@ func emitMakerETBoolTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_X(t typex.EventTime, key bool, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2211,8 +2212,8 @@ func emitMakerBoolTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_Y(key bool, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2224,8 +2225,8 @@ func emitMakerETBoolTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_Y(t typex.EventTime, key bool, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2237,8 +2238,8 @@ func emitMakerBoolTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_Z(key bool, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2250,8 +2251,8 @@ func emitMakerETBoolTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_Z(t typex.EventTime, key bool, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2263,8 +2264,8 @@ func emitMakerString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeString(elm string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2276,8 +2277,8 @@ func emitMakerETString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETString(t typex.EventTime, elm string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2289,8 +2290,8 @@ func emitMakerStringByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringByteSlice(key string, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2302,8 +2303,8 @@ func emitMakerETStringByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringByteSlice(t typex.EventTime, key string, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2315,8 +2316,8 @@ func emitMakerStringBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringBool(key string, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2328,8 +2329,8 @@ func emitMakerETStringBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringBool(t typex.EventTime, key string, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2341,8 +2342,8 @@ func emitMakerStringString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringString(key string, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2354,8 +2355,8 @@ func emitMakerETStringString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringString(t typex.EventTime, key string, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2367,8 +2368,8 @@ func emitMakerStringInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt(key string, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2380,8 +2381,8 @@ func emitMakerETStringInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt(t typex.EventTime, key string, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2393,8 +2394,8 @@ func emitMakerStringInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt8(key string, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2406,8 +2407,8 @@ func emitMakerETStringInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt8(t typex.EventTime, key string, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2419,8 +2420,8 @@ func emitMakerStringInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt16(key string, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2432,8 +2433,8 @@ func emitMakerETStringInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt16(t typex.EventTime, key string, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2445,8 +2446,8 @@ func emitMakerStringInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt32(key string, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2458,8 +2459,8 @@ func emitMakerETStringInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt32(t typex.EventTime, key string, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2471,8 +2472,8 @@ func emitMakerStringInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt64(key string, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2484,8 +2485,8 @@ func emitMakerETStringInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt64(t typex.EventTime, key string, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2497,8 +2498,8 @@ func emitMakerStringUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint(key string, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2510,8 +2511,8 @@ func emitMakerETStringUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint(t typex.EventTime, key string, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2523,8 +2524,8 @@ func emitMakerStringUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint8(key string, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2536,8 +2537,8 @@ func emitMakerETStringUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint8(t typex.EventTime, key string, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2549,8 +2550,8 @@ func emitMakerStringUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint16(key string, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2562,8 +2563,8 @@ func emitMakerETStringUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint16(t typex.EventTime, key string, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2575,8 +2576,8 @@ func emitMakerStringUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint32(key string, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2588,8 +2589,8 @@ func emitMakerETStringUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint32(t typex.EventTime, key string, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2601,8 +2602,8 @@ func emitMakerStringUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint64(key string, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2614,8 +2615,8 @@ func emitMakerETStringUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint64(t typex.EventTime, key string, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2627,8 +2628,8 @@ func emitMakerStringFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringFloat32(key string, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2640,8 +2641,8 @@ func emitMakerETStringFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringFloat32(t typex.EventTime, key string, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2653,8 +2654,8 @@ func emitMakerStringFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringFloat64(key string, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2666,8 +2667,8 @@ func emitMakerETStringFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringFloat64(t typex.EventTime, key string, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2679,8 +2680,8 @@ func emitMakerStringTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_T(key string, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2692,8 +2693,8 @@ func emitMakerETStringTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_T(t typex.EventTime, key string, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2705,8 +2706,8 @@ func emitMakerStringTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_U(key string, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2718,8 +2719,8 @@ func emitMakerETStringTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_U(t typex.EventTime, key string, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2731,8 +2732,8 @@ func emitMakerStringTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_V(key string, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2744,8 +2745,8 @@ func emitMakerETStringTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_V(t typex.EventTime, key string, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2757,8 +2758,8 @@ func emitMakerStringTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_W(key string, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2770,8 +2771,8 @@ func emitMakerETStringTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_W(t typex.EventTime, key string, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2783,8 +2784,8 @@ func emitMakerStringTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_X(key string, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2796,8 +2797,8 @@ func emitMakerETStringTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_X(t typex.EventTime, key string, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2809,8 +2810,8 @@ func emitMakerStringTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_Y(key string, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2822,8 +2823,8 @@ func emitMakerETStringTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_Y(t typex.EventTime, key string, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2835,8 +2836,8 @@ func emitMakerStringTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_Z(key string, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2848,8 +2849,8 @@ func emitMakerETStringTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_Z(t typex.EventTime, key string, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2861,8 +2862,8 @@ func emitMakerInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt(elm int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2874,8 +2875,8 @@ func emitMakerETInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt(t typex.EventTime, elm int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2887,8 +2888,8 @@ func emitMakerIntByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntByteSlice(key int, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2900,8 +2901,8 @@ func emitMakerETIntByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntByteSlice(t typex.EventTime, key int, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2913,8 +2914,8 @@ func emitMakerIntBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntBool(key int, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2926,8 +2927,8 @@ func emitMakerETIntBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntBool(t typex.EventTime, key int, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2939,8 +2940,8 @@ func emitMakerIntString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntString(key int, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2952,8 +2953,8 @@ func emitMakerETIntString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntString(t typex.EventTime, key int, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2965,8 +2966,8 @@ func emitMakerIntInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt(key int, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2978,8 +2979,8 @@ func emitMakerETIntInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt(t typex.EventTime, key int, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -2991,8 +2992,8 @@ func emitMakerIntInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt8(key int, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3004,8 +3005,8 @@ func emitMakerETIntInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt8(t typex.EventTime, key int, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3017,8 +3018,8 @@ func emitMakerIntInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt16(key int, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3030,8 +3031,8 @@ func emitMakerETIntInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt16(t typex.EventTime, key int, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3043,8 +3044,8 @@ func emitMakerIntInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt32(key int, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3056,8 +3057,8 @@ func emitMakerETIntInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt32(t typex.EventTime, key int, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3069,8 +3070,8 @@ func emitMakerIntInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt64(key int, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3082,8 +3083,8 @@ func emitMakerETIntInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt64(t typex.EventTime, key int, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3095,8 +3096,8 @@ func emitMakerIntUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint(key int, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3108,8 +3109,8 @@ func emitMakerETIntUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint(t typex.EventTime, key int, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3121,8 +3122,8 @@ func emitMakerIntUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint8(key int, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3134,8 +3135,8 @@ func emitMakerETIntUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint8(t typex.EventTime, key int, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3147,8 +3148,8 @@ func emitMakerIntUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint16(key int, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3160,8 +3161,8 @@ func emitMakerETIntUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint16(t typex.EventTime, key int, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3173,8 +3174,8 @@ func emitMakerIntUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint32(key int, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3186,8 +3187,8 @@ func emitMakerETIntUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint32(t typex.EventTime, key int, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3199,8 +3200,8 @@ func emitMakerIntUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint64(key int, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3212,8 +3213,8 @@ func emitMakerETIntUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint64(t typex.EventTime, key int, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3225,8 +3226,8 @@ func emitMakerIntFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntFloat32(key int, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3238,8 +3239,8 @@ func emitMakerETIntFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntFloat32(t typex.EventTime, key int, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3251,8 +3252,8 @@ func emitMakerIntFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntFloat64(key int, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3264,8 +3265,8 @@ func emitMakerETIntFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntFloat64(t typex.EventTime, key int, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3277,8 +3278,8 @@ func emitMakerIntTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_T(key int, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3290,8 +3291,8 @@ func emitMakerETIntTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_T(t typex.EventTime, key int, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3303,8 +3304,8 @@ func emitMakerIntTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_U(key int, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3316,8 +3317,8 @@ func emitMakerETIntTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_U(t typex.EventTime, key int, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3329,8 +3330,8 @@ func emitMakerIntTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_V(key int, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3342,8 +3343,8 @@ func emitMakerETIntTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_V(t typex.EventTime, key int, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3355,8 +3356,8 @@ func emitMakerIntTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_W(key int, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3368,8 +3369,8 @@ func emitMakerETIntTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_W(t typex.EventTime, key int, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3381,8 +3382,8 @@ func emitMakerIntTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_X(key int, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3394,8 +3395,8 @@ func emitMakerETIntTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_X(t typex.EventTime, key int, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3407,8 +3408,8 @@ func emitMakerIntTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_Y(key int, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3420,8 +3421,8 @@ func emitMakerETIntTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_Y(t typex.EventTime, key int, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3433,8 +3434,8 @@ func emitMakerIntTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_Z(key int, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3446,8 +3447,8 @@ func emitMakerETIntTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_Z(t typex.EventTime, key int, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3459,8 +3460,8 @@ func emitMakerInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8(elm int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3472,8 +3473,8 @@ func emitMakerETInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8(t typex.EventTime, elm int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3485,8 +3486,8 @@ func emitMakerInt8ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8ByteSlice(key int8, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3498,8 +3499,8 @@ func emitMakerETInt8ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8ByteSlice(t typex.EventTime, key int8, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3511,8 +3512,8 @@ func emitMakerInt8Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Bool(key int8, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3524,8 +3525,8 @@ func emitMakerETInt8Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Bool(t typex.EventTime, key int8, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3537,8 +3538,8 @@ func emitMakerInt8String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8String(key int8, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3550,8 +3551,8 @@ func emitMakerETInt8String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8String(t typex.EventTime, key int8, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3563,8 +3564,8 @@ func emitMakerInt8Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int(key int8, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3576,8 +3577,8 @@ func emitMakerETInt8Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int(t typex.EventTime, key int8, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3589,8 +3590,8 @@ func emitMakerInt8Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int8(key int8, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3602,8 +3603,8 @@ func emitMakerETInt8Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int8(t typex.EventTime, key int8, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3615,8 +3616,8 @@ func emitMakerInt8Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int16(key int8, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3628,8 +3629,8 @@ func emitMakerETInt8Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int16(t typex.EventTime, key int8, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3641,8 +3642,8 @@ func emitMakerInt8Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int32(key int8, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3654,8 +3655,8 @@ func emitMakerETInt8Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int32(t typex.EventTime, key int8, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3667,8 +3668,8 @@ func emitMakerInt8Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int64(key int8, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3680,8 +3681,8 @@ func emitMakerETInt8Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int64(t typex.EventTime, key int8, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3693,8 +3694,8 @@ func emitMakerInt8Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint(key int8, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3706,8 +3707,8 @@ func emitMakerETInt8Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint(t typex.EventTime, key int8, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3719,8 +3720,8 @@ func emitMakerInt8Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint8(key int8, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3732,8 +3733,8 @@ func emitMakerETInt8Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint8(t typex.EventTime, key int8, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3745,8 +3746,8 @@ func emitMakerInt8Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint16(key int8, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3758,8 +3759,8 @@ func emitMakerETInt8Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint16(t typex.EventTime, key int8, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3771,8 +3772,8 @@ func emitMakerInt8Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint32(key int8, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3784,8 +3785,8 @@ func emitMakerETInt8Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint32(t typex.EventTime, key int8, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3797,8 +3798,8 @@ func emitMakerInt8Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint64(key int8, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3810,8 +3811,8 @@ func emitMakerETInt8Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint64(t typex.EventTime, key int8, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3823,8 +3824,8 @@ func emitMakerInt8Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Float32(key int8, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3836,8 +3837,8 @@ func emitMakerETInt8Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Float32(t typex.EventTime, key int8, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3849,8 +3850,8 @@ func emitMakerInt8Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Float64(key int8, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3862,8 +3863,8 @@ func emitMakerETInt8Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Float64(t typex.EventTime, key int8, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3875,8 +3876,8 @@ func emitMakerInt8Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_T(key int8, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3888,8 +3889,8 @@ func emitMakerETInt8Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_T(t typex.EventTime, key int8, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3901,8 +3902,8 @@ func emitMakerInt8Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_U(key int8, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3914,8 +3915,8 @@ func emitMakerETInt8Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_U(t typex.EventTime, key int8, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3927,8 +3928,8 @@ func emitMakerInt8Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_V(key int8, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3940,8 +3941,8 @@ func emitMakerETInt8Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_V(t typex.EventTime, key int8, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3953,8 +3954,8 @@ func emitMakerInt8Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_W(key int8, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3966,8 +3967,8 @@ func emitMakerETInt8Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_W(t typex.EventTime, key int8, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3979,8 +3980,8 @@ func emitMakerInt8Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_X(key int8, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -3992,8 +3993,8 @@ func emitMakerETInt8Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_X(t typex.EventTime, key int8, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4005,8 +4006,8 @@ func emitMakerInt8Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_Y(key int8, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4018,8 +4019,8 @@ func emitMakerETInt8Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_Y(t typex.EventTime, key int8, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4031,8 +4032,8 @@ func emitMakerInt8Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_Z(key int8, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4044,8 +4045,8 @@ func emitMakerETInt8Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_Z(t typex.EventTime, key int8, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4057,8 +4058,8 @@ func emitMakerInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16(elm int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4070,8 +4071,8 @@ func emitMakerETInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16(t typex.EventTime, elm int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4083,8 +4084,8 @@ func emitMakerInt16ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16ByteSlice(key int16, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4096,8 +4097,8 @@ func emitMakerETInt16ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16ByteSlice(t typex.EventTime, key int16, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4109,8 +4110,8 @@ func emitMakerInt16Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Bool(key int16, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4122,8 +4123,8 @@ func emitMakerETInt16Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Bool(t typex.EventTime, key int16, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4135,8 +4136,8 @@ func emitMakerInt16String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16String(key int16, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4148,8 +4149,8 @@ func emitMakerETInt16String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16String(t typex.EventTime, key int16, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4161,8 +4162,8 @@ func emitMakerInt16Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int(key int16, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4174,8 +4175,8 @@ func emitMakerETInt16Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int(t typex.EventTime, key int16, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4187,8 +4188,8 @@ func emitMakerInt16Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int8(key int16, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4200,8 +4201,8 @@ func emitMakerETInt16Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int8(t typex.EventTime, key int16, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4213,8 +4214,8 @@ func emitMakerInt16Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int16(key int16, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4226,8 +4227,8 @@ func emitMakerETInt16Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int16(t typex.EventTime, key int16, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4239,8 +4240,8 @@ func emitMakerInt16Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int32(key int16, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4252,8 +4253,8 @@ func emitMakerETInt16Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int32(t typex.EventTime, key int16, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4265,8 +4266,8 @@ func emitMakerInt16Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int64(key int16, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4278,8 +4279,8 @@ func emitMakerETInt16Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int64(t typex.EventTime, key int16, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4291,8 +4292,8 @@ func emitMakerInt16Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint(key int16, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4304,8 +4305,8 @@ func emitMakerETInt16Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint(t typex.EventTime, key int16, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4317,8 +4318,8 @@ func emitMakerInt16Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint8(key int16, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4330,8 +4331,8 @@ func emitMakerETInt16Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint8(t typex.EventTime, key int16, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4343,8 +4344,8 @@ func emitMakerInt16Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint16(key int16, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4356,8 +4357,8 @@ func emitMakerETInt16Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint16(t typex.EventTime, key int16, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4369,8 +4370,8 @@ func emitMakerInt16Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint32(key int16, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4382,8 +4383,8 @@ func emitMakerETInt16Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint32(t typex.EventTime, key int16, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4395,8 +4396,8 @@ func emitMakerInt16Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint64(key int16, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4408,8 +4409,8 @@ func emitMakerETInt16Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint64(t typex.EventTime, key int16, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4421,8 +4422,8 @@ func emitMakerInt16Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Float32(key int16, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4434,8 +4435,8 @@ func emitMakerETInt16Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Float32(t typex.EventTime, key int16, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4447,8 +4448,8 @@ func emitMakerInt16Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Float64(key int16, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4460,8 +4461,8 @@ func emitMakerETInt16Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Float64(t typex.EventTime, key int16, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4473,8 +4474,8 @@ func emitMakerInt16Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_T(key int16, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4486,8 +4487,8 @@ func emitMakerETInt16Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_T(t typex.EventTime, key int16, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4499,8 +4500,8 @@ func emitMakerInt16Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_U(key int16, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4512,8 +4513,8 @@ func emitMakerETInt16Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_U(t typex.EventTime, key int16, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4525,8 +4526,8 @@ func emitMakerInt16Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_V(key int16, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4538,8 +4539,8 @@ func emitMakerETInt16Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_V(t typex.EventTime, key int16, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4551,8 +4552,8 @@ func emitMakerInt16Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_W(key int16, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4564,8 +4565,8 @@ func emitMakerETInt16Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_W(t typex.EventTime, key int16, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4577,8 +4578,8 @@ func emitMakerInt16Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_X(key int16, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4590,8 +4591,8 @@ func emitMakerETInt16Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_X(t typex.EventTime, key int16, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4603,8 +4604,8 @@ func emitMakerInt16Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_Y(key int16, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4616,8 +4617,8 @@ func emitMakerETInt16Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_Y(t typex.EventTime, key int16, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4629,8 +4630,8 @@ func emitMakerInt16Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_Z(key int16, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4642,8 +4643,8 @@ func emitMakerETInt16Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_Z(t typex.EventTime, key int16, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4655,8 +4656,8 @@ func emitMakerInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32(elm int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4668,8 +4669,8 @@ func emitMakerETInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32(t typex.EventTime, elm int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4681,8 +4682,8 @@ func emitMakerInt32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32ByteSlice(key int32, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4694,8 +4695,8 @@ func emitMakerETInt32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32ByteSlice(t typex.EventTime, key int32, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4707,8 +4708,8 @@ func emitMakerInt32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Bool(key int32, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4720,8 +4721,8 @@ func emitMakerETInt32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Bool(t typex.EventTime, key int32, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4733,8 +4734,8 @@ func emitMakerInt32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32String(key int32, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4746,8 +4747,8 @@ func emitMakerETInt32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32String(t typex.EventTime, key int32, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4759,8 +4760,8 @@ func emitMakerInt32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int(key int32, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4772,8 +4773,8 @@ func emitMakerETInt32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int(t typex.EventTime, key int32, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4785,8 +4786,8 @@ func emitMakerInt32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int8(key int32, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4798,8 +4799,8 @@ func emitMakerETInt32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int8(t typex.EventTime, key int32, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4811,8 +4812,8 @@ func emitMakerInt32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int16(key int32, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4824,8 +4825,8 @@ func emitMakerETInt32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int16(t typex.EventTime, key int32, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4837,8 +4838,8 @@ func emitMakerInt32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int32(key int32, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4850,8 +4851,8 @@ func emitMakerETInt32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int32(t typex.EventTime, key int32, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4863,8 +4864,8 @@ func emitMakerInt32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int64(key int32, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4876,8 +4877,8 @@ func emitMakerETInt32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int64(t typex.EventTime, key int32, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4889,8 +4890,8 @@ func emitMakerInt32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint(key int32, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4902,8 +4903,8 @@ func emitMakerETInt32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint(t typex.EventTime, key int32, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4915,8 +4916,8 @@ func emitMakerInt32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint8(key int32, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4928,8 +4929,8 @@ func emitMakerETInt32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint8(t typex.EventTime, key int32, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4941,8 +4942,8 @@ func emitMakerInt32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint16(key int32, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4954,8 +4955,8 @@ func emitMakerETInt32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint16(t typex.EventTime, key int32, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4967,8 +4968,8 @@ func emitMakerInt32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint32(key int32, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4980,8 +4981,8 @@ func emitMakerETInt32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint32(t typex.EventTime, key int32, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -4993,8 +4994,8 @@ func emitMakerInt32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint64(key int32, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5006,8 +5007,8 @@ func emitMakerETInt32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint64(t typex.EventTime, key int32, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5019,8 +5020,8 @@ func emitMakerInt32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Float32(key int32, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5032,8 +5033,8 @@ func emitMakerETInt32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Float32(t typex.EventTime, key int32, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5045,8 +5046,8 @@ func emitMakerInt32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Float64(key int32, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5058,8 +5059,8 @@ func emitMakerETInt32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Float64(t typex.EventTime, key int32, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5071,8 +5072,8 @@ func emitMakerInt32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_T(key int32, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5084,8 +5085,8 @@ func emitMakerETInt32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_T(t typex.EventTime, key int32, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5097,8 +5098,8 @@ func emitMakerInt32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_U(key int32, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5110,8 +5111,8 @@ func emitMakerETInt32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_U(t typex.EventTime, key int32, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5123,8 +5124,8 @@ func emitMakerInt32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_V(key int32, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5136,8 +5137,8 @@ func emitMakerETInt32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_V(t typex.EventTime, key int32, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5149,8 +5150,8 @@ func emitMakerInt32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_W(key int32, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5162,8 +5163,8 @@ func emitMakerETInt32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_W(t typex.EventTime, key int32, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5175,8 +5176,8 @@ func emitMakerInt32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_X(key int32, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5188,8 +5189,8 @@ func emitMakerETInt32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_X(t typex.EventTime, key int32, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5201,8 +5202,8 @@ func emitMakerInt32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_Y(key int32, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5214,8 +5215,8 @@ func emitMakerETInt32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_Y(t typex.EventTime, key int32, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5227,8 +5228,8 @@ func emitMakerInt32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_Z(key int32, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5240,8 +5241,8 @@ func emitMakerETInt32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_Z(t typex.EventTime, key int32, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5253,8 +5254,8 @@ func emitMakerInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64(elm int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5266,8 +5267,8 @@ func emitMakerETInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64(t typex.EventTime, elm int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5279,8 +5280,8 @@ func emitMakerInt64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64ByteSlice(key int64, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5292,8 +5293,8 @@ func emitMakerETInt64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64ByteSlice(t typex.EventTime, key int64, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5305,8 +5306,8 @@ func emitMakerInt64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Bool(key int64, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5318,8 +5319,8 @@ func emitMakerETInt64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Bool(t typex.EventTime, key int64, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5331,8 +5332,8 @@ func emitMakerInt64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64String(key int64, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5344,8 +5345,8 @@ func emitMakerETInt64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64String(t typex.EventTime, key int64, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5357,8 +5358,8 @@ func emitMakerInt64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int(key int64, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5370,8 +5371,8 @@ func emitMakerETInt64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int(t typex.EventTime, key int64, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5383,8 +5384,8 @@ func emitMakerInt64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int8(key int64, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5396,8 +5397,8 @@ func emitMakerETInt64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int8(t typex.EventTime, key int64, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5409,8 +5410,8 @@ func emitMakerInt64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int16(key int64, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5422,8 +5423,8 @@ func emitMakerETInt64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int16(t typex.EventTime, key int64, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5435,8 +5436,8 @@ func emitMakerInt64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int32(key int64, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5448,8 +5449,8 @@ func emitMakerETInt64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int32(t typex.EventTime, key int64, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5461,8 +5462,8 @@ func emitMakerInt64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int64(key int64, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5474,8 +5475,8 @@ func emitMakerETInt64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int64(t typex.EventTime, key int64, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5487,8 +5488,8 @@ func emitMakerInt64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint(key int64, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5500,8 +5501,8 @@ func emitMakerETInt64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint(t typex.EventTime, key int64, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5513,8 +5514,8 @@ func emitMakerInt64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint8(key int64, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5526,8 +5527,8 @@ func emitMakerETInt64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint8(t typex.EventTime, key int64, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5539,8 +5540,8 @@ func emitMakerInt64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint16(key int64, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5552,8 +5553,8 @@ func emitMakerETInt64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint16(t typex.EventTime, key int64, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5565,8 +5566,8 @@ func emitMakerInt64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint32(key int64, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5578,8 +5579,8 @@ func emitMakerETInt64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint32(t typex.EventTime, key int64, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5591,8 +5592,8 @@ func emitMakerInt64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint64(key int64, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5604,8 +5605,8 @@ func emitMakerETInt64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint64(t typex.EventTime, key int64, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5617,8 +5618,8 @@ func emitMakerInt64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Float32(key int64, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5630,8 +5631,8 @@ func emitMakerETInt64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Float32(t typex.EventTime, key int64, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5643,8 +5644,8 @@ func emitMakerInt64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Float64(key int64, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5656,8 +5657,8 @@ func emitMakerETInt64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Float64(t typex.EventTime, key int64, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5669,8 +5670,8 @@ func emitMakerInt64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_T(key int64, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5682,8 +5683,8 @@ func emitMakerETInt64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_T(t typex.EventTime, key int64, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5695,8 +5696,8 @@ func emitMakerInt64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_U(key int64, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5708,8 +5709,8 @@ func emitMakerETInt64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_U(t typex.EventTime, key int64, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5721,8 +5722,8 @@ func emitMakerInt64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_V(key int64, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5734,8 +5735,8 @@ func emitMakerETInt64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_V(t typex.EventTime, key int64, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5747,8 +5748,8 @@ func emitMakerInt64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_W(key int64, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5760,8 +5761,8 @@ func emitMakerETInt64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_W(t typex.EventTime, key int64, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5773,8 +5774,8 @@ func emitMakerInt64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_X(key int64, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5786,8 +5787,8 @@ func emitMakerETInt64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_X(t typex.EventTime, key int64, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5799,8 +5800,8 @@ func emitMakerInt64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_Y(key int64, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5812,8 +5813,8 @@ func emitMakerETInt64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_Y(t typex.EventTime, key int64, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5825,8 +5826,8 @@ func emitMakerInt64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_Z(key int64, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5838,8 +5839,8 @@ func emitMakerETInt64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_Z(t typex.EventTime, key int64, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5851,8 +5852,8 @@ func emitMakerUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint(elm uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5864,8 +5865,8 @@ func emitMakerETUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint(t typex.EventTime, elm uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5877,8 +5878,8 @@ func emitMakerUintByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintByteSlice(key uint, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5890,8 +5891,8 @@ func emitMakerETUintByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintByteSlice(t typex.EventTime, key uint, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5903,8 +5904,8 @@ func emitMakerUintBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintBool(key uint, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5916,8 +5917,8 @@ func emitMakerETUintBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintBool(t typex.EventTime, key uint, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5929,8 +5930,8 @@ func emitMakerUintString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintString(key uint, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5942,8 +5943,8 @@ func emitMakerETUintString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintString(t typex.EventTime, key uint, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5955,8 +5956,8 @@ func emitMakerUintInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt(key uint, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5968,8 +5969,8 @@ func emitMakerETUintInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt(t typex.EventTime, key uint, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5981,8 +5982,8 @@ func emitMakerUintInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt8(key uint, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -5994,8 +5995,8 @@ func emitMakerETUintInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt8(t typex.EventTime, key uint, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6007,8 +6008,8 @@ func emitMakerUintInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt16(key uint, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6020,8 +6021,8 @@ func emitMakerETUintInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt16(t typex.EventTime, key uint, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6033,8 +6034,8 @@ func emitMakerUintInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt32(key uint, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6046,8 +6047,8 @@ func emitMakerETUintInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt32(t typex.EventTime, key uint, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6059,8 +6060,8 @@ func emitMakerUintInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt64(key uint, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6072,8 +6073,8 @@ func emitMakerETUintInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt64(t typex.EventTime, key uint, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6085,8 +6086,8 @@ func emitMakerUintUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint(key uint, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6098,8 +6099,8 @@ func emitMakerETUintUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint(t typex.EventTime, key uint, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6111,8 +6112,8 @@ func emitMakerUintUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint8(key uint, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6124,8 +6125,8 @@ func emitMakerETUintUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint8(t typex.EventTime, key uint, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6137,8 +6138,8 @@ func emitMakerUintUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint16(key uint, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6150,8 +6151,8 @@ func emitMakerETUintUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint16(t typex.EventTime, key uint, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6163,8 +6164,8 @@ func emitMakerUintUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint32(key uint, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6176,8 +6177,8 @@ func emitMakerETUintUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint32(t typex.EventTime, key uint, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6189,8 +6190,8 @@ func emitMakerUintUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint64(key uint, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6202,8 +6203,8 @@ func emitMakerETUintUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint64(t typex.EventTime, key uint, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6215,8 +6216,8 @@ func emitMakerUintFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintFloat32(key uint, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6228,8 +6229,8 @@ func emitMakerETUintFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintFloat32(t typex.EventTime, key uint, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6241,8 +6242,8 @@ func emitMakerUintFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintFloat64(key uint, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6254,8 +6255,8 @@ func emitMakerETUintFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintFloat64(t typex.EventTime, key uint, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6267,8 +6268,8 @@ func emitMakerUintTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_T(key uint, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6280,8 +6281,8 @@ func emitMakerETUintTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_T(t typex.EventTime, key uint, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6293,8 +6294,8 @@ func emitMakerUintTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_U(key uint, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6306,8 +6307,8 @@ func emitMakerETUintTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_U(t typex.EventTime, key uint, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6319,8 +6320,8 @@ func emitMakerUintTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_V(key uint, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6332,8 +6333,8 @@ func emitMakerETUintTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_V(t typex.EventTime, key uint, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6345,8 +6346,8 @@ func emitMakerUintTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_W(key uint, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6358,8 +6359,8 @@ func emitMakerETUintTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_W(t typex.EventTime, key uint, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6371,8 +6372,8 @@ func emitMakerUintTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_X(key uint, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6384,8 +6385,8 @@ func emitMakerETUintTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_X(t typex.EventTime, key uint, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6397,8 +6398,8 @@ func emitMakerUintTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_Y(key uint, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6410,8 +6411,8 @@ func emitMakerETUintTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_Y(t typex.EventTime, key uint, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6423,8 +6424,8 @@ func emitMakerUintTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_Z(key uint, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6436,8 +6437,8 @@ func emitMakerETUintTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_Z(t typex.EventTime, key uint, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6449,8 +6450,8 @@ func emitMakerUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8(elm uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6462,8 +6463,8 @@ func emitMakerETUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8(t typex.EventTime, elm uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6475,8 +6476,8 @@ func emitMakerUint8ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8ByteSlice(key uint8, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6488,8 +6489,8 @@ func emitMakerETUint8ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8ByteSlice(t typex.EventTime, key uint8, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6501,8 +6502,8 @@ func emitMakerUint8Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Bool(key uint8, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6514,8 +6515,8 @@ func emitMakerETUint8Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Bool(t typex.EventTime, key uint8, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6527,8 +6528,8 @@ func emitMakerUint8String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8String(key uint8, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6540,8 +6541,8 @@ func emitMakerETUint8String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8String(t typex.EventTime, key uint8, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6553,8 +6554,8 @@ func emitMakerUint8Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int(key uint8, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6566,8 +6567,8 @@ func emitMakerETUint8Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int(t typex.EventTime, key uint8, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6579,8 +6580,8 @@ func emitMakerUint8Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int8(key uint8, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6592,8 +6593,8 @@ func emitMakerETUint8Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int8(t typex.EventTime, key uint8, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6605,8 +6606,8 @@ func emitMakerUint8Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int16(key uint8, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6618,8 +6619,8 @@ func emitMakerETUint8Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int16(t typex.EventTime, key uint8, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6631,8 +6632,8 @@ func emitMakerUint8Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int32(key uint8, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6644,8 +6645,8 @@ func emitMakerETUint8Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int32(t typex.EventTime, key uint8, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6657,8 +6658,8 @@ func emitMakerUint8Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int64(key uint8, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6670,8 +6671,8 @@ func emitMakerETUint8Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int64(t typex.EventTime, key uint8, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6683,8 +6684,8 @@ func emitMakerUint8Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint(key uint8, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6696,8 +6697,8 @@ func emitMakerETUint8Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint(t typex.EventTime, key uint8, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6709,8 +6710,8 @@ func emitMakerUint8Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint8(key uint8, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6722,8 +6723,8 @@ func emitMakerETUint8Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint8(t typex.EventTime, key uint8, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6735,8 +6736,8 @@ func emitMakerUint8Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint16(key uint8, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6748,8 +6749,8 @@ func emitMakerETUint8Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint16(t typex.EventTime, key uint8, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6761,8 +6762,8 @@ func emitMakerUint8Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint32(key uint8, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6774,8 +6775,8 @@ func emitMakerETUint8Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint32(t typex.EventTime, key uint8, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6787,8 +6788,8 @@ func emitMakerUint8Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint64(key uint8, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6800,8 +6801,8 @@ func emitMakerETUint8Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint64(t typex.EventTime, key uint8, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6813,8 +6814,8 @@ func emitMakerUint8Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Float32(key uint8, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6826,8 +6827,8 @@ func emitMakerETUint8Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Float32(t typex.EventTime, key uint8, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6839,8 +6840,8 @@ func emitMakerUint8Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Float64(key uint8, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6852,8 +6853,8 @@ func emitMakerETUint8Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Float64(t typex.EventTime, key uint8, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6865,8 +6866,8 @@ func emitMakerUint8Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_T(key uint8, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6878,8 +6879,8 @@ func emitMakerETUint8Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_T(t typex.EventTime, key uint8, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6891,8 +6892,8 @@ func emitMakerUint8Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_U(key uint8, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6904,8 +6905,8 @@ func emitMakerETUint8Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_U(t typex.EventTime, key uint8, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6917,8 +6918,8 @@ func emitMakerUint8Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_V(key uint8, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6930,8 +6931,8 @@ func emitMakerETUint8Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_V(t typex.EventTime, key uint8, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6943,8 +6944,8 @@ func emitMakerUint8Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_W(key uint8, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6956,8 +6957,8 @@ func emitMakerETUint8Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_W(t typex.EventTime, key uint8, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6969,8 +6970,8 @@ func emitMakerUint8Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_X(key uint8, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6982,8 +6983,8 @@ func emitMakerETUint8Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_X(t typex.EventTime, key uint8, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -6995,8 +6996,8 @@ func emitMakerUint8Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_Y(key uint8, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7008,8 +7009,8 @@ func emitMakerETUint8Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_Y(t typex.EventTime, key uint8, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7021,8 +7022,8 @@ func emitMakerUint8Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_Z(key uint8, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7034,8 +7035,8 @@ func emitMakerETUint8Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_Z(t typex.EventTime, key uint8, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7047,8 +7048,8 @@ func emitMakerUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16(elm uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7060,8 +7061,8 @@ func emitMakerETUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16(t typex.EventTime, elm uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7073,8 +7074,8 @@ func emitMakerUint16ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16ByteSlice(key uint16, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7086,8 +7087,8 @@ func emitMakerETUint16ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16ByteSlice(t typex.EventTime, key uint16, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7099,8 +7100,8 @@ func emitMakerUint16Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Bool(key uint16, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7112,8 +7113,8 @@ func emitMakerETUint16Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Bool(t typex.EventTime, key uint16, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7125,8 +7126,8 @@ func emitMakerUint16String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16String(key uint16, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7138,8 +7139,8 @@ func emitMakerETUint16String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16String(t typex.EventTime, key uint16, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7151,8 +7152,8 @@ func emitMakerUint16Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int(key uint16, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7164,8 +7165,8 @@ func emitMakerETUint16Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int(t typex.EventTime, key uint16, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7177,8 +7178,8 @@ func emitMakerUint16Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int8(key uint16, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7190,8 +7191,8 @@ func emitMakerETUint16Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int8(t typex.EventTime, key uint16, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7203,8 +7204,8 @@ func emitMakerUint16Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int16(key uint16, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7216,8 +7217,8 @@ func emitMakerETUint16Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int16(t typex.EventTime, key uint16, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7229,8 +7230,8 @@ func emitMakerUint16Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int32(key uint16, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7242,8 +7243,8 @@ func emitMakerETUint16Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int32(t typex.EventTime, key uint16, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7255,8 +7256,8 @@ func emitMakerUint16Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int64(key uint16, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7268,8 +7269,8 @@ func emitMakerETUint16Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int64(t typex.EventTime, key uint16, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7281,8 +7282,8 @@ func emitMakerUint16Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint(key uint16, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7294,8 +7295,8 @@ func emitMakerETUint16Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint(t typex.EventTime, key uint16, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7307,8 +7308,8 @@ func emitMakerUint16Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint8(key uint16, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7320,8 +7321,8 @@ func emitMakerETUint16Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint8(t typex.EventTime, key uint16, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7333,8 +7334,8 @@ func emitMakerUint16Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint16(key uint16, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7346,8 +7347,8 @@ func emitMakerETUint16Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint16(t typex.EventTime, key uint16, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7359,8 +7360,8 @@ func emitMakerUint16Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint32(key uint16, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7372,8 +7373,8 @@ func emitMakerETUint16Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint32(t typex.EventTime, key uint16, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7385,8 +7386,8 @@ func emitMakerUint16Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint64(key uint16, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7398,8 +7399,8 @@ func emitMakerETUint16Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint64(t typex.EventTime, key uint16, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7411,8 +7412,8 @@ func emitMakerUint16Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Float32(key uint16, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7424,8 +7425,8 @@ func emitMakerETUint16Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Float32(t typex.EventTime, key uint16, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7437,8 +7438,8 @@ func emitMakerUint16Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Float64(key uint16, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7450,8 +7451,8 @@ func emitMakerETUint16Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Float64(t typex.EventTime, key uint16, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7463,8 +7464,8 @@ func emitMakerUint16Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_T(key uint16, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7476,8 +7477,8 @@ func emitMakerETUint16Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_T(t typex.EventTime, key uint16, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7489,8 +7490,8 @@ func emitMakerUint16Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_U(key uint16, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7502,8 +7503,8 @@ func emitMakerETUint16Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_U(t typex.EventTime, key uint16, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7515,8 +7516,8 @@ func emitMakerUint16Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_V(key uint16, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7528,8 +7529,8 @@ func emitMakerETUint16Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_V(t typex.EventTime, key uint16, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7541,8 +7542,8 @@ func emitMakerUint16Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_W(key uint16, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7554,8 +7555,8 @@ func emitMakerETUint16Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_W(t typex.EventTime, key uint16, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7567,8 +7568,8 @@ func emitMakerUint16Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_X(key uint16, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7580,8 +7581,8 @@ func emitMakerETUint16Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_X(t typex.EventTime, key uint16, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7593,8 +7594,8 @@ func emitMakerUint16Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_Y(key uint16, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7606,8 +7607,8 @@ func emitMakerETUint16Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_Y(t typex.EventTime, key uint16, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7619,8 +7620,8 @@ func emitMakerUint16Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_Z(key uint16, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7632,8 +7633,8 @@ func emitMakerETUint16Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_Z(t typex.EventTime, key uint16, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7645,8 +7646,8 @@ func emitMakerUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32(elm uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7658,8 +7659,8 @@ func emitMakerETUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32(t typex.EventTime, elm uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7671,8 +7672,8 @@ func emitMakerUint32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32ByteSlice(key uint32, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7684,8 +7685,8 @@ func emitMakerETUint32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32ByteSlice(t typex.EventTime, key uint32, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7697,8 +7698,8 @@ func emitMakerUint32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Bool(key uint32, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7710,8 +7711,8 @@ func emitMakerETUint32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Bool(t typex.EventTime, key uint32, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7723,8 +7724,8 @@ func emitMakerUint32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32String(key uint32, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7736,8 +7737,8 @@ func emitMakerETUint32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32String(t typex.EventTime, key uint32, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7749,8 +7750,8 @@ func emitMakerUint32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int(key uint32, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7762,8 +7763,8 @@ func emitMakerETUint32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int(t typex.EventTime, key uint32, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7775,8 +7776,8 @@ func emitMakerUint32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int8(key uint32, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7788,8 +7789,8 @@ func emitMakerETUint32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int8(t typex.EventTime, key uint32, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7801,8 +7802,8 @@ func emitMakerUint32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int16(key uint32, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7814,8 +7815,8 @@ func emitMakerETUint32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int16(t typex.EventTime, key uint32, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7827,8 +7828,8 @@ func emitMakerUint32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int32(key uint32, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7840,8 +7841,8 @@ func emitMakerETUint32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int32(t typex.EventTime, key uint32, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7853,8 +7854,8 @@ func emitMakerUint32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int64(key uint32, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7866,8 +7867,8 @@ func emitMakerETUint32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int64(t typex.EventTime, key uint32, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7879,8 +7880,8 @@ func emitMakerUint32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint(key uint32, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7892,8 +7893,8 @@ func emitMakerETUint32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint(t typex.EventTime, key uint32, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7905,8 +7906,8 @@ func emitMakerUint32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint8(key uint32, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7918,8 +7919,8 @@ func emitMakerETUint32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint8(t typex.EventTime, key uint32, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7931,8 +7932,8 @@ func emitMakerUint32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint16(key uint32, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7944,8 +7945,8 @@ func emitMakerETUint32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint16(t typex.EventTime, key uint32, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7957,8 +7958,8 @@ func emitMakerUint32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint32(key uint32, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7970,8 +7971,8 @@ func emitMakerETUint32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint32(t typex.EventTime, key uint32, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7983,8 +7984,8 @@ func emitMakerUint32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint64(key uint32, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -7996,8 +7997,8 @@ func emitMakerETUint32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint64(t typex.EventTime, key uint32, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8009,8 +8010,8 @@ func emitMakerUint32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Float32(key uint32, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8022,8 +8023,8 @@ func emitMakerETUint32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Float32(t typex.EventTime, key uint32, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8035,8 +8036,8 @@ func emitMakerUint32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Float64(key uint32, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8048,8 +8049,8 @@ func emitMakerETUint32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Float64(t typex.EventTime, key uint32, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8061,8 +8062,8 @@ func emitMakerUint32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_T(key uint32, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8074,8 +8075,8 @@ func emitMakerETUint32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_T(t typex.EventTime, key uint32, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8087,8 +8088,8 @@ func emitMakerUint32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_U(key uint32, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8100,8 +8101,8 @@ func emitMakerETUint32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_U(t typex.EventTime, key uint32, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8113,8 +8114,8 @@ func emitMakerUint32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_V(key uint32, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8126,8 +8127,8 @@ func emitMakerETUint32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_V(t typex.EventTime, key uint32, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8139,8 +8140,8 @@ func emitMakerUint32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_W(key uint32, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8152,8 +8153,8 @@ func emitMakerETUint32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_W(t typex.EventTime, key uint32, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8165,8 +8166,8 @@ func emitMakerUint32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_X(key uint32, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8178,8 +8179,8 @@ func emitMakerETUint32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_X(t typex.EventTime, key uint32, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8191,8 +8192,8 @@ func emitMakerUint32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_Y(key uint32, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8204,8 +8205,8 @@ func emitMakerETUint32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_Y(t typex.EventTime, key uint32, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8217,8 +8218,8 @@ func emitMakerUint32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_Z(key uint32, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8230,8 +8231,8 @@ func emitMakerETUint32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_Z(t typex.EventTime, key uint32, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8243,8 +8244,8 @@ func emitMakerUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64(elm uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8256,8 +8257,8 @@ func emitMakerETUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64(t typex.EventTime, elm uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8269,8 +8270,8 @@ func emitMakerUint64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64ByteSlice(key uint64, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8282,8 +8283,8 @@ func emitMakerETUint64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64ByteSlice(t typex.EventTime, key uint64, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8295,8 +8296,8 @@ func emitMakerUint64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Bool(key uint64, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8308,8 +8309,8 @@ func emitMakerETUint64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Bool(t typex.EventTime, key uint64, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8321,8 +8322,8 @@ func emitMakerUint64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64String(key uint64, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8334,8 +8335,8 @@ func emitMakerETUint64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64String(t typex.EventTime, key uint64, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8347,8 +8348,8 @@ func emitMakerUint64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int(key uint64, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8360,8 +8361,8 @@ func emitMakerETUint64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int(t typex.EventTime, key uint64, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8373,8 +8374,8 @@ func emitMakerUint64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int8(key uint64, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8386,8 +8387,8 @@ func emitMakerETUint64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int8(t typex.EventTime, key uint64, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8399,8 +8400,8 @@ func emitMakerUint64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int16(key uint64, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8412,8 +8413,8 @@ func emitMakerETUint64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int16(t typex.EventTime, key uint64, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8425,8 +8426,8 @@ func emitMakerUint64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int32(key uint64, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8438,8 +8439,8 @@ func emitMakerETUint64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int32(t typex.EventTime, key uint64, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8451,8 +8452,8 @@ func emitMakerUint64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int64(key uint64, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8464,8 +8465,8 @@ func emitMakerETUint64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int64(t typex.EventTime, key uint64, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8477,8 +8478,8 @@ func emitMakerUint64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint(key uint64, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8490,8 +8491,8 @@ func emitMakerETUint64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint(t typex.EventTime, key uint64, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8503,8 +8504,8 @@ func emitMakerUint64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint8(key uint64, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8516,8 +8517,8 @@ func emitMakerETUint64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint8(t typex.EventTime, key uint64, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8529,8 +8530,8 @@ func emitMakerUint64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint16(key uint64, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8542,8 +8543,8 @@ func emitMakerETUint64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint16(t typex.EventTime, key uint64, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8555,8 +8556,8 @@ func emitMakerUint64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint32(key uint64, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8568,8 +8569,8 @@ func emitMakerETUint64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint32(t typex.EventTime, key uint64, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8581,8 +8582,8 @@ func emitMakerUint64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint64(key uint64, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8594,8 +8595,8 @@ func emitMakerETUint64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint64(t typex.EventTime, key uint64, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8607,8 +8608,8 @@ func emitMakerUint64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Float32(key uint64, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8620,8 +8621,8 @@ func emitMakerETUint64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Float32(t typex.EventTime, key uint64, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8633,8 +8634,8 @@ func emitMakerUint64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Float64(key uint64, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8646,8 +8647,8 @@ func emitMakerETUint64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Float64(t typex.EventTime, key uint64, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8659,8 +8660,8 @@ func emitMakerUint64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_T(key uint64, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8672,8 +8673,8 @@ func emitMakerETUint64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_T(t typex.EventTime, key uint64, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8685,8 +8686,8 @@ func emitMakerUint64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_U(key uint64, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8698,8 +8699,8 @@ func emitMakerETUint64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_U(t typex.EventTime, key uint64, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8711,8 +8712,8 @@ func emitMakerUint64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_V(key uint64, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8724,8 +8725,8 @@ func emitMakerETUint64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_V(t typex.EventTime, key uint64, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8737,8 +8738,8 @@ func emitMakerUint64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_W(key uint64, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8750,8 +8751,8 @@ func emitMakerETUint64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_W(t typex.EventTime, key uint64, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8763,8 +8764,8 @@ func emitMakerUint64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_X(key uint64, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8776,8 +8777,8 @@ func emitMakerETUint64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_X(t typex.EventTime, key uint64, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8789,8 +8790,8 @@ func emitMakerUint64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_Y(key uint64, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8802,8 +8803,8 @@ func emitMakerETUint64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_Y(t typex.EventTime, key uint64, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8815,8 +8816,8 @@ func emitMakerUint64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_Z(key uint64, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8828,8 +8829,8 @@ func emitMakerETUint64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_Z(t typex.EventTime, key uint64, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8841,8 +8842,8 @@ func emitMakerFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32(elm float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8854,8 +8855,8 @@ func emitMakerETFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32(t typex.EventTime, elm float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8867,8 +8868,8 @@ func emitMakerFloat32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32ByteSlice(key float32, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8880,8 +8881,8 @@ func emitMakerETFloat32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32ByteSlice(t typex.EventTime, key float32, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8893,8 +8894,8 @@ func emitMakerFloat32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Bool(key float32, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8906,8 +8907,8 @@ func emitMakerETFloat32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Bool(t typex.EventTime, key float32, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8919,8 +8920,8 @@ func emitMakerFloat32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32String(key float32, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8932,8 +8933,8 @@ func emitMakerETFloat32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32String(t typex.EventTime, key float32, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8945,8 +8946,8 @@ func emitMakerFloat32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int(key float32, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8958,8 +8959,8 @@ func emitMakerETFloat32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int(t typex.EventTime, key float32, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8971,8 +8972,8 @@ func emitMakerFloat32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int8(key float32, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8984,8 +8985,8 @@ func emitMakerETFloat32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int8(t typex.EventTime, key float32, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -8997,8 +8998,8 @@ func emitMakerFloat32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int16(key float32, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9010,8 +9011,8 @@ func emitMakerETFloat32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int16(t typex.EventTime, key float32, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9023,8 +9024,8 @@ func emitMakerFloat32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int32(key float32, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9036,8 +9037,8 @@ func emitMakerETFloat32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int32(t typex.EventTime, key float32, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9049,8 +9050,8 @@ func emitMakerFloat32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int64(key float32, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9062,8 +9063,8 @@ func emitMakerETFloat32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int64(t typex.EventTime, key float32, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9075,8 +9076,8 @@ func emitMakerFloat32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint(key float32, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9088,8 +9089,8 @@ func emitMakerETFloat32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint(t typex.EventTime, key float32, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9101,8 +9102,8 @@ func emitMakerFloat32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint8(key float32, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9114,8 +9115,8 @@ func emitMakerETFloat32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint8(t typex.EventTime, key float32, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9127,8 +9128,8 @@ func emitMakerFloat32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint16(key float32, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9140,8 +9141,8 @@ func emitMakerETFloat32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint16(t typex.EventTime, key float32, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9153,8 +9154,8 @@ func emitMakerFloat32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint32(key float32, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9166,8 +9167,8 @@ func emitMakerETFloat32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint32(t typex.EventTime, key float32, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9179,8 +9180,8 @@ func emitMakerFloat32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint64(key float32, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9192,8 +9193,8 @@ func emitMakerETFloat32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint64(t typex.EventTime, key float32, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9205,8 +9206,8 @@ func emitMakerFloat32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Float32(key float32, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9218,8 +9219,8 @@ func emitMakerETFloat32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Float32(t typex.EventTime, key float32, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9231,8 +9232,8 @@ func emitMakerFloat32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Float64(key float32, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9244,8 +9245,8 @@ func emitMakerETFloat32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Float64(t typex.EventTime, key float32, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9257,8 +9258,8 @@ func emitMakerFloat32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_T(key float32, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9270,8 +9271,8 @@ func emitMakerETFloat32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_T(t typex.EventTime, key float32, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9283,8 +9284,8 @@ func emitMakerFloat32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_U(key float32, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9296,8 +9297,8 @@ func emitMakerETFloat32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_U(t typex.EventTime, key float32, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9309,8 +9310,8 @@ func emitMakerFloat32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_V(key float32, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9322,8 +9323,8 @@ func emitMakerETFloat32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_V(t typex.EventTime, key float32, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9335,8 +9336,8 @@ func emitMakerFloat32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_W(key float32, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9348,8 +9349,8 @@ func emitMakerETFloat32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_W(t typex.EventTime, key float32, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9361,8 +9362,8 @@ func emitMakerFloat32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_X(key float32, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9374,8 +9375,8 @@ func emitMakerETFloat32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_X(t typex.EventTime, key float32, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9387,8 +9388,8 @@ func emitMakerFloat32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_Y(key float32, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9400,8 +9401,8 @@ func emitMakerETFloat32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_Y(t typex.EventTime, key float32, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9413,8 +9414,8 @@ func emitMakerFloat32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_Z(key float32, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9426,8 +9427,8 @@ func emitMakerETFloat32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_Z(t typex.EventTime, key float32, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9439,8 +9440,8 @@ func emitMakerFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64(elm float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9452,8 +9453,8 @@ func emitMakerETFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64(t typex.EventTime, elm float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9465,8 +9466,8 @@ func emitMakerFloat64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64ByteSlice(key float64, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9478,8 +9479,8 @@ func emitMakerETFloat64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64ByteSlice(t typex.EventTime, key float64, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9491,8 +9492,8 @@ func emitMakerFloat64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Bool(key float64, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9504,8 +9505,8 @@ func emitMakerETFloat64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Bool(t typex.EventTime, key float64, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9517,8 +9518,8 @@ func emitMakerFloat64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64String(key float64, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9530,8 +9531,8 @@ func emitMakerETFloat64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64String(t typex.EventTime, key float64, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9543,8 +9544,8 @@ func emitMakerFloat64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int(key float64, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9556,8 +9557,8 @@ func emitMakerETFloat64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int(t typex.EventTime, key float64, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9569,8 +9570,8 @@ func emitMakerFloat64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int8(key float64, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9582,8 +9583,8 @@ func emitMakerETFloat64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int8(t typex.EventTime, key float64, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9595,8 +9596,8 @@ func emitMakerFloat64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int16(key float64, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9608,8 +9609,8 @@ func emitMakerETFloat64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int16(t typex.EventTime, key float64, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9621,8 +9622,8 @@ func emitMakerFloat64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int32(key float64, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9634,8 +9635,8 @@ func emitMakerETFloat64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int32(t typex.EventTime, key float64, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9647,8 +9648,8 @@ func emitMakerFloat64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int64(key float64, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9660,8 +9661,8 @@ func emitMakerETFloat64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int64(t typex.EventTime, key float64, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9673,8 +9674,8 @@ func emitMakerFloat64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint(key float64, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9686,8 +9687,8 @@ func emitMakerETFloat64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint(t typex.EventTime, key float64, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9699,8 +9700,8 @@ func emitMakerFloat64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint8(key float64, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9712,8 +9713,8 @@ func emitMakerETFloat64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint8(t typex.EventTime, key float64, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9725,8 +9726,8 @@ func emitMakerFloat64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint16(key float64, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9738,8 +9739,8 @@ func emitMakerETFloat64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint16(t typex.EventTime, key float64, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9751,8 +9752,8 @@ func emitMakerFloat64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint32(key float64, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9764,8 +9765,8 @@ func emitMakerETFloat64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint32(t typex.EventTime, key float64, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9777,8 +9778,8 @@ func emitMakerFloat64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint64(key float64, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9790,8 +9791,8 @@ func emitMakerETFloat64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint64(t typex.EventTime, key float64, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9803,8 +9804,8 @@ func emitMakerFloat64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Float32(key float64, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9816,8 +9817,8 @@ func emitMakerETFloat64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Float32(t typex.EventTime, key float64, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9829,8 +9830,8 @@ func emitMakerFloat64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Float64(key float64, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9842,8 +9843,8 @@ func emitMakerETFloat64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Float64(t typex.EventTime, key float64, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9855,8 +9856,8 @@ func emitMakerFloat64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_T(key float64, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9868,8 +9869,8 @@ func emitMakerETFloat64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_T(t typex.EventTime, key float64, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9881,8 +9882,8 @@ func emitMakerFloat64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_U(key float64, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9894,8 +9895,8 @@ func emitMakerETFloat64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_U(t typex.EventTime, key float64, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9907,8 +9908,8 @@ func emitMakerFloat64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_V(key float64, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9920,8 +9921,8 @@ func emitMakerETFloat64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_V(t typex.EventTime, key float64, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9933,8 +9934,8 @@ func emitMakerFloat64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_W(key float64, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9946,8 +9947,8 @@ func emitMakerETFloat64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_W(t typex.EventTime, key float64, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9959,8 +9960,8 @@ func emitMakerFloat64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_X(key float64, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9972,8 +9973,8 @@ func emitMakerETFloat64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_X(t typex.EventTime, key float64, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9985,8 +9986,8 @@ func emitMakerFloat64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_Y(key float64, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -9998,8 +9999,8 @@ func emitMakerETFloat64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_Y(t typex.EventTime, key float64, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10011,8 +10012,8 @@ func emitMakerFloat64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_Z(key float64, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10024,8 +10025,8 @@ func emitMakerETFloat64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_Z(t typex.EventTime, key float64, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10037,8 +10038,8 @@ func emitMakerTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_T(elm typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10050,8 +10051,8 @@ func emitMakerETTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_T(t typex.EventTime, elm typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10063,8 +10064,8 @@ func emitMakerTypex_TByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TByteSlice(key typex.T, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10076,8 +10077,8 @@ func emitMakerETTypex_TByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TByteSlice(t typex.EventTime, key typex.T, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10089,8 +10090,8 @@ func emitMakerTypex_TBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TBool(key typex.T, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10102,8 +10103,8 @@ func emitMakerETTypex_TBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TBool(t typex.EventTime, key typex.T, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10115,8 +10116,8 @@ func emitMakerTypex_TString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TString(key typex.T, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10128,8 +10129,8 @@ func emitMakerETTypex_TString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TString(t typex.EventTime, key typex.T, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10141,8 +10142,8 @@ func emitMakerTypex_TInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt(key typex.T, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10154,8 +10155,8 @@ func emitMakerETTypex_TInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt(t typex.EventTime, key typex.T, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10167,8 +10168,8 @@ func emitMakerTypex_TInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt8(key typex.T, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10180,8 +10181,8 @@ func emitMakerETTypex_TInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt8(t typex.EventTime, key typex.T, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10193,8 +10194,8 @@ func emitMakerTypex_TInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt16(key typex.T, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10206,8 +10207,8 @@ func emitMakerETTypex_TInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt16(t typex.EventTime, key typex.T, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10219,8 +10220,8 @@ func emitMakerTypex_TInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt32(key typex.T, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10232,8 +10233,8 @@ func emitMakerETTypex_TInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt32(t typex.EventTime, key typex.T, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10245,8 +10246,8 @@ func emitMakerTypex_TInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt64(key typex.T, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10258,8 +10259,8 @@ func emitMakerETTypex_TInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt64(t typex.EventTime, key typex.T, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10271,8 +10272,8 @@ func emitMakerTypex_TUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint(key typex.T, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10284,8 +10285,8 @@ func emitMakerETTypex_TUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint(t typex.EventTime, key typex.T, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10297,8 +10298,8 @@ func emitMakerTypex_TUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint8(key typex.T, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10310,8 +10311,8 @@ func emitMakerETTypex_TUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint8(t typex.EventTime, key typex.T, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10323,8 +10324,8 @@ func emitMakerTypex_TUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint16(key typex.T, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10336,8 +10337,8 @@ func emitMakerETTypex_TUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint16(t typex.EventTime, key typex.T, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10349,8 +10350,8 @@ func emitMakerTypex_TUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint32(key typex.T, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10362,8 +10363,8 @@ func emitMakerETTypex_TUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint32(t typex.EventTime, key typex.T, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10375,8 +10376,8 @@ func emitMakerTypex_TUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint64(key typex.T, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10388,8 +10389,8 @@ func emitMakerETTypex_TUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint64(t typex.EventTime, key typex.T, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10401,8 +10402,8 @@ func emitMakerTypex_TFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TFloat32(key typex.T, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10414,8 +10415,8 @@ func emitMakerETTypex_TFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TFloat32(t typex.EventTime, key typex.T, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10427,8 +10428,8 @@ func emitMakerTypex_TFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TFloat64(key typex.T, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10440,8 +10441,8 @@ func emitMakerETTypex_TFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TFloat64(t typex.EventTime, key typex.T, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10453,8 +10454,8 @@ func emitMakerTypex_TTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_T(key typex.T, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10466,8 +10467,8 @@ func emitMakerETTypex_TTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_T(t typex.EventTime, key typex.T, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10479,8 +10480,8 @@ func emitMakerTypex_TTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_U(key typex.T, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10492,8 +10493,8 @@ func emitMakerETTypex_TTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_U(t typex.EventTime, key typex.T, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10505,8 +10506,8 @@ func emitMakerTypex_TTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_V(key typex.T, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10518,8 +10519,8 @@ func emitMakerETTypex_TTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_V(t typex.EventTime, key typex.T, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10531,8 +10532,8 @@ func emitMakerTypex_TTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_W(key typex.T, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10544,8 +10545,8 @@ func emitMakerETTypex_TTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_W(t typex.EventTime, key typex.T, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10557,8 +10558,8 @@ func emitMakerTypex_TTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_X(key typex.T, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10570,8 +10571,8 @@ func emitMakerETTypex_TTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_X(t typex.EventTime, key typex.T, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10583,8 +10584,8 @@ func emitMakerTypex_TTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_Y(key typex.T, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10596,8 +10597,8 @@ func emitMakerETTypex_TTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_Y(t typex.EventTime, key typex.T, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10609,8 +10610,8 @@ func emitMakerTypex_TTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_Z(key typex.T, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10622,8 +10623,8 @@ func emitMakerETTypex_TTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_Z(t typex.EventTime, key typex.T, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10635,8 +10636,8 @@ func emitMakerTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_U(elm typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10648,8 +10649,8 @@ func emitMakerETTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_U(t typex.EventTime, elm typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10661,8 +10662,8 @@ func emitMakerTypex_UByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UByteSlice(key typex.U, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10674,8 +10675,8 @@ func emitMakerETTypex_UByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UByteSlice(t typex.EventTime, key typex.U, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10687,8 +10688,8 @@ func emitMakerTypex_UBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UBool(key typex.U, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10700,8 +10701,8 @@ func emitMakerETTypex_UBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UBool(t typex.EventTime, key typex.U, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10713,8 +10714,8 @@ func emitMakerTypex_UString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UString(key typex.U, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10726,8 +10727,8 @@ func emitMakerETTypex_UString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UString(t typex.EventTime, key typex.U, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10739,8 +10740,8 @@ func emitMakerTypex_UInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt(key typex.U, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10752,8 +10753,8 @@ func emitMakerETTypex_UInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt(t typex.EventTime, key typex.U, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10765,8 +10766,8 @@ func emitMakerTypex_UInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt8(key typex.U, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10778,8 +10779,8 @@ func emitMakerETTypex_UInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt8(t typex.EventTime, key typex.U, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10791,8 +10792,8 @@ func emitMakerTypex_UInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt16(key typex.U, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10804,8 +10805,8 @@ func emitMakerETTypex_UInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt16(t typex.EventTime, key typex.U, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10817,8 +10818,8 @@ func emitMakerTypex_UInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt32(key typex.U, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10830,8 +10831,8 @@ func emitMakerETTypex_UInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt32(t typex.EventTime, key typex.U, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10843,8 +10844,8 @@ func emitMakerTypex_UInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt64(key typex.U, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10856,8 +10857,8 @@ func emitMakerETTypex_UInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt64(t typex.EventTime, key typex.U, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10869,8 +10870,8 @@ func emitMakerTypex_UUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint(key typex.U, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10882,8 +10883,8 @@ func emitMakerETTypex_UUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint(t typex.EventTime, key typex.U, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10895,8 +10896,8 @@ func emitMakerTypex_UUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint8(key typex.U, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10908,8 +10909,8 @@ func emitMakerETTypex_UUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint8(t typex.EventTime, key typex.U, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10921,8 +10922,8 @@ func emitMakerTypex_UUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint16(key typex.U, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10934,8 +10935,8 @@ func emitMakerETTypex_UUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint16(t typex.EventTime, key typex.U, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10947,8 +10948,8 @@ func emitMakerTypex_UUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint32(key typex.U, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10960,8 +10961,8 @@ func emitMakerETTypex_UUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint32(t typex.EventTime, key typex.U, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10973,8 +10974,8 @@ func emitMakerTypex_UUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint64(key typex.U, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10986,8 +10987,8 @@ func emitMakerETTypex_UUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint64(t typex.EventTime, key typex.U, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -10999,8 +11000,8 @@ func emitMakerTypex_UFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UFloat32(key typex.U, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11012,8 +11013,8 @@ func emitMakerETTypex_UFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UFloat32(t typex.EventTime, key typex.U, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11025,8 +11026,8 @@ func emitMakerTypex_UFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UFloat64(key typex.U, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11038,8 +11039,8 @@ func emitMakerETTypex_UFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UFloat64(t typex.EventTime, key typex.U, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11051,8 +11052,8 @@ func emitMakerTypex_UTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_T(key typex.U, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11064,8 +11065,8 @@ func emitMakerETTypex_UTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_T(t typex.EventTime, key typex.U, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11077,8 +11078,8 @@ func emitMakerTypex_UTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_U(key typex.U, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11090,8 +11091,8 @@ func emitMakerETTypex_UTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_U(t typex.EventTime, key typex.U, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11103,8 +11104,8 @@ func emitMakerTypex_UTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_V(key typex.U, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11116,8 +11117,8 @@ func emitMakerETTypex_UTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_V(t typex.EventTime, key typex.U, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11129,8 +11130,8 @@ func emitMakerTypex_UTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_W(key typex.U, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11142,8 +11143,8 @@ func emitMakerETTypex_UTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_W(t typex.EventTime, key typex.U, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11155,8 +11156,8 @@ func emitMakerTypex_UTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_X(key typex.U, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11168,8 +11169,8 @@ func emitMakerETTypex_UTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_X(t typex.EventTime, key typex.U, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11181,8 +11182,8 @@ func emitMakerTypex_UTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_Y(key typex.U, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11194,8 +11195,8 @@ func emitMakerETTypex_UTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_Y(t typex.EventTime, key typex.U, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11207,8 +11208,8 @@ func emitMakerTypex_UTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_Z(key typex.U, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11220,8 +11221,8 @@ func emitMakerETTypex_UTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_Z(t typex.EventTime, key typex.U, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11233,8 +11234,8 @@ func emitMakerTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_V(elm typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11246,8 +11247,8 @@ func emitMakerETTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_V(t typex.EventTime, elm typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11259,8 +11260,8 @@ func emitMakerTypex_VByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VByteSlice(key typex.V, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11272,8 +11273,8 @@ func emitMakerETTypex_VByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VByteSlice(t typex.EventTime, key typex.V, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11285,8 +11286,8 @@ func emitMakerTypex_VBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VBool(key typex.V, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11298,8 +11299,8 @@ func emitMakerETTypex_VBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VBool(t typex.EventTime, key typex.V, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11311,8 +11312,8 @@ func emitMakerTypex_VString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VString(key typex.V, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11324,8 +11325,8 @@ func emitMakerETTypex_VString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VString(t typex.EventTime, key typex.V, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11337,8 +11338,8 @@ func emitMakerTypex_VInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt(key typex.V, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11350,8 +11351,8 @@ func emitMakerETTypex_VInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt(t typex.EventTime, key typex.V, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11363,8 +11364,8 @@ func emitMakerTypex_VInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt8(key typex.V, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11376,8 +11377,8 @@ func emitMakerETTypex_VInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt8(t typex.EventTime, key typex.V, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11389,8 +11390,8 @@ func emitMakerTypex_VInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt16(key typex.V, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11402,8 +11403,8 @@ func emitMakerETTypex_VInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt16(t typex.EventTime, key typex.V, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11415,8 +11416,8 @@ func emitMakerTypex_VInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt32(key typex.V, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11428,8 +11429,8 @@ func emitMakerETTypex_VInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt32(t typex.EventTime, key typex.V, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11441,8 +11442,8 @@ func emitMakerTypex_VInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt64(key typex.V, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11454,8 +11455,8 @@ func emitMakerETTypex_VInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt64(t typex.EventTime, key typex.V, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11467,8 +11468,8 @@ func emitMakerTypex_VUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint(key typex.V, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11480,8 +11481,8 @@ func emitMakerETTypex_VUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint(t typex.EventTime, key typex.V, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11493,8 +11494,8 @@ func emitMakerTypex_VUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint8(key typex.V, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11506,8 +11507,8 @@ func emitMakerETTypex_VUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint8(t typex.EventTime, key typex.V, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11519,8 +11520,8 @@ func emitMakerTypex_VUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint16(key typex.V, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11532,8 +11533,8 @@ func emitMakerETTypex_VUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint16(t typex.EventTime, key typex.V, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11545,8 +11546,8 @@ func emitMakerTypex_VUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint32(key typex.V, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11558,8 +11559,8 @@ func emitMakerETTypex_VUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint32(t typex.EventTime, key typex.V, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11571,8 +11572,8 @@ func emitMakerTypex_VUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint64(key typex.V, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11584,8 +11585,8 @@ func emitMakerETTypex_VUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint64(t typex.EventTime, key typex.V, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11597,8 +11598,8 @@ func emitMakerTypex_VFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VFloat32(key typex.V, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11610,8 +11611,8 @@ func emitMakerETTypex_VFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VFloat32(t typex.EventTime, key typex.V, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11623,8 +11624,8 @@ func emitMakerTypex_VFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VFloat64(key typex.V, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11636,8 +11637,8 @@ func emitMakerETTypex_VFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VFloat64(t typex.EventTime, key typex.V, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11649,8 +11650,8 @@ func emitMakerTypex_VTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_T(key typex.V, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11662,8 +11663,8 @@ func emitMakerETTypex_VTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_T(t typex.EventTime, key typex.V, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11675,8 +11676,8 @@ func emitMakerTypex_VTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_U(key typex.V, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11688,8 +11689,8 @@ func emitMakerETTypex_VTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_U(t typex.EventTime, key typex.V, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11701,8 +11702,8 @@ func emitMakerTypex_VTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_V(key typex.V, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11714,8 +11715,8 @@ func emitMakerETTypex_VTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_V(t typex.EventTime, key typex.V, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11727,8 +11728,8 @@ func emitMakerTypex_VTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_W(key typex.V, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11740,8 +11741,8 @@ func emitMakerETTypex_VTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_W(t typex.EventTime, key typex.V, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11753,8 +11754,8 @@ func emitMakerTypex_VTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_X(key typex.V, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11766,8 +11767,8 @@ func emitMakerETTypex_VTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_X(t typex.EventTime, key typex.V, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11779,8 +11780,8 @@ func emitMakerTypex_VTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_Y(key typex.V, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11792,8 +11793,8 @@ func emitMakerETTypex_VTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_Y(t typex.EventTime, key typex.V, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11805,8 +11806,8 @@ func emitMakerTypex_VTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_Z(key typex.V, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11818,8 +11819,8 @@ func emitMakerETTypex_VTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_Z(t typex.EventTime, key typex.V, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11831,8 +11832,8 @@ func emitMakerTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_W(elm typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11844,8 +11845,8 @@ func emitMakerETTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_W(t typex.EventTime, elm typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11857,8 +11858,8 @@ func emitMakerTypex_WByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WByteSlice(key typex.W, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11870,8 +11871,8 @@ func emitMakerETTypex_WByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WByteSlice(t typex.EventTime, key typex.W, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11883,8 +11884,8 @@ func emitMakerTypex_WBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WBool(key typex.W, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11896,8 +11897,8 @@ func emitMakerETTypex_WBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WBool(t typex.EventTime, key typex.W, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11909,8 +11910,8 @@ func emitMakerTypex_WString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WString(key typex.W, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11922,8 +11923,8 @@ func emitMakerETTypex_WString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WString(t typex.EventTime, key typex.W, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11935,8 +11936,8 @@ func emitMakerTypex_WInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt(key typex.W, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11948,8 +11949,8 @@ func emitMakerETTypex_WInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt(t typex.EventTime, key typex.W, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11961,8 +11962,8 @@ func emitMakerTypex_WInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt8(key typex.W, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11974,8 +11975,8 @@ func emitMakerETTypex_WInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt8(t typex.EventTime, key typex.W, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -11987,8 +11988,8 @@ func emitMakerTypex_WInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt16(key typex.W, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12000,8 +12001,8 @@ func emitMakerETTypex_WInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt16(t typex.EventTime, key typex.W, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12013,8 +12014,8 @@ func emitMakerTypex_WInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt32(key typex.W, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12026,8 +12027,8 @@ func emitMakerETTypex_WInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt32(t typex.EventTime, key typex.W, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12039,8 +12040,8 @@ func emitMakerTypex_WInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt64(key typex.W, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12052,8 +12053,8 @@ func emitMakerETTypex_WInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt64(t typex.EventTime, key typex.W, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12065,8 +12066,8 @@ func emitMakerTypex_WUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint(key typex.W, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12078,8 +12079,8 @@ func emitMakerETTypex_WUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint(t typex.EventTime, key typex.W, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12091,8 +12092,8 @@ func emitMakerTypex_WUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint8(key typex.W, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12104,8 +12105,8 @@ func emitMakerETTypex_WUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint8(t typex.EventTime, key typex.W, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12117,8 +12118,8 @@ func emitMakerTypex_WUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint16(key typex.W, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12130,8 +12131,8 @@ func emitMakerETTypex_WUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint16(t typex.EventTime, key typex.W, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12143,8 +12144,8 @@ func emitMakerTypex_WUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint32(key typex.W, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12156,8 +12157,8 @@ func emitMakerETTypex_WUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint32(t typex.EventTime, key typex.W, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12169,8 +12170,8 @@ func emitMakerTypex_WUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint64(key typex.W, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12182,8 +12183,8 @@ func emitMakerETTypex_WUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint64(t typex.EventTime, key typex.W, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12195,8 +12196,8 @@ func emitMakerTypex_WFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WFloat32(key typex.W, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12208,8 +12209,8 @@ func emitMakerETTypex_WFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WFloat32(t typex.EventTime, key typex.W, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12221,8 +12222,8 @@ func emitMakerTypex_WFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WFloat64(key typex.W, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12234,8 +12235,8 @@ func emitMakerETTypex_WFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WFloat64(t typex.EventTime, key typex.W, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12247,8 +12248,8 @@ func emitMakerTypex_WTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_T(key typex.W, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12260,8 +12261,8 @@ func emitMakerETTypex_WTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_T(t typex.EventTime, key typex.W, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12273,8 +12274,8 @@ func emitMakerTypex_WTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_U(key typex.W, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12286,8 +12287,8 @@ func emitMakerETTypex_WTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_U(t typex.EventTime, key typex.W, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12299,8 +12300,8 @@ func emitMakerTypex_WTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_V(key typex.W, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12312,8 +12313,8 @@ func emitMakerETTypex_WTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_V(t typex.EventTime, key typex.W, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12325,8 +12326,8 @@ func emitMakerTypex_WTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_W(key typex.W, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12338,8 +12339,8 @@ func emitMakerETTypex_WTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_W(t typex.EventTime, key typex.W, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12351,8 +12352,8 @@ func emitMakerTypex_WTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_X(key typex.W, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12364,8 +12365,8 @@ func emitMakerETTypex_WTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_X(t typex.EventTime, key typex.W, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12377,8 +12378,8 @@ func emitMakerTypex_WTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_Y(key typex.W, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12390,8 +12391,8 @@ func emitMakerETTypex_WTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_Y(t typex.EventTime, key typex.W, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12403,8 +12404,8 @@ func emitMakerTypex_WTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_Z(key typex.W, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12416,8 +12417,8 @@ func emitMakerETTypex_WTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_Z(t typex.EventTime, key typex.W, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12429,8 +12430,8 @@ func emitMakerTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_X(elm typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12442,8 +12443,8 @@ func emitMakerETTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_X(t typex.EventTime, elm typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12455,8 +12456,8 @@ func emitMakerTypex_XByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XByteSlice(key typex.X, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12468,8 +12469,8 @@ func emitMakerETTypex_XByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XByteSlice(t typex.EventTime, key typex.X, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12481,8 +12482,8 @@ func emitMakerTypex_XBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XBool(key typex.X, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12494,8 +12495,8 @@ func emitMakerETTypex_XBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XBool(t typex.EventTime, key typex.X, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12507,8 +12508,8 @@ func emitMakerTypex_XString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XString(key typex.X, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12520,8 +12521,8 @@ func emitMakerETTypex_XString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XString(t typex.EventTime, key typex.X, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12533,8 +12534,8 @@ func emitMakerTypex_XInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt(key typex.X, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12546,8 +12547,8 @@ func emitMakerETTypex_XInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt(t typex.EventTime, key typex.X, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12559,8 +12560,8 @@ func emitMakerTypex_XInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt8(key typex.X, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12572,8 +12573,8 @@ func emitMakerETTypex_XInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt8(t typex.EventTime, key typex.X, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12585,8 +12586,8 @@ func emitMakerTypex_XInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt16(key typex.X, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12598,8 +12599,8 @@ func emitMakerETTypex_XInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt16(t typex.EventTime, key typex.X, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12611,8 +12612,8 @@ func emitMakerTypex_XInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt32(key typex.X, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12624,8 +12625,8 @@ func emitMakerETTypex_XInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt32(t typex.EventTime, key typex.X, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12637,8 +12638,8 @@ func emitMakerTypex_XInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt64(key typex.X, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12650,8 +12651,8 @@ func emitMakerETTypex_XInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt64(t typex.EventTime, key typex.X, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12663,8 +12664,8 @@ func emitMakerTypex_XUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint(key typex.X, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12676,8 +12677,8 @@ func emitMakerETTypex_XUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint(t typex.EventTime, key typex.X, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12689,8 +12690,8 @@ func emitMakerTypex_XUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint8(key typex.X, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12702,8 +12703,8 @@ func emitMakerETTypex_XUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint8(t typex.EventTime, key typex.X, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12715,8 +12716,8 @@ func emitMakerTypex_XUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint16(key typex.X, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12728,8 +12729,8 @@ func emitMakerETTypex_XUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint16(t typex.EventTime, key typex.X, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12741,8 +12742,8 @@ func emitMakerTypex_XUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint32(key typex.X, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12754,8 +12755,8 @@ func emitMakerETTypex_XUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint32(t typex.EventTime, key typex.X, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12767,8 +12768,8 @@ func emitMakerTypex_XUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint64(key typex.X, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12780,8 +12781,8 @@ func emitMakerETTypex_XUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint64(t typex.EventTime, key typex.X, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12793,8 +12794,8 @@ func emitMakerTypex_XFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XFloat32(key typex.X, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12806,8 +12807,8 @@ func emitMakerETTypex_XFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XFloat32(t typex.EventTime, key typex.X, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12819,8 +12820,8 @@ func emitMakerTypex_XFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XFloat64(key typex.X, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12832,8 +12833,8 @@ func emitMakerETTypex_XFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XFloat64(t typex.EventTime, key typex.X, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12845,8 +12846,8 @@ func emitMakerTypex_XTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_T(key typex.X, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12858,8 +12859,8 @@ func emitMakerETTypex_XTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_T(t typex.EventTime, key typex.X, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12871,8 +12872,8 @@ func emitMakerTypex_XTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_U(key typex.X, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12884,8 +12885,8 @@ func emitMakerETTypex_XTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_U(t typex.EventTime, key typex.X, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12897,8 +12898,8 @@ func emitMakerTypex_XTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_V(key typex.X, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12910,8 +12911,8 @@ func emitMakerETTypex_XTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_V(t typex.EventTime, key typex.X, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12923,8 +12924,8 @@ func emitMakerTypex_XTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_W(key typex.X, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12936,8 +12937,8 @@ func emitMakerETTypex_XTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_W(t typex.EventTime, key typex.X, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12949,8 +12950,8 @@ func emitMakerTypex_XTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_X(key typex.X, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12962,8 +12963,8 @@ func emitMakerETTypex_XTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_X(t typex.EventTime, key typex.X, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12975,8 +12976,8 @@ func emitMakerTypex_XTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_Y(key typex.X, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -12988,8 +12989,8 @@ func emitMakerETTypex_XTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_Y(t typex.EventTime, key typex.X, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13001,8 +13002,8 @@ func emitMakerTypex_XTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_Z(key typex.X, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13014,8 +13015,8 @@ func emitMakerETTypex_XTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_Z(t typex.EventTime, key typex.X, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13027,8 +13028,8 @@ func emitMakerTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_Y(elm typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13040,8 +13041,8 @@ func emitMakerETTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_Y(t typex.EventTime, elm typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13053,8 +13054,8 @@ func emitMakerTypex_YByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YByteSlice(key typex.Y, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13066,8 +13067,8 @@ func emitMakerETTypex_YByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YByteSlice(t typex.EventTime, key typex.Y, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13079,8 +13080,8 @@ func emitMakerTypex_YBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YBool(key typex.Y, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13092,8 +13093,8 @@ func emitMakerETTypex_YBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YBool(t typex.EventTime, key typex.Y, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13105,8 +13106,8 @@ func emitMakerTypex_YString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YString(key typex.Y, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13118,8 +13119,8 @@ func emitMakerETTypex_YString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YString(t typex.EventTime, key typex.Y, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13131,8 +13132,8 @@ func emitMakerTypex_YInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt(key typex.Y, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13144,8 +13145,8 @@ func emitMakerETTypex_YInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt(t typex.EventTime, key typex.Y, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13157,8 +13158,8 @@ func emitMakerTypex_YInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt8(key typex.Y, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13170,8 +13171,8 @@ func emitMakerETTypex_YInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt8(t typex.EventTime, key typex.Y, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13183,8 +13184,8 @@ func emitMakerTypex_YInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt16(key typex.Y, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13196,8 +13197,8 @@ func emitMakerETTypex_YInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt16(t typex.EventTime, key typex.Y, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13209,8 +13210,8 @@ func emitMakerTypex_YInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt32(key typex.Y, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13222,8 +13223,8 @@ func emitMakerETTypex_YInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt32(t typex.EventTime, key typex.Y, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13235,8 +13236,8 @@ func emitMakerTypex_YInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt64(key typex.Y, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13248,8 +13249,8 @@ func emitMakerETTypex_YInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt64(t typex.EventTime, key typex.Y, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13261,8 +13262,8 @@ func emitMakerTypex_YUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint(key typex.Y, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13274,8 +13275,8 @@ func emitMakerETTypex_YUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint(t typex.EventTime, key typex.Y, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13287,8 +13288,8 @@ func emitMakerTypex_YUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint8(key typex.Y, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13300,8 +13301,8 @@ func emitMakerETTypex_YUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint8(t typex.EventTime, key typex.Y, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13313,8 +13314,8 @@ func emitMakerTypex_YUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint16(key typex.Y, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13326,8 +13327,8 @@ func emitMakerETTypex_YUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint16(t typex.EventTime, key typex.Y, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13339,8 +13340,8 @@ func emitMakerTypex_YUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint32(key typex.Y, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13352,8 +13353,8 @@ func emitMakerETTypex_YUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint32(t typex.EventTime, key typex.Y, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13365,8 +13366,8 @@ func emitMakerTypex_YUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint64(key typex.Y, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13378,8 +13379,8 @@ func emitMakerETTypex_YUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint64(t typex.EventTime, key typex.Y, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13391,8 +13392,8 @@ func emitMakerTypex_YFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YFloat32(key typex.Y, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13404,8 +13405,8 @@ func emitMakerETTypex_YFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YFloat32(t typex.EventTime, key typex.Y, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13417,8 +13418,8 @@ func emitMakerTypex_YFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YFloat64(key typex.Y, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13430,8 +13431,8 @@ func emitMakerETTypex_YFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YFloat64(t typex.EventTime, key typex.Y, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13443,8 +13444,8 @@ func emitMakerTypex_YTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_T(key typex.Y, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13456,8 +13457,8 @@ func emitMakerETTypex_YTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_T(t typex.EventTime, key typex.Y, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13469,8 +13470,8 @@ func emitMakerTypex_YTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_U(key typex.Y, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13482,8 +13483,8 @@ func emitMakerETTypex_YTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_U(t typex.EventTime, key typex.Y, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13495,8 +13496,8 @@ func emitMakerTypex_YTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_V(key typex.Y, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13508,8 +13509,8 @@ func emitMakerETTypex_YTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_V(t typex.EventTime, key typex.Y, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13521,8 +13522,8 @@ func emitMakerTypex_YTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_W(key typex.Y, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13534,8 +13535,8 @@ func emitMakerETTypex_YTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_W(t typex.EventTime, key typex.Y, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13547,8 +13548,8 @@ func emitMakerTypex_YTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_X(key typex.Y, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13560,8 +13561,8 @@ func emitMakerETTypex_YTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_X(t typex.EventTime, key typex.Y, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13573,8 +13574,8 @@ func emitMakerTypex_YTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_Y(key typex.Y, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13586,8 +13587,8 @@ func emitMakerETTypex_YTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_Y(t typex.EventTime, key typex.Y, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13599,8 +13600,8 @@ func emitMakerTypex_YTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_Z(key typex.Y, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13612,8 +13613,8 @@ func emitMakerETTypex_YTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_Z(t typex.EventTime, key typex.Y, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13625,8 +13626,8 @@ func emitMakerTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_Z(elm typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13638,8 +13639,8 @@ func emitMakerETTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_Z(t typex.EventTime, elm typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13651,8 +13652,8 @@ func emitMakerTypex_ZByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZByteSlice(key typex.Z, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13664,8 +13665,8 @@ func emitMakerETTypex_ZByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZByteSlice(t typex.EventTime, key typex.Z, val []byte) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13677,8 +13678,8 @@ func emitMakerTypex_ZBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZBool(key typex.Z, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13690,8 +13691,8 @@ func emitMakerETTypex_ZBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZBool(t typex.EventTime, key typex.Z, val bool) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13703,8 +13704,8 @@ func emitMakerTypex_ZString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZString(key typex.Z, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13716,8 +13717,8 @@ func emitMakerETTypex_ZString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZString(t typex.EventTime, key typex.Z, val string) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13729,8 +13730,8 @@ func emitMakerTypex_ZInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt(key typex.Z, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13742,8 +13743,8 @@ func emitMakerETTypex_ZInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt(t typex.EventTime, key typex.Z, val int) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13755,8 +13756,8 @@ func emitMakerTypex_ZInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt8(key typex.Z, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13768,8 +13769,8 @@ func emitMakerETTypex_ZInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt8(t typex.EventTime, key typex.Z, val int8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13781,8 +13782,8 @@ func emitMakerTypex_ZInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt16(key typex.Z, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13794,8 +13795,8 @@ func emitMakerETTypex_ZInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt16(t typex.EventTime, key typex.Z, val int16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13807,8 +13808,8 @@ func emitMakerTypex_ZInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt32(key typex.Z, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13820,8 +13821,8 @@ func emitMakerETTypex_ZInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt32(t typex.EventTime, key typex.Z, val int32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13833,8 +13834,8 @@ func emitMakerTypex_ZInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt64(key typex.Z, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13846,8 +13847,8 @@ func emitMakerETTypex_ZInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt64(t typex.EventTime, key typex.Z, val int64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13859,8 +13860,8 @@ func emitMakerTypex_ZUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint(key typex.Z, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13872,8 +13873,8 @@ func emitMakerETTypex_ZUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint(t typex.EventTime, key typex.Z, val uint) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13885,8 +13886,8 @@ func emitMakerTypex_ZUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint8(key typex.Z, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13898,8 +13899,8 @@ func emitMakerETTypex_ZUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint8(t typex.EventTime, key typex.Z, val uint8) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13911,8 +13912,8 @@ func emitMakerTypex_ZUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint16(key typex.Z, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13924,8 +13925,8 @@ func emitMakerETTypex_ZUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint16(t typex.EventTime, key typex.Z, val uint16) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13937,8 +13938,8 @@ func emitMakerTypex_ZUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint32(key typex.Z, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13950,8 +13951,8 @@ func emitMakerETTypex_ZUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint32(t typex.EventTime, key typex.Z, val uint32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13963,8 +13964,8 @@ func emitMakerTypex_ZUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint64(key typex.Z, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13976,8 +13977,8 @@ func emitMakerETTypex_ZUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint64(t typex.EventTime, key typex.Z, val uint64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -13989,8 +13990,8 @@ func emitMakerTypex_ZFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZFloat32(key typex.Z, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14002,8 +14003,8 @@ func emitMakerETTypex_ZFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZFloat32(t typex.EventTime, key typex.Z, val float32) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14015,8 +14016,8 @@ func emitMakerTypex_ZFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZFloat64(key typex.Z, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14028,8 +14029,8 @@ func emitMakerETTypex_ZFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZFloat64(t typex.EventTime, key typex.Z, val float64) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14041,8 +14042,8 @@ func emitMakerTypex_ZTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_T(key typex.Z, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14054,8 +14055,8 @@ func emitMakerETTypex_ZTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_T(t typex.EventTime, key typex.Z, val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14067,8 +14068,8 @@ func emitMakerTypex_ZTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_U(key typex.Z, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14080,8 +14081,8 @@ func emitMakerETTypex_ZTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_U(t typex.EventTime, key typex.Z, val typex.U) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14093,8 +14094,8 @@ func emitMakerTypex_ZTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_V(key typex.Z, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14106,8 +14107,8 @@ func emitMakerETTypex_ZTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_V(t typex.EventTime, key typex.Z, val typex.V) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14119,8 +14120,8 @@ func emitMakerTypex_ZTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_W(key typex.Z, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14132,8 +14133,8 @@ func emitMakerETTypex_ZTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_W(t typex.EventTime, key typex.Z, val typex.W) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14145,8 +14146,8 @@ func emitMakerTypex_ZTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_X(key typex.Z, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14158,8 +14159,8 @@ func emitMakerETTypex_ZTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_X(t typex.EventTime, key typex.Z, val typex.X) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14171,8 +14172,8 @@ func emitMakerTypex_ZTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_Y(key typex.Z, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14184,8 +14185,8 @@ func emitMakerETTypex_ZTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_Y(t typex.EventTime, key typex.Z, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14197,8 +14198,8 @@ func emitMakerTypex_ZTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_Z(key typex.Z, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -14210,8 +14211,8 @@ func emitMakerETTypex_ZTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_Z(t typex.EventTime, key typex.Z, val typex.Z) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/optimized/emitters.tmpl
+++ b/sdks/go/pkg/beam/core/runtime/exec/optimized/emitters.tmpl
@@ -44,6 +44,7 @@ type emitNative struct {
 	ctx context.Context
 	ws  []typex.Window
 	et  typex.EventTime
+	value exec.FullValue
 }
 
 func (e *emitNative) Init(ctx context.Context, ws  []typex.Window, et typex.EventTime) error {
@@ -65,8 +66,8 @@ func emitMaker{{$x.Name}}(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invoke{{$x.Name}}(elm {{$x.Type}}) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm }
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm }
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -78,8 +79,8 @@ func emitMakerET{{$x.Name}}(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeET{{$x.Name}}(t typex.EventTime, elm {{$x.Type}}) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm }
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm }
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -92,8 +93,8 @@ func emitMaker{{$x.Name}}{{$y.Name}}(n exec.ElementProcessor) exec.ReusableEmitt
 }
 
 func (e *emitNative) invoke{{$x.Name}}{{$y.Name}}(key {{$x.Type}}, val {{$y.Type}}) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val }
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val }
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -105,8 +106,8 @@ func emitMakerET{{$x.Name}}{{$y.Name}}(n exec.ElementProcessor) exec.ReusableEmi
 }
 
 func (e *emitNative) invokeET{{$x.Name}}{{$y.Name}}(t typex.EventTime, key {{$x.Type}}, val {{$y.Type}}) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val }
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val }
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/sideinput.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sideinput.go
@@ -98,7 +98,7 @@ func (s *elementStream) Close() error {
 	return s.r.Close()
 }
 
-func (s *elementStream) Read() (FullValue, error) {
+func (s *elementStream) Read() (*FullValue, error) {
 	// We should see a stream of unwindowed values -- no sizes, no key.
 	return s.ec.Decode(s.r)
 }
@@ -125,10 +125,10 @@ func (n *FixedKey) StartBundle(ctx context.Context, id string, data DataContext)
 	return n.Out.StartBundle(ctx, id, data)
 }
 
-func (n *FixedKey) ProcessElement(ctx context.Context, elm FullValue, values ...ReStream) error {
+func (n *FixedKey) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	// Transform: V to KV<K,V>
 
-	v := FullValue{
+	v := &FullValue{
 		Elm:       n.Key,
 		Elm2:      elm,
 		Timestamp: elm.Timestamp,

--- a/sdks/go/pkg/beam/core/runtime/exec/unit.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/unit.go
@@ -64,7 +64,8 @@ type Root interface {
 type ElementProcessor interface {
 	// Call processes a single element. If GBK or CoGBK result, the values
 	// are populated. Otherwise, they're empty.
-	ProcessElement(ctx context.Context, elm FullValue, values ...ReStream) error
+	// The *FullValue  is owned by the caller, and is not safe to cache.
+	ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error
 }
 
 // Node represents an single-bundle processing unit. Each node contains

--- a/sdks/go/pkg/beam/core/runtime/exec/unit_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/unit_test.go
@@ -51,12 +51,12 @@ func (n *CaptureNode) StartBundle(ctx context.Context, id string, data DataConte
 	return nil
 }
 
-func (n *CaptureNode) ProcessElement(ctx context.Context, elm FullValue, values ...ReStream) error {
+func (n *CaptureNode) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	if n.status != Active {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Active", n.UID, n.status)
 	}
 
-	n.Elements = append(n.Elements, elm)
+	n.Elements = append(n.Elements, *elm)
 	return nil
 }
 
@@ -97,7 +97,7 @@ func (n *FixedRoot) StartBundle(ctx context.Context, id string, data DataContext
 
 func (n *FixedRoot) Process(ctx context.Context) error {
 	for _, elm := range n.Elements {
-		if err := n.Out.ProcessElement(ctx, elm.Key, elm.Values...); err != nil {
+		if err := n.Out.ProcessElement(ctx, &elm.Key, elm.Values...); err != nil {
 			return err
 		}
 	}
@@ -142,7 +142,7 @@ func (n *BenchRoot) StartBundle(ctx context.Context, id string, data DataContext
 
 func (n *BenchRoot) Process(ctx context.Context) error {
 	for elm := range n.Elements {
-		if err := n.Out.ProcessElement(ctx, elm.Key, elm.Values...); err != nil {
+		if err := n.Out.ProcessElement(ctx, &elm.Key, elm.Values...); err != nil {
 			return err
 		}
 	}

--- a/sdks/go/pkg/beam/core/runtime/exec/window.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/window.go
@@ -44,8 +44,8 @@ func (w *WindowInto) StartBundle(ctx context.Context, id string, data DataContex
 	return w.Out.StartBundle(ctx, id, data)
 }
 
-func (w *WindowInto) ProcessElement(ctx context.Context, elm FullValue, values ...ReStream) error {
-	windowed := FullValue{
+func (w *WindowInto) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
+	windowed := &FullValue{
 		Windows:   assignWindows(w.Fn, elm.Timestamp),
 		Timestamp: elm.Timestamp,
 		Elm:       elm.Elm,

--- a/sdks/go/pkg/beam/runners/direct/buffer.go
+++ b/sdks/go/pkg/beam/runners/direct/buffer.go
@@ -50,8 +50,8 @@ func (n *buffer) StartBundle(ctx context.Context, id string, data exec.DataConte
 	return nil
 }
 
-func (n *buffer) ProcessElement(ctx context.Context, elm exec.FullValue, values ...exec.ReStream) error {
-	n.buf = append(n.buf, elm)
+func (n *buffer) ProcessElement(ctx context.Context, elm *exec.FullValue, values ...exec.ReStream) error {
+	n.buf = append(n.buf, *elm)
 	return nil
 }
 
@@ -113,7 +113,7 @@ func (w *wait) notify(ctx context.Context) error {
 		return err
 	}
 	for _, elm := range w.buf {
-		if err := w.next.ProcessElement(ctx, elm); err != nil {
+		if err := w.next.ProcessElement(ctx, &elm); err != nil {
 			return err
 		}
 	}
@@ -136,10 +136,10 @@ func (w *wait) StartBundle(ctx context.Context, id string, data exec.DataContext
 	return nil // done in notify
 }
 
-func (w *wait) ProcessElement(ctx context.Context, elm exec.FullValue, values ...exec.ReStream) error {
+func (w *wait) ProcessElement(ctx context.Context, elm *exec.FullValue, values ...exec.ReStream) error {
 	if w.ready < w.need {
 		// log.Printf("buffer[%v]: %v", w.UID, elm)
-		w.buf = append(w.buf, elm)
+		w.buf = append(w.buf, *elm)
 		return nil
 	}
 

--- a/sdks/go/pkg/beam/runners/direct/impulse.go
+++ b/sdks/go/pkg/beam/runners/direct/impulse.go
@@ -44,7 +44,7 @@ func (n *Impulse) StartBundle(ctx context.Context, id string, data exec.DataCont
 }
 
 func (n *Impulse) Process(ctx context.Context) error {
-	value := exec.FullValue{
+	value := &exec.FullValue{
 		Windows:   window.SingleGlobalWindow,
 		Timestamp: mtime.Now(),
 		Elm:       n.Value,

--- a/sdks/go/pkg/beam/testing/passert/passert.shims.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.shims.go
@@ -262,6 +262,7 @@ type emitNative struct {
 	ctx context.Context
 	ws  []typex.Window
 	et  typex.EventTime
+	value exec.FullValue
 }
 
 func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
@@ -282,8 +283,8 @@ func emitMakerTypex۰T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex۰T(val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }

--- a/sdks/go/pkg/beam/transforms/filter/filter.shims.go
+++ b/sdks/go/pkg/beam/transforms/filter/filter.shims.go
@@ -163,6 +163,7 @@ type emitNative struct {
 	ctx context.Context
 	ws  []typex.Window
 	et  typex.EventTime
+	value exec.FullValue
 }
 
 func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
@@ -183,8 +184,8 @@ func emitMakerTypex۰T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex۰T(val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }

--- a/sdks/go/pkg/beam/util/shimx/generate.go
+++ b/sdks/go/pkg/beam/util/shimx/generate.go
@@ -307,6 +307,7 @@ type emitNative struct {
 	ctx context.Context
 	ws  []typex.Window
 	et  typex.EventTime
+	value exec.FullValue
 }
 
 func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
@@ -329,8 +330,8 @@ func emitMaker{{$x.Name}}(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invoke{{$x.Name}}({{if $x.Time -}} t typex.EventTime, {{end}}{{if $x.Key}}key {{$x.Key}}, {{end}}val {{$x.Val}}) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: {{- if $x.Time}} t{{else}} e.et{{end}}, {{- if $x.Key}} Elm: key, Elm2: val {{else}} Elm: val{{end -}} }
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: {{- if $x.Time}} t{{else}} e.et{{end}}, {{- if $x.Key}} Elm: key, Elm2: val {{else}} Elm: val{{end -}} }
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }

--- a/sdks/go/pkg/beam/x/debug/debug.shims.go
+++ b/sdks/go/pkg/beam/x/debug/debug.shims.go
@@ -255,6 +255,7 @@ type emitNative struct {
 	ctx context.Context
 	ws  []typex.Window
 	et  typex.EventTime
+	value exec.FullValue
 }
 
 func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
@@ -275,8 +276,8 @@ func emitMakerTypex۰T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex۰T(val typex.T) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }
@@ -288,8 +289,8 @@ func emitMakerTypex۰XTypex۰Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex۰XTypex۰Y(key typex.X, val typex.Y) {
-	value := exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val }
-	if err := e.n.ProcessElement(e.ctx, value); err != nil {
+	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val }
+	if err := e.n.ProcessElement(e.ctx, &e.value); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
This is a breaking change.
In Go, passing a value to an interface method will cause that value to escape to the heap. Changing these to pointers reduces this overhead significantly, since the value will not need to be checked and allocated at each level.

FullValue is an implementation detail of the GoSDK to be able to handle the event time, windowing, and K,V status of a given PCollection value, since go doesn't have Generics or similar. This means they're everywhere in the execution stack, and used by the ElementProcessor interface in the exec package.
Since FullValue is simply a transport for values between DoFns, they remain in control by the exec package, allowing us to cache their allocation where appropriate, and re-use them.

This PR updates the ElementProcessor interface to accept *FullValue instead of FullValue, and changes all beam implementations of ElementProcessor to follow suit.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

