### PR TITLE
Fixing Python tornadoes test for Google

### DIFF
--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes.py
@@ -87,7 +87,7 @@ def run(argv=None):
     rows = p | 'read' >> beam.io.Read(beam.io.BigQuerySource(known_args.input))
     counts = count_tornadoes(rows)
 
-    if p.options.get_all_options()['temp_location'].startswith('gs://'):
+    if 'temp_location' in p.options.get_all_options():
       location = p.options.get_all_options()['temp_location']
     else:
       location = known_args.gcs_location

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes.py
@@ -87,6 +87,11 @@ def run(argv=None):
     rows = p | 'read' >> beam.io.Read(beam.io.BigQuerySource(known_args.input))
     counts = count_tornadoes(rows)
 
+    if p.options.get_all_options()['temp_location'].startswith('gs://'):
+      location = p.options.get_all_options()['temp_location']
+    else:
+      location = known_args.gcs_location
+
     # Write the output using a "Write" transform that has side effects.
     # pylint: disable=expression-not-assigned
     counts | 'Write' >> beam.io.WriteToBigQuery(
@@ -94,7 +99,7 @@ def run(argv=None):
         schema='month:INTEGER, tornado_count:INTEGER',
         create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
         write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
-        gs_location=known_args.gcs_location)
+        gs_location=location)
 
     # Run the pipeline (all operations are deferred until run() is called).
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -619,6 +619,10 @@ class BigQueryWrapper(object):
                                          dataset_id=dataset_id,
                                          table_id=table_id,
                                          schema=schema or found_table.schema)
+      logging.info('Created table %s.%s.%s with schema %s. Result: %s.',
+                   project_id, dataset_id, table_id,
+                   schema or found_table.schema,
+                   created_table)
       # if write_disposition == BigQueryDisposition.WRITE_TRUNCATE we delete
       # the table before this point.
       if write_disposition == BigQueryDisposition.WRITE_TRUNCATE:


### PR DESCRIPTION
The tornadoes test, when run from DirectRunner needs a GCS location. When running on Dataflow, it should just use the GCS-based temp location of the pipeline.

r: @markflyhigh 