### PR TITLE
[BEAM-6652] Reinstate Maps- Validate json is deterministic.

### DIFF
--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -219,7 +219,12 @@ func inferCoders(list []FullType) ([]*coder.Coder, error) {
 
 // protoEnc marshals the supplied proto.Message.
 func protoEnc(in T) ([]byte, error) {
-	return proto.Marshal(in.(proto.Message))
+	buf := proto.NewBuffer(nil)
+	buf.SetDeterministic(true)
+	if err := buf.Marshal(in.(proto.Message)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // protoDec unmarshals the supplied bytes into an instance of the supplied

--- a/sdks/go/pkg/beam/coder_test.go
+++ b/sdks/go/pkg/beam/coder_test.go
@@ -16,27 +16,50 @@
 package beam
 
 import (
+	"reflect"
 	"testing"
-
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
 
 func TestJSONCoder(t *testing.T) {
-	tests := []int{43, 12431235, -2, 0, 1}
+	v := "teststring"
+	tests := []interface{}{
+		43,
+		12431235,
+		-2,
+		0,
+		1,
+		true,
+		"a string",
+		map[int64]string{1: "one", 11: "oneone", 21: "twoone", 1211: "onetwooneone"},
+		struct {
+			A int
+			B *string
+			C bool
+		}{4, &v, false},
+	}
 
 	for _, test := range tests {
-		data, err := jsonEnc(test)
-		if err != nil {
-			t.Fatalf("Failed to encode %v: %v", tests, err)
+		var results []string
+		for i := 0; i < 10; i++ {
+			data, err := jsonEnc(test)
+			if err != nil {
+				t.Fatalf("Failed to encode %v: %v", tests, err)
+			}
+			results = append(results, string(data))
 		}
-		decoded, err := jsonDec(reflectx.Int, data)
+		for i, data := range results {
+			if data != results[0] {
+				t.Errorf("coder not deterministic: data[%d]: %v != %v ", i, data, results[0])
+			}
+		}
+
+		decoded, err := jsonDec(reflect.TypeOf(test), []byte(results[0]))
 		if err != nil {
 			t.Fatalf("Failed to decode: %v", err)
 		}
-		actual := decoded.(int)
 
-		if test != actual {
-			t.Errorf("Corrupt coding: %v, want %v", actual, test)
+		if !reflect.DeepEqual(decoded, test) {
+			t.Errorf("Corrupt coding: %v, want %v", decoded, test)
 		}
 	}
 }

--- a/sdks/go/pkg/beam/core/typex/class.go
+++ b/sdks/go/pkg/beam/core/typex/class.go
@@ -122,16 +122,8 @@ func isConcrete(t reflect.Type, visited map[uintptr]bool) bool {
 		return false // no unserializable types
 
 	case reflect.Map:
-		// TODO(BEAM-6652): 2019.02.11
-		// Maps have random default iteration order, and the "default coder"
-		// doesn't ensure a specific encoding order for key/value pairs in maps.
-		// To ensure correctness we're better off restricting map usage from
-		// casual users, until the default coder handles the random iteration
-		// order properly.
-		// Power users can continue to handle map coding themselves, though
-		// it remains their responsibility to encode them consistently.
-		// return isConcrete(t.Elem(), visited) && isConcrete(t.Key(), visited)
-		return false
+		return isConcrete(t.Elem(), visited) && isConcrete(t.Key(), visited)
+
 	case reflect.Array, reflect.Slice, reflect.Ptr:
 		return isConcrete(t.Elem(), visited)
 

--- a/sdks/go/pkg/beam/core/typex/class_test.go
+++ b/sdks/go/pkg/beam/core/typex/class_test.go
@@ -51,7 +51,7 @@ func TestClassOf(t *testing.T) {
 		}{}), Concrete},
 		{reflect.TypeOf(struct{ A []int }{}), Concrete},
 		{reflect.TypeOf(reflect.Value{}), Concrete}, // ok: private fields
-		{reflect.TypeOf(map[string]int{}), Invalid},
+		{reflect.TypeOf(map[string]int{}), Concrete},
 		{reflect.TypeOf(map[string]func(){}), Invalid},
 		{reflect.TypeOf(map[error]int{}), Invalid},
 		{reflect.TypeOf([4]int{}), Concrete},
@@ -74,7 +74,7 @@ func TestClassOf(t *testing.T) {
 		{reflect.TypeOf(RecursivePtrTest{}), Concrete},
 		{reflect.TypeOf(RecursiveSliceTest{}), Concrete},
 		{reflect.TypeOf(RecursivePtrArrayTest{}), Concrete},
-		{reflect.TypeOf(RecursiveMapTest{}), Invalid},
+		{reflect.TypeOf(RecursiveMapTest{}), Concrete},
 		{reflect.TypeOf(RecursiveBadTest{}), Invalid},
 
 		{reflect.TypeOf([]X{}), Container},


### PR DESCRIPTION
I determined that the Go Standard Library JSON encoder handles maps deterministically. This PR:
* extends the tests on the default encoder (JSON) to validate deterministic map encoding.
* Re-allows maps as a valid PCollection type.
* Sets Protobuf encoding to be deterministic.

Still to do for [BEAM-6652] is to extend ptest with a way for users to test registered coders since most of this scaffolding would be common for all coders. The "default" JSON coder can't use this directly since it would introduce a beam -> ptest -> beam import cycle.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](../.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
