### PR TITLE
[BEAM-5381] Fix two issues with generating the pipeline plan for Go SDK

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -336,7 +336,7 @@ func (m *marshaller) expandCoGBK(edge NamedEdge) string {
 	for i, in := range edge.Edge.Input {
 		m.addNode(in.From)
 
-		out := fmt.Sprintf("%v_inject%v", nodeID(in.From), i)
+		out := fmt.Sprintf("%v_%v_inject%v", nodeID(in.From), id, i)
 		m.makeNode(out, kvCoderID, in.From)
 
 		// Inject(i)

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -436,7 +436,7 @@ func (m *marshaller) expandCoGBK(edge NamedEdge) string {
 		UniqueName:    edge.Name,
 		Subtransforms: subtransforms,
 	}
-	return id
+	return cogbkID
 }
 
 func (m *marshaller) addNode(n *graph.Node) string {


### PR DESCRIPTION
- Wrong id was returned for CoGBK expansions, so the expanded transform didn't end up in the subtransform of the parent Scope.
- CoGBK inject node outputs need to include edge name as well, not just input node name, otherwise there's an output name collision (caught by Flink runner's consistency check).

R: @herohde 
CC: @schroederc 