### PR TITLE
[BEAM-6697] Upgrades gcsio to 1.9.16

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -344,7 +344,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // Maven artifacts.
     def generated_grpc_beta_version = "0.44.0"
     def generated_grpc_ga_version = "1.43.0"
-    def google_cloud_bigdataoss_version = "1.9.15"
+    def google_cloud_bigdataoss_version = "1.9.16"
     def google_cloud_spanner_version = "1.6.0"
     def google_clients_version = "1.27.0"
     def google_auth_version = "0.12.0"

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilTest.java
@@ -53,6 +53,7 @@ import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadChannel;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -773,9 +774,11 @@ public class GcsUtilTest {
 
   @Test
   public void testGCSChannelCloseIdempotent() throws IOException {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFound(false).build();
     SeekableByteChannel channel =
         new GoogleCloudStorageReadChannel(
-            null, "dummybucket", "dummyobject", null, new ClientRequestHelper<>());
+            null, "dummybucket", "dummyobject", null, new ClientRequestHelper<>(), readOptions);
     channel.close();
     channel.close();
   }


### PR DESCRIPTION
gcsio 1.9.15 and prior has a bug which will result in a failure if a user invoke a metadata request before reading data. ParquetIO fails due to this.

Please see https://issues.apache.org/jira/browse/BEAM-6697 for more info.