### PR TITLE
[BEAM-6731] Move ExpansionService to core-construction-java

### DIFF
--- a/runners/core-construction-java/build.gradle
+++ b/runners/core-construction-java/build.gradle
@@ -51,3 +51,29 @@ dependencies {
   shadowTest project(path: ":beam-model-fn-execution", configuration: "shadow")
 }
 
+task runExpansionService (type: JavaExec) {
+  main = "org.apache.beam.runners.core.construction.expansion.ExpansionService"
+  classpath = sourceSets.main.runtimeClasspath
+  args = [project.findProperty("constructionService.port") ?: "8097"]
+}
+
+task runTestExpansionService (type: JavaExec) {
+  main = "org.apache.beam.runners.core.construction.expansion.TestExpansionService"
+  classpath = sourceSets.test.runtimeClasspath
+  args = [project.findProperty("constructionService.port") ?: "8097"]
+}
+
+task buildTestExpansionServiceJar(type: Jar) {
+  dependsOn = [shadowJar, shadowTestJar]
+  appendix = "testExpansionService"
+  // Use zip64 mode to avoid "Archive contains more than 65535 entries".
+  zip64 = true
+  manifest {
+    attributes(
+            'Main-Class': 'org.apache.beam.runners.core.construction.expansion.TestExpansionService'
+    )
+  }
+  from { configurations.testRuntime.collect { it.isDirectory() ? it : zipTree(it) }}
+  from sourceSets.main.output
+  from sourceSets.test.output
+}

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/expansion/ExpansionServer.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/expansion/ExpansionServer.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.construction.expansion;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.Server;
+import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.netty.NettyServerBuilder;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions;
+
+/** A {@link Server gRPC Server} for an ExpansionService. */
+public class ExpansionServer implements AutoCloseable {
+  /**
+   * Create a {@link ExpansionServer} for the provided ExpansionService running on an arbitrary
+   * port.
+   *
+   * <p>If port is 0, a free port will be assigned.
+   */
+  public static ExpansionServer create(ExpansionService service, String host, int port)
+      throws IOException {
+    return new ExpansionServer(service, host, port);
+  }
+
+  private final String host;
+  private final Server server;
+  private final ExpansionService service;
+
+  private ExpansionServer(ExpansionService service, String host, int port) throws IOException {
+    this.service = Preconditions.checkNotNull(service);
+    this.host = Preconditions.checkNotNull(host);
+    this.server =
+        NettyServerBuilder.forAddress(new InetSocketAddress(host, port))
+            .addService(service)
+            .build()
+            .start();
+  }
+
+  /** Get the ExpansionService exposed by this {@link ExpansionServer}. */
+  public ExpansionService getService() {
+    return service;
+  }
+
+  /** Get the host that this {@link ExpansionServer} is bound to. */
+  public String getHost() {
+    return host;
+  }
+
+  /** Get the port that this {@link ExpansionServer} is bound to. */
+  public int getPort() {
+    return server.getPort();
+  }
+
+  @Override
+  public void close() throws Exception {
+    try {
+      // The server has been closed, and should not respond to any new incoming calls.
+      server.shutdown();
+      service.close();
+      server.awaitTermination(60, TimeUnit.SECONDS);
+    } finally {
+      server.shutdownNow();
+      server.awaitTermination();
+    }
+  }
+}

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/expansion/ExpansionService.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/expansion/ExpansionService.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.fnexecution.expansion;
+package org.apache.beam.runners.core.construction.expansion;
 
 import com.google.auto.service.AutoService;
 import java.io.IOException;
@@ -32,7 +32,6 @@ import org.apache.beam.runners.core.construction.Environments;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.SdkComponents;
-import org.apache.beam.runners.fnexecution.FnService;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
@@ -52,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 /** A service that allows pipeline expand transforms from a remote SDK. */
 public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplBase
-    implements FnService {
+    implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExpansionService.class);
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/expansion/package-info.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/expansion/package-info.java
@@ -17,4 +17,4 @@
  */
 
 /** Classes used to expand cross-language transforms. */
-package org.apache.beam.runners.fnexecution.expansion;
+package org.apache.beam.runners.core.construction.expansion;

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/expansion/ExpansionServiceTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/expansion/ExpansionServiceTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.fnexecution.expansion;
+package org.apache.beam.runners.core.construction.expansion;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -35,7 +35,7 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterables;
 import org.junit.Test;
 
-/** Tests for {@link org.apache.beam.runners.fnexecution.expansion.ExpansionService}. */
+/** Tests for {@link ExpansionService}. */
 public class ExpansionServiceTest {
 
   private static final String TEST_URN = "test:beam:transforms:count";

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/expansion/TestExpansionService.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/expansion/TestExpansionService.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.fnexecution.expansion;
+package org.apache.beam.runners.core.construction.expansion;
 
 import com.google.auto.service.AutoService;
 import java.util.Map;
@@ -25,7 +25,9 @@ import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.Server;
 import org.apache.beam.vendor.grpc.v1p13p1.io.grpc.ServerBuilder;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
 
-/** An {@link ExpansionService} useful for tests. */
+/**
+ * An {@link org.apache.beam.runners.core.construction.expansion.ExpansionService} useful for tests.
+ */
 public class TestExpansionService {
 
   private static final String TEST_COUNT_URN = "pytest:beam:transforms:count";

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
@@ -89,25 +89,21 @@ public class FlinkJobServerDriver extends JobServerDriver {
     return create(
         configuration,
         createJobServerFactory(configuration),
-        createArtifactServerFactory(configuration),
-        createExpansionServerFactory(configuration));
+        createArtifactServerFactory(configuration));
   }
 
   public static FlinkJobServerDriver create(
       FlinkServerConfiguration configuration,
       ServerFactory jobServerFactory,
-      ServerFactory artifactServerFactory,
-      ServerFactory expansionServerFactory) {
-    return new FlinkJobServerDriver(
-        configuration, jobServerFactory, artifactServerFactory, expansionServerFactory);
+      ServerFactory artifactServerFactory) {
+    return new FlinkJobServerDriver(configuration, jobServerFactory, artifactServerFactory);
   }
 
   private FlinkJobServerDriver(
       FlinkServerConfiguration configuration,
       ServerFactory jobServerFactory,
-      ServerFactory artifactServerFactory,
-      ServerFactory expansionServerFactory) {
-    super(configuration, jobServerFactory, artifactServerFactory, expansionServerFactory);
+      ServerFactory artifactServerFactory) {
+    super(configuration, jobServerFactory, artifactServerFactory);
   }
 
   @Override

--- a/runners/java-fn-execution/build.gradle
+++ b/runners/java-fn-execution/build.gradle
@@ -58,30 +58,3 @@ task testDocker(type: Test) {
     includeCategories "org.apache.beam.runners.fnexecution.environment.testing.NeedsDocker"
   }
 }
-
-task runExpansionService (type: JavaExec) {
-  main = "org.apache.beam.runners.fnexecution.expansion.ExpansionService"
-  classpath = sourceSets.main.runtimeClasspath
-  args = [project.findProperty("constructionService.port") ?: "8097"]
-}
-
-task runTestExpansionService (type: JavaExec) {
-  main = "org.apache.beam.runners.fnexecution.expansion.TestExpansionService"
-  classpath = sourceSets.test.runtimeClasspath
-  args = [project.findProperty("constructionService.port") ?: "8097"]
-}
-
-task buildTestExpansionServiceJar(type: Jar) {
-  dependsOn = [shadowJar, shadowTestJar]
-  appendix = "testExpansionService"
-  // Use zip64 mode to avoid "Archive contains more than 65535 entries".
-  zip64 = true
-  manifest {
-    attributes(
-            'Main-Class': 'org.apache.beam.runners.fnexecution.expansion.TestExpansionService'
-    )
-  }
-  from { configurations.testRuntime.collect { it.isDirectory() ? it : zipTree(it) }}
-  from sourceSets.main.output
-  from sourceSets.test.output
-}

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -210,7 +210,7 @@ task portableWordCount {
 def portableWordCountTask(name, streaming, crossLanguage) {
   tasks.create(name) {
     dependsOn = ['installGcpTest']
-    mustRunAfter = [':beam-runners-flink_2.11-job-server-container:docker', ':beam-sdks-python-container:docker', ':beam-sdks-java-container:docker', ':beam-runners-java-fn-execution:buildTestExpansionServiceJar']
+    mustRunAfter = [':beam-runners-flink_2.11-job-server-container:docker', ':beam-sdks-python-container:docker', ':beam-sdks-java-container:docker', ':beam-runners-core-construction-java:buildTestExpansionServiceJar']
     doLast {
       // TODO: Figure out GCS credentials and use real GCS input and output.
       def options = [
@@ -227,7 +227,7 @@ def portableWordCountTask(name, streaming, crossLanguage) {
         // workaround for local file output in docker container
         options += ["--environment_cache_millis=10000"]
       if (crossLanguage)
-        options += ["--expansion_service_jar=${project(":beam-runners-java-fn-execution:").buildTestExpansionServiceJar.archivePath}"]
+        options += ["--expansion_service_jar=${project(":beam-runners-core-construction-java:").buildTestExpansionServiceJar.archivePath}"]
       if (project.hasProperty("jobEndpoint"))
         options += ["--job_endpoint=${project.property('jobEndpoint')}"]
       def wordcountMain = crossLanguage ? "apache_beam.examples.wordcount_xlang" : "apache_beam.examples.wordcount"
@@ -455,11 +455,11 @@ project.task('createProcessWorker') {
 project.task('crossLanguagePythonJava') {
   dependsOn 'setupVirtualenv'
   dependsOn ':beam-sdks-java-container:docker'
-  dependsOn ':beam-runners-java-fn-execution:buildTestExpansionServiceJar'
+  dependsOn ':beam-runners-core-construction-java:buildTestExpansionServiceJar'
   doLast {
     exec {
       executable 'sh'
-      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.transforms.external_test --expansion_service_jar=${project(":beam-runners-java-fn-execution:").buildTestExpansionServiceJar.archivePath}"
+      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.transforms.external_test --expansion_service_jar=${project(":beam-runners-core-construction-java:").buildTestExpansionServiceJar.archivePath}"
     }
   }
 }


### PR DESCRIPTION
This moves the previously relocated ExpansionService back to core-construction-java. 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
