### PR TITLE
[BEAM-6678] Persist watermark holds view in Flink checkpoints

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -59,7 +59,6 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
-import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
@@ -78,11 +77,13 @@ public class FlinkStateInternals<K> implements StateInternals {
   private Coder<K> keyCoder;
 
   // Combined watermark holds for all keys of this partition
-  private final Map<String, Long> watermarkHolds = new HashMap<>();
+  private final Map<String, Instant> watermarkHolds = new HashMap<>();
   // State to persist combined watermark holds for all keys of this partition
-  private final MapStateDescriptor<String, Long> watermarkHoldState =
+  private final MapStateDescriptor<String, Instant> watermarkHoldStateDescriptor =
       new MapStateDescriptor<>(
-          "watermark-holds", StringSerializer.INSTANCE, LongSerializer.INSTANCE);
+          "watermark-holds",
+          StringSerializer.INSTANCE,
+          new CoderTypeSerializer<>(InstantCoder.of()));
 
   public FlinkStateInternals(KeyedStateBackend<ByteBuffer> flinkStateBackend, Coder<K> keyCoder)
       throws Exception {
@@ -94,8 +95,8 @@ public class FlinkStateInternals<K> implements StateInternals {
   /** Returns the minimum over all watermark holds. */
   public Instant watermarkHold() {
     long min = Long.MAX_VALUE;
-    for (Long hold : watermarkHolds.values()) {
-      min = Math.min(min, hold);
+    for (Instant hold : watermarkHolds.values()) {
+      min = Math.min(min, hold.getMillis());
     }
     return new Instant(min);
   }
@@ -121,7 +122,11 @@ public class FlinkStateInternals<K> implements StateInternals {
         .bind(
             address.getId(),
             new FlinkStateBinder(
-                namespace, context, flinkStateBackend, watermarkHolds, watermarkHoldState));
+                namespace,
+                context,
+                flinkStateBackend,
+                watermarkHolds,
+                watermarkHoldStateDescriptor));
   }
 
   private static class FlinkStateBinder implements StateBinder {
@@ -129,20 +134,20 @@ public class FlinkStateInternals<K> implements StateInternals {
     private final StateNamespace namespace;
     private final StateContext<?> stateContext;
     private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
-    private final Map<String, Long> watermarkHolds;
-    private final MapStateDescriptor<String, Long> watermarkHoldState;
+    private final Map<String, Instant> watermarkHolds;
+    private final MapStateDescriptor<String, Instant> watermarkHoldStateDescriptor;
 
     private FlinkStateBinder(
         StateNamespace namespace,
         StateContext<?> stateContext,
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
-        Map<String, Long> watermarkHolds,
-        MapStateDescriptor<String, Long> watermarkHoldState) {
+        Map<String, Instant> watermarkHolds,
+        MapStateDescriptor<String, Instant> watermarkHoldStateDescriptor) {
       this.namespace = namespace;
       this.stateContext = stateContext;
       this.flinkStateBackend = flinkStateBackend;
       this.watermarkHolds = watermarkHolds;
-      this.watermarkHoldState = watermarkHoldState;
+      this.watermarkHoldStateDescriptor = watermarkHoldStateDescriptor;
     }
 
     @Override
@@ -199,7 +204,12 @@ public class FlinkStateInternals<K> implements StateInternals {
     public WatermarkHoldState bindWatermark(
         String id, StateSpec<WatermarkHoldState> spec, TimestampCombiner timestampCombiner) {
       return new FlinkWatermarkHoldState<>(
-          flinkStateBackend, watermarkHolds, watermarkHoldState, id, namespace, timestampCombiner);
+          flinkStateBackend,
+          watermarkHolds,
+          watermarkHoldStateDescriptor,
+          id,
+          namespace,
+          timestampCombiner);
     }
   }
 
@@ -747,34 +757,34 @@ public class FlinkStateInternals<K> implements StateInternals {
 
   private static class FlinkWatermarkHoldState<K, W extends BoundedWindow>
       implements WatermarkHoldState {
-    private final String stateId;
+
     private final TimestampCombiner timestampCombiner;
-    private final StateNamespace namespace;
-    private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
-    private final Map<String, Long> watermarkHolds;
-    private org.apache.flink.api.common.state.MapState<String, Long> watermarkHoldsPartitionState;
-    private final ValueStateDescriptor<Instant> flinkStateDescriptor;
+    private final Map<String, Instant> watermarkHolds;
+    private final String namespaceString;
+    private org.apache.flink.api.common.state.MapState<String, Instant> watermarkHoldsState;
 
     public FlinkWatermarkHoldState(
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
-        Map<String, Long> watermarkHolds,
-        MapStateDescriptor<String, Long> watermarkHoldState,
+        Map<String, Instant> watermarkHolds,
+        MapStateDescriptor<String, Instant> watermarkHoldStateDescriptor,
         String stateId,
         StateNamespace namespace,
         TimestampCombiner timestampCombiner) {
-      this.stateId = stateId;
       this.timestampCombiner = timestampCombiner;
-      this.namespace = namespace;
-      this.flinkStateBackend = flinkStateBackend;
       this.watermarkHolds = watermarkHolds;
+      // Combines StateNamespace and stateId to generate a unique namespace for
+      // watermarkHoldsState. We do not want to use Flink's namespacing to be
+      // able to recover watermark holds efficiently during recovery.
+      this.namespaceString = namespace.stringKey() + stateId;
       try {
-        this.watermarkHoldsPartitionState = flinkStateBackend.getPartitionedState(
-            VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, watermarkHoldState);
+        this.watermarkHoldsState =
+            flinkStateBackend.getPartitionedState(
+                VoidNamespace.INSTANCE,
+                VoidNamespaceSerializer.INSTANCE,
+                watermarkHoldStateDescriptor);
       } catch (Exception e) {
         throw new RuntimeException("Could not access state for watermark partition view");
       }
-      this.flinkStateDescriptor =
-          new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(InstantCoder.of()));
     }
 
     @Override
@@ -793,11 +803,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         @Override
         public Boolean read() {
           try {
-            return flinkStateBackend
-                    .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
-                    .value()
-                == null;
+            return watermarkHoldsState.get(namespaceString) == null;
           } catch (Exception e) {
             throw new RuntimeException("Error reading state.", e);
           }
@@ -813,20 +819,14 @@ public class FlinkStateInternals<K> implements StateInternals {
     @Override
     public void add(Instant value) {
       try {
-        org.apache.flink.api.common.state.ValueState<Instant> state =
-            flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
-
-        Instant current = state.value();
+        Instant current = watermarkHoldsState.get(namespaceString);
         if (current == null) {
-          state.update(value);
-          watermarkHolds.put(namespace.stringKey(), value.getMillis());
-          watermarkHoldsPartitionState.put(namespace.stringKey(), value.getMillis());
+          watermarkHolds.put(namespaceString, value);
+          watermarkHoldsState.put(namespaceString, value);
         } else {
           Instant combined = timestampCombiner.combine(current, value);
-          state.update(combined);
-          watermarkHolds.put(namespace.stringKey(), combined.getMillis());
-          watermarkHoldsPartitionState.put(namespace.stringKey(), combined.getMillis());
+          watermarkHolds.put(namespaceString, combined);
+          watermarkHoldsState.put(namespaceString, combined);
         }
       } catch (Exception e) {
         throw new RuntimeException("Error updating state.", e);
@@ -836,11 +836,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     @Override
     public Instant read() {
       try {
-        watermarkHoldsPartitionState.get(namespace.stringKey());
-        org.apache.flink.api.common.state.ValueState<Instant> state =
-            flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
-        return state.value();
+        return watermarkHoldsState.get(namespaceString);
       } catch (Exception e) {
         throw new RuntimeException("Error reading state.", e);
       }
@@ -848,13 +844,9 @@ public class FlinkStateInternals<K> implements StateInternals {
 
     @Override
     public void clear() {
-      watermarkHolds.remove(namespace.stringKey());
+      watermarkHolds.remove(namespaceString);
       try {
-        watermarkHoldsPartitionState.remove(namespace.stringKey());
-        org.apache.flink.api.common.state.ValueState<Instant> state =
-            flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
-        state.clear();
+        watermarkHoldsState.remove(namespaceString);
       } catch (Exception e) {
         throw new RuntimeException("Error reading state.", e);
       }
@@ -871,20 +863,16 @@ public class FlinkStateInternals<K> implements StateInternals {
 
       FlinkWatermarkHoldState<?, ?> that = (FlinkWatermarkHoldState<?, ?>) o;
 
-      if (!stateId.equals(that.stateId)) {
-        return false;
-      }
       if (!timestampCombiner.equals(that.timestampCombiner)) {
         return false;
       }
-      return namespace.equals(that.namespace);
+      return namespaceString.equals(that.namespaceString);
     }
 
     @Override
     public int hashCode() {
-      int result = stateId.hashCode();
+      int result = namespaceString.hashCode();
       result = 31 * result + timestampCombiner.hashCode();
-      result = 31 * result + namespace.hashCode();
       return result;
     }
   }
@@ -1229,11 +1217,11 @@ public class FlinkStateInternals<K> implements StateInternals {
 
   /** Restores a view of the watermark holds of all keys of this partiton. */
   private void restoreWatermarkHoldsView() throws Exception {
-    org.apache.flink.api.common.state.MapState<String, Long> mapState =
+    org.apache.flink.api.common.state.MapState<String, Instant> mapState =
         flinkStateBackend.getPartitionedState(
-            VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, watermarkHoldState);
+            VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, watermarkHoldStateDescriptor);
     try (Stream<ByteBuffer> keys =
-        flinkStateBackend.getKeys(watermarkHoldState.getName(), VoidNamespace.INSTANCE)) {
+        flinkStateBackend.getKeys(watermarkHoldStateDescriptor.getName(), VoidNamespace.INSTANCE)) {
       Iterator<ByteBuffer> iterator = keys.iterator();
       while (iterator.hasNext()) {
         flinkStateBackend.setCurrentKey(iterator.next());

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
@@ -17,11 +17,22 @@
  */
 package org.apache.beam.runners.flink.streaming;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
 import java.nio.ByteBuffer;
+import java.util.UUID;
 import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.runners.core.StateInternalsTest;
+import org.apache.beam.runners.core.StateNamespaces;
+import org.apache.beam.runners.core.StateTag;
+import org.apache.beam.runners.core.StateTags;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateInternals;
+import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.state.WatermarkHoldState;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
@@ -31,7 +42,10 @@ import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.joda.time.Instant;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -41,24 +55,90 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
 
   @Override
   protected StateInternals createStateInternals() {
-    MemoryStateBackend backend = new MemoryStateBackend();
     try {
-      AbstractKeyedStateBackend<ByteBuffer> keyedStateBackend =
-          backend.createKeyedStateBackend(
-              new DummyEnvironment("test", 1, 0),
-              new JobID(),
-              "test_op",
-              new GenericTypeInfo<>(ByteBuffer.class).createSerializer(new ExecutionConfig()),
-              1,
-              new KeyGroupRange(0, 0),
-              new KvStateRegistry().createTaskRegistry(new JobID(), new JobVertexID()));
-
-      keyedStateBackend.setCurrentKey(
-          ByteBuffer.wrap(CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "Hello")));
-
+      KeyedStateBackend<ByteBuffer> keyedStateBackend = createStateBackend();
       return new FlinkStateInternals<>(keyedStateBackend, StringUtf8Coder.of());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Test
+  public void testWatermarkHoldsPersistence() throws Exception {
+    KeyedStateBackend<ByteBuffer> keyedStateBackend = createStateBackend();
+    FlinkStateInternals stateInternals =
+        new FlinkStateInternals<>(keyedStateBackend, StringUtf8Coder.of());
+
+    StateTag<WatermarkHoldState> stateTag =
+        StateTags.watermarkStateInternal("hold", TimestampCombiner.EARLIEST);
+    WatermarkHoldState globalWindow = stateInternals.state(StateNamespaces.global(), stateTag);
+    WatermarkHoldState fixedWindow =
+        stateInternals.state(
+            StateNamespaces.window(
+                IntervalWindow.getCoder(), new IntervalWindow(new Instant(0), new Instant(10))),
+            stateTag);
+
+    Instant noHold = new Instant(Long.MAX_VALUE);
+    assertThat(stateInternals.watermarkHold(), is(noHold));
+
+    Instant high = new Instant(10);
+    globalWindow.add(high);
+    assertThat(stateInternals.watermarkHold(), is(high));
+
+    Instant middle = new Instant(5);
+    fixedWindow.add(middle);
+    assertThat(stateInternals.watermarkHold(), is(middle));
+
+    Instant low = new Instant(1);
+    globalWindow.add(low);
+    assertThat(stateInternals.watermarkHold(), is(low));
+
+    // Try to overwrite with later hold (should not succeed)
+    globalWindow.add(high);
+    assertThat(stateInternals.watermarkHold(), is(low));
+    fixedWindow.add(high);
+    assertThat(stateInternals.watermarkHold(), is(low));
+
+    changeKey(keyedStateBackend);
+    // Discard watermark view and recover it
+    stateInternals = new FlinkStateInternals<>(keyedStateBackend, StringUtf8Coder.of());
+    globalWindow = stateInternals.state(StateNamespaces.global(), stateTag);
+    fixedWindow =
+        stateInternals.state(
+            StateNamespaces.window(
+                IntervalWindow.getCoder(), new IntervalWindow(new Instant(0), new Instant(10))),
+            stateTag);
+
+    assertThat(stateInternals.watermarkHold(), is(low));
+
+    fixedWindow.clear();
+    assertThat(stateInternals.watermarkHold(), is(low));
+
+    globalWindow.clear();
+    assertThat(stateInternals.watermarkHold(), is(noHold));
+  }
+
+  private KeyedStateBackend<ByteBuffer> createStateBackend() throws Exception {
+    MemoryStateBackend backend = new MemoryStateBackend();
+
+    AbstractKeyedStateBackend<ByteBuffer> keyedStateBackend =
+        backend.createKeyedStateBackend(
+            new DummyEnvironment("test", 1, 0),
+            new JobID(),
+            "test_op",
+            new GenericTypeInfo<>(ByteBuffer.class).createSerializer(new ExecutionConfig()),
+            2,
+            new KeyGroupRange(0, 1),
+            new KvStateRegistry().createTaskRegistry(new JobID(), new JobVertexID()));
+
+    changeKey(keyedStateBackend);
+
+    return keyedStateBackend;
+  }
+
+  private void changeKey(KeyedStateBackend<ByteBuffer> keyedStateBackend) throws CoderException {
+    keyedStateBackend.setCurrentKey(
+        ByteBuffer.wrap(
+            CoderUtils.encodeToByteArray(StringUtf8Coder.of(), UUID.randomUUID().toString())));
   }
 }


### PR DESCRIPTION
The FlinkRunner maintains a partition view of the pending watermark holds. This
view is used to hold back the watermark at the operator. It must be persisted,
otherwise elements may be late after recovering a Beam job.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](../.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
