### PR TITLE
[BEAM-6754] Use subprocess instead of threads in loopback environment

### DIFF
--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -17,11 +17,13 @@
 
 from __future__ import absolute_import
 
+import atexit
 import functools
 import itertools
 import json
 import logging
 import os
+import subprocess
 import threading
 import time
 from concurrent import futures
@@ -160,9 +162,13 @@ class PortableRunner(runner.PipelineRunner):
     # This is needed as we start a worker server if one is requested
     # but none is provided.
     if portable_options.environment_type == 'LOOPBACK':
+      use_loopback_process_worker = options.view_as(
+          DebugOptions).lookup_experiment(
+              'use_loopback_process_worker', False)
       portable_options.environment_config, server = (
           BeamFnExternalWorkerPoolServicer.start(
-              sdk_worker_main._get_worker_count(options)))
+              sdk_worker_main._get_worker_count(options),
+              use_process=use_loopback_process_worker))
       globals()['x'] = server
       cleanup_callbacks = [functools.partial(server.stop, 1)]
     else:
@@ -431,29 +437,45 @@ class PipelineResult(runner.PipelineResult):
 class BeamFnExternalWorkerPoolServicer(
     beam_fn_api_pb2_grpc.BeamFnExternalWorkerPoolServicer):
 
-  def __init__(self, worker_threads):
+  def __init__(self, worker_threads, use_process=False):
     self._worker_threads = worker_threads
+    self._use_process = use_process
 
   @classmethod
-  def start(cls, worker_threads=1):
+  def start(cls, worker_threads=1, use_process=False):
     worker_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     worker_address = 'localhost:%s' % worker_server.add_insecure_port('[::]:0')
     beam_fn_api_pb2_grpc.add_BeamFnExternalWorkerPoolServicer_to_server(
-        cls(worker_threads), worker_server)
+        cls(worker_threads, use_process=use_process), worker_server)
     worker_server.start()
     return worker_address, worker_server
 
   def NotifyRunnerAvailable(self, start_worker_request, context):
     try:
-      worker = sdk_worker.SdkHarness(
-          start_worker_request.control_endpoint.url,
-          worker_count=self._worker_threads,
-          worker_id=start_worker_request.worker_id)
-      worker_thread = threading.Thread(
-          name='run_worker_%s' % start_worker_request.worker_id,
-          target=worker.run)
-      worker_thread.daemon = True
-      worker_thread.start()
+      if self._use_process:
+        command = ['python', '-c',
+                   'from apache_beam.runners.worker.sdk_worker '
+                   'import SdkHarness; '
+                   'SdkHarness("%s",worker_count=%d,worker_id="%s").run()' % (
+                       start_worker_request.control_endpoint.url,
+                       self._worker_threads,
+                       start_worker_request.worker_id)]
+        logging.warn("Starting worker with command %s" % (command))
+        worker_process = subprocess.Popen(command, stdout=subprocess.PIPE)
+
+        # Register to kill the subprocess on exit.
+        atexit.register(worker_process.kill)
+      else:
+        worker = sdk_worker.SdkHarness(
+            start_worker_request.control_endpoint.url,
+            worker_count=self._worker_threads,
+            worker_id=start_worker_request.worker_id)
+        worker_thread = threading.Thread(
+            name='run_worker_%s' % start_worker_request.worker_id,
+            target=worker.run)
+        worker_thread.daemon = True
+        worker_thread.start()
+
       return beam_fn_api_pb2.NotifyRunnerAvailableResponse()
     except Exception as exn:
       return beam_fn_api_pb2.NotifyRunnerAvailableResponse(


### PR DESCRIPTION
To Take advantage of multi cores, we need to start separate processes to for worker harness.
Using subprocess instead of threads to run the sdk harness.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
