### PR TITLE
[BEAM-6778] Enable Bundle Finalization in Python SDK harness over FnApi

### DIFF
--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -56,6 +56,7 @@ cdef class DoFnInvoker(object):
   cdef public DoFnSignature signature
   cdef OutputProcessor output_processor
   cdef object user_state_context
+  cdef public object bundle_finalizer_param
 
   cpdef invoke_process(self, WindowedValue windowed_value,
                        restriction_tracker=*,
@@ -92,7 +93,7 @@ cdef class DoFnRunner(Receiver):
   cdef object step_name
   cdef list side_inputs
   cdef DoFnInvoker do_fn_invoker
-
+  cdef public object bundle_finalizer_param
   cpdef process(self, WindowedValue windowed_value)
 
 

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -201,6 +201,12 @@ if __name__ == '__main__':
     def test_sdf(self):
       raise unittest.SkipTest("BEAM-2939")
 
+    def test_callbacks_with_exception(self):
+      raise unittest.SkipTest("BEAM-6868")
+
+    def test_register_finalizations(self):
+      raise unittest.SkipTest("BEAM-6868")
+
     # Inherits all other tests.
 
   # Run the tests.

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -1298,6 +1298,15 @@ class BundleManager(object):
     if result.error:
       raise RuntimeError(result.error)
 
+    if result.process_bundle.requires_finalization:
+      finalize_request = beam_fn_api_pb2.InstructionRequest(
+          finalize_bundle=
+          beam_fn_api_pb2.FinalizeBundleRequest(
+              instruction_reference=process_bundle_id
+          ))
+      self._controller.control_handler.push(
+          finalize_request)
+
     return result, split_results
 
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -871,6 +871,9 @@ class FnApiRunnerTestWithBundleRepeat(FnApiRunnerTest):
   def create_pipeline(self):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(bundle_repeat=3))
+  
+  def test_register_finalizations(self):
+    raise unittest.SkipTest("TODO: Avoid bundle finalizations on repeat.")
 
 
 class FnApiRunnerSplitTest(unittest.TestCase):
@@ -1141,7 +1144,7 @@ class EventRecorder(object):
 
   def record(self, content):
     file_path = os.path.join(self.tmp_dir, uuid.uuid4().hex + '.txt')
-    with open(file_path, 'a') as f:
+    with open(file_path, 'w') as f:
       f.write(content)
 
   def events(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -871,7 +871,7 @@ class FnApiRunnerTestWithBundleRepeat(FnApiRunnerTest):
   def create_pipeline(self):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(bundle_repeat=3))
-  
+
   def test_register_finalizations(self):
     raise unittest.SkipTest("TODO: Avoid bundle finalizations on repeat.")
 

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -469,7 +469,6 @@ class BundleProcessor(object):
     self.splitting_lock = threading.Lock()
 
   def create_execution_tree(self, descriptor):
-
     transform_factory = BeamTransformFactory(
         descriptor, self.data_channel_factory, self.counter_factory,
         self.state_sampler, self.state_handler)
@@ -559,15 +558,27 @@ class BundleProcessor(object):
         logging.debug('finish %s', op)
         op.finish()
 
-      return [
-          self.delayed_bundle_application(op, residual)
-          for op, residual in execution_context.delayed_applications]
+      return ([self.delayed_bundle_application(op, residual)
+               for op, residual in execution_context.delayed_applications],
+              self.requires_finalization())
 
     finally:
       # Ensure any in-flight split attempts complete.
       with self.splitting_lock:
         pass
       self.state_sampler.stop_if_still_running()
+
+  def finalize_bundle(self):
+    try:
+      for op in self.ops.values():
+        op.finalize_bundle()
+    except Exception as e:
+      logging.warn("Got exception from finalization call: %s", e)
+    finally:
+      return beam_fn_api_pb2.FinalizeBundleResponse()
+
+  def requires_finalization(self):
+    return any(op.needs_finalization() for op in self.ops.values())
 
   def try_split(self, bundle_split_request):
     split_response = beam_fn_api_pb2.ProcessBundleSplitResponse()

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -569,13 +569,9 @@ class BundleProcessor(object):
       self.state_sampler.stop_if_still_running()
 
   def finalize_bundle(self):
-    try:
-      for op in self.ops.values():
-        op.finalize_bundle()
-    except Exception as e:
-      logging.warn("Got exception from finalization call: %s", e)
-    finally:
-      return beam_fn_api_pb2.FinalizeBundleResponse()
+    for op in self.ops.values():
+      op.finalize_bundle()
+    return beam_fn_api_pb2.FinalizeBundleResponse()
 
   def requires_finalization(self):
     return any(op.needs_finalization() for op in self.ops.values())

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -223,6 +223,12 @@ class Operation(object):
     """Process element in operation."""
     pass
 
+  def finalize_bundle(self):
+    pass
+
+  def needs_finalization(self):
+    return False
+
   def try_split(self, fraction_of_remainder):
     return None
 
@@ -557,6 +563,12 @@ class DoOperation(Operation):
         self.execution_context.delayed_applications.append(
             (self, delayed_application))
 
+  def finalize_bundle(self):
+    self.dofn_receiver.finalize()
+
+  def needs_finalization(self):
+    return self.dofn_receiver.bundle_finalizer_param.has_callbacks()
+
   def process_timer(self, tag, windowed_timer):
     key, timer_data = windowed_timer.value
     timer_spec = self.timer_specs[tag]
@@ -575,6 +587,7 @@ class DoOperation(Operation):
       side_input_map.reset()
     if self.user_state_context:
       self.user_state_context.reset()
+    self.dofn_receiver.bundle_finalizer_param.reset()
 
   def progress_metrics(self):
     metrics = super(DoOperation, self).progress_metrics()

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -328,7 +328,7 @@ class SdkWorker(object):
           instruction_id):
         with self.maybe_profile(instruction_id):
           delayed_applications, requests_finalization = (
-            bundle_processor.process_bundle(instruction_id))
+              bundle_processor.process_bundle(instruction_id))
           response = beam_fn_api_pb2.InstructionResponse(
               instruction_id=instruction_id,
               process_bundle=beam_fn_api_pb2.ProcessBundleResponse(

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -337,7 +337,7 @@ class SdkWorker(object):
                   monitoring_infos=bundle_processor.monitoring_infos(),
                   requires_finalization=requests_finalization))
       # Don't release here if finalize is needed.
-      if not bundle_processor.requires_finalization():
+      if not requests_finalization:
         self.bundle_processor_cache.release(instruction_id)
       return response
     except:  # pylint: disable=broad-except

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -326,6 +326,27 @@ class _TimerDoFnParam(_DoFnParam):
     self.param_id = 'TimerParam(%s)' % timer_spec.name
 
 
+class _BundleFinalizerParam(_DoFnParam):
+  """Bundle Finalization DoFn parameter."""
+
+  def __init__(self):
+    self._callbacks = []
+    self.param_id = "FinalizeBundle"
+
+  def register(self, callback):
+    self._callbacks.append(callback)
+
+  def finalize_bundle(self):
+    for callback in self._callbacks:
+      callback()
+
+  def has_callbacks(self):
+    return len(self._callbacks) > 0
+
+  def reset(self):
+    del self._callbacks[:]
+
+
 class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   """A function object used by a transform with custom processing.
 
@@ -344,9 +365,11 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   TimestampParam = _DoFnParam('TimestampParam')
   WindowParam = _DoFnParam('WindowParam')
   WatermarkReporterParam = _DoFnParam('WatermarkReporterParam')
+  BundleFinalizerParam = _BundleFinalizerParam
 
   DoFnProcessParams = [ElementParam, SideInputParam, TimestampParam,
-                       WindowParam, WatermarkReporterParam]
+                       WindowParam, WatermarkReporterParam,
+                       BundleFinalizerParam]
 
   # Parameters to access state and timers.  Not restricted to use only in the
   # .process() method. Usage: DoFn.StateParam(state_spec),

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -336,9 +336,14 @@ class _BundleFinalizerParam(_DoFnParam):
   def register(self, callback):
     self._callbacks.append(callback)
 
+  # Log errors when calling callback to make sure all callbacks get called
+  # though there are errors. And errors should not fail pipeline.
   def finalize_bundle(self):
     for callback in self._callbacks:
-      callback()
+      try:
+        callback()
+      except Exception as e:
+        logging.warn("Got exception from finalization call: %s", e)
 
   def has_callbacks(self):
     return len(self._callbacks) > 0

--- a/sdks/python/scripts/generate_pydoc.sh
+++ b/sdks/python/scripts/generate_pydoc.sh
@@ -171,6 +171,7 @@ ignore_identifiers = [
   # DoFn param inner classes, due to a Sphinx misparsing of inner classes
   '_StateDoFnParam',
   '_TimerDoFnParam',
+  '_BundleFinalizerParam',
 
   # Sphinx cannot find this py:class reference target
   'typing.Generic',


### PR DESCRIPTION
This PR is focus on supporting [Bundle Finalization](https://s.apache.org/beam-finalizing-bundles) in the Python SDK harness level. The finalizer API design is under discussing and would be changed in the future. 
In order to implement the finalization logic inside the sdk harness, there are some simplifications in other components:
1. For the finalizer API, it may be changed by upcoming PR.
2. For the Python Fnapi runner, it simply requests a finalization if the ```ProcessBundleResponse``` sets the ```requires_finalization``` to true.

R: @aaltay @robertwb 