### PR TITLE
[BEAM-5731] Only accept key operator in Python 3.

### DIFF
--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -23,6 +23,8 @@ from __future__ import division
 import heapq
 import operator
 import random
+import sys
+import warnings
 from builtins import object
 from builtins import zip
 from functools import cmp_to_key
@@ -167,7 +169,7 @@ class Top(object):
     function supplied as the compare argument.
     """
 
-    def __init__(self, n, compare=None, *args, **kwargs):
+    def _py2__init__(self, n, compare=None, *args, **kwargs):
       """Initializer.
 
       compare should be an implementation of "a < b" taking at least two
@@ -184,12 +186,38 @@ class Top(object):
         *args: as described above.
         **kwargs: as described above.
       """
+      if compare:
+        warnings.warn('Compare not available in Python 3, use key instead.',
+                      DeprecationWarning)
       self._n = n
       self._compare = compare
       self._key = kwargs.pop('key', None)
       self._reverse = kwargs.pop('reverse', False)
       self._args = args
       self._kwargs = kwargs
+
+    def _py3__init__(self, n, **kwargs):
+      """Creates a global Top operation.
+
+      The arguments 'key' and 'reverse' may be passed as keyword arguments,
+      and have the same meaning as for Python's sort functions.
+
+      Args:
+        pcoll: PCollection to process.
+        n: number of elements to extract from pcoll.
+        **kwargs: may contain 'key' and/or 'reverse'
+      """
+      unknown_kwargs = set(kwargs.keys()) - set(['key', 'reverse'])
+      if unknown_kwargs:
+        raise ValueError(
+            'Unknown keyword arguments: ' + ', '.join(unknown_kwargs))
+      self._py2__init__(n, None, **kwargs)
+
+    # Python 3 sort does not accept a comparison operator, and nor do we.
+    if sys.version_info[0] < 3:
+      __init__ = _py2__init__
+    else:
+      __init__ = _py3__init__
 
     def default_label(self):
       return 'Top(%d)' % self._n
@@ -227,7 +255,7 @@ class Top(object):
     "greatest" is determined by the comparator function supplied as the compare
     argument in the initializer.
     """
-    def __init__(self, n, compare=None, *args, **kwargs):
+    def _py2__init__(self, n, compare=None, *args, **kwargs):
       """Initializer.
 
       compare should be an implementation of "a < b" taking at least two
@@ -244,12 +272,38 @@ class Top(object):
         *args: as described above.
         **kwargs: as described above.
       """
+      if compare:
+        warnings.warn('Compare not available in Python 3, use key instead.',
+                      DeprecationWarning)
       self._n = n
       self._compare = compare
       self._key = kwargs.pop('key', None)
       self._reverse = kwargs.pop('reverse', False)
       self._args = args
       self._kwargs = kwargs
+
+    def _py3__init__(self, n, **kwargs):
+      """Creates a per-key Top operation.
+
+      The arguments 'key' and 'reverse' may be passed as keyword arguments,
+      and have the same meaning as for Python's sort functions.
+
+      Args:
+        pcoll: PCollection to process.
+        n: number of elements to extract from pcoll.
+        **kwargs: may contain 'key' and/or 'reverse'
+      """
+      unknown_kwargs = set(kwargs.keys()) - set(['key', 'reverse'])
+      if unknown_kwargs:
+        raise ValueError(
+            'Unknown keyword arguments: ' + ', '.join(unknown_kwargs))
+      self._py2__init__(n, None, **kwargs)
+
+    # Python 3 sort does not accept a comparison operator, and nor do we.
+    if sys.version_info[0] < 3:
+      __init__ = _py2__init__
+    else:
+      __init__ = _py3__init__
 
     def default_label(self):
       return 'TopPerKey(%d)' % self._n

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -89,7 +89,7 @@ class CombineTest(unittest.TestCase):
                 label='key:bot')
     pipeline.run()
 
-  @unittest.skipIf(sys.version_info[0] > 1, 'deprecated comparator')
+  @unittest.skipIf(sys.version_info[0] > 2, 'deprecated comparator')
   def test_top_py2(self):
     pipeline = TestPipeline()
 
@@ -152,7 +152,7 @@ class CombineTest(unittest.TestCase):
         ['aa', 'bbb', 'c', 'dddd'] | combine.Top.Of(3, key=len, reverse=True),
         [['c', 'aa', 'bbb']])
 
-  @unittest.skipIf(sys.version_info[0] > 1, 'deprecated comparator')
+  @unittest.skipIf(sys.version_info[0] > 2, 'deprecated comparator')
   def test_top_key_py2(self):
     # The largest elements compared by their length mod 5.
     self.assertEqual(

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -21,6 +21,7 @@ from __future__ import division
 
 import itertools
 import random
+import sys
 import unittest
 
 import hamcrest as hc
@@ -70,6 +71,28 @@ class CombineTest(unittest.TestCase):
   def test_top(self):
     pipeline = TestPipeline()
 
+    # First for global combines.
+    pcoll = pipeline | 'start' >> Create([6, 3, 1, 1, 9, 1, 5, 2, 0, 6])
+    result_top = pcoll | 'top' >> combine.Top.Largest(5)
+    result_bot = pcoll | 'bot' >> combine.Top.Smallest(4)
+    assert_that(result_top, equal_to([[9, 6, 6, 5, 3]]), label='assert:top')
+    assert_that(result_bot, equal_to([[0, 1, 1, 1]]), label='assert:bot')
+
+    # Again for per-key combines.
+    pcoll = pipeline | 'start-perkye' >> Create(
+        [('a', x) for x in [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]])
+    result_key_top = pcoll | 'top-perkey' >> combine.Top.LargestPerKey(5)
+    result_key_bot = pcoll | 'bot-perkey' >> combine.Top.SmallestPerKey(4)
+    assert_that(result_key_top, equal_to([('a', [9, 6, 6, 5, 3])]),
+                label='key:top')
+    assert_that(result_key_bot, equal_to([('a', [0, 1, 1, 1])]),
+                label='key:bot')
+    pipeline.run()
+
+  @unittest.skipIf(sys.version_info[0] > 1, 'deprecated comparator')
+  def test_top_py2(self):
+    pipeline = TestPipeline()
+
     # A parameter we'll be sharing with a custom comparator.
     names = {0: 'zo',
              1: 'one',
@@ -81,8 +104,7 @@ class CombineTest(unittest.TestCase):
 
     # First for global combines.
     pcoll = pipeline | 'start' >> Create([6, 3, 1, 1, 9, 1, 5, 2, 0, 6])
-    result_top = pcoll | 'top' >> combine.Top.Largest(5)
-    result_bot = pcoll | 'bot' >> combine.Top.Smallest(4)
+
     result_cmp = pcoll | 'cmp' >> combine.Top.Of(
         6,
         lambda a, b, names: len(names[a]) < len(names[b]),
@@ -92,24 +114,16 @@ class CombineTest(unittest.TestCase):
         lambda a, b, names: len(names[a]) < len(names[b]),
         names,  # Note parameter passed to comparator.
         reverse=True)
-    assert_that(result_top, equal_to([[9, 6, 6, 5, 3]]), label='assert:top')
-    assert_that(result_bot, equal_to([[0, 1, 1, 1]]), label='assert:bot')
     assert_that(result_cmp, equal_to([[9, 6, 6, 5, 3, 2]]), label='assert:cmp')
     assert_that(result_cmp_rev, equal_to([[0, 1, 1]]), label='assert:cmp_rev')
 
     # Again for per-key combines.
     pcoll = pipeline | 'start-perkye' >> Create(
         [('a', x) for x in [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]])
-    result_key_top = pcoll | 'top-perkey' >> combine.Top.LargestPerKey(5)
-    result_key_bot = pcoll | 'bot-perkey' >> combine.Top.SmallestPerKey(4)
     result_key_cmp = pcoll | 'cmp-perkey' >> combine.Top.PerKey(
         6,
         lambda a, b, names: len(names[a]) < len(names[b]),
         names)  # Note parameter passed to comparator.
-    assert_that(result_key_top, equal_to([('a', [9, 6, 6, 5, 3])]),
-                label='key:top')
-    assert_that(result_key_bot, equal_to([('a', [0, 1, 1, 1])]),
-                label='key:bot')
     assert_that(result_key_cmp, equal_to([('a', [9, 6, 6, 5, 3, 2])]),
                 label='key:cmp')
     pipeline.run()
@@ -138,6 +152,8 @@ class CombineTest(unittest.TestCase):
         ['aa', 'bbb', 'c', 'dddd'] | combine.Top.Of(3, key=len, reverse=True),
         [['c', 'aa', 'bbb']])
 
+  @unittest.skipIf(sys.version_info[0] > 1, 'deprecated comparator')
+  def test_top_key_py2(self):
     # The largest elements compared by their length mod 5.
     self.assertEqual(
         ['aa', 'bbbb', 'c', 'ddddd', 'eee', 'ffffff'] | combine.Top.Of(

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1852,7 +1852,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_top_of_pipeline_checking_satisfied(self):
     d = (self.p
          | beam.Create(range(5, 11)).with_output_types(int)
-         | 'Top 3' >> combine.Top.Of(3, lambda x, y: x < y))
+         | 'Top 3' >> combine.Top.Of(3))
 
     self.assertCompatible(typehints.Iterable[int],
                           d.element_type)
@@ -1864,7 +1864,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     d = (self.p
          | beam.Create(list('testing')).with_output_types(str)
-         | 'AciiTop' >> combine.Top.Of(3, lambda x, y: x < y))
+         | 'AciiTop' >> combine.Top.Of(3))
 
     self.assertCompatible(typehints.Iterable[str], d.element_type)
     assert_that(d, equal_to([['t', 't', 's']]))
@@ -1875,7 +1875,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       (self.p
        | beam.Create(range(100)).with_output_types(int)
        | 'Num + 1' >> beam.Map(lambda x: x + 1).with_output_types(int)
-       | 'TopMod' >> combine.Top.PerKey(1, lambda a, b: a < b))
+       | 'TopMod' >> combine.Top.PerKey(1))
 
     self.assertEqual(
         "Type hint violation for 'CombinePerKey(TopCombineFn)': "
@@ -1888,7 +1888,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create(range(100)).with_output_types(int)
          | ('GroupMod 3' >> beam.Map(lambda x: (x % 3, x))
             .with_output_types(typehints.KV[int, int]))
-         | 'TopMod' >> combine.Top.PerKey(1, lambda a, b: a < b))
+         | 'TopMod' >> combine.Top.PerKey(1))
 
     self.assertCompatible(typehints.Tuple[int, typehints.Iterable[int]],
                           d.element_type)
@@ -1902,7 +1902,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create(range(21))
          | ('GroupMod 3' >> beam.Map(lambda x: (x % 3, x))
             .with_output_types(typehints.KV[int, int]))
-         | 'TopMod' >> combine.Top.PerKey(1, lambda a, b: a < b))
+         | 'TopMod' >> combine.Top.PerKey(1))
 
     self.assertCompatible(typehints.KV[int, typehints.Iterable[int]],
                           d.element_type)


### PR DESCRIPTION
This is in line with Python's change to its sorting operations.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

