### PR TITLE
[BEAM-6738] Cache Combine Invokers.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/combine.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/combine.go
@@ -22,7 +22,6 @@ import (
 	"path"
 	"reflect"
 
-	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
@@ -41,6 +40,11 @@ type Combine struct {
 
 	status Status
 	err    errorx.GuardedError
+
+	// reusable invokers
+	createAccumInv, addInputInv, mergeInv, extractOutputInv *invoker
+	// cached value converter for add input.
+	aiValConvert func(interface{}) interface{}
 }
 
 // ID returns the UnitID for this node.
@@ -59,8 +63,17 @@ func (n *Combine) Up(ctx context.Context) error {
 		return n.fail(err)
 	}
 
-	if n.Fn.AddInputFn() == nil {
+	if ca := n.Fn.CreateAccumulatorFn(); ca != nil {
+		n.createAccumInv = newInvoker(ca)
+	}
+	if ai := n.Fn.AddInputFn(); ai != nil {
+		n.addInputInv = newInvoker(ai)
+	} else {
 		n.optimizeMergeFn()
+	}
+	n.mergeInv = newInvoker(n.Fn.MergeAccumulatorsFn())
+	if eo := n.Fn.ExtractOutputFn(); eo != nil {
+		n.extractOutputInv = newInvoker(eo)
 	}
 	return nil
 }
@@ -79,7 +92,7 @@ func (n *Combine) mergeAccumulators(ctx context.Context, a, b interface{}) (inte
 	}
 
 	in := &MainInput{Key: FullValue{Elm: a}}
-	val, err := InvokeWithoutEventTime(ctx, n.Fn.MergeAccumulatorsFn(), in, b)
+	val, err := n.mergeInv.InvokeWithoutEventTime(ctx, in, b)
 	if err != nil {
 		return nil, n.fail(fmt.Errorf("MergeAccumulators failed: %v", err))
 	}
@@ -149,6 +162,18 @@ func (n *Combine) FinishBundle(ctx context.Context) error {
 		return fmt.Errorf("invalid status for combine %v: %v", n.UID, n.status)
 	}
 	n.status = Up
+	if n.createAccumInv != nil {
+		n.createAccumInv.Reset()
+	}
+	if n.addInputInv != nil {
+		n.addInputInv.Reset()
+	}
+	if n.mergeInv != nil {
+		n.mergeInv.Reset()
+	}
+	if n.extractOutputInv != nil {
+		n.extractOutputInv.Reset()
+	}
 
 	if err := n.Out.FinishBundle(ctx); err != nil {
 		return n.fail(err)
@@ -180,7 +205,7 @@ func (n *Combine) newAccum(ctx context.Context, key interface{}) (interface{}, e
 		opt = &MainInput{Key: FullValue{Elm: key}}
 	}
 
-	val, err := InvokeWithoutEventTime(ctx, fn, opt)
+	val, err := n.createAccumInv.InvokeWithoutEventTime(ctx, opt)
 	if err != nil {
 		return nil, fmt.Errorf("CreateAccumulator failed: %v", err)
 	}
@@ -211,15 +236,19 @@ func (n *Combine) addInput(ctx context.Context, accum, key, value interface{}, t
 		},
 	}
 
-	in := fn.Params(funcx.FnValue | funcx.FnIter | funcx.FnReIter)
 	i := 1
 	if n.UsesKey {
-		opt.Key.Elm2 = Convert(key, fn.Param[in[i]].T)
+		//opt.Key.Elm2 = Convert(key, n.addInputInv.fn.Param[n.addInputInv.in[i]].T)
+		opt.Key.Elm2 = key
 		i++
 	}
-	v := Convert(value, fn.Param[i].T)
+	if n.aiValConvert == nil {
+		from := reflect.TypeOf(value)
+		n.aiValConvert = ConvertFn(from, n.addInputInv.fn.Param[i].T)
+	}
+	v := n.aiValConvert(value)
 
-	val, err := InvokeWithoutEventTime(ctx, n.Fn.AddInputFn(), opt, v)
+	val, err := n.addInputInv.InvokeWithoutEventTime(ctx, opt, v)
 	if err != nil {
 		return nil, n.fail(fmt.Errorf("AddInput failed: %v", err))
 	}
@@ -233,7 +262,7 @@ func (n *Combine) extract(ctx context.Context, accum interface{}) (interface{}, 
 		return accum, nil
 	}
 
-	val, err := InvokeWithoutEventTime(ctx, n.Fn.ExtractOutputFn(), nil, accum)
+	val, err := n.extractOutputInv.InvokeWithoutEventTime(ctx, nil, accum)
 	if err != nil {
 		return nil, n.fail(fmt.Errorf("ExtractOutput failed: %v", err))
 	}
@@ -287,8 +316,9 @@ func (n *LiftedCombine) StartBundle(ctx context.Context, id string, data DataCon
 	return nil
 }
 
-// ProcessElement takes a KV pair and combines values with the same into an accumulator,
-// caching them until the bundle is complete.
+// ProcessElement takes a KV pair and combines values with the same key into an accumulator,
+// caching them until the bundle is complete. If the cache grows too large, a random eviction
+// policy is used.
 func (n *LiftedCombine) ProcessElement(ctx context.Context, value *FullValue, values ...ReStream) error {
 	if n.status != Active {
 		return fmt.Errorf("invalid status for precombine %v: %v", n.UID, n.status)
@@ -348,11 +378,6 @@ func (n *LiftedCombine) ProcessElement(ctx context.Context, value *FullValue, va
 // FinishBundle iterates through the cached (key, accumulator) pairs, and then
 // processes the value in the bundle as normal.
 func (n *LiftedCombine) FinishBundle(ctx context.Context) error {
-	if n.status != Active {
-		return fmt.Errorf("invalid status for precombine %v: %v", n.UID, n.status)
-	}
-	n.status = Up
-
 	// Need to run n.Out.ProcessElement for all the cached precombined KVs, and
 	// then finally Finish bundle as normal.
 	for _, a := range n.cache {
@@ -364,7 +389,7 @@ func (n *LiftedCombine) FinishBundle(ctx context.Context) error {
 	// Down isn't guaranteed to be called.
 	n.cache = nil
 
-	return n.Out.FinishBundle(ctx)
+	return n.Combine.FinishBundle(ctx)
 }
 
 // Down tears down the cache.

--- a/sdks/go/pkg/beam/core/runtime/exec/combine_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/combine_test.go
@@ -304,6 +304,10 @@ type MyErrorCombine struct {
 	MyCombine // Embedding to re-use the exisitng AddInput implementations
 }
 
+func (*MyErrorCombine) CreateAccumulator() (int64, error) {
+	return 0, nil
+}
+
 func (*MyErrorCombine) MergeAccumulators(a, b int64) (int64, error) {
 	return a + b, nil
 }


### PR DESCRIPTION
Applies the invoker caching optimization to Combines, as previously applied to ParDo.

Change log
* Caching the infrastructure for invoking user functions avoids repeated work and allocations as before, especially for shim generated functions.
* Fix bug in the eviction code. It was sometimes evicting the current key being mutated leading to overcontributions.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
