### PR TITLE
[BEAM-6720] Add binary compatibility adapters for ProcessFunction/InferableFunction overloads

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Contextful.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Contextful.java
@@ -112,6 +112,12 @@ public final class Contextful<ClosureT> implements Serializable {
     return new Contextful<>((element, c) -> fn.apply(element), Requirements.empty());
   }
 
+  /** Binary compatibility adapter for {@link #fn(ProcessFunction)}. */
+  public static <InputT, OutputT> Contextful<Fn<InputT, OutputT>> fn(
+      final SerializableFunction<InputT, OutputT> fn) {
+    return fn((ProcessFunction<InputT, OutputT>) fn);
+  }
+
   /** Same with {@link #of} but with better type inference behavior for the case of {@link Fn}. */
   public static <InputT, OutputT> Contextful<Fn<InputT, OutputT>> fn(
       final Fn<InputT, OutputT> fn, Requirements requirements) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Filter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Filter.java
@@ -51,6 +51,12 @@ public class Filter<T> extends PTransform<PCollection<T>, PCollection<T>> {
     return new Filter<>(predicate);
   }
 
+  /** Binary compatibility adapter for {@link #by(ProcessFunction)}. */
+  public static <T, PredicateT extends SerializableFunction<T, Boolean>> Filter<T> by(
+      PredicateT predicate) {
+    return by((ProcessFunction<T, Boolean>) predicate);
+  }
+
   /**
    * Returns a {@code PTransform} that takes an input {@link PCollection} and returns a {@link
    * PCollection} with elements that are less than a given value, based on the elements' natural

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FlatMapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FlatMapElements.java
@@ -85,6 +85,12 @@ public class FlatMapElements<InputT, OutputT>
     return new FlatMapElements<>(wrapped, fn, inputType, outputType);
   }
 
+  /** Binary compatibility adapter for {@link #via(ProcessFunction)}. */
+  public static <InputT, OutputT> FlatMapElements<InputT, OutputT> via(
+      SimpleFunction<? super InputT, ? extends Iterable<OutputT>> fn) {
+    return via((InferableFunction<? super InputT, ? extends Iterable<OutputT>>) fn);
+  }
+
   /**
    * Returns a new {@link FlatMapElements} transform with the given type descriptor for the output
    * type, but the mapping function yet to be specified using {@link #via(ProcessFunction)}.
@@ -111,6 +117,12 @@ public class FlatMapElements<InputT, OutputT>
       ProcessFunction<NewInputT, ? extends Iterable<OutputT>> fn) {
     return new FlatMapElements<>(
         (Contextful) Contextful.fn(fn), fn, TypeDescriptors.inputOf(fn), outputType);
+  }
+
+  /** Binary compatibility adapter for {@link #via(ProcessFunction)}. */
+  public <NewInputT> FlatMapElements<NewInputT, OutputT> via(
+      SerializableFunction<NewInputT, ? extends Iterable<OutputT>> fn) {
+    return via((ProcessFunction<NewInputT, ? extends Iterable<OutputT>>) fn);
   }
 
   /** Like {@link #via(ProcessFunction)}, but allows access to additional context. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
@@ -76,6 +76,12 @@ public class MapElements<InputT, OutputT>
         Contextful.fn(fn), fn, fn.getInputTypeDescriptor(), fn.getOutputTypeDescriptor());
   }
 
+  /** Binary compatibility adapter for {@link #via(InferableFunction)}. */
+  public static <InputT, OutputT> MapElements<InputT, OutputT> via(
+      final SimpleFunction<InputT, OutputT> fn) {
+    return via((InferableFunction<InputT, OutputT>) fn);
+  }
+
   /**
    * Returns a new {@link MapElements} transform with the given type descriptor for the output type,
    * but the mapping function yet to be specified using {@link #via(ProcessFunction)}.
@@ -99,6 +105,12 @@ public class MapElements<InputT, OutputT>
    */
   public <NewInputT> MapElements<NewInputT, OutputT> via(ProcessFunction<NewInputT, OutputT> fn) {
     return new MapElements<>(Contextful.fn(fn), fn, TypeDescriptors.inputOf(fn), outputType);
+  }
+
+  /** Binary compatibility adapter for {@link #via(ProcessFunction)}. */
+  public <NewInputT> MapElements<NewInputT, OutputT> via(
+      SerializableFunction<NewInputT, OutputT> fn) {
+    return via((ProcessFunction<NewInputT, OutputT>) fn);
   }
 
   /** Like {@link #via(ProcessFunction)}, but supports access to context, such as side inputs. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TypeDescriptors.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TypeDescriptors.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.beam.sdk.transforms.Contextful;
 import org.apache.beam.sdk.transforms.ProcessFunction;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 
 /**
  * A utility class for creating {@link TypeDescriptor} objects for different types, such as Java
@@ -394,6 +395,12 @@ public class TypeDescriptors {
         new TypeVariableExtractor<ProcessFunction<InputT, OutputT>, InputT>() {});
   }
 
+  /** Binary compatibility adapter for {@link #inputOf(ProcessFunction)}. */
+  public static <InputT, OutputT> TypeDescriptor<InputT> inputOf(
+      SerializableFunction<InputT, OutputT> fn) {
+    return inputOf((ProcessFunction<InputT, OutputT>) fn);
+  }
+
   /**
    * Returns a type descriptor for the output of the given {@link ProcessFunction}, subject to Java
    * type erasure: may contain unresolved type variables if the type was erased.
@@ -404,6 +411,12 @@ public class TypeDescriptors {
         fn,
         ProcessFunction.class,
         new TypeVariableExtractor<ProcessFunction<InputT, OutputT>, OutputT>() {});
+  }
+
+  /** Binary compatibility adapter for {@link #outputOf(ProcessFunction)}. */
+  public static <InputT, OutputT> TypeDescriptor<OutputT> outputOf(
+      SerializableFunction<InputT, OutputT> fn) {
+    return outputOf((ProcessFunction<InputT, OutputT>) fn);
   }
 
   /** Like {@link #inputOf(ProcessFunction)} but for {@link Contextful.Fn}. */


### PR DESCRIPTION
Because method overloads are resolved statically, 2.10.0 is compile compatible but not binary compatible with 2.9.0.

This introduces adapters where needed to restore binary compatibility.

Testing will be by hand and one-off as I'm not sure the infrastructure that would be needed to test these automatically.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](../.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
