### PR TITLE
[BEAM-6703] Adds a job running Direct runner's ValidatesRunner with Java 11

### DIFF
--- a/.test-infra/jenkins/job_PostCommit_Java11_ValudatesRunner_Direct.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java11_ValudatesRunner_Direct.groovy
@@ -39,9 +39,7 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java11_ValidatesRunner_Direc
     // Gradle goals for this job.
     def JAVA_JDK_8=tool name: 'JDK 1.8 (latest)', type: 'hudson.model.JDK'
     def JAVA_JDK_11=tool name: 'JDK 11 (latest)', type: 'hudson.model.JDK'
-
-    steps {
-
+    stage('Compile with Java 1.8') {
         withEnv(["Path+JDK=$JAVA_JDK_8/bin","JAVA_HOME=$JAVA_JDK_8"]) {
             gradle {
                 rootBuildScriptDir(commonJobProperties.checkoutDir)
@@ -55,7 +53,9 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java11_ValidatesRunner_Direc
                 commonJobProperties.setGradleSwitches(delegate, 3 * Runtime.runtime.availableProcessors())
             }
         }
+    }
 
+    stage('Run tests with Java 11') {
         withEnv(["Path+JDK=$JAVA_JDK_11/bin","JAVA_HOME=$JAVA_JDK_11"]) {
             gradle {
                 rootBuildScriptDir(commonJobProperties.checkoutDir)

--- a/.test-infra/jenkins/job_PostCommit_Java11_ValudatesRunner_Direct.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java11_ValudatesRunner_Direct.groovy
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonJobProperties as commonJobProperties
+import PostcommitJobBuilder
+
+
+// This job runs the suite of ValidatesRunner tests against the Direct
+// runner using Java 8 to build binaries and JRE 11 to run them.
+PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java11_ValidatesRunner_Direct',
+        'Run Direct ValidatesRunner in Java 11', 'Direct Runner ValidatesRunner Tests for Java 11', this) {
+
+    description('Runs the ValidatesRunner suite on the Direct runner using Java 11.')
+
+    // Set common parameters. Sets a 3 hour timeout.
+    commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 300)
+
+    // Publish all test results to Jenkins
+    publishers {
+        archiveJunit('**/build/test-results/**/*.xml')
+    }
+
+    delegate.jdk('1.8')
+    // Gradle goals for this job.
+    def JAVA_JDK_8=tool name: 'JDK 1.8 (latest)', type: 'hudson.model.JDK'
+    def JAVA_JDK_11=tool name: 'JDK 11 (latest)', type: 'hudson.model.JDK'
+
+    steps {
+
+        withEnv(["Path+JDK=$JAVA_JDK_8/bin","JAVA_HOME=$JAVA_JDK_8"]) {
+            gradle {
+                rootBuildScriptDir(commonJobProperties.checkoutDir)
+                tasks(':beam-runners-direct-java:shadowJar')
+                tasks(':beam-runners-direct-java:shadowTestJar')
+                // Increase parallel worker threads above processor limit since most time is
+                // spent waiting on Dataflow jobs. ValidatesRunner tests on Dataflow are slow
+                // because each one launches a Dataflow job with about 3 mins of overhead.
+                // 3 x num_cores strikes a good balance between maxing out parallelism without
+                // overloading the machines.
+                commonJobProperties.setGradleSwitches(delegate, 3 * Runtime.runtime.availableProcessors())
+            }
+        }
+
+        withEnv(["Path+JDK=$JAVA_JDK_11/bin","JAVA_HOME=$JAVA_JDK_11"]) {
+            gradle {
+                rootBuildScriptDir(commonJobProperties.checkoutDir)
+                tasks(':beam-runners-direct-java:validatesRunner')
+                switches('-x shadowJar')
+                switches('-x shadowTestJar')
+                switches('-x compileJava')
+                switches('-x compileTestJava')
+                switches('-x build')
+                commonJobProperties.setGradleSwitches(delegate, 3 * Runtime.runtime.availableProcessors())
+            }
+        }
+    }
+}

--- a/.test-infra/jenkins/job_PostCommit_Java11_ValudatesRunner_Direct.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java11_ValudatesRunner_Direct.groovy
@@ -19,7 +19,8 @@
 import CommonJobProperties as commonJobProperties
 import PostcommitJobBuilder
 
-
+def JAVA_JDK_8=tool name: 'JDK 1.8 (latest)', type: 'hudson.model.JDK'
+def JAVA_JDK_11=tool name: 'JDK 11 (latest)', type: 'hudson.model.JDK'
 // This job runs the suite of ValidatesRunner tests against the Direct
 // runner using Java 8 to build binaries and JRE 11 to run them.
 PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java11_ValidatesRunner_Direct',
@@ -37,8 +38,7 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java11_ValidatesRunner_Direc
 
     delegate.jdk('1.8')
     // Gradle goals for this job.
-    def JAVA_JDK_8=tool name: 'JDK 1.8 (latest)', type: 'hudson.model.JDK'
-    def JAVA_JDK_11=tool name: 'JDK 11 (latest)', type: 'hudson.model.JDK'
+
     stage('Compile with Java 1.8') {
         withEnv(["Path+JDK=$JAVA_JDK_8/bin","JAVA_HOME=$JAVA_JDK_8"]) {
             gradle {


### PR DESCRIPTION
Added a Jenkins job to run ValidatesRunner test suite on Direct Runner built using Java 8 with Java 11 runtime.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
