### PR TITLE
[BEAM-4775] Clean up metric protos; support integer distributions, gauges

### DIFF
--- a/model/fn-execution/src/main/proto/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/beam_fn_api.proto
@@ -501,48 +501,9 @@ message MonitoringInfoTypeUrns {
 message Metric {
   // (Required) The data for this metric.
   oneof data {
-    CounterData counter_data = 1;
-    DistributionData distribution_data = 2;
-    ExtremaData extrema_data = 3;
-  }
-}
-
-// Data associated with a Counter or Gauge metric.
-// This is designed to be compatible with metric collection
-// systems such as DropWizard.
-message CounterData {
-  oneof value {
-    int64 int64_value = 1;
-    double double_value = 2;
-    string string_value = 3;
-  }
-}
-
-// Extrema messages are used for calculating
-// Top-N/Bottom-N metrics.
-message ExtremaData {
-  oneof extrema {
-    IntExtremaData int_extrema_data = 1;
-    DoubleExtremaData double_extrema_data = 2;
-  }
-}
-
-message IntExtremaData {
-  repeated int64 int_values = 1;
-}
-
-message DoubleExtremaData {
-  repeated double double_values = 2;
-}
-
-// Data associated with a distribution metric.
-// This is based off of the current DistributionData metric.
-// This is not a stackdriver or dropwizard compatible
-// style of distribution metric.
-message DistributionData {
-  oneof distribution {
-    IntDistributionData int_distribution_data = 1;
-    DoubleDistributionData double_distribution_data = 2;
+    int64 counter = 1;
+    IntDistributionData distribution = 2;
+    IntGaugeData gauge = 3;
   }
 }
 
@@ -553,11 +514,9 @@ message IntDistributionData {
   int64 max = 4;
 }
 
-message DoubleDistributionData {
-  int64 count = 1;
-  double sum = 2;
-  double min = 3;
-  double max = 4;
+message IntGaugeData {
+  int64 value = 1;
+  int64 timestamp_ms = 2;
 }
 
 // General MonitoredState information which contains

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/metrics/MetricKey.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/metrics/MetricKey.java
@@ -38,7 +38,11 @@ public abstract class MetricKey implements Serializable {
 
   @Override
   public String toString() {
-    return String.format("%s:%s", stepName(), metricName());
+    return toString(":");
+  }
+
+  public String toString(String delimiter) {
+    return String.format("%s%s%s", stepName(), delimiter, metricName().toString(delimiter));
   }
 
   public static MetricKey create(String stepName, MetricName metricName) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionProtos.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionProtos.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.metrics;
+
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.IntDistributionData;
+import org.apache.beam.sdk.metrics.DistributionResult;
+
+/** Convert distributions between protobuf and SDK representations. */
+public class DistributionProtos {
+  public static DistributionResult fromProto(IntDistributionData distributionData) {
+    return DistributionResult.create(
+        distributionData.getSum(),
+        distributionData.getCount(),
+        distributionData.getMin(),
+        distributionData.getMax());
+  }
+
+  public static IntDistributionData toProto(DistributionResult distributionResult) {
+    return IntDistributionData.newBuilder()
+        .setMin(distributionResult.getMin())
+        .setMax(distributionResult.getMax())
+        .setCount(distributionResult.getCount())
+        .setSum(distributionResult.getSum())
+        .build();
+  }
+}

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/GaugeProtos.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/GaugeProtos.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.metrics;
+
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.IntGaugeData;
+import org.apache.beam.sdk.metrics.GaugeResult;
+import org.joda.time.Instant;
+
+/** Convert gauges between protobuf and SDK representations. */
+public class GaugeProtos {
+  public static GaugeResult fromProto(IntGaugeData gaugeData) {
+    return GaugeResult.create(gaugeData.getValue(), new Instant(gaugeData.getTimestampMs()));
+  }
+
+  public static IntGaugeData toProto(GaugeResult gauge) {
+    return IntGaugeData.newBuilder()
+        .setValue(gauge.getValue())
+        .setTimestampMs(gauge.getTimestamp().getMillis())
+        .build();
+  }
+}

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/LabeledMetrics.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/LabeledMetrics.java
@@ -19,17 +19,18 @@ package org.apache.beam.runners.core.metrics;
 
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.DelegatingCounter;
+import org.apache.beam.sdk.metrics.MetricName;
 
 /**
  * Define a metric on the current MetricContainer with a specific URN and a set of labels. This is a
  * more convenient way to collect the necessary fields to repackage the metric into a MonitoringInfo
- * proto later. Intended for internal use only (SDK and RunnerHarness developement).
+ * proto later. Intended for internal use only (SDK and RunnerHarness development).
  */
 public class LabeledMetrics {
   /**
    * Create a metric that can be incremented and decremented, and is aggregated by taking the sum.
    */
-  public static Counter counter(MonitoringInfoMetricName metricName) {
+  public static Counter counter(MetricName metricName) {
     return new DelegatingCounter(metricName);
   }
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricUrns.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricUrns.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.core.metrics;
 
 import static org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder.USER_COUNTER_URN_PREFIX;
 
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.metrics.MetricName;
 
 /** Utility for parsing a URN to a {@link MetricName}. */
@@ -29,9 +30,12 @@ public class MetricUrns {
    *
    * <p>Should be consistent with {@code parse_namespace_and_name} in monitoring_infos.py.
    */
+  @Nullable
   public static MetricName parseUrn(String urn) {
     if (urn.startsWith(USER_COUNTER_URN_PREFIX)) {
       urn = urn.substring(USER_COUNTER_URN_PREFIX.length());
+    } else {
+      return null;
     }
     // If it is not a user counter, just use the first part of the URN, i.e. 'beam'
     String[] pieces = urn.split(":", 2);

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MonitoringInfoMetricName.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MonitoringInfoMetricName.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfo;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Strings;
 
@@ -108,6 +109,11 @@ public class MonitoringInfoMetricName extends MetricName {
       return new MonitoringInfoMetricName(urn, labels);
     }
     return metricName;
+  }
+
+  /** @return a MetricName for a specific urn and labels map. */
+  public static MetricName create(MonitoringInfo monitoringInfo) {
+    return named(monitoringInfo.getUrn(), monitoringInfo.getLabelsMap());
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MonitoringInfos.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MonitoringInfos.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.metrics;
+
+import java.util.function.Consumer;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.Metric;
+import org.apache.beam.runners.core.construction.metrics.MetricKey;
+import org.apache.beam.sdk.metrics.DistributionResult;
+import org.apache.beam.sdk.metrics.GaugeResult;
+
+/**
+ * Helpers for working with {@link Metric}s and converting {@link MonitoringInfo}s to {@link
+ * MetricKey}s.
+ */
+public class MonitoringInfos {
+
+  /**
+   * Helper for handling each case of a {@link Metric}'s "oneof" value field (counter, distribution,
+   * or gauge).
+   */
+  public static void processMetric(
+      Metric metric,
+      Consumer<Long> counterFn,
+      Consumer<DistributionResult> distributionFn,
+      Consumer<GaugeResult> gaugeFn) {
+    Metric.DataCase dataCase = metric.getDataCase();
+    switch (dataCase) {
+      case COUNTER:
+        counterFn.accept(metric.getCounter());
+        break;
+      case DISTRIBUTION:
+        distributionFn.accept(DistributionProtos.fromProto(metric.getDistribution()));
+        break;
+      case GAUGE:
+        gaugeFn.accept(GaugeProtos.fromProto(metric.getGauge()));
+        break;
+      case DATA_NOT_SET:
+        throw new IllegalStateException("Metric value not set: " + metric);
+    }
+  }
+}

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MonitoringInfos.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MonitoringInfos.java
@@ -17,8 +17,11 @@
  */
 package org.apache.beam.runners.core.metrics;
 
+import static org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder.PTRANSFORM_LABEL;
+
 import java.util.function.Consumer;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.Metric;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfo;
 import org.apache.beam.runners.core.construction.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.GaugeResult;
@@ -52,5 +55,10 @@ public class MonitoringInfos {
       case DATA_NOT_SET:
         throw new IllegalStateException("Metric value not set: " + metric);
     }
+  }
+
+  public static MetricKey keyFromMonitoringInfo(MonitoringInfo monitoringInfo) {
+    String ptransform = monitoringInfo.getLabelsMap().get(PTRANSFORM_LABEL);
+    return MetricKey.create(ptransform, MonitoringInfoMetricName.create(monitoringInfo));
   }
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilder.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilder.java
@@ -155,7 +155,7 @@ public class SimpleMonitoringInfoBuilder {
 
   /** Sets the int64Value of the CounterData in the MonitoringInfo, and the appropriate type URN. */
   public SimpleMonitoringInfoBuilder setInt64Value(long value) {
-    this.builder.getMetricBuilder().getCounterDataBuilder().setInt64Value(value);
+    this.builder.getMetricBuilder().setCounter(value);
     this.setInt64TypeUrn();
     return this;
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilder.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilder.java
@@ -17,6 +17,9 @@
  */
 package org.apache.beam.runners.core.metrics;
 
+import static org.apache.beam.model.fnexecution.v1.BeamFnApi.IntDistributionData;
+import static org.apache.beam.model.fnexecution.v1.BeamFnApi.IntGaugeData;
+
 import java.time.Instant;
 import java.util.HashMap;
 import javax.annotation.Nullable;
@@ -29,6 +32,8 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfoSpecs;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfoTypeUrns;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfoUrns;
 import org.apache.beam.runners.core.construction.BeamUrns;
+import org.apache.beam.sdk.metrics.DistributionResult;
+import org.apache.beam.sdk.metrics.GaugeResult;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +75,10 @@ public class SimpleMonitoringInfoBuilder {
       BeamUrns.getUrn(MonitoringInfoUrns.Enum.USER_COUNTER_URN_PREFIX);
   public static final String SUM_INT64_TYPE_URN =
       BeamUrns.getUrn(MonitoringInfoTypeUrns.Enum.SUM_INT64_TYPE);
+  public static final String DISTRIBUTION_INT64_TYPE_URN =
+      BeamUrns.getUrn(MonitoringInfoTypeUrns.Enum.DISTRIBUTION_INT64_TYPE);
+  public static final String LATEST_INT64_TYPE_URN =
+      BeamUrns.getUrn(MonitoringInfoTypeUrns.Enum.LATEST_INT64_TYPE);
 
   private static final HashMap<String, MonitoringInfoSpec> specs =
       new HashMap<String, MonitoringInfoSpec>();
@@ -163,6 +172,36 @@ public class SimpleMonitoringInfoBuilder {
   /** Sets the the appropriate type URN for sum int64 counters. */
   public SimpleMonitoringInfoBuilder setInt64TypeUrn() {
     this.builder.setType(SUM_INT64_TYPE_URN);
+    return this;
+  }
+
+  public SimpleMonitoringInfoBuilder setIntDistributionValue(DistributionData value) {
+    return setIntDistributionValue(value.extractResult());
+  }
+
+  public SimpleMonitoringInfoBuilder setIntDistributionValue(DistributionResult value) {
+    return setIntDistributionValue(DistributionProtos.toProto(value));
+  }
+
+  /** Sets the int64Value of the CounterData in the MonitoringInfo, and the appropraite type URN. */
+  public SimpleMonitoringInfoBuilder setIntDistributionValue(IntDistributionData value) {
+    this.builder.getMetricBuilder().setDistribution(value);
+    this.builder.setType(DISTRIBUTION_INT64_TYPE_URN);
+    return this;
+  }
+
+  public SimpleMonitoringInfoBuilder setGaugeValue(GaugeData value) {
+    return setGaugeValue(value.extractResult());
+  }
+
+  public SimpleMonitoringInfoBuilder setGaugeValue(GaugeResult value) {
+    return setGaugeValue(GaugeProtos.toProto(value));
+  }
+
+  /** Sets the int64Value of the CounterData in the MonitoringInfo, and the appropraite type URN. */
+  public SimpleMonitoringInfoBuilder setGaugeValue(IntGaugeData value) {
+    this.builder.getMetricBuilder().setGauge(value);
+    this.builder.setType(LATEST_INT64_TYPE_URN);
     return this;
   }
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/LabeledMetricsTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/LabeledMetricsTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import java.io.Serializable;
 import java.util.HashMap;
 import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.junit.Rule;
@@ -42,7 +43,7 @@ public class LabeledMetricsTest implements Serializable {
     assertNull(MetricsEnvironment.getCurrentContainer());
     HashMap<String, String> labels = new HashMap<String, String>();
     String urn = SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN;
-    MonitoringInfoMetricName name = MonitoringInfoMetricName.named(urn, labels);
+    MetricName name = MonitoringInfoMetricName.named(urn, labels);
 
     Counter counter = LabeledMetrics.counter(name);
     counter.inc();
@@ -55,7 +56,7 @@ public class LabeledMetricsTest implements Serializable {
   public void testOperationsUpdateCounterFromContainerWhenContainerIsPresent() {
     HashMap<String, String> labels = new HashMap<String, String>();
     String urn = SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN;
-    MonitoringInfoMetricName name = MonitoringInfoMetricName.named(urn, labels);
+    MetricName name = MonitoringInfoMetricName.named(urn, labels);
 
     MetricsContainer mockContainer = Mockito.mock(MetricsContainer.class);
     Counter mockCounter = Mockito.mock(Counter.class);

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MonitoringInfoMatchers.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MonitoringInfoMatchers.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.core.metrics;
 
+import static org.apache.beam.model.fnexecution.v1.BeamFnApi.Metric.DataCase.COUNTER;
+
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfo;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -45,9 +47,9 @@ public class MonitoringInfoMatchers {
           return false;
         }
 
-        if (mi.getMetric().hasCounterData()) {
-          long valueToMatch = mi.getMetric().getCounterData().getInt64Value();
-          if (valueToMatch != item.getMetric().getCounterData().getInt64Value()) {
+        if (mi.getMetric().getDataCase() == COUNTER) {
+          long valueToMatch = mi.getMetric().getCounter();
+          if (valueToMatch != item.getMetric().getCounter()) {
             return false;
           }
         }
@@ -63,10 +65,8 @@ public class MonitoringInfoMatchers {
             .appendValue(mi.getLabels())
             .appendText(", type=")
             .appendValue(mi.getType());
-        if (mi.getMetric().hasCounterData()) {
-          description
-              .appendText(", value=")
-              .appendValue(mi.getMetric().getCounterData().getInt64Value());
+        if (mi.getMetric().getDataCase() == COUNTER) {
+          description.appendText(", value=").appendValue(mi.getMetric().getCounter());
         }
       }
     };
@@ -83,7 +83,7 @@ public class MonitoringInfoMatchers {
 
       @Override
       protected boolean matchesSafely(MonitoringInfo item) {
-        if (item.getMetric().getCounterData().getInt64Value() < value) {
+        if (item.getMetric().getCounter() < value) {
           return false;
         }
         return true;

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MonitoringInfoMetricNameTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MonitoringInfoMetricNameTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.sdk.metrics.MetricName;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -33,9 +35,10 @@ public class MonitoringInfoMetricNameTest implements Serializable {
 
   @Test
   public void testElementCountConstruction() {
-    HashMap<String, String> labels = new HashMap<String, String>();
+    Map<String, String> labels = new HashMap<>();
     String urn = SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN;
-    MonitoringInfoMetricName name = MonitoringInfoMetricName.named(urn, labels);
+    MonitoringInfoMetricName name =
+        (MonitoringInfoMetricName) MonitoringInfoMetricName.named(urn, labels);
     assertEquals(null, name.getName());
     assertEquals(null, name.getNamespace());
     assertEquals(labels, name.getLabels());
@@ -45,8 +48,8 @@ public class MonitoringInfoMetricNameTest implements Serializable {
 
     // Reconstruct and test equality and hash code equivalence
     urn = SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN;
-    labels = new HashMap<String, String>();
-    MonitoringInfoMetricName name2 = MonitoringInfoMetricName.named(urn, labels);
+    labels = new HashMap<>();
+    MetricName name2 = MonitoringInfoMetricName.named(urn, labels);
 
     assertEquals(name, name2);
     assertEquals(name.hashCode(), name2.hashCode());
@@ -55,19 +58,17 @@ public class MonitoringInfoMetricNameTest implements Serializable {
   @Test
   public void testUserCounterUrnConstruction() {
     String urn = SimpleMonitoringInfoBuilder.userMetricUrn("namespace", "name");
-    HashMap<String, String> labels = new HashMap<String, String>();
-    MonitoringInfoMetricName name = MonitoringInfoMetricName.named(urn, labels);
+    Map<String, String> labels = new HashMap<>();
+    MetricName name = MonitoringInfoMetricName.named(urn, labels);
     assertEquals("name", name.getName());
     assertEquals("namespace", name.getNamespace());
-    assertEquals(labels, name.getLabels());
-    assertEquals(urn, name.getUrn());
 
     assertEquals(name, name); // test self equals;
 
     // Reconstruct and test equality and hash code equivalence
     urn = SimpleMonitoringInfoBuilder.userMetricUrn("namespace", "name");
-    labels = new HashMap<String, String>();
-    MonitoringInfoMetricName name2 = MonitoringInfoMetricName.named(urn, labels);
+    labels = new HashMap<>();
+    MetricName name2 = MonitoringInfoMetricName.named(urn, labels);
 
     assertEquals(name, name2);
     assertEquals(name.hashCode(), name2.hashCode());
@@ -75,15 +76,15 @@ public class MonitoringInfoMetricNameTest implements Serializable {
 
   @Test
   public void testNotEqualsDiffLabels() {
-    HashMap<String, String> labels = new HashMap<String, String>();
+    Map<String, String> labels = new HashMap<>();
     String urn = SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN;
-    MonitoringInfoMetricName name = MonitoringInfoMetricName.named(urn, labels);
+    MetricName name = MonitoringInfoMetricName.named(urn, labels);
 
     // Reconstruct and test equality and hash code equivalence
     urn = SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN;
-    labels = new HashMap<String, String>();
+    labels = new HashMap<>();
     labels.put("label", "value1");
-    MonitoringInfoMetricName name2 = MonitoringInfoMetricName.named(urn, labels);
+    MetricName name2 = MonitoringInfoMetricName.named(urn, labels);
 
     assertNotEquals(name, name2);
     assertNotEquals(name.hashCode(), name2.hashCode());
@@ -91,14 +92,14 @@ public class MonitoringInfoMetricNameTest implements Serializable {
 
   @Test
   public void testNotEqualsDiffUrn() {
-    HashMap<String, String> labels = new HashMap<String, String>();
+    Map<String, String> labels = new HashMap<>();
     String urn = SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN;
-    MonitoringInfoMetricName name = MonitoringInfoMetricName.named(urn, labels);
+    MetricName name = MonitoringInfoMetricName.named(urn, labels);
 
     // Reconstruct and test equality and hash code equivalence
     urn = "differentUrn";
-    labels = new HashMap<String, String>();
-    MonitoringInfoMetricName name2 = MonitoringInfoMetricName.named(urn, labels);
+    labels = new HashMap<>();
+    MetricName name2 = MonitoringInfoMetricName.named(urn, labels);
 
     assertNotEquals(name, name2);
     assertNotEquals(name.hashCode(), name2.hashCode());
@@ -107,20 +108,20 @@ public class MonitoringInfoMetricNameTest implements Serializable {
   @Test
   public void testNullLabelsThrows() {
     thrown.expect(IllegalArgumentException.class);
-    HashMap<String, String> labels = null;
+    Map<String, String> labels = null;
     MonitoringInfoMetricName.named(SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN, labels);
   }
 
   @Test
   public void testNullUrnThrows() {
-    HashMap<String, String> labels = new HashMap<String, String>();
-    thrown.expect(IllegalArgumentException.class);
+    Map<String, String> labels = new HashMap<>();
+    thrown.expect(NullPointerException.class);
     MonitoringInfoMetricName.named(null, labels);
   }
 
   @Test
   public void testEmptyUrnThrows() {
-    HashMap<String, String> labels = new HashMap<String, String>();
+    Map<String, String> labels = new HashMap<>();
     thrown.expect(IllegalArgumentException.class);
     MonitoringInfoMetricName.named("", labels);
   }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MonitoringInfoTestUtil.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MonitoringInfoTestUtil.java
@@ -19,16 +19,17 @@ package org.apache.beam.runners.core.metrics;
 
 import java.util.HashMap;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfo;
+import org.apache.beam.sdk.metrics.MetricName;
 
 /**
  * Provides convenient one line factories for unit tests that need to generate test MonitoringInfos.
  */
 public class MonitoringInfoTestUtil {
   /** @return A basic MonitoringInfoMetricName to test. */
-  public static MonitoringInfoMetricName testElementCountName() {
+  public static MetricName testElementCountName() {
     HashMap labels = new HashMap<String, String>();
     labels.put(SimpleMonitoringInfoBuilder.PCOLLECTION_LABEL, "testPCollection");
-    MonitoringInfoMetricName name =
+    MetricName name =
         MonitoringInfoMetricName.named(SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN, labels);
     return name;
   }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilderTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilderTest.java
@@ -48,7 +48,7 @@ public class SimpleMonitoringInfoBuilderTest {
         monitoringInfo.getLabelsOrDefault(SimpleMonitoringInfoBuilder.PCOLLECTION_LABEL, null));
     assertEquals(SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN, monitoringInfo.getUrn());
     assertEquals(SimpleMonitoringInfoBuilder.SUM_INT64_TYPE_URN, monitoringInfo.getType());
-    assertEquals(1, monitoringInfo.getMetric().getCounterData().getInt64Value());
+    assertEquals(1, monitoringInfo.getMetric().getCounter());
   }
 
   @Test
@@ -65,7 +65,7 @@ public class SimpleMonitoringInfoBuilderTest {
         SimpleMonitoringInfoBuilder.USER_COUNTER_URN_PREFIX + "myNamespace:myName",
         monitoringInfo.getUrn());
     assertEquals(SimpleMonitoringInfoBuilder.SUM_INT64_TYPE_URN, monitoringInfo.getType());
-    assertEquals(1, monitoringInfo.getMetric().getCounterData().getInt64Value());
+    assertEquals(1, monitoringInfo.getMetric().getCounter());
   }
 
   @Test
@@ -80,6 +80,6 @@ public class SimpleMonitoringInfoBuilderTest {
         SimpleMonitoringInfoBuilder.USER_COUNTER_URN_PREFIX + "myNamespace_withInvalidChar:myName",
         monitoringInfo.getUrn());
     assertEquals(SimpleMonitoringInfoBuilder.SUM_INT64_TYPE_URN, monitoringInfo.getType());
-    assertEquals(1, monitoringInfo.getMetric().getCounterData().getInt64Value());
+    assertEquals(1, monitoringInfo.getMetric().getCounter());
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/DoFnRunnerWithMetricsUpdate.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/DoFnRunnerWithMetricsUpdate.java
@@ -90,7 +90,7 @@ public class DoFnRunnerWithMetricsUpdate<InputT, OutputT> implements DoFnRunner<
     }
 
     // update metrics
-    container.updateMetrics(stepName);
+    container.updateMetrics();
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
@@ -17,15 +17,17 @@
  */
 package org.apache.beam.runners.flink.metrics;
 
-import static org.apache.beam.runners.core.metrics.MetricUrns.parseUrn;
 import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
+import static org.apache.beam.runners.core.metrics.MonitoringInfos.keyFromMonitoringInfo;
 import static org.apache.beam.runners.core.metrics.MonitoringInfos.processMetric;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.Metric;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfo;
+import org.apache.beam.runners.core.construction.metrics.MetricKey;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.sdk.metrics.DistributionResult;
@@ -36,13 +38,14 @@ import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.sdk.metrics.MetricsFilter;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.function.TriFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,109 +93,128 @@ public class FlinkMetricContainer {
         : null;
   }
 
+  public MetricsContainer getUnboundMetricsContainer() {
+    return metricsAccumulator != null
+        ? metricsAccumulator.getLocalValue().getUnboundContainer()
+        : null;
+  }
+
   /**
    * Update this container with metrics from the passed {@link MonitoringInfo}s, and send updates
    * along to Flink's internal metrics framework.
    */
-  public void updateMetrics(String stepName, List<MonitoringInfo> monitoringInfos) {
-    MetricsContainer metricsContainer = getMetricsContainer(stepName);
+  public void updateMetrics(List<MonitoringInfo> monitoringInfos) {
+    LOG.info("Flink updating metrics with {} monitoring infos", monitoringInfos.size());
     monitoringInfos.forEach(
         monitoringInfo -> {
           if (!monitoringInfo.hasMetric()) {
+            LOG.info("Skipping metric-less MonitoringInfo: {}", monitoringInfo);
             return;
           }
-          String urn = monitoringInfo.getUrn();
-          MetricName metricName = parseUrn(urn);
+
           Metric metric = monitoringInfo.getMetric();
 
+          MetricKey metricKey = keyFromMonitoringInfo(monitoringInfo);
+
+          String ptransform = metricKey.stepName();
+          MetricName metricName = metricKey.metricName();
+
+          MetricsContainer container = getMetricsContainer(ptransform);
+          if (container == null) {
+            LOG.warn("Can't add monitoringinfo to null MetricsContainer: {}", monitoringInfo);
+            return;
+          }
+
+          // Update Beam metrics
           processMetric(
               metric,
-              counter -> metricsContainer.getCounter(metricName).inc(counter),
-              distribution ->
-                  metricsContainer
+              update -> container.getCounter(metricName).inc(update),
+              update ->
+                  container
                       .getDistribution(metricName)
-                      .update(
-                          distribution.getSum(),
-                          distribution.getCount(),
-                          distribution.getMin(),
-                          distribution.getMax()),
-              gauge -> metricsContainer.getGauge(metricName).set(gauge.getValue()));
+                      .update(update.getSum(), update.getCount(), update.getMin(), update.getMax()),
+              update -> container.getGauge(metricName).set(update.getValue()));
+
+          // Update Flink internal metrics
+          processMetric(
+              metric,
+              counter -> updateCounter(metricKey, counter),
+              distribution -> updateDistribution(metricKey, distribution),
+              gauge -> updateGauge(metricKey, gauge));
         });
-    updateMetrics(stepName);
   }
 
   /**
    * Update Flink's internal metrics ({@link this#flinkCounterCache}) with the latest metrics for a
    * given step.
    */
-  void updateMetrics(String stepName) {
+  void updateMetrics() {
     MetricResults metricResults = asAttemptedOnlyMetricResults(metricsAccumulator.getLocalValue());
     MetricQueryResults metricQueryResults =
-        metricResults.queryMetrics(MetricsFilter.builder().addStep(stepName).build());
-    updateCounters(metricQueryResults.getCounters());
-    updateDistributions(metricQueryResults.getDistributions());
-    updateGauge(metricQueryResults.getGauges());
+        metricResults.queryMetrics(MetricsFilter.builder().build());
+
+    updateMetrics(metricQueryResults.getCounters(), this::updateCounter);
+    updateMetrics(metricQueryResults.getDistributions(), this::updateDistribution);
+    updateMetrics(metricQueryResults.getGauges(), this::updateGauge);
   }
 
-  private void updateCounters(Iterable<MetricResult<Long>> counters) {
-    for (MetricResult<Long> metricResult : counters) {
-      String flinkMetricName = getFlinkMetricNameString(metricResult);
-
-      Long update = metricResult.getAttempted();
-
-      // update flink metric
-      Counter counter =
-          flinkCounterCache.computeIfAbsent(
-              flinkMetricName, n -> runtimeContext.getMetricGroup().counter(n));
-      counter.dec(counter.getCount());
-      counter.inc(update);
+  private <T> void updateMetrics(
+      Iterable<MetricResult<T>> metricResults, BiConsumer<MetricKey, T> fn) {
+    for (MetricResult<T> metricResult : metricResults) {
+      MetricKey key = MetricKey.create(metricResult.getStep(), metricResult.getName());
+      fn.accept(key, metricResult.getAttempted());
     }
   }
 
-  private void updateDistributions(Iterable<MetricResult<DistributionResult>> distributions) {
-    for (MetricResult<DistributionResult> metricResult : distributions) {
-      String flinkMetricName = getFlinkMetricNameString(metricResult);
+  private <T, FlinkT> void updateMetric(
+      MetricKey key,
+      Map<String, FlinkT> flinkMetricMap,
+      TriFunction<String, MetricGroup, T, FlinkT> create,
+      BiConsumer<FlinkT, T> update,
+      T value) {
+    String flinkMetricName = getFlinkMetricNameString(key);
 
-      DistributionResult update = metricResult.getAttempted();
-
-      // update flink metric
-      FlinkDistributionGauge gauge = flinkDistributionGaugeCache.get(flinkMetricName);
-      if (gauge == null) {
-        gauge =
-            runtimeContext
-                .getMetricGroup()
-                .gauge(flinkMetricName, new FlinkDistributionGauge(update));
-        flinkDistributionGaugeCache.put(flinkMetricName, gauge);
-      } else {
-        gauge.update(update);
-      }
+    // update flink metric
+    FlinkT metric = flinkMetricMap.get(flinkMetricName);
+    if (metric == null) {
+      metric = create.apply(flinkMetricName, runtimeContext.getMetricGroup(), value);
+      flinkMetricMap.put(flinkMetricName, metric);
     }
+    update.accept(metric, value);
   }
 
-  private void updateGauge(Iterable<MetricResult<GaugeResult>> gauges) {
-    for (MetricResult<GaugeResult> metricResult : gauges) {
-      String flinkMetricName = getFlinkMetricNameString(metricResult);
-
-      GaugeResult update = metricResult.getAttempted();
-
-      // update flink metric
-      FlinkGauge gauge = flinkGaugeCache.get(flinkMetricName);
-      if (gauge == null) {
-        gauge = runtimeContext.getMetricGroup().gauge(flinkMetricName, new FlinkGauge(update));
-        flinkGaugeCache.put(flinkMetricName, gauge);
-      } else {
-        gauge.update(update);
-      }
-    }
+  private void updateCounter(MetricKey metricKey, long attempted) {
+    updateMetric(
+        metricKey,
+        flinkCounterCache,
+        (name, group, value) -> group.counter(name),
+        (counter, value) -> {
+          counter.dec(counter.getCount());
+          counter.inc(value);
+        },
+        attempted);
   }
 
-  @VisibleForTesting
-  static String getFlinkMetricNameString(MetricResult<?> metricResult) {
-    MetricName metricName = metricResult.getName();
-    // We use only the MetricName here, the step name is already contained
-    // in the operator name which is passed to Flink's MetricGroup to which
-    // the metric with the following name will be added.
-    return metricName.toString(METRIC_KEY_SEPARATOR);
+  private void updateDistribution(MetricKey metricKey, DistributionResult attempted) {
+    updateMetric(
+        metricKey,
+        flinkDistributionGaugeCache,
+        (name, group, value) -> group.gauge(name, new FlinkDistributionGauge(value)),
+        FlinkDistributionGauge::update,
+        attempted);
+  }
+
+  private void updateGauge(MetricKey metricKey, GaugeResult attempted) {
+    updateMetric(
+        metricKey,
+        flinkGaugeCache,
+        (name, group, value) -> group.gauge(name, new FlinkGauge(value)),
+        FlinkGauge::update,
+        attempted);
+  }
+
+  static String getFlinkMetricNameString(MetricKey metricKey) {
+    return metricKey.toString(METRIC_KEY_SEPARATOR);
   }
 
   /** Flink {@link Gauge} for {@link DistributionResult}. */

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
@@ -192,7 +192,7 @@ public class FlinkMetricContainer {
     // We use only the MetricName here, the step name is already contained
     // in the operator name which is passed to Flink's MetricGroup to which
     // the metric with the following name will be added.
-    return metricName.getNamespace() + METRIC_KEY_SEPARATOR + metricName.getName();
+    return metricName.toString(METRIC_KEY_SEPARATOR);
   }
 
   /** Flink {@link Gauge} for {@link DistributionResult}. */

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
@@ -49,7 +49,7 @@ public class ReaderInvocationUtil<OutputT, ReaderT extends Source.Reader<OutputT
       try (Closeable ignored =
           MetricsEnvironment.scopedMetricsContainer(container.getMetricsContainer(stepName))) {
         boolean result = reader.start();
-        container.updateMetrics(stepName);
+        container.updateMetrics();
         return result;
       }
     } else {
@@ -62,7 +62,7 @@ public class ReaderInvocationUtil<OutputT, ReaderT extends Source.Reader<OutputT
       try (Closeable ignored =
           MetricsEnvironment.scopedMetricsContainer(container.getMetricsContainer(stepName))) {
         boolean result = reader.advance();
-        container.updateMetrics(stepName);
+        container.updateMetrics();
         return result;
       }
     } else {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
@@ -100,8 +100,6 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
   private final Map<String, Integer> outputMap;
   private final FlinkExecutableStageContext.Factory contextFactory;
   private final Coder windowCoder;
-  // Unique name for namespacing metrics; currently just takes the input ID
-  private final String stageName;
 
   // Worker-local fields. These should only be constructed and consumed on Flink TaskManagers.
   private transient RuntimeContext runtimeContext;
@@ -127,7 +125,6 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
     this.outputMap = outputMap;
     this.contextFactory = contextFactory;
     this.windowCoder = windowCoder;
-    this.stageName = stagePayload.getInput();
   }
 
   @Override
@@ -151,12 +148,12 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
         new BundleProgressHandler() {
           @Override
           public void onProgress(ProcessBundleProgressResponse progress) {
-            container.updateMetrics(stageName, progress.getMonitoringInfosList());
+            container.updateMetrics(progress.getMonitoringInfosList());
           }
 
           @Override
           public void onCompleted(ProcessBundleResponse response) {
-            container.updateMetrics(stageName, response.getMonitoringInfosList());
+            container.updateMetrics(response.getMonitoringInfosList());
           }
         };
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -187,12 +187,12 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
         new BundleProgressHandler() {
           @Override
           public void onProgress(ProcessBundleProgressResponse progress) {
-            flinkMetricContainer.updateMetrics(stepName, progress.getMonitoringInfosList());
+            flinkMetricContainer.updateMetrics(progress.getMonitoringInfosList());
           }
 
           @Override
           public void onCompleted(ProcessBundleResponse response) {
-            flinkMetricContainer.updateMetrics(stepName, response.getMonitoringInfosList());
+            flinkMetricContainer.updateMetrics(response.getMonitoringInfosList());
           }
         };
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
@@ -34,6 +34,7 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi.IntDistributionData;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.Metric;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfo;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfo.MonitoringInfoLabels;
+import org.apache.beam.runners.core.construction.metrics.MetricKey;
 import org.apache.beam.runners.core.metrics.CounterCell;
 import org.apache.beam.runners.core.metrics.DistributionCell;
 import org.apache.beam.runners.core.metrics.DistributionData;
@@ -46,7 +47,6 @@ import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.Gauge;
 import org.apache.beam.sdk.metrics.GaugeResult;
 import org.apache.beam.sdk.metrics.MetricName;
-import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.vendor.grpc.v1p13p1.com.google.common.collect.ImmutableList;
 import org.apache.flink.api.common.functions.RuntimeContext;
@@ -56,7 +56,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link FlinkMetricContainer}. */
@@ -83,18 +82,15 @@ public class FlinkMetricContainerTest {
 
   @Test
   public void testMetricNameGeneration() {
-    MetricResult mock = Mockito.mock(MetricResult.class);
-    when(mock.getStep()).thenReturn("step");
-    MetricName metricName = MetricName.named("namespace", "name");
-    when(mock.getName()).thenReturn(metricName);
-    String name = FlinkMetricContainer.getFlinkMetricNameString(mock);
-    assertThat(name, is("namespace.name"));
+    MetricKey key = MetricKey.create("step", MetricName.named("namespace", "name"));
+    String name = FlinkMetricContainer.getFlinkMetricNameString(key);
+    assertThat(name, is("step.namespace.name"));
   }
 
   @Test
   public void testCounter() {
     SimpleCounter flinkCounter = new SimpleCounter();
-    when(metricGroup.counter("namespace.name")).thenReturn(flinkCounter);
+    when(metricGroup.counter("step.namespace.name")).thenReturn(flinkCounter);
 
     FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");
@@ -104,7 +100,7 @@ public class FlinkMetricContainerTest {
     counter.inc();
 
     assertThat(flinkCounter.getCount(), is(0L));
-    container.updateMetrics("step");
+    container.updateMetrics();
     assertThat(flinkCounter.getCount(), is(2L));
   }
 
@@ -112,7 +108,7 @@ public class FlinkMetricContainerTest {
   public void testGauge() {
     FlinkMetricContainer.FlinkGauge flinkGauge =
         new FlinkMetricContainer.FlinkGauge(GaugeResult.empty());
-    when(metricGroup.gauge(eq("namespace.name"), anyObject())).thenReturn(flinkGauge);
+    when(metricGroup.gauge(eq("step.namespace.name"), anyObject())).thenReturn(flinkGauge);
 
     FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");
@@ -121,10 +117,10 @@ public class FlinkMetricContainerTest {
 
     assertThat(flinkGauge.getValue(), is(GaugeResult.empty()));
     // first set will install the mocked gauge
-    container.updateMetrics("step");
+    container.updateMetrics();
     gauge.set(1);
     gauge.set(42);
-    container.updateMetrics("step");
+    container.updateMetrics();
     assertThat(flinkGauge.getValue().getValue(), is(42L));
   }
 
@@ -134,10 +130,10 @@ public class FlinkMetricContainerTest {
     MetricsContainer step = container.getMetricsContainer("step");
 
     SimpleCounter userCounter = new SimpleCounter();
-    when(metricGroup.counter("ns1.metric1")).thenReturn(userCounter);
+    when(metricGroup.counter("step.ns1.metric1")).thenReturn(userCounter);
 
     SimpleCounter elemCounter = new SimpleCounter();
-    when(metricGroup.counter("beam.metric:element_count:v1")).thenReturn(elemCounter);
+    when(metricGroup.counter("step.pcoll.beam.metric.element_count.v1")).thenReturn(elemCounter);
 
     SimpleMonitoringInfoBuilder userCountBuilder = new SimpleMonitoringInfoBuilder();
     userCountBuilder.setUrnForUserMetric("ns1", "metric1");
@@ -156,8 +152,7 @@ public class FlinkMetricContainerTest {
 
     assertThat(userCounter.getCount(), is(0L));
     assertThat(elemCounter.getCount(), is(0L));
-    container.updateMetrics(
-        "step", ImmutableList.of(userCountMonitoringInfo, elemCountMonitoringInfo));
+    container.updateMetrics(ImmutableList.of(userCountMonitoringInfo, elemCountMonitoringInfo));
     assertThat(userCounter.getCount(), is(111L));
     assertThat(elemCounter.getCount(), is(222L));
   }
@@ -165,7 +160,7 @@ public class FlinkMetricContainerTest {
   @Test
   public void testSupportMultipleMonitoringInfoTypes() {
     FlinkMetricContainer flinkContainer = new FlinkMetricContainer(runtimeContext);
-    MetricsContainer step = flinkContainer.getMetricsContainer("step");
+    MetricsContainer container = flinkContainer.getMetricsContainer("step");
 
     MonitoringInfo counter1 =
         MonitoringInfo.newBuilder()
@@ -195,7 +190,7 @@ public class FlinkMetricContainerTest {
                             .setMax(5)))
             .build();
 
-    // Mock out the counter that Flink returns; the distribution gets created by
+    // Mock out the counters that Flink returns; the distribution gets created by
     // FlinkMetricContainer, not by Flink itself, so we verify it in a different way below
 
     SimpleCounter flinkCounter1 = new SimpleCounter();
@@ -205,10 +200,10 @@ public class FlinkMetricContainerTest {
     DistributionResult distributionResult = distributionData.extractResult();
     FlinkDistributionGauge distributionGauge = new FlinkDistributionGauge(distributionResult);
 
-    when(metricGroup.counter("ns1.counter1")).thenReturn(flinkCounter1);
-    when(metricGroup.counter("ns2.counter2")).thenReturn(flinkCounter2);
+    when(metricGroup.counter("step.ns1.counter1")).thenReturn(flinkCounter1);
+    when(metricGroup.counter("step.ns2.counter2")).thenReturn(flinkCounter2);
     when(metricGroup.gauge(
-            eq("ns3.distribution"),
+            eq("step.ns3.distribution"),
             argThat(
                 new ArgumentMatcher<FlinkDistributionGauge>() {
                   @Override
@@ -219,27 +214,27 @@ public class FlinkMetricContainerTest {
                 })))
         .thenReturn(distributionGauge);
 
-    flinkContainer.updateMetrics("step", ImmutableList.of(counter1, counter2, distribution));
+    flinkContainer.updateMetrics(ImmutableList.of(counter1, counter2, distribution));
 
-    verify(metricGroup).counter(eq("ns1.counter1"));
-    verify(metricGroup).counter(eq("ns2.counter2"));
+    verify(metricGroup).counter(eq("step.ns1.counter1"));
+    verify(metricGroup).counter(eq("step.ns2.counter2"));
 
-    // Verify that the counter injected into flink has the right value
+    // Verify that the counters injected into flink has the right value
     assertThat(flinkCounter1.getCount(), is(111L));
     assertThat(flinkCounter2.getCount(), is(222L));
 
     // Verify the counter in the java SDK MetricsContainer
     long count1 =
-        ((CounterCell) step.getCounter(MetricName.named("ns1", "counter1"))).getCumulative();
+        ((CounterCell) container.getCounter(MetricName.named("ns1", "counter1"))).getCumulative();
     assertThat(count1, is(111L));
 
     long count2 =
-        ((CounterCell) step.getCounter(MetricName.named("ns2", "counter2"))).getCumulative();
+        ((CounterCell) container.getCounter(MetricName.named("ns2", "counter2"))).getCumulative();
     assertThat(count2, is(222L));
 
     // Verify that the Java SDK MetricsContainer holds the same information
     DistributionData actualDistributionData =
-        ((DistributionCell) step.getDistribution(MetricName.named("ns3", "distribution")))
+        ((DistributionCell) container.getDistribution(MetricName.named("ns3", "distribution")))
             .getCumulative();
     assertThat(actualDistributionData, is(distributionData));
   }
@@ -248,7 +243,7 @@ public class FlinkMetricContainerTest {
   public void testDistribution() {
     FlinkMetricContainer.FlinkDistributionGauge flinkGauge =
         new FlinkMetricContainer.FlinkDistributionGauge(DistributionResult.IDENTITY_ELEMENT);
-    when(metricGroup.gauge(eq("namespace.name"), anyObject())).thenReturn(flinkGauge);
+    when(metricGroup.gauge(eq("step.namespace.name"), anyObject())).thenReturn(flinkGauge);
 
     FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");
@@ -257,12 +252,12 @@ public class FlinkMetricContainerTest {
 
     assertThat(flinkGauge.getValue(), is(DistributionResult.IDENTITY_ELEMENT));
     // first set will install the mocked distribution
-    container.updateMetrics("step");
+    container.updateMetrics();
     distribution.update(42);
     distribution.update(-23);
     distribution.update(0);
     distribution.update(1);
-    container.updateMetrics("step");
+    container.updateMetrics();
     assertThat(flinkGauge.getValue().getMax(), is(42L));
     assertThat(flinkGauge.getValue().getMin(), is(-23L));
     assertThat(flinkGauge.getValue().getCount(), is(4L));

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/MSecMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/MSecMonitoringInfoToCounterUpdateTransformer.java
@@ -115,7 +115,7 @@ public class MSecMonitoringInfoToCounterUpdateTransformer
       return null;
     }
 
-    long value = monitoringInfo.getMetric().getCounterData().getInt64Value();
+    long value = monitoringInfo.getMetric().getCounter();
     String urn = monitoringInfo.getUrn();
 
     final String ptransform = monitoringInfo.getLabelsMap().get("PTRANSFORM");

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/UserMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/UserMonitoringInfoToCounterUpdateTransformer.java
@@ -97,7 +97,7 @@ class UserMonitoringInfoToCounterUpdateTransformer
       return null;
     }
 
-    long value = monitoringInfo.getMetric().getCounterData().getInt64Value();
+    long value = monitoringInfo.getMetric().getCounter();
     String urn = monitoringInfo.getUrn();
 
     final String ptransform = monitoringInfo.getLabelsMap().get("PTRANSFORM");

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/BeamFnMapTaskExecutorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/BeamFnMapTaskExecutorTest.java
@@ -474,13 +474,7 @@ public class BeamFnMapTaskExecutorTest {
             .setUrn("beam:metric:user:ExpectedCounter")
             .setType("beam:metrics:sum_int_64")
             .putLabels("PTRANSFORM", "ExpectedPTransform")
-            .setMetric(
-                BeamFnApi.Metric.newBuilder()
-                    .setCounterData(
-                        BeamFnApi.CounterData.newBuilder()
-                            .setInt64Value(expectedCounterValue)
-                            .build())
-                    .build())
+            .setMetric(BeamFnApi.Metric.newBuilder().setCounter(expectedCounterValue).build())
             .build();
 
     InstructionRequestHandler instructionRequestHandler =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricName.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricName.java
@@ -52,7 +52,11 @@ public abstract class MetricName implements Serializable {
 
   @Override
   public String toString() {
-    return String.format("%s:%s", getNamespace(), getName());
+    return toString(":");
+  }
+
+  public String toString(String delimiter) {
+    return String.format("%s%s%s", getNamespace(), delimiter, getName());
   }
 
   /**

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/ElementCountFnDataReceiver.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/ElementCountFnDataReceiver.java
@@ -25,6 +25,7 @@ import org.apache.beam.runners.core.metrics.MonitoringInfoMetricName;
 import org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -48,7 +49,7 @@ public class ElementCountFnDataReceiver<T> implements FnDataReceiver<WindowedVal
     this.original = original;
     HashMap<String, String> labels = new HashMap<String, String>();
     labels.put(SimpleMonitoringInfoBuilder.PCOLLECTION_LABEL, pCollection);
-    MonitoringInfoMetricName metricName =
+    MetricName metricName =
         MonitoringInfoMetricName.named(SimpleMonitoringInfoBuilder.ELEMENT_COUNT_URN, labels);
     this.counter = LabeledMetrics.counter(metricName);
     // Collect the metric in a metric container which is not bound to the step name.

--- a/sdks/python/apache_beam/metrics/cells.py
+++ b/sdks/python/apache_beam/metrics/cells.py
@@ -172,9 +172,7 @@ class CounterCell(Counter, MetricCell):
     # was added to CounterCell. Consider adding a CounterData class or
     # removing the GaugeData and DistributionData classes.
     return beam_fn_api_pb2.Metric(
-        counter_data=beam_fn_api_pb2.CounterData(
-            int64_value=self.get_cumulative()
-        )
+        counter=self.get_cumulative()
     )
 
 
@@ -405,9 +403,7 @@ class GaugeData(object):
   def to_runner_api_monitoring_info(self):
     """Returns a Metric with this value for use in a MonitoringInfo."""
     return beam_fn_api_pb2.Metric(
-        counter_data=beam_fn_api_pb2.CounterData(
-            int64_value=self.value
-        )
+        counter=self.value
     )
 
 
@@ -479,9 +475,8 @@ class DistributionData(object):
   def to_runner_api_monitoring_info(self):
     """Returns a Metric with this value for use in a MonitoringInfo."""
     return beam_fn_api_pb2.Metric(
-        distribution_data=beam_fn_api_pb2.DistributionData(
-            int_distribution_data=beam_fn_api_pb2.IntDistributionData(
-                count=self.count, sum=self.sum, min=self.min, max=self.max)))
+        distribution=beam_fn_api_pb2.IntDistributionData(
+            count=self.count, sum=self.sum, min=self.min, max=self.max))
 
 
 class MetricAggregator(object):

--- a/sdks/python/apache_beam/metrics/monitoring_infos.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos.py
@@ -29,7 +29,6 @@ from apache_beam.metrics.cells import DistributionResult
 from apache_beam.metrics.cells import GaugeData
 from apache_beam.metrics.cells import GaugeResult
 from apache_beam.portability import common_urns
-from apache_beam.portability.api.beam_fn_api_pb2 import CounterData
 from apache_beam.portability.api.beam_fn_api_pb2 import Metric
 from apache_beam.portability.api.beam_fn_api_pb2 import MonitoringInfo
 
@@ -77,7 +76,7 @@ def to_timestamp_secs(timestamp_proto):
 def extract_counter_value(monitoring_info_proto):
   """Returns the int coutner value of the monitoring info."""
   if is_counter(monitoring_info_proto) or is_gauge(monitoring_info_proto):
-    return monitoring_info_proto.metric.counter_data.int64_value
+    return monitoring_info_proto.metric.counter
   return None
 
 
@@ -88,7 +87,7 @@ def extract_distribution(monitoring_info_proto):
     monitoring_info_proto: The monitoring infor for the distribution.
   """
   if is_distribution(monitoring_info_proto):
-    return monitoring_info_proto.metric.distribution_data.int_distribution_data
+    return monitoring_info_proto.metric.distribution
   return None
 
 
@@ -120,9 +119,7 @@ def int64_counter(urn, metric, ptransform='', tag=''):
   labels = create_labels(ptransform=ptransform, tag=tag)
   if isinstance(metric, int):
     metric = Metric(
-        counter_data=CounterData(
-            int64_value=metric
-        )
+        counter=metric
     )
   return create_monitoring_info(urn, SUM_INT64_TYPE, metric, labels)
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -689,10 +689,10 @@ class FnApiRunnerTest(unittest.TestCase):
         for m in monitoring_infos:
           if m.labels == labels and m.urn == urn:
             if (ge_value is not None and
-                m.metric.counter_data.int64_value >= ge_value):
+                m.metric.counter >= ge_value):
               found = found + 1
             elif (value is not None and
-                  m.metric.counter_data.int64_value == value):
+                  m.metric.counter == value):
               found = found + 1
         ge_value_str = {'ge_value' : ge_value} if ge_value else ''
         value_str = {'value' : value} if value else ''


### PR DESCRIPTION
(factored out of #7823)

- Drops extrema protos, adds gauges.
- Drops non-integer metric proto types

Also starts tying together `MetricName` and `MonitoringInfoMetricName`:
- the former is used for "user" metrics (defined by {ptransform,namespace,name}), the latter for "system" metrics ({urn,labels})
- user-metrics are also representable in {urn,labels} form, but as of this PR the Java SDK intercepts attempts to create user-metrics that way (in `MonitoringInfoMetricName.create`) and creates a `MetricName` `AutoValue` instance instead, which preserves existing behavior most straightforwardly.

R: @robertwb, @ajamato 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](../.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
