### PR TITLE
[BEAM-4776] Add MetricQueryResults.allMetrics() helper

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsPusher.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsPusher.java
@@ -29,7 +29,6 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResults;
-import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.metrics.MetricsSink;
 import org.apache.beam.sdk.util.InstanceBuilder;
@@ -96,8 +95,7 @@ public class MetricsPusher implements Serializable {
       try {
         // merge metrics
         MetricResults metricResults = asAttemptedOnlyMetricResults(metricsContainerStepMap);
-        MetricQueryResults metricQueryResults =
-            metricResults.queryMetrics(MetricsFilter.builder().build());
+        MetricQueryResults metricQueryResults = metricResults.allMetrics();
         if ((Iterables.size(metricQueryResults.getDistributions()) != 0)
             || (Iterables.size(metricQueryResults.getGauges()) != 0)
             || (Iterables.size(metricQueryResults.getCounters()) != 0)) {

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMapTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMapTest.java
@@ -124,7 +124,7 @@ public class MetricsContainerStepMapTest {
         false);
     assertGauge(GAUGE_NAME, step2res, STEP2, GaugeResult.create(VALUE, Instant.now()), false);
 
-    MetricQueryResults allres = metricResults.queryMetrics(MetricsFilter.builder().build());
+    MetricQueryResults allres = metricResults.allMetrics();
 
     assertIterableSize(allres.getCounters(), 2);
     assertIterableSize(allres.getDistributions(), 2);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectMetricsTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectMetricsTest.java
@@ -99,7 +99,7 @@ public class DirectMetricsTest {
             ImmutableList.of(
                 MetricUpdate.create(MetricKey.create("step1", NAME4), GaugeData.create(27L)))));
 
-    MetricQueryResults results = metrics.queryMetrics(MetricsFilter.builder().build());
+    MetricQueryResults results = metrics.allMetrics();
     assertThat(
         results.getCounters(),
         containsInAnyOrder(

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/DirectMetricsTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/DirectMetricsTest.java
@@ -88,7 +88,7 @@ public class DirectMetricsTest {
             ImmutableList.of(
                 MetricUpdate.create(MetricKey.create("step1", NAME4), GaugeData.create(27L)))));
 
-    MetricQueryResults results = metrics.queryMetrics(MetricsFilter.builder().build());
+    MetricQueryResults results = metrics.allMetrics();
     assertThat(
         results.getCounters(),
         containsInAnyOrder(

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
@@ -105,7 +105,7 @@ public class DataflowMetricsTest {
     when(dataflowClient.getJobMetrics(JOB_ID)).thenReturn(jobMetrics);
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
-    MetricQueryResults result = dataflowMetrics.queryMetrics(null);
+    MetricQueryResults result = dataflowMetrics.allMetrics();
     assertThat(ImmutableList.copyOf(result.getCounters()), is(empty()));
     assertThat(ImmutableList.copyOf(result.getDistributions()), is(empty()));
   }
@@ -129,9 +129,9 @@ public class DataflowMetricsTest {
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
     verify(dataflowClient, times(0)).getJobMetrics(JOB_ID);
-    dataflowMetrics.queryMetrics(null);
+    dataflowMetrics.allMetrics();
     verify(dataflowClient, times(1)).getJobMetrics(JOB_ID);
-    dataflowMetrics.queryMetrics(null);
+    dataflowMetrics.allMetrics();
     verify(dataflowClient, times(1)).getJobMetrics(JOB_ID);
   }
 
@@ -207,7 +207,7 @@ public class DataflowMetricsTest {
     when(dataflowClient.getJobMetrics(JOB_ID)).thenReturn(jobMetrics);
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
-    MetricQueryResults result = dataflowMetrics.queryMetrics(null);
+    MetricQueryResults result = dataflowMetrics.allMetrics();
     assertThat(
         result.getCounters(),
         containsInAnyOrder(
@@ -245,7 +245,7 @@ public class DataflowMetricsTest {
             makeCounterMetricUpdate("otherCounter[MIN]", "otherNamespace", "s2", 0L, true)));
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
-    MetricQueryResults result = dataflowMetrics.queryMetrics(null);
+    MetricQueryResults result = dataflowMetrics.allMetrics();
     assertThat(
         result.getCounters(),
         containsInAnyOrder(
@@ -283,7 +283,7 @@ public class DataflowMetricsTest {
                 "distributionName", "distributionNamespace", "s2", 18L, 2L, 2L, 16L, true)));
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
-    MetricQueryResults result = dataflowMetrics.queryMetrics(null);
+    MetricQueryResults result = dataflowMetrics.allMetrics();
     assertThat(
         result.getDistributions(),
         contains(
@@ -329,7 +329,7 @@ public class DataflowMetricsTest {
                 "distributionName", "distributionNamespace", "s2", 18L, 2L, 2L, 16L, true)));
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
-    MetricQueryResults result = dataflowMetrics.queryMetrics(null);
+    MetricQueryResults result = dataflowMetrics.allMetrics();
     try {
       result.getDistributions().iterator().next().getCommitted();
       fail("Expected UnsupportedOperationException");
@@ -388,7 +388,7 @@ public class DataflowMetricsTest {
             makeCounterMetricUpdate("lostName", "otherNamespace", "s5", 1200L, true)));
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
-    MetricQueryResults result = dataflowMetrics.queryMetrics(null);
+    MetricQueryResults result = dataflowMetrics.allMetrics();
     assertThat(
         result.getCounters(),
         containsInAnyOrder(
@@ -438,7 +438,7 @@ public class DataflowMetricsTest {
             makeCounterMetricUpdate("counterName", "otherNamespace", "s4", 1233L, true)));
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
-    MetricQueryResults result = dataflowMetrics.queryMetrics(null);
+    MetricQueryResults result = dataflowMetrics.allMetrics();
     try {
       result.getCounters().iterator().next().getCommitted();
       fail("Expected UnsupportedOperationException");

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/metrics/SamzaMetricsContainer.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/metrics/SamzaMetricsContainer.java
@@ -27,7 +27,6 @@ import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsContainer;
-import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Gauge;
 import org.apache.samza.metrics.Metric;
@@ -61,7 +60,7 @@ public class SamzaMetricsContainer {
     assert metricsRegistry != null;
 
     final MetricResults metricResults = asAttemptedOnlyMetricResults(metricsContainers);
-    final MetricQueryResults results = metricResults.queryMetrics(MetricsFilter.builder().build());
+    final MetricQueryResults results = metricResults.allMetrics();
 
     final CounterUpdater updateCounter = new CounterUpdater();
     results.getCounters().forEach(updateCounter);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/SparkBeamMetric.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/SparkBeamMetric.java
@@ -29,7 +29,6 @@ import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;
-import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
 
 /**
@@ -43,8 +42,7 @@ class SparkBeamMetric implements Metric {
     Map<String, Object> metrics = new HashMap<>();
     MetricResults metricResults =
         asAttemptedOnlyMetricResults(MetricsAccumulator.getInstance().value());
-    MetricQueryResults metricQueryResults =
-        metricResults.queryMetrics(MetricsFilter.builder().build());
+    MetricQueryResults metricQueryResults = metricResults.allMetrics();
     for (MetricResult<Long> metricResult : metricQueryResults.getCounters()) {
       metrics.put(renderName(metricResult), metricResult.getAttempted());
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricResults.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricResults.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.metrics;
 
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -59,5 +58,14 @@ public abstract class MetricResults {
    * // applications.
    * }</pre>
    */
-  public abstract MetricQueryResults queryMetrics(@Nullable MetricsFilter filter);
+  public abstract MetricQueryResults queryMetrics(MetricsFilter filter);
+
+  public MetricQueryResults allMetrics() {
+    return queryMetrics(MetricsFilter.builder().build());
+  }
+
+  @Override
+  public String toString() {
+    return allMetrics().toString();
+  }
 }

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -927,7 +927,7 @@ public class KafkaIOTest {
     MetricName backlogElementsOfSplit = SourceMetrics.backlogElementsOfSplit(splitId).getName();
     MetricName backlogBytesOfSplit = SourceMetrics.backlogBytesOfSplit(splitId).getName();
 
-    MetricQueryResults metrics = result.metrics().queryMetrics(MetricsFilter.builder().build());
+    MetricQueryResults metrics = result.metrics().allMetrics();
 
     Iterable<MetricResult<Long>> counters = metrics.getCounters();
 


### PR DESCRIPTION
(factored out of #7823)

Simple helper for the common case of fetching all metrics from a `MetricQueryResults`, replacing both `queryResults(null)` and `queryMetrics(MetricsFilter.builder().build()`

R: @robertwb, @ajamato 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](../.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
