### PR TITLE
[BEAM-6165] Flink portable metrics: get ptransform from MonitoringInfo, not stage name

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricUrns.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricUrns.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.core.metrics;
 
 import static org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder.USER_COUNTER_URN_PREFIX;
 
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.metrics.MetricName;
 
 /** Utility for parsing a URN to a {@link MetricName}. */
@@ -29,9 +30,12 @@ public class MetricUrns {
    *
    * <p>Should be consistent with {@code parse_namespace_and_name} in monitoring_infos.py.
    */
-  public static MetricName parseUrn(String urn) {
+  @Nullable
+  public static MetricName parseUserUrn(String urn) {
     if (urn.startsWith(USER_COUNTER_URN_PREFIX)) {
       urn = urn.substring(USER_COUNTER_URN_PREFIX.length());
+    } else {
+      return null;
     }
     // If it is not a user counter, just use the first part of the URN, i.e. 'beam'
     String[] pieces = urn.split(":", 2);

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.runners.core.metrics.MetricUpdates.MetricUpdate;
 import org.apache.beam.sdk.metrics.MetricKey;
@@ -53,7 +54,7 @@ public class MetricsContainerStepMap implements Serializable {
   }
 
   /** Returns the container for the given step name. */
-  public MetricsContainerImpl getContainer(String stepName) {
+  public MetricsContainerImpl getContainer(@Nullable String stepName) {
     if (stepName == null) {
       // TODO(BEAM-6538): Disallow this in the future, some tests rely on an empty step name today.
       return getUnboundContainer();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/DoFnRunnerWithMetricsUpdate.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/DoFnRunnerWithMetricsUpdate.java
@@ -90,7 +90,7 @@ public class DoFnRunnerWithMetricsUpdate<InputT, OutputT> implements DoFnRunner<
     }
 
     // update metrics
-    container.updateMetrics(stepName);
+    container.updateFlinkMetrics(stepName);
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
@@ -135,14 +135,14 @@ public class FlinkMetricContainer {
             }
           }
         });
-    updateMetrics(stepName);
+    updateFlinkMetrics(stepName);
   }
 
   /**
    * Update Flink's internal metrics ({@link this#flinkCounterCache}) with the latest metrics for a
    * given step.
    */
-  void updateMetrics(String stepName) {
+  void updateFlinkMetrics(String stepName) {
     MetricResults metricResults = asAttemptedOnlyMetricResults(metricsAccumulator.getLocalValue());
     MetricQueryResults metricQueryResults =
         metricResults.queryMetrics(MetricsFilter.builder().addStep(stepName).build());

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
@@ -49,7 +49,7 @@ public class ReaderInvocationUtil<OutputT, ReaderT extends Source.Reader<OutputT
       try (Closeable ignored =
           MetricsEnvironment.scopedMetricsContainer(container.getMetricsContainer(stepName))) {
         boolean result = reader.start();
-        container.updateMetrics(stepName);
+        container.updateFlinkMetrics(stepName);
         return result;
       }
     } else {
@@ -62,7 +62,7 @@ public class ReaderInvocationUtil<OutputT, ReaderT extends Source.Reader<OutputT
       try (Closeable ignored =
           MetricsEnvironment.scopedMetricsContainer(container.getMetricsContainer(stepName))) {
         boolean result = reader.advance();
-        container.updateMetrics(stepName);
+        container.updateFlinkMetrics(stepName);
         return result;
       }
     } else {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
@@ -151,12 +151,12 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
         new BundleProgressHandler() {
           @Override
           public void onProgress(ProcessBundleProgressResponse progress) {
-            container.updateMetrics(stageName, progress.getMonitoringInfosList());
+            container.updateMetrics(progress.getMonitoringInfosList());
           }
 
           @Override
           public void onCompleted(ProcessBundleResponse response) {
-            container.updateMetrics(stageName, response.getMonitoringInfosList());
+            container.updateMetrics(response.getMonitoringInfosList());
           }
         };
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -190,12 +190,12 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
         new BundleProgressHandler() {
           @Override
           public void onProgress(ProcessBundleProgressResponse progress) {
-            flinkMetricContainer.updateMetrics(stepName, progress.getMonitoringInfosList());
+            flinkMetricContainer.updateMetrics(progress.getMonitoringInfosList());
           }
 
           @Override
           public void onCompleted(ProcessBundleResponse response) {
-            flinkMetricContainer.updateMetrics(stepName, response.getMonitoringInfosList());
+            flinkMetricContainer.updateMetrics(response.getMonitoringInfosList());
           }
         };
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSavepointTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSavepointTest.java
@@ -133,6 +133,8 @@ public class FlinkSavepointTest implements Serializable {
     runSavepointAndRestore(false);
   }
 
+  // TODO(ryan): make these fail when an exception is thrown (in the runner, I
+  //  think?), instead of just timing out
   @Test(timeout = 60_000)
   public void testSavepointRestorePortable() throws Exception {
     runSavepointAndRestore(true);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
@@ -88,13 +88,13 @@ public class FlinkMetricContainerTest {
   public void testMetricNameGeneration() {
     MetricKey key = MetricKey.create("step", MetricName.named("namespace", "name"));
     String name = getFlinkMetricNameString(key);
-    assertThat(name, is("namespace.name"));
+    assertThat(name, is("step.namespace.name"));
   }
 
   @Test
   public void testCounter() {
     SimpleCounter flinkCounter = new SimpleCounter();
-    when(metricGroup.counter("namespace.name")).thenReturn(flinkCounter);
+    when(metricGroup.counter("step.namespace.name")).thenReturn(flinkCounter);
 
     FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");
@@ -112,7 +112,7 @@ public class FlinkMetricContainerTest {
   public void testGauge() {
     FlinkMetricContainer.FlinkGauge flinkGauge =
         new FlinkMetricContainer.FlinkGauge(GaugeResult.empty());
-    when(metricGroup.gauge(eq("namespace.name"), anyObject())).thenReturn(flinkGauge);
+    when(metricGroup.gauge(eq("step.namespace.name"), anyObject())).thenReturn(flinkGauge);
 
     FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");
@@ -134,13 +134,11 @@ public class FlinkMetricContainerTest {
     MetricsContainer step = container.getMetricsContainer("step");
 
     SimpleCounter userCounter = new SimpleCounter();
-    when(metricGroup.counter("ns1.metric1")).thenReturn(userCounter);
-
-    SimpleCounter elemCounter = new SimpleCounter();
-    when(metricGroup.counter("beam.metric:element_count:v1")).thenReturn(elemCounter);
+    when(metricGroup.counter("step.ns1.metric1")).thenReturn(userCounter);
 
     SimpleMonitoringInfoBuilder userCountBuilder = new SimpleMonitoringInfoBuilder();
     userCountBuilder.setUrnForUserMetric("ns1", "metric1");
+    userCountBuilder.setPTransformLabel("step");
     userCountBuilder.setInt64Value(111);
     MonitoringInfo userCountMonitoringInfo = userCountBuilder.build();
     assertNotNull(userCountMonitoringInfo);
@@ -148,23 +146,19 @@ public class FlinkMetricContainerTest {
     SimpleMonitoringInfoBuilder elemCountBuilder = new SimpleMonitoringInfoBuilder();
     elemCountBuilder.setUrn(ELEMENT_COUNT_URN);
     elemCountBuilder.setInt64Value(222);
-    elemCountBuilder.setPTransformLabel("step");
     elemCountBuilder.setPCollectionLabel("pcoll");
     MonitoringInfo elemCountMonitoringInfo = elemCountBuilder.build();
     assertNotNull(elemCountMonitoringInfo);
 
     assertThat(userCounter.getCount(), is(0L));
-    assertThat(elemCounter.getCount(), is(0L));
-    container.updateMetrics(
-        "step", ImmutableList.of(userCountMonitoringInfo, elemCountMonitoringInfo));
+    container.updateMetrics(ImmutableList.of(userCountMonitoringInfo, elemCountMonitoringInfo));
     assertThat(userCounter.getCount(), is(111L));
-    assertThat(elemCounter.getCount(), is(222L));
   }
 
   @Test
   public void testDropUnexpectedMonitoringInfoTypes() {
     FlinkMetricContainer flinkContainer = new FlinkMetricContainer(runtimeContext);
-    MetricsContainer step = flinkContainer.getMetricsContainer("step");
+    MetricsContainer container = flinkContainer.getMetricsContainer("step");
 
     MonitoringInfo intCounter =
         MonitoringInfo.newBuilder()
@@ -214,53 +208,53 @@ public class FlinkMetricContainerTest {
                                     .setMax(5))))
             .build();
 
-    // Mock out the counter that Flink returns; the distribution gets created by
-    // FlinkMetricContainer, not by Flink itself, so we verify it in a different way below
     SimpleCounter counter = new SimpleCounter();
-    when(metricGroup.counter("ns1.int_counter")).thenReturn(counter);
+    when(metricGroup.counter("step.ns1.int_counter")).thenReturn(counter);
+
+    DistributionData distributionData = DistributionData.create(30, 10, 1, 5);
+    DistributionResult distributionResult = distributionData.extractResult();
+    FlinkDistributionGauge distributionGauge = new FlinkDistributionGauge(distributionResult);
+
+    when(metricGroup.gauge(
+            eq("step.ns3.int_distribution"),
+            argThat(
+                new ArgumentMatcher<FlinkDistributionGauge>() {
+                  @Override
+                  public boolean matches(Object argument) {
+                    DistributionResult actual = ((FlinkDistributionGauge) argument).getValue();
+                    return actual.equals(distributionResult);
+                  }
+                })))
+        .thenReturn(distributionGauge);
 
     flinkContainer.updateMetrics(
-        "step", ImmutableList.of(intCounter, doubleCounter, intDistribution, doubleDistribution));
+        ImmutableList.of(intCounter, doubleCounter, intDistribution, doubleDistribution));
 
     // Flink's MetricGroup should only have asked for one counter (the integer-typed one) to be
     // created (the double-typed one is dropped currently)
-    verify(metricGroup).counter(eq("ns1.int_counter"));
+    verify(metricGroup).counter(eq("step.ns1.int_counter"));
 
     // Verify that the counter injected into flink has the right value
     assertThat(counter.getCount(), is(111L));
 
     // Verify the counter in the java SDK MetricsContainer
     long count =
-        ((CounterCell) step.getCounter(MetricName.named("ns1", "int_counter"))).getCumulative();
+        ((CounterCell) container.getCounter(MetricName.named("ns1", "int_counter")))
+            .getCumulative();
     assertThat(count, is(111L));
 
-    // The one Flink distribution that gets created is a FlinkDistributionGauge; here we verify its
-    // initial (and in this test, final) value
-    verify(metricGroup)
-        .gauge(
-            eq("ns3.int_distribution"),
-            argThat(
-                new ArgumentMatcher<FlinkDistributionGauge>() {
-                  @Override
-                  public boolean matches(Object argument) {
-                    DistributionResult actual = ((FlinkDistributionGauge) argument).getValue();
-                    DistributionResult expected = DistributionResult.create(30, 10, 1, 5);
-                    return actual.equals(expected);
-                  }
-                }));
-
     // Verify that the Java SDK MetricsContainer holds the same information
-    DistributionData distributionData =
-        ((DistributionCell) step.getDistribution(MetricName.named("ns3", "int_distribution")))
+    DistributionData actualDistributionData =
+        ((DistributionCell) container.getDistribution(MetricName.named("ns3", "int_distribution")))
             .getCumulative();
-    assertThat(distributionData, is(DistributionData.create(30, 10, 1, 5)));
+    assertThat(actualDistributionData, is(distributionData));
   }
 
   @Test
   public void testDistribution() {
     FlinkMetricContainer.FlinkDistributionGauge flinkGauge =
         new FlinkMetricContainer.FlinkDistributionGauge(DistributionResult.IDENTITY_ELEMENT);
-    when(metricGroup.gauge(eq("namespace.name"), anyObject())).thenReturn(flinkGauge);
+    when(metricGroup.gauge(eq("step.namespace.name"), anyObject())).thenReturn(flinkGauge);
 
     FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
@@ -131,23 +131,24 @@ public class FlinkMetricContainerTest {
   @Test
   public void testMonitoringInfoUpdate() {
     FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
-    MetricsContainer step = container.getMetricsContainer("step");
 
     SimpleCounter userCounter = new SimpleCounter();
     when(metricGroup.counter("step.ns1.metric1")).thenReturn(userCounter);
 
-    SimpleMonitoringInfoBuilder userCountBuilder = new SimpleMonitoringInfoBuilder();
-    userCountBuilder.setUrnForUserMetric("ns1", "metric1");
-    userCountBuilder.setPTransformLabel("step");
-    userCountBuilder.setInt64Value(111);
-    MonitoringInfo userCountMonitoringInfo = userCountBuilder.build();
+    MonitoringInfo userCountMonitoringInfo =
+        new SimpleMonitoringInfoBuilder()
+            .setUrnForUserMetric("ns1", "metric1")
+            .setPTransformLabel("step")
+            .setInt64Value(111)
+            .build();
     assertNotNull(userCountMonitoringInfo);
 
-    SimpleMonitoringInfoBuilder elemCountBuilder = new SimpleMonitoringInfoBuilder();
-    elemCountBuilder.setUrn(ELEMENT_COUNT_URN);
-    elemCountBuilder.setInt64Value(222);
-    elemCountBuilder.setPCollectionLabel("pcoll");
-    MonitoringInfo elemCountMonitoringInfo = elemCountBuilder.build();
+    MonitoringInfo elemCountMonitoringInfo =
+        new SimpleMonitoringInfoBuilder()
+            .setUrn(ELEMENT_COUNT_URN)
+            .setInt64Value(222)
+            .setPCollectionLabel("pcoll")
+            .build();
     assertNotNull(elemCountMonitoringInfo);
 
     assertThat(userCounter.getCount(), is(0L));
@@ -161,15 +162,17 @@ public class FlinkMetricContainerTest {
     MetricsContainer container = flinkContainer.getMetricsContainer("step");
 
     MonitoringInfo intCounter =
-        MonitoringInfo.newBuilder()
-            .setUrn(USER_COUNTER_URN_PREFIX + "ns1:int_counter")
-            .putLabels(PTRANSFORM_LABEL, "step")
-            .setMetric(
-                Metric.newBuilder().setCounterData(CounterData.newBuilder().setInt64Value(111)))
+        new SimpleMonitoringInfoBuilder()
+            .setUrnForUserMetric("ns1", "int_counter")
+            .setPTransformLabel("step")
+            .setInt64TypeUrn()
+            .setInt64Value(111)
             .build();
 
     MonitoringInfo doubleCounter =
         MonitoringInfo.newBuilder()
+            // TODO(ryan): use SimpleMonitoringInfoBuilder helpers, when double counters are
+            // supported (e.g. with a dedicated "type" value)
             .setUrn(USER_COUNTER_URN_PREFIX + "ns2:double_counter")
             .putLabels(PTRANSFORM_LABEL, "step")
             .setMetric(

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
@@ -104,7 +104,7 @@ public class FlinkMetricContainerTest {
     counter.inc();
 
     assertThat(flinkCounter.getCount(), is(0L));
-    container.updateMetrics("step");
+    container.updateFlinkMetrics("step");
     assertThat(flinkCounter.getCount(), is(2L));
   }
 
@@ -121,10 +121,10 @@ public class FlinkMetricContainerTest {
 
     assertThat(flinkGauge.getValue(), is(GaugeResult.empty()));
     // first set will install the mocked gauge
-    container.updateMetrics("step");
+    container.updateFlinkMetrics("step");
     gauge.set(1);
     gauge.set(42);
-    container.updateMetrics("step");
+    container.updateFlinkMetrics("step");
     assertThat(flinkGauge.getValue().getValue(), is(42L));
   }
 
@@ -269,12 +269,12 @@ public class FlinkMetricContainerTest {
 
     assertThat(flinkGauge.getValue(), is(DistributionResult.IDENTITY_ELEMENT));
     // first set will install the mocked distribution
-    container.updateMetrics("step");
+    container.updateFlinkMetrics("step");
     distribution.update(42);
     distribution.update(-23);
     distribution.update(0);
     distribution.update(1);
-    container.updateMetrics("step");
+    container.updateFlinkMetrics("step");
     assertThat(flinkGauge.getValue().getMax(), is(42L));
     assertThat(flinkGauge.getValue().getMin(), is(-23L));
     assertThat(flinkGauge.getValue().getCount(), is(4L));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricFiltering.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricFiltering.java
@@ -40,7 +40,7 @@ public class MetricFiltering {
   public static boolean matches(MetricsFilter filter, MetricKey key) {
     return filter == null
         || (matchesName(key.metricName(), filter.names())
-            && matchesScope(key.stepName(), filter.steps()));
+            && (key.stepName() == null || matchesScope(key.stepName(), filter.steps())));
   }
 
   /**


### PR DESCRIPTION
This fixes a problem with portable Flink metrics that dates back to #7183: the runner's "step name" is just the name of an executable stage, not the ptransform that metrics are actually part of (which come over the fn API in MIs' "ptransform" label). 

Metrics weren't properly tagged with the ptransform they came from until #7624; it wasn't possible to do the right thing before that.

Versions of these Flink-specific changes exist in both #7915 and #7934, so I'm seeing about factoring them out here; if this is straightforward and can go in first, I can simplify those others by rebasing them on top of this.

R: @mxm, @ajamato 
CC: @robertwb 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
