### PR TITLE
[BEAM-6701] Add logical types to schema

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
@@ -171,6 +171,8 @@ public class RowCoder extends CustomCoder<Row> {
 
   private static long estimatedSizeBytes(FieldType typeDescriptor, Object value) {
     switch (typeDescriptor.getTypeName()) {
+      case LOGICAL_TYPE:
+        return estimatedSizeBytes(typeDescriptor.getLogicalType().getBaseType(), value);
       case ROW:
         return estimatedSizeBytes((Row) value);
       case ARRAY:

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
@@ -381,7 +381,7 @@ public abstract class RowCoderGenerator {
   }
 
   static StackManipulation mapCoder(Schema.FieldType keyType, Schema.FieldType valueType) {
-    StackManipulation keyCoder = coderForPrimitiveType(keyType.getTypeName());
+    StackManipulation keyCoder = getCoder(keyType);
     StackManipulation valueCoder = getCoder(valueType);
     return new Compound(
         keyCoder,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
@@ -341,7 +341,9 @@ public abstract class RowCoderGenerator {
   }
 
   private static StackManipulation getCoder(Schema.FieldType fieldType) {
-    if (TypeName.ARRAY.equals(fieldType.getTypeName())) {
+    if (TypeName.LOGICAL_TYPE.equals(fieldType.getTypeName())) {
+      return getCoder(fieldType.getLogicalType().getBaseType());
+    } else if (TypeName.ARRAY.equals(fieldType.getTypeName())) {
       return listCoder(fieldType.getCollectionElementType());
     } else if (TypeName.MAP.equals(fieldType.getTypeName())) {
       return mapCoder(fieldType.getMapKeyType(), fieldType.getMapValueType());

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldTypeDescriptors.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldTypeDescriptors.java
@@ -53,6 +53,9 @@ public class FieldTypeDescriptors {
   /** Get a {@link TypeDescriptor} from a {@link FieldType}. */
   public static TypeDescriptor javaTypeForFieldType(FieldType fieldType) {
     switch (fieldType.getTypeName()) {
+      case LOGICAL_TYPE:
+        // TODO: shouldn't we handle this differently?
+        return javaTypeForFieldType(fieldType.getLogicalType().getBaseType());
       case ARRAY:
         return TypeDescriptors.lists(javaTypeForFieldType(fieldType.getCollectionElementType()));
       case MAP:

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldTypeDescriptors.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldTypeDescriptors.java
@@ -70,6 +70,7 @@ public class FieldTypeDescriptors {
   }
   /** Get a {@link FieldType} from a {@link TypeDescriptor}. */
   public static FieldType fieldTypeForJavaType(TypeDescriptor typeDescriptor) {
+    // TODO: Convert for registered logical types.
     if (typeDescriptor.isArray()
         || typeDescriptor.isSubtypeOf(TypeDescriptor.of(Collection.class))) {
       return getArrayFieldType(typeDescriptor);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas;
+
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.LogicalType;
+
+public class LogicalTypes {
+  private static final Map<String, LogicalType> logicalTypes = new ConcurrentHashMap<>();
+
+  public static <InputT, BaseT> void registerLogicalType(
+      String identifier, LogicalType<InputT, BaseT> logicalType) {
+    if (logicalTypes.putIfAbsent(identifier, logicalType) != null) {
+      throw new IllegalStateException("Multiple logical types registered with id " + identifier);
+    }
+  }
+
+  public static <InputT, BaseT> LogicalType<InputT, BaseT> getLogicalType(String identifer) {
+    return (LogicalType<InputT, BaseT>) logicalTypes.get(identifer);
+  }
+
+  /** Represents a fixed-size byte array. */
+  public static class FixedBytes implements LogicalType<byte[], byte[]> {
+    public static String IDENTIFIER = "FixedBytes";
+    private final int byteArraySize;
+
+    private FixedBytes(int byteArraySize) {
+      this.byteArraySize = byteArraySize;
+    }
+
+    public static FixedBytes of(int byteArraySize) {
+      return new FixedBytes(byteArraySize);
+    }
+
+    public int getLength() {
+      return byteArraySize;
+    }
+
+    @Override
+    public String getIdentifier() {
+      return IDENTIFIER;
+    }
+
+    @Override
+    public FieldType getBaseType() {
+      return FieldType.BYTES;
+    }
+
+    @Override
+    public byte[] toBaseType(byte[] input) {
+      checkArgument(input.length == byteArraySize);
+      return input;
+    }
+
+    @Override
+    public byte[] toInputType(byte[] base) {
+      checkArgument(base.length <= byteArraySize);
+      if (base.length == byteArraySize) {
+        return base;
+      } else {
+        return Arrays.copyOf(base, byteArraySize);
+      }
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
@@ -58,7 +58,7 @@ public class LogicalTypes {
 
   /** A LogicalType representing a fixed-size byte array. */
   public static class FixedBytes implements LogicalType<byte[], byte[]> {
-    public static String IDENTIFIER = "FixedBytes";
+    public static final String IDENTIFIER = "FixedBytes";
     private final int byteArraySize;
 
     private FixedBytes(int byteArraySize) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
@@ -23,8 +23,9 @@ import java.util.Arrays;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 
+/** A collection of common {@link Schema.LogicalType} classes. */
 public class LogicalTypes {
-
+  /** A base class for LogicalTypes that use the same Java type as the underlying base type. */
   public abstract static class PassThroughLogicalType<T> implements LogicalType<T, T> {
     private final String identifier;
     private final FieldType fieldType;
@@ -55,7 +56,7 @@ public class LogicalTypes {
     }
   }
 
-  /** Represents a fixed-size byte array. */
+  /** A LogicalType representing a fixed-size byte array. */
   public static class FixedBytes implements LogicalType<byte[], byte[]> {
     public static String IDENTIFIER = "FixedBytes";
     private final int byteArraySize;
@@ -75,6 +76,11 @@ public class LogicalTypes {
     @Override
     public String getIdentifier() {
       return IDENTIFIER;
+    }
+
+    @Override
+    public String getArgument() {
+      return Integer.toString(byteArraySize);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
@@ -20,14 +20,12 @@ package org.apache.beam.sdk.schemas;
 import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Arrays;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 
 public class LogicalTypes {
 
-  public static abstract class PassThroughLogicalType<T> implements LogicalType<T, T> {
+  public abstract static class PassThroughLogicalType<T> implements LogicalType<T, T> {
     private final String identifier;
     private final FieldType fieldType;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
@@ -26,17 +26,35 @@ import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 
 public class LogicalTypes {
-  private static final Map<String, LogicalType> logicalTypes = new ConcurrentHashMap<>();
 
-  public static <InputT, BaseT> void registerLogicalType(
-      String identifier, LogicalType<InputT, BaseT> logicalType) {
-    if (logicalTypes.putIfAbsent(identifier, logicalType) != null) {
-      throw new IllegalStateException("Multiple logical types registered with id " + identifier);
+  public static abstract class PassThroughLogicalType<T> implements LogicalType<T, T> {
+    private final String identifier;
+    private final FieldType fieldType;
+
+    protected PassThroughLogicalType(String identifier, FieldType fieldType) {
+      this.identifier = identifier;
+      this.fieldType = fieldType;
     }
-  }
 
-  public static <InputT, BaseT> LogicalType<InputT, BaseT> getLogicalType(String identifer) {
-    return (LogicalType<InputT, BaseT>) logicalTypes.get(identifer);
+    @Override
+    public String getIdentifier() {
+      return identifier;
+    }
+
+    @Override
+    public FieldType getBaseType() {
+      return fieldType;
+    }
+
+    @Override
+    public T toBaseType(T input) {
+      return input;
+    }
+
+    @Override
+    public T toInputType(T base) {
+      return base;
+    }
   }
 
   /** Represents a fixed-size byte array. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/LogicalTypes.java
@@ -28,16 +28,23 @@ public class LogicalTypes {
   /** A base class for LogicalTypes that use the same Java type as the underlying base type. */
   public abstract static class PassThroughLogicalType<T> implements LogicalType<T, T> {
     private final String identifier;
+    private final String argument;
     private final FieldType fieldType;
 
-    protected PassThroughLogicalType(String identifier, FieldType fieldType) {
+    protected PassThroughLogicalType(String identifier, String argument, FieldType fieldType) {
       this.identifier = identifier;
+      this.argument = argument;
       this.fieldType = fieldType;
     }
 
     @Override
     public String getIdentifier() {
       return identifier;
+    }
+
+    @Override
+    public String getArgument() {
+      return argument;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -643,7 +643,16 @@ public class Schema implements Serializable {
           .withMetadata(LOGICAL_TYPE_ARGUMENT, logicalType.getArgument());
     }
 
-    /** Returns a copy of the descriptor with metadata set. */
+    /**
+     * Set the metadata map for the type, overriding any existing metadata. (/ public FieldType
+     * withMetadata(Map<String, byte[]> metadata) { Map<String, ByteArrayWrapper> wrapped =
+     * metadata.entrySet().stream() .collect(Collectors.toMap( Map.Entry::getKey, e ->
+     * ByteArrayWrapper.wrap(e.getValue())));
+     *
+     * <p>return toBuilder().setMetadata(wrapped).build(); }
+     *
+     * <p>/** Returns a copy of the descriptor with metadata set for the given key.
+     */
     public FieldType withMetadata(String key, byte[] metadata) {
       Map<String, ByteArrayWrapper> newMetadata =
           ImmutableMap.<String, ByteArrayWrapper>builder()
@@ -653,7 +662,7 @@ public class Schema implements Serializable {
       return toBuilder().setMetadata(newMetadata).build();
     }
 
-    /** Returns a copy of the descriptor with metadata set. */
+    /** Returns a copy of the descriptor with metadata set for the given key. */
     public FieldType withMetadata(String key, String metadata) {
       return withMetadata(key, metadata.getBytes(StandardCharsets.UTF_8));
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.schemas;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -39,6 +38,7 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.BiMap;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.HashBiMap;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
 
@@ -404,6 +404,7 @@ public class Schema implements Serializable {
       return other.isSupertypeOf(this);
     }
 
+    /** Whether this is a super type of the another type. */
     public boolean isSupertypeOf(TypeName other) {
       if (this == other) {
         return true;
@@ -657,6 +658,7 @@ public class Schema implements Serializable {
       return withMetadata(key, metadata.getBytes(StandardCharsets.UTF_8));
     }
 
+    @Nullable
     public byte[] getMetadata(String key) {
       ByteArrayWrapper metadata = getMetadata().get(key);
       return (metadata != null) ? metadata.array : null;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -361,7 +361,7 @@ public class Schema implements Serializable {
     public static final Set<TypeName> COMPOSITE_TYPES = ImmutableSet.of(ROW);
 
     public boolean isPrimitiveType() {
-      return !isCollectionType() && !isMapType() && !isCompositeType();
+      return !isCollectionType() && !isMapType() && !isCompositeType() && !isLogicalType();
     }
 
     public boolean isNumericType() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -643,16 +643,7 @@ public class Schema implements Serializable {
           .withMetadata(LOGICAL_TYPE_ARGUMENT, logicalType.getArgument());
     }
 
-    /**
-     * Set the metadata map for the type, overriding any existing metadata. (/ public FieldType
-     * withMetadata(Map<String, byte[]> metadata) { Map<String, ByteArrayWrapper> wrapped =
-     * metadata.entrySet().stream() .collect(Collectors.toMap( Map.Entry::getKey, e ->
-     * ByteArrayWrapper.wrap(e.getValue())));
-     *
-     * <p>return toBuilder().setMetadata(wrapped).build(); }
-     *
-     * <p>/** Returns a copy of the descriptor with metadata set for the given key.
-     */
+    /** Set the metadata map for the type, overriding any existing metadata. */
     public FieldType withMetadata(String key, byte[] metadata) {
       Map<String, ByteArrayWrapper> newMetadata =
           ImmutableMap.<String, ByteArrayWrapper>builder()

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -643,7 +643,16 @@ public class Schema implements Serializable {
           .withMetadata(LOGICAL_TYPE_ARGUMENT, logicalType.getArgument());
     }
 
-    /** Set the metadata map for the type, overriding any existing metadata. */
+    /** Set the metadata map for the type, overriding any existing metadata.. */
+    public FieldType withMetadata(Map<String, byte[]> metadata) {
+      Map<String, ByteArrayWrapper> wrapped =
+          metadata.entrySet().stream()
+              .collect(
+                  Collectors.toMap(Map.Entry::getKey, e -> ByteArrayWrapper.wrap(e.getValue())));
+      return toBuilder().setMetadata(wrapped).build();
+    }
+
+    /** Returns a copy of the descriptor with metadata set for the given key. */
     public FieldType withMetadata(String key, byte[] metadata) {
       Map<String, ByteArrayWrapper> newMetadata =
           ImmutableMap.<String, ByteArrayWrapper>builder()

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -521,9 +521,10 @@ public class AvroUtils {
         if (fixedBytesField != null) {
           baseType = fixedBytesField.toAvroType();
         } else {
-          throw new RuntimeException("Unhandled logical type "
-              + fieldType.getLogicalType().getIdentifier());
+          throw new RuntimeException(
+              "Unhandled logical type " + fieldType.getLogicalType().getIdentifier());
         }
+        break;
 
       case ARRAY:
         baseType =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -113,6 +113,7 @@ public class AvroUtils {
 
   /** Wrapper for fixed byte fields. */
   public static class FixedBytesField {
+    public static String METADATA_FIELD = "AVROTYPE";
     private static final String PREFIX = "FIXED:";
 
     private final int size;
@@ -129,7 +130,7 @@ public class AvroUtils {
     /** Create a {@link FixedBytesField} from a Beam {@link FieldType}. */
     @Nullable
     public static FixedBytesField fromBeamFieldType(FieldType fieldType) {
-      String metadata = fieldType.getMetadataString();
+      String metadata = fieldType.getMetadataString(METADATA_FIELD);
       if (fieldType.getTypeName().equals(TypeName.BYTES) && metadata.startsWith(PREFIX)) {
         return new FixedBytesField(Integer.parseInt(metadata.substring(6)));
       } else {
@@ -154,7 +155,7 @@ public class AvroUtils {
 
     /** Convert to a Beam type. */
     public FieldType toBeamType() {
-      return Schema.FieldType.BYTES.withMetadata(PREFIX + Integer.toString(size));
+      return Schema.FieldType.BYTES.withMetadata(METADATA_FIELD, PREFIX + Integer.toString(size));
     }
 
     /** Convert to an AVRO type. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -513,13 +513,17 @@ public class AvroUtils {
         break;
 
       case BYTES:
+        baseType = org.apache.avro.Schema.create(Type.BYTES);
+        break;
+
+      case LOGICAL_TYPE:
         FixedBytesField fixedBytesField = FixedBytesField.fromBeamFieldType(fieldType);
         if (fixedBytesField != null) {
           baseType = fixedBytesField.toAvroType();
         } else {
-          baseType = org.apache.avro.Schema.create(Type.BYTES);
+          throw new RuntimeException("Unhandled logical type "
+              + fieldType.getLogicalType().getIdentifier());
         }
-        break;
 
       case ARRAY:
         baseType =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -567,8 +567,7 @@ public abstract class Row implements Serializable {
       if (TypeName.ARRAY.equals(type.getTypeName())) {
         return verifyArray(value, type.getCollectionElementType(), fieldName);
       } else if (TypeName.MAP.equals(type.getTypeName())) {
-        return verifyMap(
-            value, type.getMapKeyType().getTypeName(), type.getMapValueType(), fieldName);
+        return verifyMap(value, type.getMapKeyType(), type.getMapValueType(), fieldName);
       } else if (TypeName.ROW.equals(type.getTypeName())) {
         return verifyRow(value, fieldName);
       } else if (TypeName.LOGICAL_TYPE.equals(type.getTypeName())) {
@@ -610,7 +609,7 @@ public abstract class Row implements Serializable {
     }
 
     private Map<Object, Object> verifyMap(
-        Object value, TypeName keyTypeName, FieldType valueType, String fieldName) {
+        Object value, FieldType keyType, FieldType valueType, String fieldName) {
       boolean valueTypeNullable = valueType.getNullable();
       if (!(value instanceof Map)) {
         throw new IllegalArgumentException(
@@ -627,11 +626,10 @@ public abstract class Row implements Serializable {
             throw new IllegalArgumentException(
                 String.format("%s is not nullable in Map field %s", valueType, fieldName));
           }
-          verifiedMap.put(verifyPrimitiveType(kv.getKey(), keyTypeName, fieldName), null);
+          verifiedMap.put(verify(kv.getKey(), keyType, fieldName), null);
         } else {
           verifiedMap.put(
-              verifyPrimitiveType(kv.getKey(), keyTypeName, fieldName),
-              verify(kv.getValue(), valueType, fieldName));
+              verify(kv.getKey(), keyType, fieldName), verify(kv.getValue(), valueType, fieldName));
         }
       }
       return verifiedMap;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
@@ -31,9 +31,9 @@ import org.apache.avro.reflect.AvroIgnore;
 import org.apache.avro.reflect.AvroName;
 import org.apache.avro.reflect.AvroSchema;
 import org.apache.avro.util.Utf8;
+import org.apache.beam.sdk.schemas.LogicalTypes.FixedBytes;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.utils.AvroUtils;
-import org.apache.beam.sdk.schemas.utils.AvroUtils.FixedBytesField;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -196,7 +196,7 @@ public class AvroSchemaTest {
           .addNullableField("double", FieldType.DOUBLE)
           .addNullableField("string", FieldType.STRING)
           .addNullableField("bytes", FieldType.BYTES)
-          .addField("fixed", FixedBytesField.withSize(4).toBeamType())
+          .addField("fixed", FieldType.logicalType(FixedBytes.of(4)))
           .addNullableField("timestampMillis", FieldType.DATETIME)
           .addNullableField("row", SUB_TYPE)
           .addNullableField("array", FieldType.array(SUB_TYPE))
@@ -212,7 +212,7 @@ public class AvroSchemaTest {
           .addNullableField("double", FieldType.DOUBLE)
           .addNullableField("string", FieldType.STRING)
           .addNullableField("bytes", FieldType.BYTES)
-          .addField("fixed", FixedBytesField.withSize(4).toBeamType())
+          .addField("fixed", FieldType.logicalType(FixedBytes.of(4)))
           .addNullableField("row", SUB_TYPE)
           .addNullableField("array", FieldType.array(SUB_TYPE.withNullable(false)))
           .addNullableField("map", FieldType.map(FieldType.STRING, SUB_TYPE.withNullable(false)))
@@ -276,7 +276,7 @@ public class AvroSchemaTest {
               (double) 44.2,
               "mystring",
               ByteBuffer.wrap(BYTE_ARRAY),
-              ByteBuffer.wrap(BYTE_ARRAY),
+              BYTE_ARRAY,
               DATE_TIME,
               NESTED_ROW,
               ImmutableList.of(NESTED_ROW, NESTED_ROW),
@@ -346,7 +346,7 @@ public class AvroSchemaTest {
               (double) 44.2,
               "mystring",
               ByteBuffer.wrap(BYTE_ARRAY),
-              ByteBuffer.wrap(BYTE_ARRAY),
+              BYTE_ARRAY,
               NESTED_ROW,
               ImmutableList.of(NESTED_ROW, NESTED_ROW),
               ImmutableMap.of("k1", NESTED_ROW, "k2", NESTED_ROW))

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.stream.Stream;
+import org.apache.beam.sdk.schemas.LogicalTypes.PassThroughLogicalType;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.junit.Rule;
@@ -263,5 +264,28 @@ public class SchemaTest {
         Schema.builder().addMapField("foo", FieldType.STRING, FieldType.row(nestedSchema2)).build();
     assertNotEquals(schema1, schema2);
     assertFalse(schema1.equivalent(schema2));
+  }
+
+  static class TestType extends PassThroughLogicalType<Long> {
+    TestType(String id, String arg) {
+      super(id, arg, FieldType.INT64);
+    }
+  }
+
+  @Test
+  public void testLogicalType() {
+    Schema schema1 =
+        Schema.builder().addLogicalTypeField("logical", new TestType("id", "arg")).build();
+    Schema schema2 =
+        Schema.builder().addLogicalTypeField("logical", new TestType("id", "arg")).build();
+    assertEquals(schema1, schema2); // Logical types are the same.
+
+    Schema schema3 =
+        Schema.builder().addLogicalTypeField("logical", new TestType("id2", "arg")).build();
+    assertNotEquals(schema1, schema3); // Logical type id is different.
+
+    Schema schema4 =
+        Schema.builder().addLogicalTypeField("logical", new TestType("id", "arg2")).build();
+    assertNotEquals(schema1, schema4); // Logical type arg is different.
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.extensions.sql.impl.planner.BeamJavaTypeFactory;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
+import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.CharType;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.DateType;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.TimeType;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.TimeWithLocalTzType;
@@ -350,6 +351,7 @@ public class BeamCalcRel extends Calc implements BeamRelNode {
             .put(TimeType.IDENTIFIER, "getDateTime")
             .put(TimeWithLocalTzType.IDENTIFIER, "getDateTime")
             .put(TimestampWithLocalTzType.IDENTIFIER, "getDateTime")
+            .put(CharType.IDENTIFIER, "getString")
             .build();
 
     private final Expression input;
@@ -391,9 +393,9 @@ public class BeamCalcRel extends Calc implements BeamRelNode {
           field =
               Expressions.convert_(
                   Expressions.modulo(field, Expressions.constant(MILLIS_PER_DAY)), int.class);
-        } else {
+        } else if (!logicalId.equals(CharType.IDENTIFIER)) {
           throw new IllegalArgumentException(
-              "Unknown DateTime type " + fromType.getLogicalType().getIdentifier());
+              "Unknown LogicalType " + fromType.getLogicalType().getIdentifier());
         }
       } else if (CalciteUtils.isDateTimeType(fromType)) {
         field = Expressions.call(field, "getMillis");

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -302,7 +302,8 @@ public class BeamCalcRel extends Calc implements BeamRelNode {
       valueDateTime = Expressions.multiply(valueDateTime, Expressions.constant(MILLIS_PER_DAY));
     } else {
       throw new IllegalArgumentException(
-          "Unknown DateTime type " + new String(toType.getMetadata(), UTF_8));
+          "Unknown DateTime type "
+              + new String(toType.getMetadata(CalciteUtils.TYPE_METADATA_KEY), UTF_8));
     }
 
     // Second, convert to joda DateTime
@@ -371,15 +372,20 @@ public class BeamCalcRel extends Calc implements BeamRelNode {
       Expression field = Expressions.call(expression, getter, Expressions.constant(index));
       if (fromType.getTypeName().isDateType()) {
         field = Expressions.call(field, "getMillis");
-        if (Arrays.equals(fromType.getMetadata(), CalciteUtils.TIME.getMetadata())) {
+        if (Arrays.equals(
+            fromType.getMetadata(CalciteUtils.TYPE_METADATA_KEY),
+            CalciteUtils.TIME.getMetadata(CalciteUtils.TYPE_METADATA_KEY))) {
           field = Expressions.convert_(field, int.class);
-        } else if (Arrays.equals(fromType.getMetadata(), CalciteUtils.DATE.getMetadata())) {
+        } else if (Arrays.equals(
+            fromType.getMetadata(CalciteUtils.TYPE_METADATA_KEY),
+            CalciteUtils.DATE.getMetadata(CalciteUtils.TYPE_METADATA_KEY))) {
           field =
               Expressions.convert_(
                   Expressions.modulo(field, Expressions.constant(MILLIS_PER_DAY)), int.class);
-        } else if (fromType.getMetadata() != null) {
+        } else if (fromType.getMetadata(CalciteUtils.TYPE_METADATA_KEY) != null) {
           throw new IllegalArgumentException(
-              "Unknown DateTime type " + new String(fromType.getMetadata(), UTF_8));
+              "Unknown DateTime type "
+                  + new String(fromType.getMetadata(CalciteUtils.TYPE_METADATA_KEY), UTF_8));
         }
       } else if (fromType.getTypeName().isCompositeType()
           || (fromType.getTypeName().isCollectionType()

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -17,12 +17,10 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -36,10 +34,8 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
-import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.DateType;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.TimeType;
-import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.TimestampType;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.MetricNameFilter;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -276,9 +272,7 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
     switch (type.getTypeName()) {
       case LOGICAL_TYPE:
         String logicalId = type.getLogicalType().getIdentifier();
-        if (logicalId.equals(TimestampType.IDENTIFIER)) {
-          return ((ReadableInstant) beamValue).getMillis();
-        } else if (logicalId.equals(TimeType.IDENTIFIER)) {
+        if (logicalId.equals(TimeType.IDENTIFIER)) {
           return (int) ((ReadableInstant) beamValue).getMillis();
         } else if (logicalId.equals(DateType.IDENTIFIER)) {
           return (int) (((ReadableInstant) beamValue).getMillis() / MILLIS_PER_DAY);
@@ -286,7 +280,7 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
           throw new IllegalArgumentException("Unknown DateTime type " + logicalId);
         }
       case DATETIME:
-          throw new IllegalArgumentException("Unknown DateTime type " + type);
+        return ((ReadableInstant) beamValue).getMillis();
       case BYTE:
       case INT16:
       case INT32:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
+import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.CharType;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.DateType;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils.TimeType;
 import org.apache.beam.sdk.metrics.Counter;
@@ -276,6 +277,8 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
           return (int) ((ReadableInstant) beamValue).getMillis();
         } else if (logicalId.equals(DateType.IDENTIFIER)) {
           return (int) (((ReadableInstant) beamValue).getMillis() / MILLIS_PER_DAY);
+        } else if (logicalId.equals(CharType.IDENTIFIER)) {
+          return beamValue;
         } else {
           throw new IllegalArgumentException("Unknown DateTime type " + logicalId);
         }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -272,15 +272,22 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
   private static Object fieldToAvatica(Schema.FieldType type, Object beamValue) {
     switch (type.getTypeName()) {
       case DATETIME:
-        if (Arrays.equals(type.getMetadata(), CalciteUtils.TIMESTAMP.getMetadata())) {
+        if (Arrays.equals(
+            type.getMetadata(CalciteUtils.TYPE_METADATA_KEY),
+            CalciteUtils.TIMESTAMP.getMetadata(CalciteUtils.TYPE_METADATA_KEY))) {
           return ((ReadableInstant) beamValue).getMillis();
-        } else if (Arrays.equals(type.getMetadata(), CalciteUtils.TIME.getMetadata())) {
+        } else if (Arrays.equals(
+            type.getMetadata(CalciteUtils.TYPE_METADATA_KEY),
+            CalciteUtils.TIME.getMetadata(CalciteUtils.TYPE_METADATA_KEY))) {
           return (int) ((ReadableInstant) beamValue).getMillis();
-        } else if (Arrays.equals(type.getMetadata(), CalciteUtils.DATE.getMetadata())) {
+        } else if (Arrays.equals(
+            type.getMetadata(CalciteUtils.TYPE_METADATA_KEY),
+            CalciteUtils.DATE.getMetadata(CalciteUtils.TYPE_METADATA_KEY))) {
           return (int) (((ReadableInstant) beamValue).getMillis() / MILLIS_PER_DAY);
         } else {
           throw new IllegalArgumentException(
-              "Unknown DateTime type " + new String(type.getMetadata(), UTF_8));
+              "Unknown DateTime type "
+                  + new String(type.getMetadata(CalciteUtils.TYPE_METADATA_KEY), UTF_8));
         }
       case BYTE:
       case INT16:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.util.NlsString;
@@ -105,21 +106,21 @@ public final class BeamTableUtils {
       return null;
     }
 
-    TypeName type = field.getType().getTypeName();
-    if (type.isStringType()) {
+    FieldType type = field.getType();
+    if (CalciteUtils.isStringType(type)) {
       if (rawObj instanceof NlsString) {
         return ((NlsString) rawObj).getValue();
       } else {
         return rawObj;
       }
-    } else if (CalciteUtils.isDateTimeType(field.getType())) {
+    } else if (CalciteUtils.isDateTimeType(type)) {
       // Internal representation of DateType in Calcite is convertible to Joda's Datetime.
       return new DateTime(rawObj);
-    } else if (type.isNumericType()
+    } else if (type.getTypeName().isNumericType()
         && ((rawObj instanceof String)
-            || (rawObj instanceof BigDecimal && type != TypeName.DECIMAL))) {
+            || (rawObj instanceof BigDecimal && type.getTypeName() != TypeName.DECIMAL))) {
       String raw = rawObj.toString();
-      switch (type) {
+      switch (type.getTypeName()) {
         case BYTE:
           return Byte.valueOf(raw);
         case INT16:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
@@ -25,6 +25,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
@@ -111,7 +112,7 @@ public final class BeamTableUtils {
       } else {
         return rawObj;
       }
-    } else if (type.isDateType()) {
+    } else if (CalciteUtils.isDateTimeType(field.getType())) {
       // Internal representation of DateType in Calcite is convertible to Joda's Datetime.
       return new DateTime(rawObj);
     } else if (type.isNumericType()

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
@@ -30,7 +30,9 @@ import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.extensions.sql.impl.transform.agg.CovarianceFn;
 import org.apache.beam.sdk.extensions.sql.impl.transform.agg.VarianceFn;
+import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.Count;
@@ -40,37 +42,33 @@ import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
 
-/**
- * Built-in aggregations functions for COUNT/MAX/MIN/SUM/AVG/VAR_POP/VAR_SAMP.
- *
- * <p>TODO: Consider making the interface in terms of (1-column) rows. reuvenlax
- */
+/** Built-in aggregations functions for COUNT/MAX/MIN/SUM/AVG/VAR_POP/VAR_SAMP. */
 public class BeamBuiltinAggregations {
 
-  public static final Map<String, Function<Schema.TypeName, CombineFn<?, ?, ?>>>
+  public static final Map<String, Function<Schema.FieldType, CombineFn<?, ?, ?>>>
       BUILTIN_AGGREGATOR_FACTORIES =
-          ImmutableMap.<String, Function<Schema.TypeName, CombineFn<?, ?, ?>>>builder()
+          ImmutableMap.<String, Function<Schema.FieldType, CombineFn<?, ?, ?>>>builder()
               .put("COUNT", typeName -> Count.combineFn())
               .put("MAX", BeamBuiltinAggregations::createMax)
               .put("MIN", BeamBuiltinAggregations::createMin)
               .put("SUM", BeamBuiltinAggregations::createSum)
               .put("$SUM0", BeamBuiltinAggregations::createSum)
               .put("AVG", BeamBuiltinAggregations::createAvg)
-              .put("VAR_POP", VarianceFn::newPopulation)
-              .put("VAR_SAMP", VarianceFn::newSample)
-              .put("COVAR_POP", CovarianceFn::newPopulation)
-              .put("COVAR_SAMP", CovarianceFn::newSample)
+              .put("VAR_POP", t -> VarianceFn.newPopulation(t.getTypeName()))
+              .put("VAR_SAMP", t -> VarianceFn.newSample(t.getTypeName()))
+              .put("COVAR_POP", t -> CovarianceFn.newPopulation(t.getTypeName()))
+              .put("COVAR_SAMP", t -> CovarianceFn.newSample(t.getTypeName()))
               .build();
 
   private static MathContext mc = new MathContext(10, RoundingMode.HALF_UP);
 
-  public static CombineFn<?, ?, ?> create(String functionName, Schema.TypeName fieldTypeName) {
+  public static CombineFn<?, ?, ?> create(String functionName, Schema.FieldType fieldType) {
 
-    Function<Schema.TypeName, CombineFn<?, ?, ?>> aggregatorFactory =
+    Function<Schema.FieldType, CombineFn<?, ?, ?>> aggregatorFactory =
         BUILTIN_AGGREGATOR_FACTORIES.get(functionName);
 
     if (aggregatorFactory != null) {
-      return aggregatorFactory.apply(fieldTypeName);
+      return aggregatorFactory.apply(fieldType);
     }
 
     throw new UnsupportedOperationException(
@@ -78,8 +76,11 @@ public class BeamBuiltinAggregations {
   }
 
   /** {@link CombineFn} for MAX based on {@link Max} and {@link Combine.BinaryCombineFn}. */
-  static CombineFn createMax(Schema.TypeName fieldType) {
-    switch (fieldType) {
+  static CombineFn createMax(FieldType fieldType) {
+    if (CalciteUtils.isDateTimeType(fieldType)) {
+      return new CustMax<>();
+    }
+    switch (fieldType.getTypeName()) {
       case BOOLEAN:
       case INT16:
       case BYTE:
@@ -100,8 +101,11 @@ public class BeamBuiltinAggregations {
   }
 
   /** {@link CombineFn} for MIN based on {@link Min} and {@link Combine.BinaryCombineFn}. */
-  static CombineFn createMin(Schema.TypeName fieldType) {
-    switch (fieldType) {
+  static CombineFn createMin(Schema.FieldType fieldType) {
+    if (CalciteUtils.isDateTimeType(fieldType)) {
+      return new CustMin();
+    }
+    switch (fieldType.getTypeName()) {
       case BOOLEAN:
       case BYTE:
       case INT16:
@@ -122,8 +126,8 @@ public class BeamBuiltinAggregations {
   }
 
   /** {@link CombineFn} for Sum based on {@link Sum} and {@link Combine.BinaryCombineFn}. */
-  static CombineFn createSum(Schema.TypeName fieldType) {
-    switch (fieldType) {
+  static CombineFn createSum(Schema.FieldType fieldType) {
+    switch (fieldType.getTypeName()) {
       case INT32:
         return Sum.ofIntegers();
       case INT16:
@@ -145,8 +149,8 @@ public class BeamBuiltinAggregations {
   }
 
   /** {@link CombineFn} for AVG. */
-  static CombineFn createAvg(Schema.TypeName fieldType) {
-    switch (fieldType) {
+  static CombineFn createAvg(Schema.FieldType fieldType) {
+    switch (fieldType.getTypeName()) {
       case INT32:
         return new IntegerAvg();
       case INT16:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/AggregationCombineFnAdapter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/AggregationCombineFnAdapter.java
@@ -144,7 +144,7 @@ public class AggregationCombineFnAdapter<T> {
     if (call.getAggregation() instanceof SqlUserDefinedAggFunction) {
       combineFn = getUdafCombineFn(call);
     } else {
-      combineFn = BeamBuiltinAggregations.create(functionName, field.getType().getTypeName());
+      combineFn = BeamBuiltinAggregations.create(functionName, field.getType());
     }
     if (call.getArgList().isEmpty()) {
       return new SingleInputCombiner(combineFn);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -38,7 +38,6 @@ import org.joda.time.base.AbstractInstant;
 
 /** Utility methods for Calcite related operations. */
 public class CalciteUtils {
-  public static final String TYPE_METADATA_KEY = "SqlType";
   private static final long UNLIMITED_ARRAY_SIZE = -1L;
 
   // Represent a DATE type.
@@ -74,18 +73,38 @@ public class CalciteUtils {
     }
   }
 
+  public static class CharType extends PassThroughLogicalType<String> {
+    public static String IDENTIFIER = "SqlCharType";
+
+    public CharType() {
+      super(IDENTIFIER, FieldType.STRING);
+    }
+  }
+
   /** Returns true if the type is any of the various date time types. */
   public static boolean isDateTimeType(FieldType fieldType) {
     if (fieldType.getTypeName() == TypeName.DATETIME) {
       return true;
     }
 
-    if (fieldType.getTypeName() == TypeName.LOGICAL_TYPE) {
+    if (fieldType.getTypeName().isLogicalType()) {
       String logicalId = fieldType.getLogicalType().getIdentifier();
       return logicalId.equals(DateType.IDENTIFIER)
           || logicalId.equals(TimeType.IDENTIFIER)
           || logicalId.equals(TimeWithLocalTzType.IDENTIFIER)
           || logicalId.equals(TimestampWithLocalTzType.IDENTIFIER);
+    }
+    return false;
+  }
+
+  public static boolean isStringType(FieldType fieldType) {
+    if (fieldType.getTypeName() == TypeName.STRING) {
+      return true;
+    }
+
+    if (fieldType.getTypeName().isLogicalType()) {
+      String logicalId = fieldType.getLogicalType().getIdentifier();
+      return logicalId.equals(CharType.IDENTIFIER);
     }
     return false;
   }
@@ -115,7 +134,7 @@ public class CalciteUtils {
           .put(
               FieldType.logicalType(new TimestampWithLocalTzType()),
               SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-          .put(FieldType.STRING.withMetadata(TYPE_METADATA_KEY, "CHAR"), SqlTypeName.CHAR)
+          .put(FieldType.logicalType(new CharType()), SqlTypeName.CHAR)
           .put(FieldType.STRING, SqlTypeName.VARCHAR)
           .build();
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -21,8 +21,10 @@ import java.lang.reflect.Type;
 import java.util.Date;
 import java.util.Map;
 import java.util.stream.IntStream;
+import org.apache.beam.sdk.schemas.LogicalTypes.PassThroughLogicalType;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.LogicalType;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.BiMap;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableBiMap;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
@@ -31,12 +33,50 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.joda.time.Instant;
 import org.joda.time.base.AbstractInstant;
 
 /** Utility methods for Calcite related operations. */
 public class CalciteUtils {
   public static final String TYPE_METADATA_KEY = "SqlType";
   private static final long UNLIMITED_ARRAY_SIZE = -1L;
+
+  // Represent a DATE type.
+  public static class DateType extends PassThroughLogicalType<Instant> {
+    public static String IDENTIFIER = "SqlDateType";
+    public DateType() {
+      super(IDENTIFIER, FieldType.DATETIME);
+    }
+  }
+
+  public static class TimeType extends PassThroughLogicalType<Instant> {
+    public static String IDENTIFIER = "SqlTimeType";
+    public TimeType() {
+      super(IDENTIFIER, FieldType.DATETIME);
+    }
+  }
+
+  public static class TimeWithLocalTzType extends PassThroughLogicalType<Instant> {
+    public static String IDENTIFIER = "SqlTimeWithLocalTzType";
+    public TimeWithLocalTzType() {
+      super(IDENTIFIER, FieldType.DATETIME);
+    }
+  }
+
+  public static class TimestampWithLocalTzType extends PassThroughLogicalType<Instant> {
+    public static String IDENTIFIER = "SqlTimestampWithLocalTzType";
+    public TimestampWithLocalTzType() {
+      super(IDENTIFIER, FieldType.DATETIME);
+    }
+  }
+
+  public static class TimestampType extends PassThroughLogicalType<Instant> {
+    public static String IDENTIFIER = "SqlTimestamp";
+    public TimestampType() {
+      super(IDENTIFIER, FieldType.DATETIME);
+    }
+  }
+
   // Beam's Schema class has a single DATETIME type, so we need a way to distinguish the different
   // Calcite time classes. We do this by storing extra metadata in the FieldType so we
   // can tell which time class this is.
@@ -53,15 +93,11 @@ public class CalciteUtils {
           .put(FieldType.DECIMAL, SqlTypeName.DECIMAL)
           .put(FieldType.BOOLEAN, SqlTypeName.BOOLEAN)
           .put(FieldType.BYTES, SqlTypeName.VARBINARY)
-          .put(FieldType.DATETIME.withMetadata(TYPE_METADATA_KEY, "DATE"), SqlTypeName.DATE)
-          .put(FieldType.DATETIME.withMetadata(TYPE_METADATA_KEY, "TIME"), SqlTypeName.TIME)
-          .put(
-              FieldType.DATETIME.withMetadata(TYPE_METADATA_KEY, "TIME_WITH_LOCAL_TZ"),
-              SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE)
-          .put(FieldType.DATETIME, SqlTypeName.TIMESTAMP)
-          .put(
-              FieldType.DATETIME.withMetadata(TYPE_METADATA_KEY, "TS_WITH_LOCAL_TZ"),
-              SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+          .put(FieldType.logicalType(new DateType()), SqlTypeName.DATE)
+          .put(FieldType.logicalType(new TimeType()), SqlTypeName.TIME)
+          .put(FieldType.logicalType(new TimeWithLocalTzType()), SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE)
+          .put(FieldType.logicalType(new TimestampType()), SqlTypeName.TIMESTAMP)
+          .put(FieldType.logicalType(new TimestampWithLocalTzType()), SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
           .put(FieldType.STRING.withMetadata(TYPE_METADATA_KEY, "CHAR"), SqlTypeName.CHAR)
           .put(FieldType.STRING, SqlTypeName.VARCHAR)
           .build();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -48,7 +48,7 @@ public class CalciteUtils {
     public static final String IDENTIFIER = "SqlDateType";
 
     public DateType() {
-      super(IDENTIFIER, FieldType.DATETIME);
+      super(IDENTIFIER, "", FieldType.DATETIME);
     }
   }
 
@@ -57,7 +57,7 @@ public class CalciteUtils {
     public static final String IDENTIFIER = "SqlTimeType";
 
     public TimeType() {
-      super(IDENTIFIER, FieldType.DATETIME);
+      super(IDENTIFIER, "", FieldType.DATETIME);
     }
   }
 
@@ -66,7 +66,7 @@ public class CalciteUtils {
     public static final String IDENTIFIER = "SqlTimeWithLocalTzType";
 
     public TimeWithLocalTzType() {
-      super(IDENTIFIER, FieldType.DATETIME);
+      super(IDENTIFIER, "", FieldType.DATETIME);
     }
   }
 
@@ -75,7 +75,7 @@ public class CalciteUtils {
     public static final String IDENTIFIER = "SqlTimestampWithLocalTzType";
 
     public TimestampWithLocalTzType() {
-      super(IDENTIFIER, FieldType.DATETIME);
+      super(IDENTIFIER, "", FieldType.DATETIME);
     }
   }
 
@@ -84,7 +84,7 @@ public class CalciteUtils {
     public static final String IDENTIFIER = "SqlCharType";
 
     public CharType() {
-      super(IDENTIFIER, FieldType.STRING);
+      super(IDENTIFIER, "", FieldType.STRING);
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -40,7 +40,10 @@ import org.joda.time.base.AbstractInstant;
 public class CalciteUtils {
   private static final long UNLIMITED_ARRAY_SIZE = -1L;
 
-  // Represent a DATE type.
+  // SQL has schema types that do not directly correspond to Beam Schema types. We define
+  // LogicalTypes to represent each of these types.
+
+  /** A LogicalType corresponding to DATE. */
   public static class DateType extends PassThroughLogicalType<Instant> {
     public static String IDENTIFIER = "SqlDateType";
 
@@ -49,6 +52,7 @@ public class CalciteUtils {
     }
   }
 
+  /** A LogicalType corresponding to TIME. */
   public static class TimeType extends PassThroughLogicalType<Instant> {
     public static String IDENTIFIER = "SqlTimeType";
 
@@ -57,6 +61,7 @@ public class CalciteUtils {
     }
   }
 
+  /** A LogicalType corresponding to TIME_WITH_LOCAL_TIME_ZONE. */
   public static class TimeWithLocalTzType extends PassThroughLogicalType<Instant> {
     public static String IDENTIFIER = "SqlTimeWithLocalTzType";
 
@@ -65,6 +70,7 @@ public class CalciteUtils {
     }
   }
 
+  /** A LogicalType corresponding to TIMESTAMP_WITH_LOCAL_TIME_ZONE. */
   public static class TimestampWithLocalTzType extends PassThroughLogicalType<Instant> {
     public static String IDENTIFIER = "SqlTimestampWithLocalTzType";
 
@@ -73,6 +79,7 @@ public class CalciteUtils {
     }
   }
 
+  /** A LogicalType corresponding to CHAR. */
   public static class CharType extends PassThroughLogicalType<String> {
     public static String IDENTIFIER = "SqlCharType";
 
@@ -109,52 +116,48 @@ public class CalciteUtils {
     return false;
   }
 
-  // Beam's Schema class has a single DATETIME type, so we need a way to distinguish the different
-  // Calcite time classes. We do this by storing extra metadata in the FieldType so we
-  // can tell which time class this is.
-  //
-  // Same story with CHAR and VARCHAR - they both map to STRING.
+  // The list of field type names used in SQL as Beam field types.
+  public static final FieldType TINY_INT = FieldType.BYTE;
+  public static final FieldType SMALL_INT = FieldType.INT16;
+  public static final FieldType INTEGER = FieldType.INT32;
+  public static final FieldType BIG_INT = FieldType.INT64;
+  public static final FieldType FLOAT = FieldType.FLOAT;
+  public static final FieldType DOUBLE = FieldType.DOUBLE;
+  public static final FieldType DECIMAL = FieldType.DECIMAL;
+  public static final FieldType BOOLEAN = FieldType.BOOLEAN;
+  public static final FieldType VARBINARY = FieldType.BYTES;
+  public static final FieldType VARCHAR = FieldType.STRING;
+  public static final FieldType CHAR = FieldType.logicalType(new CharType());
+  public static final FieldType DATE = FieldType.logicalType(new DateType());
+  public static final FieldType TIME = FieldType.logicalType(new TimeType());
+  public static final FieldType TIME_WITH_LOCAL_TZ =
+      FieldType.logicalType(new TimeWithLocalTzType());
+  public static final FieldType TIMESTAMP = FieldType.DATETIME;
+  public static FieldType TIMESTAMP_WITH_LOCAL_TZ =
+      FieldType.logicalType(new TimestampWithLocalTzType());
+
   private static final BiMap<FieldType, SqlTypeName> BEAM_TO_CALCITE_TYPE_MAPPING =
       ImmutableBiMap.<FieldType, SqlTypeName>builder()
-          .put(FieldType.BYTE, SqlTypeName.TINYINT)
-          .put(FieldType.INT16, SqlTypeName.SMALLINT)
-          .put(FieldType.INT32, SqlTypeName.INTEGER)
-          .put(FieldType.INT64, SqlTypeName.BIGINT)
-          .put(FieldType.FLOAT, SqlTypeName.FLOAT)
-          .put(FieldType.DOUBLE, SqlTypeName.DOUBLE)
-          .put(FieldType.DECIMAL, SqlTypeName.DECIMAL)
-          .put(FieldType.BOOLEAN, SqlTypeName.BOOLEAN)
-          .put(FieldType.BYTES, SqlTypeName.VARBINARY)
-          .put(FieldType.logicalType(new DateType()), SqlTypeName.DATE)
-          .put(FieldType.logicalType(new TimeType()), SqlTypeName.TIME)
-          .put(
-              FieldType.logicalType(new TimeWithLocalTzType()),
-              SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE)
-          .put(FieldType.DATETIME, SqlTypeName.TIMESTAMP)
-          .put(
-              FieldType.logicalType(new TimestampWithLocalTzType()),
-              SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-          .put(FieldType.logicalType(new CharType()), SqlTypeName.CHAR)
-          .put(FieldType.STRING, SqlTypeName.VARCHAR)
+          .put(TINY_INT, SqlTypeName.TINYINT)
+          .put(SMALL_INT, SqlTypeName.SMALLINT)
+          .put(INTEGER, SqlTypeName.INTEGER)
+          .put(BIG_INT, SqlTypeName.BIGINT)
+          .put(FLOAT, SqlTypeName.FLOAT)
+          .put(DOUBLE, SqlTypeName.DOUBLE)
+          .put(DECIMAL, SqlTypeName.DECIMAL)
+          .put(BOOLEAN, SqlTypeName.BOOLEAN)
+          .put(VARBINARY, SqlTypeName.VARBINARY)
+          .put(VARCHAR, SqlTypeName.VARCHAR)
+          .put(CHAR, SqlTypeName.CHAR)
+          .put(DATE, SqlTypeName.DATE)
+          .put(TIME, SqlTypeName.TIME)
+          .put(TIME_WITH_LOCAL_TZ, SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE)
+          .put(TIMESTAMP, SqlTypeName.TIMESTAMP)
+          .put(TIMESTAMP_WITH_LOCAL_TZ, SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
           .build();
 
   private static final BiMap<SqlTypeName, FieldType> CALCITE_TO_BEAM_TYPE_MAPPING =
       BEAM_TO_CALCITE_TYPE_MAPPING.inverse();
-
-  // The list of field type names used in SQL as Beam field types.
-  public static final FieldType TINY_INT = toFieldType(SqlTypeName.TINYINT);
-  public static final FieldType SMALL_INT = toFieldType(SqlTypeName.SMALLINT);
-  public static final FieldType INTEGER = toFieldType(SqlTypeName.INTEGER);
-  public static final FieldType BIG_INT = toFieldType(SqlTypeName.BIGINT);
-  public static final FieldType FLOAT = toFieldType(SqlTypeName.FLOAT);
-  public static final FieldType DOUBLE = toFieldType(SqlTypeName.DOUBLE);
-  public static final FieldType DECIMAL = toFieldType(SqlTypeName.DECIMAL);
-  public static final FieldType BOOLEAN = toFieldType(SqlTypeName.BOOLEAN);
-  public static final FieldType CHAR = toFieldType(SqlTypeName.CHAR);
-  public static final FieldType VARCHAR = toFieldType(SqlTypeName.VARCHAR);
-  public static final FieldType TIME = toFieldType(SqlTypeName.TIME);
-  public static final FieldType DATE = toFieldType(SqlTypeName.DATE);
-  public static final FieldType TIMESTAMP = toFieldType(SqlTypeName.TIMESTAMP);
 
   // Since there are multiple Calcite type that correspond to a single Beam type, this is the
   // default mapping.

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -35,6 +35,7 @@ import org.joda.time.base.AbstractInstant;
 
 /** Utility methods for Calcite related operations. */
 public class CalciteUtils {
+  public static final String TYPE_METADATA_KEY = "SqlType";
   private static final long UNLIMITED_ARRAY_SIZE = -1L;
   // Beam's Schema class has a single DATETIME type, so we need a way to distinguish the different
   // Calcite time classes. We do this by storing extra metadata in the FieldType so we
@@ -52,16 +53,16 @@ public class CalciteUtils {
           .put(FieldType.DECIMAL, SqlTypeName.DECIMAL)
           .put(FieldType.BOOLEAN, SqlTypeName.BOOLEAN)
           .put(FieldType.BYTES, SqlTypeName.VARBINARY)
-          .put(FieldType.DATETIME.withMetadata("DATE"), SqlTypeName.DATE)
-          .put(FieldType.DATETIME.withMetadata("TIME"), SqlTypeName.TIME)
+          .put(FieldType.DATETIME.withMetadata(TYPE_METADATA_KEY, "DATE"), SqlTypeName.DATE)
+          .put(FieldType.DATETIME.withMetadata(TYPE_METADATA_KEY, "TIME"), SqlTypeName.TIME)
           .put(
-              FieldType.DATETIME.withMetadata("TIME_WITH_LOCAL_TZ"),
+              FieldType.DATETIME.withMetadata(TYPE_METADATA_KEY, "TIME_WITH_LOCAL_TZ"),
               SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE)
           .put(FieldType.DATETIME, SqlTypeName.TIMESTAMP)
           .put(
-              FieldType.DATETIME.withMetadata("TS_WITH_LOCAL_TZ"),
+              FieldType.DATETIME.withMetadata(TYPE_METADATA_KEY, "TS_WITH_LOCAL_TZ"),
               SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-          .put(FieldType.STRING.withMetadata("CHAR"), SqlTypeName.CHAR)
+          .put(FieldType.STRING.withMetadata(TYPE_METADATA_KEY, "CHAR"), SqlTypeName.CHAR)
           .put(FieldType.STRING, SqlTypeName.VARCHAR)
           .build();
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -45,7 +45,7 @@ public class CalciteUtils {
 
   /** A LogicalType corresponding to DATE. */
   public static class DateType extends PassThroughLogicalType<Instant> {
-    public static String IDENTIFIER = "SqlDateType";
+    public static final String IDENTIFIER = "SqlDateType";
 
     public DateType() {
       super(IDENTIFIER, FieldType.DATETIME);
@@ -54,7 +54,7 @@ public class CalciteUtils {
 
   /** A LogicalType corresponding to TIME. */
   public static class TimeType extends PassThroughLogicalType<Instant> {
-    public static String IDENTIFIER = "SqlTimeType";
+    public static final String IDENTIFIER = "SqlTimeType";
 
     public TimeType() {
       super(IDENTIFIER, FieldType.DATETIME);
@@ -63,7 +63,7 @@ public class CalciteUtils {
 
   /** A LogicalType corresponding to TIME_WITH_LOCAL_TIME_ZONE. */
   public static class TimeWithLocalTzType extends PassThroughLogicalType<Instant> {
-    public static String IDENTIFIER = "SqlTimeWithLocalTzType";
+    public static final String IDENTIFIER = "SqlTimeWithLocalTzType";
 
     public TimeWithLocalTzType() {
       super(IDENTIFIER, FieldType.DATETIME);
@@ -72,7 +72,7 @@ public class CalciteUtils {
 
   /** A LogicalType corresponding to TIMESTAMP_WITH_LOCAL_TIME_ZONE. */
   public static class TimestampWithLocalTzType extends PassThroughLogicalType<Instant> {
-    public static String IDENTIFIER = "SqlTimestampWithLocalTzType";
+    public static final String IDENTIFIER = "SqlTimestampWithLocalTzType";
 
     public TimestampWithLocalTzType() {
       super(IDENTIFIER, FieldType.DATETIME);
@@ -81,7 +81,7 @@ public class CalciteUtils {
 
   /** A LogicalType corresponding to CHAR. */
   public static class CharType extends PassThroughLogicalType<String> {
-    public static String IDENTIFIER = "SqlCharType";
+    public static final String IDENTIFIER = "SqlCharType";
 
     public CharType() {
       super(IDENTIFIER, FieldType.STRING);
@@ -133,7 +133,7 @@ public class CalciteUtils {
   public static final FieldType TIME_WITH_LOCAL_TZ =
       FieldType.logicalType(new TimeWithLocalTzType());
   public static final FieldType TIMESTAMP = FieldType.DATETIME;
-  public static FieldType TIMESTAMP_WITH_LOCAL_TZ =
+  public static final FieldType TIMESTAMP_WITH_LOCAL_TZ =
       FieldType.logicalType(new TimestampWithLocalTzType());
 
   private static final BiMap<FieldType, SqlTypeName> BEAM_TO_CALCITE_TYPE_MAPPING =

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryReadWriteIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryReadWriteIT.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BeamPCollectionTable;
+import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 import org.apache.beam.sdk.io.gcp.bigquery.TestBigQuery;
@@ -76,7 +77,8 @@ public class BigQueryReadWriteIT implements Serializable {
           .addNullableField("c_float", FLOAT)
           .addNullableField("c_double", DOUBLE)
           .addNullableField("c_boolean", BOOLEAN)
-          .addNullableField("c_timestamp", FieldType.DATETIME.withMetadata("TS"))
+          .addNullableField(
+              "c_timestamp", FieldType.DATETIME.withMetadata(CalciteUtils.TYPE_METADATA_KEY, "TS"))
           .addNullableField("c_varchar", STRING)
           .addNullableField("c_char", STRING)
           .addNullableField("c_arr", FieldType.array(STRING))

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryReadWriteIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryReadWriteIT.java
@@ -77,8 +77,7 @@ public class BigQueryReadWriteIT implements Serializable {
           .addNullableField("c_float", FLOAT)
           .addNullableField("c_double", DOUBLE)
           .addNullableField("c_boolean", BOOLEAN)
-          .addNullableField(
-              "c_timestamp", FieldType.DATETIME.withMetadata(CalciteUtils.TYPE_METADATA_KEY, "TS"))
+          .addNullableField("c_timestamp", CalciteUtils.TIMESTAMP)
           .addNullableField("c_varchar", STRING)
           .addNullableField("c_char", STRING)
           .addNullableField("c_arr", FieldType.array(STRING))

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -113,10 +113,11 @@ public class BigQueryUtils {
   private static StandardSQLTypeName toStandardSQLTypeName(FieldType fieldType) {
     StandardSQLTypeName sqlType = BEAM_TO_BIGQUERY_TYPE_MAPPING.get(fieldType.getTypeName());
 
-    if (sqlType == StandardSQLTypeName.TIMESTAMP && fieldType.getMetadata() != null) {
+    // TODO: BigQuery code should not be relying on Calcite metadata fields.
+    if (sqlType == StandardSQLTypeName.TIMESTAMP && fieldType.getMetadata("SqlType") != null) {
       sqlType =
           BEAM_TO_BIGQUERY_METADATA_MAPPING.get(
-              new String(fieldType.getMetadata(), StandardCharsets.UTF_8));
+              new String(fieldType.getMetadata("SqlType"), StandardCharsets.UTF_8));
     }
 
     return sqlType;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -97,13 +97,15 @@ public class BigQueryUtils {
                       (long) (Double.parseDouble(str) * 1000), ISOChronology.getInstanceUTC()))
           .build();
 
-  private static final Map<String, StandardSQLTypeName> BEAM_TO_BIGQUERY_METADATA_MAPPING =
+  // TODO: BigQuery code should not be relying on Calcite metadata fields. If so, this belongs
+  // in the SQL package.
+  private static final Map<String, StandardSQLTypeName> BEAM_TO_BIGQUERY_LOGICAL_MAPPING =
       ImmutableMap.<String, StandardSQLTypeName>builder()
-          .put("DATE", StandardSQLTypeName.DATE)
-          .put("TIME", StandardSQLTypeName.TIME)
-          .put("TIME_WITH_LOCAL_TZ", StandardSQLTypeName.TIME)
-          .put("TS", StandardSQLTypeName.TIMESTAMP)
-          .put("TS_WITH_LOCAL_TZ", StandardSQLTypeName.TIMESTAMP)
+          .put("SqlDateType", StandardSQLTypeName.DATE)
+          .put("SqlTimeType", StandardSQLTypeName.TIME)
+          .put("SqlTimeWithLocalTzType", StandardSQLTypeName.TIME)
+          .put("SqlTimestamp", StandardSQLTypeName.TIMESTAMP)
+          .put("SqlTimestampWithLocalTzType", StandardSQLTypeName.TIMESTAMP)
           .build();
 
   /**
@@ -113,11 +115,12 @@ public class BigQueryUtils {
   private static StandardSQLTypeName toStandardSQLTypeName(FieldType fieldType) {
     StandardSQLTypeName sqlType = BEAM_TO_BIGQUERY_TYPE_MAPPING.get(fieldType.getTypeName());
 
-    // TODO: BigQuery code should not be relying on Calcite metadata fields.
-    if (sqlType == StandardSQLTypeName.TIMESTAMP && fieldType.getMetadata("SqlType") != null) {
-      sqlType =
-          BEAM_TO_BIGQUERY_METADATA_MAPPING.get(
-              new String(fieldType.getMetadata("SqlType"), StandardCharsets.UTF_8));
+    if (sqlType == StandardSQLTypeName.TIMESTAMP && fieldType.getTypeName().isLogicalType()) {
+      StandardSQLTypeName foundType  =
+          BEAM_TO_BIGQUERY_LOGICAL_MAPPING.get(fieldType.getLogicalType().getIdentifier());
+      if (foundType != null) {
+        return foundType;
+      }
     }
 
     return sqlType;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -26,7 +26,6 @@ import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +115,7 @@ public class BigQueryUtils {
     StandardSQLTypeName sqlType = BEAM_TO_BIGQUERY_TYPE_MAPPING.get(fieldType.getTypeName());
 
     if (sqlType == StandardSQLTypeName.TIMESTAMP && fieldType.getTypeName().isLogicalType()) {
-      StandardSQLTypeName foundType  =
+      StandardSQLTypeName foundType =
           BEAM_TO_BIGQUERY_LOGICAL_MAPPING.get(fieldType.getLogicalType().getIdentifier());
       if (foundType != null) {
         return foundType;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -212,6 +212,7 @@ public class BigQueryUtils {
     return Row.withSchema(schema).addValues(values).build();
   }
 
+  /** Convert a BigQuery TableRow to a Beam Row. */
   public static TableRow toTableRow(Row row) {
     TableRow output = new TableRow();
     for (int i = 0; i < row.getFieldCount(); i++) {


### PR DESCRIPTION
Beam schemas define a limited number of fundamental types, and often users of schemas have slightly different needs for field types. An example is Beam SQL: SQL has many different date/time/timestamp types, while Beam has only the one DATETIME field type. Today SQL stuffs magic strings into the FieldType metadata to identify _which_ type it is really using, which is quite ad hoc.

Logical types introduce a principled way of doing this. A new LogicalType class can be defined that uses one of the fundamental Beam field types as storage. The user can then add this logical type to their schema, and Beam will use the underlying field type and record the logical type in the field as well. Logical types have globally unique identifiers that are understood by the system, so this provides a much more principled way of storing custom types in schemas.

This PR adds LogicalType and converts Avro and Beam SQL over to the new framework. Follow-on PRs will add CoderLogicalType (so any existing Coder can be used as a Schema field) as well as adding logical-type support to POJOs. 