### PR TITLE
[BEAM-6714] Move runner-agnostic code out of FlinkJobServerDriver

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
@@ -17,79 +17,30 @@
  */
 package org.apache.beam.runners.flink;
 
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import javax.annotation.Nullable;
-import org.apache.beam.model.pipeline.v1.Endpoints;
-import org.apache.beam.runners.fnexecution.GrpcFnServer;
 import org.apache.beam.runners.fnexecution.ServerFactory;
-import org.apache.beam.runners.fnexecution.artifact.BeamFileSystemArtifactStagingService;
-import org.apache.beam.runners.fnexecution.jobsubmission.InMemoryJobService;
 import org.apache.beam.runners.fnexecution.jobsubmission.JobInvoker;
+import org.apache.beam.runners.fnexecution.jobsubmission.JobServerDriver;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.util.concurrent.ListeningExecutorService;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.util.concurrent.MoreExecutors;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Driver program that starts a job server. */
-public class FlinkJobServerDriver implements Runnable {
+/** Driver program that starts a job server for the Flink runner. */
+public class FlinkJobServerDriver extends JobServerDriver {
 
   private static final Logger LOG = LoggerFactory.getLogger(FlinkJobServerDriver.class);
 
-  private final ListeningExecutorService executor;
-  @VisibleForTesting ServerConfiguration configuration;
-  private final ServerFactory jobServerFactory;
-  private final ServerFactory artifactServerFactory;
-  private volatile GrpcFnServer<InMemoryJobService> jobServer;
-  private volatile GrpcFnServer<BeamFileSystemArtifactStagingService> artifactStagingServer;
-
-  /** Configuration for the jobServer. */
-  public static class ServerConfiguration {
-    @Option(name = "--job-host", usage = "The job server host name")
-    String host = "localhost";
-
-    @Option(
-        name = "--job-port",
-        usage = "The job service port. 0 to use a dynamic port. (Default: 8099)")
-    int port = 8099;
-
-    @Option(
-        name = "--artifact-port",
-        usage = "The artifact service port. 0 to use a dynamic port. (Default: 8098)")
-    int artifactPort = 8098;
-
-    @Option(name = "--artifacts-dir", usage = "The location to store staged artifact files")
-    String artifactStagingPath =
-        Paths.get(System.getProperty("java.io.tmpdir"), "beam-artifact-staging").toString();
-
-    @Option(
-        name = "--clean-artifacts-per-job",
-        usage = "When true, remove each job's staged artifacts when it completes")
-    boolean cleanArtifactsPerJob = false;
-
+  /** Flink runner-specific Configuration for the jobServer. */
+  public static class FlinkServerConfiguration extends ServerConfiguration {
     @Option(name = "--flink-master-url", usage = "Flink master url to submit job.")
-    String flinkMasterUrl = "[auto]";
+    private String flinkMasterUrl = "[auto]";
 
     String getFlinkMasterUrl() {
       return this.flinkMasterUrl;
-    }
-
-    @Option(
-        name = "--sdk-worker-parallelism",
-        usage = "Default parallelism for SDK worker processes (see portable pipeline options)")
-    Long sdkWorkerParallelism = 1L;
-
-    Long getSdkWorkerParallelism() {
-      return this.sdkWorkerParallelism;
     }
 
     @Option(
@@ -98,7 +49,7 @@ public class FlinkJobServerDriver implements Runnable {
             "Directory containing Flink YAML configuration files. "
                 + "These properties will be set to all jobs submitted to Flink and take precedence "
                 + "over configurations in FLINK_CONF_DIR.")
-    String flinkConfDir = null;
+    private String flinkConfDir = null;
 
     @Nullable
     String getFlinkConfDir() {
@@ -121,7 +72,7 @@ public class FlinkJobServerDriver implements Runnable {
   }
 
   public static FlinkJobServerDriver fromParams(String[] args) {
-    ServerConfiguration configuration = new ServerConfiguration();
+    FlinkServerConfiguration configuration = new FlinkServerConfiguration();
     CmdLineParser parser = new CmdLineParser(configuration);
     try {
       parser.parseArgument(args);
@@ -134,141 +85,29 @@ public class FlinkJobServerDriver implements Runnable {
     return fromConfig(configuration);
   }
 
-  public static FlinkJobServerDriver fromConfig(ServerConfiguration configuration) {
-    ThreadFactory threadFactory =
-        new ThreadFactoryBuilder().setNameFormat("flink-runner-job-server").setDaemon(true).build();
-    ListeningExecutorService executor =
-        MoreExecutors.listeningDecorator(Executors.newCachedThreadPool(threadFactory));
-    ServerFactory jobServerFactory = ServerFactory.createWithPortSupplier(() -> configuration.port);
-    ServerFactory artifactServerFactory =
-        ServerFactory.createWithPortSupplier(() -> configuration.artifactPort);
-    return create(configuration, executor, jobServerFactory, artifactServerFactory);
+  public static FlinkJobServerDriver fromConfig(FlinkServerConfiguration configuration) {
+    return create(
+        configuration,
+        createJobServerFactory(configuration),
+        createArtifactServerFactory(configuration));
   }
 
   public static FlinkJobServerDriver create(
-      ServerConfiguration configuration,
-      ListeningExecutorService executor,
+      FlinkServerConfiguration configuration,
       ServerFactory jobServerFactory,
       ServerFactory artifactServerFactory) {
-    return new FlinkJobServerDriver(
-        configuration, executor, jobServerFactory, artifactServerFactory);
+    return new FlinkJobServerDriver(configuration, jobServerFactory, artifactServerFactory);
   }
 
   private FlinkJobServerDriver(
-      ServerConfiguration configuration,
-      ListeningExecutorService executor,
+      FlinkServerConfiguration configuration,
       ServerFactory jobServerFactory,
       ServerFactory artifactServerFactory) {
-    this.configuration = configuration;
-    this.executor = executor;
-    this.jobServerFactory = jobServerFactory;
-    this.artifactServerFactory = artifactServerFactory;
+    super(configuration, jobServerFactory, artifactServerFactory);
   }
 
   @Override
-  public void run() {
-    try {
-      jobServer = createJobServer();
-      jobServer.getServer().awaitTermination();
-    } catch (InterruptedException e) {
-      LOG.warn("Job server interrupted", e);
-    } catch (Exception e) {
-      LOG.warn("Exception during job server creation", e);
-    } finally {
-      stop();
-    }
-  }
-
-  // This method is executed by TestPortableRunner via Reflection
-  public String start() throws IOException {
-    jobServer = createJobServer();
-    return jobServer.getApiServiceDescriptor().getUrl();
-  }
-
-  // This method is executed by TestPortableRunner via Reflection
-  // Needs to be synchronized to prevent concurrency issues in testing shutdown
-  @SuppressWarnings("WeakerAccess")
-  public synchronized void stop() {
-    if (jobServer != null) {
-      try {
-        jobServer.close();
-        LOG.info("JobServer stopped on {}", jobServer.getApiServiceDescriptor().getUrl());
-        jobServer = null;
-      } catch (Exception e) {
-        LOG.error("Error while closing the jobServer.", e);
-      }
-    }
-    if (artifactStagingServer != null) {
-      try {
-        artifactStagingServer.close();
-        LOG.info(
-            "ArtifactStagingServer stopped on {}",
-            artifactStagingServer.getApiServiceDescriptor().getUrl());
-        artifactStagingServer = null;
-      } catch (Exception e) {
-        LOG.error("Error while closing the artifactStagingServer.", e);
-      }
-    }
-  }
-
-  private GrpcFnServer<InMemoryJobService> createJobServer() throws IOException {
-    InMemoryJobService service = createJobService();
-    GrpcFnServer<InMemoryJobService> jobServiceGrpcFnServer;
-    if (configuration.port == 0) {
-      jobServiceGrpcFnServer = GrpcFnServer.allocatePortAndCreateFor(service, jobServerFactory);
-    } else {
-      Endpoints.ApiServiceDescriptor descriptor =
-          Endpoints.ApiServiceDescriptor.newBuilder()
-              .setUrl(configuration.host + ":" + configuration.port)
-              .build();
-      jobServiceGrpcFnServer = GrpcFnServer.create(service, descriptor, jobServerFactory);
-    }
-    LOG.info("JobService started on {}", jobServiceGrpcFnServer.getApiServiceDescriptor().getUrl());
-    return jobServiceGrpcFnServer;
-  }
-
-  private InMemoryJobService createJobService() throws IOException {
-    artifactStagingServer = createArtifactStagingService();
-    JobInvoker invoker = createJobInvoker();
-    return InMemoryJobService.create(
-        artifactStagingServer.getApiServiceDescriptor(),
-        (String session) -> {
-          try {
-            return BeamFileSystemArtifactStagingService.generateStagingSessionToken(
-                session, configuration.artifactStagingPath);
-          } catch (Exception exn) {
-            throw new RuntimeException(exn);
-          }
-        },
-        (String stagingSessionToken) -> {
-          if (configuration.cleanArtifactsPerJob) {
-            artifactStagingServer.getService().removeArtifacts(stagingSessionToken);
-          }
-        },
-        invoker);
-  }
-
-  private GrpcFnServer<BeamFileSystemArtifactStagingService> createArtifactStagingService()
-      throws IOException {
-    BeamFileSystemArtifactStagingService service = new BeamFileSystemArtifactStagingService();
-    final GrpcFnServer<BeamFileSystemArtifactStagingService> artifactStagingService;
-    if (configuration.artifactPort == 0) {
-      artifactStagingService =
-          GrpcFnServer.allocatePortAndCreateFor(service, artifactServerFactory);
-    } else {
-      Endpoints.ApiServiceDescriptor descriptor =
-          Endpoints.ApiServiceDescriptor.newBuilder()
-              .setUrl(configuration.host + ":" + configuration.artifactPort)
-              .build();
-      artifactStagingService = GrpcFnServer.create(service, descriptor, artifactServerFactory);
-    }
-    LOG.info(
-        "ArtifactStagingService started on {}",
-        artifactStagingService.getApiServiceDescriptor().getUrl());
-    return artifactStagingService;
-  }
-
-  private JobInvoker createJobInvoker() {
-    return FlinkJobInvoker.create(executor, configuration);
+  protected JobInvoker createJobInvoker() {
+    return FlinkJobInvoker.create((FlinkServerConfiguration) configuration);
   }
 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkJobServerDriverTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkJobServerDriverTest.java
@@ -36,14 +36,14 @@ public class FlinkJobServerDriverTest {
 
   @Test
   public void testConfigurationDefaults() {
-    FlinkJobServerDriver.ServerConfiguration config =
-        new FlinkJobServerDriver.ServerConfiguration();
-    assertThat(config.host, is("localhost"));
-    assertThat(config.port, is(8099));
-    assertThat(config.artifactPort, is(8098));
-    assertThat(config.flinkMasterUrl, is("[auto]"));
-    assertThat(config.sdkWorkerParallelism, is(1L));
-    assertThat(config.cleanArtifactsPerJob, is(false));
+    FlinkJobServerDriver.FlinkServerConfiguration config =
+        new FlinkJobServerDriver.FlinkServerConfiguration();
+    assertThat(config.getHost(), is("localhost"));
+    assertThat(config.getPort(), is(8099));
+    assertThat(config.getArtifactPort(), is(8098));
+    assertThat(config.getFlinkMasterUrl(), is("[auto]"));
+    assertThat(config.getSdkWorkerParallelism(), is(1L));
+    assertThat(config.isCleanArtifactsPerJob(), is(false));
     FlinkJobServerDriver flinkJobServerDriver = FlinkJobServerDriver.fromConfig(config);
     assertThat(flinkJobServerDriver, is(not(nullValue())));
   }
@@ -62,18 +62,20 @@ public class FlinkJobServerDriverTest {
               "--sdk-worker-parallelism=4",
               "--clean-artifacts-per-job",
             });
-    assertThat(driver.configuration.host, is("test"));
-    assertThat(driver.configuration.port, is(42));
-    assertThat(driver.configuration.artifactPort, is(43));
-    assertThat(driver.configuration.flinkMasterUrl, is("jobmanager"));
-    assertThat(driver.configuration.sdkWorkerParallelism, is(4L));
-    assertThat(driver.configuration.cleanArtifactsPerJob, is(true));
+    FlinkJobServerDriver.FlinkServerConfiguration config =
+        (FlinkJobServerDriver.FlinkServerConfiguration) driver.configuration;
+    assertThat(config.getHost(), is("test"));
+    assertThat(config.getPort(), is(42));
+    assertThat(config.getArtifactPort(), is(43));
+    assertThat(config.getFlinkMasterUrl(), is("jobmanager"));
+    assertThat(config.getSdkWorkerParallelism(), is(4L));
+    assertThat(config.isCleanArtifactsPerJob(), is(true));
   }
 
   @Test
   public void testConfigurationFromConfig() {
-    FlinkJobServerDriver.ServerConfiguration config =
-        new FlinkJobServerDriver.ServerConfiguration();
+    FlinkJobServerDriver.FlinkServerConfiguration config =
+        new FlinkJobServerDriver.FlinkServerConfiguration();
     FlinkJobServerDriver driver = FlinkJobServerDriver.fromConfig(config);
     assertThat(driver.configuration, is(config));
   }

--- a/runners/java-fn-execution/build.gradle
+++ b/runners/java-fn-execution/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   shadow project(path: ":beam-vendor-sdks-java-extensions-protobuf", configuration: "shadow")
   shadow library.java.vendored_grpc_1_13_1
   shadow library.java.slf4j_api
+  shadow library.java.args4j
   testCompile project(":beam-sdks-java-harness")
   testCompile project(path: ":beam-runners-core-construction-java", configuration: "shadow")
   testCompile project(path: ":beam-runners-core-java", configuration: "shadowTest")

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactStagingService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactStagingService.java
@@ -134,8 +134,7 @@ public class BeamFileSystemArtifactStagingService extends ArtifactStagingService
    * @param basePath Base path to upload artifacts.
    * @return Encoded stagingSessionToken.
    */
-  public static String generateStagingSessionToken(String sessionId, String basePath)
-      throws Exception {
+  public static String generateStagingSessionToken(String sessionId, String basePath) {
     StagingSessionToken stagingSessionToken = new StagingSessionToken();
     stagingSessionToken.setSessionId(sessionId);
     stagingSessionToken.setBasePath(basePath);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/JobServerDriver.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/JobServerDriver.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.fnexecution.jobsubmission;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.apache.beam.model.pipeline.v1.Endpoints;
+import org.apache.beam.runners.fnexecution.GrpcFnServer;
+import org.apache.beam.runners.fnexecution.ServerFactory;
+import org.apache.beam.runners.fnexecution.artifact.BeamFileSystemArtifactStagingService;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Shared code for starting and serving an {@link InMemoryJobService}. */
+public abstract class JobServerDriver implements Runnable {
+
+  protected abstract JobInvoker createJobInvoker();
+
+  protected InMemoryJobService createJobService() throws IOException {
+    artifactStagingServer = createArtifactStagingService();
+    JobInvoker invoker = createJobInvoker();
+    return InMemoryJobService.create(
+        artifactStagingServer.getApiServiceDescriptor(),
+        this::createSessionToken,
+        (String stagingSessionToken) -> {
+          if (configuration.cleanArtifactsPerJob) {
+            artifactStagingServer.getService().removeArtifacts(stagingSessionToken);
+          }
+        },
+        invoker);
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(JobServerDriver.class);
+
+  @VisibleForTesting public ServerConfiguration configuration;
+
+  private final ServerFactory jobServerFactory;
+  private final ServerFactory artifactServerFactory;
+  private volatile GrpcFnServer<InMemoryJobService> jobServer;
+  private volatile GrpcFnServer<BeamFileSystemArtifactStagingService> artifactStagingServer;
+
+  /** Configuration for the jobServer. */
+  public static class ServerConfiguration {
+    @Option(name = "--job-host", usage = "The job server host name")
+    private String host = "localhost";
+
+    @Option(
+        name = "--job-port",
+        usage = "The job service port. 0 to use a dynamic port. (Default: 8099)")
+    private int port = 8099;
+
+    @Option(
+        name = "--artifact-port",
+        usage = "The artifact service port. 0 to use a dynamic port. (Default: 8098)")
+    private int artifactPort = 8098;
+
+    @Option(name = "--artifacts-dir", usage = "The location to store staged artifact files")
+    private String artifactStagingPath =
+        Paths.get(System.getProperty("java.io.tmpdir"), "beam-artifact-staging").toString();
+
+    @Option(
+        name = "--clean-artifacts-per-job",
+        usage = "When true, remove each job's staged artifacts when it completes")
+    private boolean cleanArtifactsPerJob = false;
+
+    @Option(
+        name = "--sdk-worker-parallelism",
+        usage = "Default parallelism for SDK worker processes (see portable pipeline options)")
+    private Long sdkWorkerParallelism = 1L;
+
+    public String getHost() {
+      return host;
+    }
+
+    public int getPort() {
+      return port;
+    }
+
+    public int getArtifactPort() {
+      return artifactPort;
+    }
+
+    public String getArtifactStagingPath() {
+      return artifactStagingPath;
+    }
+
+    public boolean isCleanArtifactsPerJob() {
+      return cleanArtifactsPerJob;
+    }
+
+    public Long getSdkWorkerParallelism() {
+      return this.sdkWorkerParallelism;
+    }
+  }
+
+  protected static ServerFactory createJobServerFactory(ServerConfiguration configuration) {
+    return ServerFactory.createWithPortSupplier(() -> configuration.port);
+  }
+
+  protected static ServerFactory createArtifactServerFactory(ServerConfiguration configuration) {
+    return ServerFactory.createWithPortSupplier(() -> configuration.artifactPort);
+  }
+
+  protected JobServerDriver(
+      ServerConfiguration configuration,
+      ServerFactory jobServerFactory,
+      ServerFactory artifactServerFactory) {
+    this.configuration = configuration;
+    this.jobServerFactory = jobServerFactory;
+    this.artifactServerFactory = artifactServerFactory;
+  }
+
+  // This method is executed by TestPortableRunner via Reflection
+  public String start() throws IOException {
+    jobServer = createJobServer();
+    return jobServer.getApiServiceDescriptor().getUrl();
+  }
+
+  @Override
+  public void run() {
+    try {
+      jobServer = createJobServer();
+      jobServer.getServer().awaitTermination();
+    } catch (InterruptedException e) {
+      LOG.warn("Job server interrupted", e);
+    } catch (Exception e) {
+      LOG.warn("Exception during job server creation", e);
+    } finally {
+      stop();
+    }
+  }
+
+  // This method is executed by TestPortableRunner via Reflection
+  // Needs to be synchronized to prevent concurrency issues in testing shutdown
+  @SuppressWarnings("WeakerAccess")
+  public synchronized void stop() {
+    if (jobServer != null) {
+      try {
+        jobServer.close();
+        LOG.info("JobServer stopped on {}", jobServer.getApiServiceDescriptor().getUrl());
+        jobServer = null;
+      } catch (Exception e) {
+        LOG.error("Error while closing the jobServer.", e);
+      }
+    }
+    if (artifactStagingServer != null) {
+      try {
+        artifactStagingServer.close();
+        LOG.info(
+            "ArtifactStagingServer stopped on {}",
+            artifactStagingServer.getApiServiceDescriptor().getUrl());
+        artifactStagingServer = null;
+      } catch (Exception e) {
+        LOG.error("Error while closing the artifactStagingServer.", e);
+      }
+    }
+  }
+
+  protected String createSessionToken(String session) {
+    return BeamFileSystemArtifactStagingService.generateStagingSessionToken(
+        session, configuration.artifactStagingPath);
+  }
+
+  private GrpcFnServer<InMemoryJobService> createJobServer() throws IOException {
+    InMemoryJobService service = createJobService();
+    GrpcFnServer<InMemoryJobService> jobServiceGrpcFnServer;
+    if (configuration.port == 0) {
+      jobServiceGrpcFnServer = GrpcFnServer.allocatePortAndCreateFor(service, jobServerFactory);
+    } else {
+      Endpoints.ApiServiceDescriptor descriptor =
+          Endpoints.ApiServiceDescriptor.newBuilder()
+              .setUrl(configuration.host + ":" + configuration.port)
+              .build();
+      jobServiceGrpcFnServer = GrpcFnServer.create(service, descriptor, jobServerFactory);
+    }
+    LOG.info("JobService started on {}", jobServiceGrpcFnServer.getApiServiceDescriptor().getUrl());
+    return jobServiceGrpcFnServer;
+  }
+
+  private GrpcFnServer<BeamFileSystemArtifactStagingService> createArtifactStagingService()
+      throws IOException {
+    BeamFileSystemArtifactStagingService service = new BeamFileSystemArtifactStagingService();
+    final GrpcFnServer<BeamFileSystemArtifactStagingService> artifactStagingService;
+    if (configuration.artifactPort == 0) {
+      artifactStagingService =
+          GrpcFnServer.allocatePortAndCreateFor(service, artifactServerFactory);
+    } else {
+      Endpoints.ApiServiceDescriptor descriptor =
+          Endpoints.ApiServiceDescriptor.newBuilder()
+              .setUrl(configuration.host + ":" + configuration.artifactPort)
+              .build();
+      artifactStagingService = GrpcFnServer.create(service, descriptor, artifactServerFactory);
+    }
+    LOG.info(
+        "ArtifactStagingService started on {}",
+        artifactStagingService.getApiServiceDescriptor().getUrl());
+    return artifactStagingService;
+  }
+}


### PR DESCRIPTION
I moved runner-agnostic code in `FlinkJobServerDriver` to the new abstract class `JobServerDriver`, which can be reused by other portable runners going forward.

I did *not* make any changes to `SamzaJobServerDriver` yet, but it might be a good idea to adapt `SamzaJobServerDriver` to extend `JobServerDriver`. As far as I can tell, the former only includes a subset of the latter's features.

R: @angoenka 
R: @robertwb 

------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](../.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
