### PR TITLE
[BEAM-6751] Add KafkaIO EOS support to Flink via @RequiresStableInput

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -88,6 +88,7 @@ dependencies {
   shadow project(path: ":beam-runners-core-java", configuration: "shadow")
   shadow project(path: ":beam-runners-core-construction-java", configuration: "shadow")
   shadow project(path: ":beam-runners-java-fn-execution", configuration: "shadow")
+  shadow project(path: ":beam-sdks-java-build-tools", configuration: "shadow")
   shadow library.java.vendored_grpc_1_13_1
   shadow library.java.jackson_annotations
   shadow library.java.slf4j_api

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkTransformOverrides.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkTransformOverrides.java
@@ -25,7 +25,6 @@ import org.apache.beam.runners.core.construction.PTransformMatchers;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.SplittableParDo;
 import org.apache.beam.runners.core.construction.SplittableParDoNaiveBounded;
-import org.apache.beam.runners.core.construction.UnsupportedOverrideFactory;
 import org.apache.beam.sdk.runners.PTransformOverride;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
@@ -35,12 +34,6 @@ class FlinkTransformOverrides {
   static List<PTransformOverride> getDefaultOverrides(FlinkPipelineOptions options) {
     ImmutableList.Builder<PTransformOverride> builder = ImmutableList.builder();
     builder
-        // TODO: [BEAM-5359] Support @RequiresStableInput on Flink runner
-        .add(
-            PTransformOverride.of(
-                PTransformMatchers.requiresStableInputParDoMulti(),
-                UnsupportedOverrideFactory.withMessage(
-                    "Flink runner currently doesn't support @RequiresStableInput annotation.")))
         .add(
             PTransformOverride.of(
                 PTransformMatchers.splittableParDo(), new SplittableParDo.OverrideFactory()))

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -58,6 +58,7 @@ import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.metrics.DoFnRunnerWithMetricsUpdate;
 import org.apache.beam.runners.flink.translation.types.CoderTypeSerializer;
 import org.apache.beam.runners.flink.translation.utils.FlinkClassloading;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput.BufferingDoFnRunner;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkBroadcastStateInternals;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkSplitStateInternals;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateInternals;
@@ -73,6 +74,7 @@ import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
 import org.apache.beam.sdk.transforms.join.RawUnionValue;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
@@ -91,6 +93,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
@@ -104,6 +107,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
 import org.joda.time.Instant;
 
 /**
@@ -133,6 +137,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
 
   protected transient DoFnRunner<InputT, OutputT> doFnRunner;
   protected transient PushbackSideInputDoFnRunner<InputT, OutputT> pushbackDoFnRunner;
+  protected transient BufferingDoFnRunner<InputT, OutputT> bufferingDoFnRunner;
 
   protected transient SideInputHandler sideInputHandler;
 
@@ -171,6 +176,9 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
 
   private final DoFnSchemaInformation doFnSchemaInformation;
 
+  /** If true, we must process elements only after a checkpoint is finished. */
+  private final boolean requiresStableInput;
+
   protected transient InternalTimerService<TimerData> timerService;
 
   protected transient FlinkTimerInternals timerInternals;
@@ -190,6 +198,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
   /** Callback to be executed after the current bundle was finshed. */
   private transient Runnable bundleFinishedCallback;
 
+  /** Constructor for DoFnOperator. */
   public DoFnOperator(
       DoFn<InputT, OutputT> doFn,
       String stepName,
@@ -232,6 +241,25 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
     this.maxBundleSize = flinkOptions.getMaxBundleSize();
     this.maxBundleTimeMills = flinkOptions.getMaxBundleTimeMills();
     this.doFnSchemaInformation = doFnSchemaInformation;
+
+    this.requiresStableInput =
+        // WindowDoFnOperator does not use a DoFn
+        doFn != null
+            && DoFnSignatures.getSignature(doFn.getClass()).processElement().requiresStableInput();
+
+    if (requiresStableInput) {
+      Preconditions.checkState(
+          flinkOptions.getCheckpointingMode() == CheckpointingMode.EXACTLY_ONCE,
+          "Checkpointing mode is not set to exactly once but @RequiresStableInput is used.");
+      Preconditions.checkState(
+          flinkOptions.getCheckpointingInterval() > 0,
+          "No checkpointing configured but pipeline uses @RequiresStableInput");
+      LOG.warn(
+          "Enabling stable input for transform {}. Will only process elements at most every {} milliseconds.",
+          stepName,
+          flinkOptions.getCheckpointingInterval()
+              + Math.max(0, flinkOptions.getMinPauseBetweenCheckpoints()));
+    }
   }
 
   // allow overriding this in WindowDoFnOperator because this one dynamically creates
@@ -363,6 +391,18 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
             windowingStrategy,
             doFnSchemaInformation);
 
+    if (requiresStableInput) {
+      // put this in front of the root FnRunner before any additional wrappers
+      doFnRunner =
+          bufferingDoFnRunner =
+              BufferingDoFnRunner.create(
+                  doFnRunner,
+                  "stable-input-buffer",
+                  windowedInputCoder,
+                  windowingStrategy.getWindowFn().windowCoder(),
+                  getOperatorStateBackend(),
+                  getKeyedStateBackend());
+    }
     doFnRunner = createWrappingDoFnRunner(doFnRunner);
 
     if (options.getEnableMetrics()) {
@@ -464,7 +504,8 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
   }
 
   @Override
-  public final void processElement(StreamRecord<WindowedValue<InputT>> streamRecord) {
+  public final void processElement(StreamRecord<WindowedValue<InputT>> streamRecord)
+      throws Exception {
     checkInvokeStartBundle();
     doFnRunner.processElement(streamRecord.getValue());
     checkInvokeFinishBundleByCount();
@@ -551,9 +592,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
 
   @Override
   public void processWatermark1(Watermark mark) throws Exception {
-
     checkInvokeStartBundle();
-
     // We do the check here because we are guaranteed to at least get the +Inf watermark on the
     // main input when the job finishes.
     if (currentSideInputWatermark >= BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
@@ -563,16 +602,15 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       emitAllPushedBackData();
     }
 
+    setCurrentInputWatermark(mark.getTimestamp());
+
     if (keyCoder == null) {
-      setCurrentInputWatermark(mark.getTimestamp());
       long potentialOutputWatermark = Math.min(getPushbackWatermarkHold(), currentInputWatermark);
       if (potentialOutputWatermark > currentOutputWatermark) {
         setCurrentOutputWatermark(potentialOutputWatermark);
         emitWatermark(currentOutputWatermark);
       }
     } else {
-      setCurrentInputWatermark(mark.getTimestamp());
-
       // hold back by the pushed back values waiting for side inputs
       long pushedBackInputWatermark = Math.min(getPushbackWatermarkHold(), mark.getTimestamp());
 
@@ -695,16 +733,30 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
   }
 
   @Override
-  public void snapshotState(StateSnapshotContext context) throws Exception {
+  public final void snapshotState(StateSnapshotContext context) throws Exception {
+    if (requiresStableInput) {
+      // We notify the BufferingDoFnRunner to associate buffered state with this
+      // snapshot id and start a new buffer for elements arriving after this snapshot.
+      bufferingDoFnRunner.checkpoint(context.getCheckpointId());
+    }
 
-    // Forced finish a bundle in checkpoint barrier otherwise may lose data.
-    // Careful, it use OperatorState or KeyGroupState to store outputs, So it
-    // must be called before their snapshot.
+    // We can't output here anymore because the checkpoint barrier has already been
+    // sent downstream. This is going to change with 1.6/1.7's prepareSnapshotBarrier.
     outputManager.openBuffer();
     invokeFinishBundle();
     outputManager.closeBuffer();
 
     super.snapshotState(context);
+  }
+
+  @Override
+  public final void notifyCheckpointComplete(long checkpointId) throws Exception {
+    super.notifyCheckpointComplete(checkpointId);
+    if (requiresStableInput) {
+      // We can now release all buffered data which was held back for
+      // @RequiresStableInput guarantees.
+      bufferingDoFnRunner.checkpointCompleted(checkpointId);
+    }
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferedElement.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferedElement.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import org.apache.beam.runners.core.DoFnRunner;
+
+/** An interface for elements buffered during a checkpoint when using @RequiresStableInput. */
+public interface BufferedElement {
+
+  /** Processes this element with the provided DoFnRunner. */
+  <InputT, OutputT> void processWith(DoFnRunner<InputT, OutputT> doFnRunner);
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferedElements.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferedElements.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.apache.beam.runners.core.DoFnRunner;
+import org.apache.beam.sdk.coders.InstantCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.joda.time.Instant;
+
+/** Elements which can be buffered as part of a checkpoint for @RequiresStableInput. */
+class BufferedElements {
+
+  static final class Element implements BufferedElement {
+    private final WindowedValue element;
+
+    Element(WindowedValue element) {
+      this.element = element;
+    }
+
+    @Override
+    public void processWith(DoFnRunner doFnRunner) {
+      doFnRunner.processElement(element);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Element element1 = (Element) o;
+      return element.equals(element1.element);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(element);
+    }
+  }
+
+  static final class Timer implements BufferedElement {
+
+    private final String timerId;
+    private final BoundedWindow window;
+    private final Instant timestamp;
+    private final TimeDomain timeDomain;
+
+    Timer(String timerId, BoundedWindow window, Instant timestamp, TimeDomain timeDomain) {
+      this.timerId = timerId;
+      this.window = window;
+      this.timestamp = timestamp;
+      this.timeDomain = timeDomain;
+    }
+
+    @Override
+    public void processWith(DoFnRunner doFnRunner) {
+      doFnRunner.onTimer(timerId, window, timestamp, timeDomain);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Timer timer = (Timer) o;
+      return timerId.equals(timer.timerId)
+          && window.equals(timer.window)
+          && timestamp.equals(timer.timestamp)
+          && timeDomain == timer.timeDomain;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(timerId, window, timestamp, timeDomain);
+    }
+  }
+
+  static class Coder extends org.apache.beam.sdk.coders.Coder<BufferedElement> {
+
+    private static final StringUtf8Coder STRING_CODER = StringUtf8Coder.of();
+    private static final InstantCoder INSTANT_CODER = InstantCoder.of();
+    private static final int ELEMENT_MAGIC_BYTE = 0;
+    private static final int TIMER_MAGIC_BYTE = 1;
+
+    private final org.apache.beam.sdk.coders.Coder<WindowedValue> elementCoder;
+    private final org.apache.beam.sdk.coders.Coder<BoundedWindow> windowCoder;
+
+    public Coder(
+        org.apache.beam.sdk.coders.Coder<WindowedValue> elementCoder,
+        org.apache.beam.sdk.coders.Coder<BoundedWindow> windowCoder) {
+      this.elementCoder = elementCoder;
+      this.windowCoder = windowCoder;
+    }
+
+    @Override
+    public void encode(BufferedElement value, OutputStream outStream) throws IOException {
+      if (value instanceof Element) {
+        outStream.write(ELEMENT_MAGIC_BYTE);
+        elementCoder.encode(((Element) value).element, outStream);
+      } else if (value instanceof Timer) {
+        outStream.write(TIMER_MAGIC_BYTE);
+        Timer timer = (Timer) value;
+        STRING_CODER.encode(timer.timerId, outStream);
+        windowCoder.encode(timer.window, outStream);
+        INSTANT_CODER.encode(timer.timestamp, outStream);
+        outStream.write(timer.timeDomain.ordinal());
+      } else {
+        throw new IllegalStateException("Unexpected element " + value);
+      }
+    }
+
+    @Override
+    public BufferedElement decode(InputStream inStream) throws IOException {
+      int firstByte = inStream.read();
+      switch (firstByte) {
+        case ELEMENT_MAGIC_BYTE:
+          return new Element(elementCoder.decode(inStream));
+        case TIMER_MAGIC_BYTE:
+          return new Timer(
+              STRING_CODER.decode(inStream),
+              windowCoder.decode(inStream),
+              INSTANT_CODER.decode(inStream),
+              TimeDomain.values()[inStream.read()]);
+        default:
+          throw new IllegalStateException(
+              "Unexpected byte while reading BufferedElement: " + firstByte);
+      }
+    }
+
+    @Override
+    public List<? extends org.apache.beam.sdk.coders.Coder<?>> getCoderArguments() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public void verifyDeterministic() {}
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunner.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.apache.beam.runners.core.DoFnRunner;
+import org.apache.beam.runners.flink.translation.types.CoderTypeSerializer;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.joda.time.Instant;
+
+/**
+ * A {@link DoFnRunner} which buffers data for supporting {@link
+ * org.apache.beam.sdk.transforms.DoFn.RequiresStableInput}.
+ *
+ * <p>When a DoFn is annotated with @RequiresStableInput we are only allowed to process elements
+ * after a checkpoint has completed. This ensures that the input is stable and we produce idempotent
+ * results on failures.
+ */
+public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, OutputT> {
+
+  public static <InputT, OutputT> BufferingDoFnRunner<InputT, OutputT> create(
+      DoFnRunner<InputT, OutputT> doFnRunner,
+      String stateName,
+      org.apache.beam.sdk.coders.Coder windowedInputCoder,
+      org.apache.beam.sdk.coders.Coder windowCoder,
+      OperatorStateBackend operatorStateBackend,
+      @Nullable KeyedStateBackend<Object> keyedStateBackend)
+      throws Exception {
+    return new BufferingDoFnRunner<>(
+        doFnRunner,
+        stateName,
+        windowedInputCoder,
+        windowCoder,
+        operatorStateBackend,
+        keyedStateBackend);
+  }
+
+  /** The underlying DoFnRunner that any buffered data will be handed over to eventually. */
+  private final DoFnRunner<InputT, OutputT> underlying;
+  /** A union list state which contains all to-be-acknowledged snapshot ids. */
+  private final ListState<CheckpointElement> notYetAcknowledgedSnapshots;
+  /** A factory for constructing new BufferingElementsHandler scoped by an internal id. */
+  private final BufferingElementsHandlerFactory bufferingElementsHandlerFactory;
+
+  /** The current active state id which is later linked to a checkpoint id. */
+  private String currentStateId;
+  /** The current handler used for buffering. */
+  private BufferingElementsHandler currentBufferingElementsHandler;
+
+  private BufferingDoFnRunner(
+      DoFnRunner<InputT, OutputT> underlying,
+      String stateName,
+      org.apache.beam.sdk.coders.Coder inputCoder,
+      org.apache.beam.sdk.coders.Coder windowCoder,
+      OperatorStateBackend operatorStateBackend,
+      @Nullable KeyedStateBackend keyedStateBackend)
+      throws Exception {
+
+    this.underlying = underlying;
+    this.notYetAcknowledgedSnapshots =
+        operatorStateBackend.getUnionListState(
+            new ListStateDescriptor<>("notYetAcknowledgedSnapshots", CheckpointElement.class));
+    this.bufferingElementsHandlerFactory =
+        (stateId) -> {
+          ListStateDescriptor<BufferedElement> stateDescriptor =
+              new ListStateDescriptor<>(
+                  stateName + stateId,
+                  new CoderTypeSerializer<>(new BufferedElements.Coder(inputCoder, windowCoder)));
+          if (keyedStateBackend != null) {
+            return KeyedBufferingElementsHandler.create(keyedStateBackend, stateDescriptor);
+          } else {
+            return NonKeyedBufferingElementsHandler.create(
+                operatorStateBackend.getListState(stateDescriptor));
+          }
+        };
+    this.currentStateId = generateNewId();
+    this.currentBufferingElementsHandler = bufferingElementsHandlerFactory.get(currentStateId);
+  }
+
+  @Override
+  public void startBundle() {
+    // Do not start a bundle, start it later when emitting elements
+  }
+
+  @Override
+  public void processElement(WindowedValue<InputT> elem) {
+    currentBufferingElementsHandler.buffer(new BufferedElements.Element(elem));
+  }
+
+  @Override
+  public void onTimer(
+      String timerId, BoundedWindow window, Instant timestamp, TimeDomain timeDomain) {
+    currentBufferingElementsHandler.buffer(
+        new BufferedElements.Timer(timerId, window, timestamp, timeDomain));
+  }
+
+  @Override
+  public void finishBundle() {
+    // Do not finish a bundle, finish it later when emitting elements
+  }
+
+  @Override
+  public DoFn<InputT, OutputT> getFn() {
+    return underlying.getFn();
+  }
+
+  /** Should be called when a checkpoint is created. */
+  public void checkpoint(long checkpointId) throws Exception {
+    // We are about to get checkpointed. The elements buffered thus far
+    // have to be added to the global CheckpointElement state which will
+    // be used to emit elements later when this checkpoint is acknowledged.
+    addToBeAcknowledgedCheckpoint(checkpointId, currentStateId);
+    currentStateId = generateNewId();
+    currentBufferingElementsHandler = bufferingElementsHandlerFactory.get(currentStateId);
+  }
+
+  /** Should be called when a checkpoint is completed. */
+  public void checkpointCompleted(long checkpointId) throws Exception {
+    List<CheckpointElement> toAck = removeToBeAcknowledgedCheckpoints(checkpointId);
+    for (CheckpointElement toBeAcked : toAck) {
+      BufferingElementsHandler bufferingElementsHandler =
+          bufferingElementsHandlerFactory.get(toBeAcked.internalId);
+      Iterator<BufferedElement> iterator = bufferingElementsHandler.getElements().iterator();
+      boolean hasElements = iterator.hasNext();
+      if (hasElements) {
+        underlying.startBundle();
+      }
+      while (iterator.hasNext()) {
+        BufferedElement bufferedElement = iterator.next();
+        bufferedElement.processWith(underlying);
+      }
+      if (hasElements) {
+        underlying.finishBundle();
+      }
+      bufferingElementsHandler.clear();
+    }
+  }
+
+  private void addToBeAcknowledgedCheckpoint(long checkpointId, String internalId)
+      throws Exception {
+    notYetAcknowledgedSnapshots.addAll(
+        Collections.singletonList(new CheckpointElement(internalId, checkpointId)));
+  }
+
+  private List<CheckpointElement> removeToBeAcknowledgedCheckpoints(long checkpointId)
+      throws Exception {
+    List<CheckpointElement> toBeAcknowledged = new ArrayList<>();
+    List<CheckpointElement> checkpoints = new ArrayList<>();
+    for (CheckpointElement element : notYetAcknowledgedSnapshots.get()) {
+      if (element.checkpointId <= checkpointId) {
+        toBeAcknowledged.add(element);
+      } else {
+        checkpoints.add(element);
+      }
+    }
+    notYetAcknowledgedSnapshots.update(checkpoints);
+    // Sort by checkpoint id to preserve order
+    toBeAcknowledged.sort(Comparator.comparingLong(o -> o.checkpointId));
+    return toBeAcknowledged;
+  }
+
+  private static String generateNewId() {
+    return UUID.randomUUID().toString();
+  }
+
+  /** Constructs a new instance of BufferingElementsHandler with a provided state namespace. */
+  private interface BufferingElementsHandlerFactory {
+    BufferingElementsHandler get(String stateId) throws Exception;
+  }
+
+  private static class CheckpointElement {
+
+    final String internalId;
+    final long checkpointId;
+
+    CheckpointElement(String internalId, long checkpointId) {
+      this.internalId = internalId;
+      this.checkpointId = checkpointId;
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingElementsHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import java.util.stream.Stream;
+
+/**
+ * A handler for buffering elements which cannot be processed yet because {@link
+ * org.apache.beam.sdk.transforms.DoFn.RequiresStableInput} is used and a checkpoint is currently
+ * pending.
+ *
+ * <p>When a DoFn is annotated with @RequiresStableInput we are only allowed to process elements
+ * after a checkpoint has completed. This ensures that the input is stable and we produce idempotent
+ * results on failures.
+ */
+interface BufferingElementsHandler {
+
+  /** Returns all buffered elements. */
+  Stream<BufferedElement> getElements();
+
+  /** Adds the given element to the buffered elements. */
+  void buffer(BufferedElement element);
+
+  /** Clears buffered elements. */
+  void clear();
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/KeyedBufferingElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/KeyedBufferingElementsHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+
+/** A keyed implementation of a {@link BufferingElementsHandler}. */
+public class KeyedBufferingElementsHandler implements BufferingElementsHandler {
+
+  static KeyedBufferingElementsHandler create(
+      KeyedStateBackend backend, ListStateDescriptor<BufferedElement> stateDescriptor) {
+    return new KeyedBufferingElementsHandler(backend, stateDescriptor);
+  }
+
+  private final KeyedStateBackend backend;
+  private final ListStateDescriptor<BufferedElement> stateDescriptor;
+
+  private KeyedBufferingElementsHandler(
+      KeyedStateBackend backend, ListStateDescriptor<BufferedElement> stateDescriptor) {
+    this.backend = backend;
+    this.stateDescriptor = stateDescriptor;
+  }
+
+  @Override
+  public void buffer(BufferedElement element) {
+    try {
+      ListState<BufferedElement> state =
+          (ListState<BufferedElement>)
+              backend.getPartitionedState(
+                  VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+
+      // assumes state backend is already keyed
+      state.add(element);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to buffer element in state backend." + element, e);
+    }
+  }
+
+  @Override
+  public Stream<BufferedElement> getElements() {
+    return backend
+        .getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
+        .flatMap(
+            key -> {
+              try {
+                backend.setCurrentKey(key);
+
+                ListState<BufferedElement> state =
+                    (ListState<BufferedElement>)
+                        backend.getPartitionedState(
+                            VoidNamespace.INSTANCE,
+                            VoidNamespaceSerializer.INSTANCE,
+                            stateDescriptor);
+
+                return StreamSupport.stream(state.get().spliterator(), false);
+              } catch (Exception e) {
+                throw new RuntimeException(
+                    "Failed to retrieve buffered element from state backend.", e);
+              }
+            });
+  }
+
+  @Override
+  public void clear() {
+    List keys =
+        (List)
+            backend
+                .getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
+                .collect(Collectors.toList());
+
+    try {
+      for (Object key : keys) {
+        backend.setCurrentKey(key);
+
+        ListState<BufferedElement> state =
+            (ListState<BufferedElement>)
+                backend.getPartitionedState(
+                    VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+
+        state.clear();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to clear buffered element state", e);
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/NonKeyedBufferingElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/NonKeyedBufferingElementsHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.flink.api.common.state.ListState;
+
+/** A non-keyed implementation of a {@link BufferingElementsHandler}. */
+public class NonKeyedBufferingElementsHandler<T> implements BufferingElementsHandler {
+
+  static <T> NonKeyedBufferingElementsHandler<T> create(ListState<BufferedElement> elementState) {
+    return new NonKeyedBufferingElementsHandler<>(elementState);
+  }
+
+  private final ListState<BufferedElement> elementState;
+
+  private NonKeyedBufferingElementsHandler(ListState<BufferedElement> elementState) {
+    this.elementState = checkNotNull(elementState);
+  }
+
+  @Override
+  public Stream<BufferedElement> getElements() {
+    try {
+      return StreamSupport.stream(elementState.get().spliterator(), false);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to retrieve buffered element from state backend.", e);
+    }
+  }
+
+  @Override
+  public void buffer(BufferedElement element) {
+    try {
+      elementState.add(element);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to buffer element in state backend.", e);
+    }
+  }
+
+  @Override
+  public void clear() {
+    elementState.clear();
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/package-info.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Classes for buffering elements for achieving @RequiresStableInput. */
+@ParametersAreNonnullByDefault
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/package-info.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/package-info.java
@@ -17,7 +17,8 @@
  */
 
 /** Classes for buffering elements for achieving @RequiresStableInput. */
-@ParametersAreNonnullByDefault
+@DefaultAnnotation(NonnullByDefault.class)
 package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import org.apache.beam.buildtools.NonnullByDefault;

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkRequiresStableInputTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkRequiresStableInputTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.RequiresStableInputIT;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.FileChecksumMatcher;
+import org.apache.beam.sdk.testing.SerializableMatchers;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.util.FilePatternMatchingShardedFile;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests {@link org.apache.beam.sdk.transforms.DoFn.RequiresStableInput} with Flink. */
+public class FlinkRequiresStableInputTest {
+
+  @ClassRule public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static CountDownLatch latch;
+
+  private static final String VALUE = "value";
+  // SHA-1 hash of string "value"
+  private static final String VALUE_CHECKSUM = "f32b67c7e26342af42efabc674d441dca0a281c5";
+
+  private static transient MiniCluster flinkCluster;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    final int parallelism = 1;
+
+    Configuration config = new Configuration();
+    // Avoid port collision in parallel tests
+    config.setInteger(RestOptions.PORT, 0);
+    config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+    // It is necessary to configure the checkpoint directory for the state backend,
+    // even though we only create savepoints in this test.
+    config.setString(
+        CheckpointingOptions.CHECKPOINTS_DIRECTORY,
+        "file://" + tempFolder.getRoot().getAbsolutePath());
+    // Checkpoints will go into a subdirectory of this directory
+    config.setString(
+        CheckpointingOptions.SAVEPOINT_DIRECTORY,
+        "file://" + tempFolder.getRoot().getAbsolutePath());
+
+    MiniClusterConfiguration clusterConfig =
+        new MiniClusterConfiguration.Builder()
+            .setConfiguration(config)
+            .setNumTaskManagers(1)
+            .setNumSlotsPerTaskManager(1)
+            .build();
+
+    flinkCluster = new MiniCluster(clusterConfig);
+    flinkCluster.start();
+
+    TestStreamEnvironment.setAsContext(flinkCluster, parallelism);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    TestStreamEnvironment.unsetAsContext();
+    flinkCluster.close();
+    flinkCluster = null;
+  }
+
+  /**
+   * Test for the support of {@link org.apache.beam.sdk.transforms.DoFn.RequiresStableInput} in both
+   * {@link ParDo.SingleOutput} and {@link ParDo.MultiOutput}.
+   *
+   * <p>In each test, a singleton string value is paired with a random key. In the following
+   * transform, the value is written to a file, whose path is specified by the random key, and then
+   * the transform fails. When the pipeline retries, the latter transform should receive the same
+   * input from the former transform, because its {@link DoFn} is annotated with {@link
+   * org.apache.beam.sdk.transforms.DoFn.RequiresStableInput}, and it will not fail due to presence
+   * of the file. Therefore, only one file for each transform is expected.
+   *
+   * <p>A Savepoint is taken until the desired state in the operators has been reached. We then
+   * restore the savepoint to check if we produce impotent results.
+   */
+  @Test(timeout = 30_000)
+  public void testParDoRequiresStableInput() throws Exception {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setParallelism(1);
+    // We only want to trigger external savepoints but we require
+    // checkpointing to be enabled for @RequiresStableInput
+    options.setCheckpointingInterval(Long.MAX_VALUE);
+    options.setRunner(FlinkRunner.class);
+    options.setStreaming(true);
+
+    ResourceId outputDir =
+        FileSystems.matchNewResource(tempFolder.getRoot().getAbsolutePath(), true)
+            .resolve(
+                String.format("requires-stable-input-%tF-%<tH-%<tM-%<tS-%<tL", new Date()),
+                ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY);
+    String singleOutputPrefix =
+        outputDir
+            .resolve("pardo-single-output", ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY)
+            .resolve("key-", ResolveOptions.StandardResolveOptions.RESOLVE_FILE)
+            .toString();
+    String multiOutputPrefix =
+        outputDir
+            .resolve("pardo-multi-output", ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY)
+            .resolve("key-", ResolveOptions.StandardResolveOptions.RESOLVE_FILE)
+            .toString();
+
+    Pipeline p = createPipeline(options, singleOutputPrefix, multiOutputPrefix);
+
+    // a latch used by the transforms to signal completion
+    latch = new CountDownLatch(2);
+    JobID jobID = executePipeline(p);
+    String savepointDir;
+    do {
+      // Take a savepoint (checkpoint) which will trigger releasing the buffered elements
+      // and trigger the latch
+      savepointDir = takeSavepoint(jobID);
+    } while (!latch.await(100, TimeUnit.MILLISECONDS));
+    flinkCluster.cancelJob(jobID).get();
+
+    options.setShutdownSourcesOnFinalWatermark(true);
+    restoreFromSavepoint(p, savepointDir);
+    waitUntilJobIsDone();
+
+    assertThat(
+        new FlinkRunnerResult(Collections.emptyMap(), 1L),
+        SerializableMatchers.allOf(
+            new FileChecksumMatcher(
+                VALUE_CHECKSUM, new FilePatternMatchingShardedFile(singleOutputPrefix + "*")),
+            new FileChecksumMatcher(
+                VALUE_CHECKSUM, new FilePatternMatchingShardedFile(multiOutputPrefix + "*"))));
+  }
+
+  private JobGraph getJobGraph(Pipeline pipeline) {
+    FlinkRunner flinkRunner = FlinkRunner.fromOptions(pipeline.getOptions());
+    return flinkRunner.getJobGraph(pipeline);
+  }
+
+  private JobID executePipeline(Pipeline pipeline) throws Exception {
+    JobGraph jobGraph = getJobGraph(pipeline);
+    flinkCluster.submitJob(jobGraph).get();
+    return jobGraph.getJobID();
+  }
+
+  private String takeSavepoint(JobID jobID) throws Exception {
+    Exception exception = null;
+    // try multiple times because the job might not be ready yet
+    for (int i = 0; i < 10; i++) {
+      try {
+        return flinkCluster.triggerSavepoint(jobID, null, false).get();
+      } catch (Exception e) {
+        exception = e;
+        Thread.sleep(100);
+      }
+    }
+    throw exception;
+  }
+
+  private JobID restoreFromSavepoint(Pipeline pipeline, String savepointDir)
+      throws ExecutionException, InterruptedException {
+    JobGraph jobGraph = getJobGraph(pipeline);
+    SavepointRestoreSettings savepointSettings = SavepointRestoreSettings.forPath(savepointDir);
+    jobGraph.setSavepointRestoreSettings(savepointSettings);
+    return flinkCluster.submitJob(jobGraph).get().getJobID();
+  }
+
+  private void waitUntilJobIsDone() throws InterruptedException, ExecutionException {
+    while (flinkCluster.listJobs().get().stream()
+        .anyMatch(message -> message.getJobState() == JobStatus.RUNNING)) {
+      Thread.sleep(100);
+    }
+  }
+
+  private static Pipeline createPipeline(
+      PipelineOptions options, String singleOutputPrefix, String multiOutputPrefix) {
+    Pipeline p = Pipeline.create(options);
+
+    SerializableFunction<Void, Void> firstTime =
+        (SerializableFunction<Void, Void>)
+            value -> {
+              latch.countDown();
+              return null;
+            };
+
+    PCollection<String> impulse = p.apply("CreatePCollectionOfOneValue", Create.of(VALUE));
+    impulse
+        .apply(
+            "Single-PairWithRandomKey",
+            MapElements.via(new RequiresStableInputIT.PairWithRandomKeyFn()))
+        .apply(
+            "Single-MakeSideEffectAndThenFail",
+            ParDo.of(
+                new RequiresStableInputIT.MakeSideEffectAndThenFailFn(
+                    singleOutputPrefix, firstTime)));
+    impulse
+        .apply(
+            "Multi-PairWithRandomKey",
+            MapElements.via(new RequiresStableInputIT.PairWithRandomKeyFn()))
+        .apply(
+            "Multi-MakeSideEffectAndThenFail",
+            ParDo.of(
+                    new RequiresStableInputIT.MakeSideEffectAndThenFailFn(
+                        multiOutputPrefix, firstTime))
+                .withOutputTags(new TupleTag<>(), TupleTagList.empty()));
+
+    return p;
+  }
+}

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferedElementsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferedElementsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+import org.hamcrest.Matchers;
+import org.joda.time.Instant;
+import org.junit.Test;
+
+/** Tests for {@link BufferedElements}. */
+public class BufferedElementsTest {
+
+  @Test
+  public void testCoder() throws IOException {
+
+    StringUtf8Coder elementCoder = StringUtf8Coder.of();
+    // Generics fail to see here that this is Coder<BoundedWindow>
+    org.apache.beam.sdk.coders.Coder windowCoder = GlobalWindow.Coder.INSTANCE;
+    WindowedValue.WindowedValueCoder windowedValueCoder =
+        WindowedValue.FullWindowedValueCoder.of(elementCoder, windowCoder);
+
+    BufferedElements.Coder coder = new BufferedElements.Coder(windowedValueCoder, windowCoder);
+
+    BufferedElement element =
+        new BufferedElements.Element(
+            WindowedValue.of("test", new Instant(2), GlobalWindow.INSTANCE, PaneInfo.NO_FIRING));
+    BufferedElement timerElement =
+        new BufferedElements.Timer(
+            "timerId", GlobalWindow.INSTANCE, new Instant(1), TimeDomain.EVENT_TIME);
+
+    testRoundTrip(ImmutableList.of(element), coder);
+    testRoundTrip(ImmutableList.of(timerElement), coder);
+    testRoundTrip(ImmutableList.of(element, timerElement), coder);
+    testRoundTrip(ImmutableList.of(element, timerElement, element), coder);
+    testRoundTrip(ImmutableList.of(element, element, element, timerElement, timerElement), coder);
+  }
+
+  private static void testRoundTrip(
+      List<BufferedElement> bufferedElements, BufferedElements.Coder coder) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    for (BufferedElement bufferedElement : bufferedElements) {
+      coder.encode(bufferedElement, baos);
+    }
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    for (BufferedElement bufferedElement : bufferedElements) {
+      assertThat(coder.decode(bais), Matchers.is(bufferedElement));
+    }
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/RequiresStableInputIT.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/RequiresStableInputIT.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.util.FilePatternMatchingShardedFile;
 import org.apache.beam.sdk.values.KV;
@@ -58,7 +59,8 @@ public class RequiresStableInputIT {
   // SHA-1 hash of string "value"
   private static final String VALUE_CHECKSUM = "f32b67c7e26342af42efabc674d441dca0a281c5";
 
-  private static class PairWithRandomKeyFn extends SimpleFunction<String, KV<String, String>> {
+  /** Assigns a random key to a value. */
+  public static class PairWithRandomKeyFn extends SimpleFunction<String, KV<String, String>> {
     @Override
     public KV<String, String> apply(String value) {
       String key = UUID.randomUUID().toString();
@@ -66,11 +68,15 @@ public class RequiresStableInputIT {
     }
   }
 
-  private static class MakeSideEffectAndThenFailFn extends DoFn<KV<String, String>, String> {
+  /** Simulates side effect by writing input to a file. */
+  public static class MakeSideEffectAndThenFailFn extends DoFn<KV<String, String>, String> {
     private final String outputPrefix;
+    private final SerializableFunction<Void, Void> firstTimeCallback;
 
-    private MakeSideEffectAndThenFailFn(String outputPrefix) {
+    public MakeSideEffectAndThenFailFn(
+        String outputPrefix, SerializableFunction<Void, Void> firstTimeCallback) {
       this.outputPrefix = outputPrefix;
+      this.firstTimeCallback = firstTimeCallback;
     }
 
     @RequiresStableInput
@@ -82,13 +88,11 @@ public class RequiresStableInputIT {
       KV<String, String> kv = c.element();
       writeTextToFileSideEffect(kv.getValue(), outputPrefix + kv.getKey());
       if (firstTime) {
-        throw new Exception(
-            "Deliberate failure: should happen only once for each application of the DoFn"
-                + "within the transform graph.");
+        firstTimeCallback.apply(null);
       }
     }
 
-    private static void writeTextToFileSideEffect(String text, String filename) throws IOException {
+    public static void writeTextToFileSideEffect(String text, String filename) throws IOException {
       ResourceId rid = FileSystems.matchNewResource(filename, false);
       WritableByteChannel chan = FileSystems.create(rid, "text/plain");
       chan.write(ByteBuffer.wrap(text.getBytes(StandardCharsets.UTF_8)));
@@ -142,17 +146,25 @@ public class RequiresStableInputIT {
 
     Pipeline p = Pipeline.create(options);
 
+    SerializableFunction<Void, Void> firstTime =
+        (SerializableFunction<Void, Void>)
+            value -> {
+              throw new RuntimeException(
+                  "Deliberate failure: should happen only once for each application of the DoFn"
+                      + "within the transform graph.");
+            };
+
     PCollection<String> singleton = p.apply("CreatePCollectionOfOneValue", Create.of(VALUE));
     singleton
         .apply("Single-PairWithRandomKey", MapElements.via(new PairWithRandomKeyFn()))
         .apply(
             "Single-MakeSideEffectAndThenFail",
-            ParDo.of(new MakeSideEffectAndThenFailFn(singleOutputPrefix)));
+            ParDo.of(new MakeSideEffectAndThenFailFn(singleOutputPrefix, firstTime)));
     singleton
         .apply("Multi-PairWithRandomKey", MapElements.via(new PairWithRandomKeyFn()))
         .apply(
             "Multi-MakeSideEffectAndThenFail",
-            ParDo.of(new MakeSideEffectAndThenFailFn(multiOutputPrefix))
+            ParDo.of(new MakeSideEffectAndThenFailFn(multiOutputPrefix, firstTime))
                 .withOutputTags(new TupleTag<>(), TupleTagList.empty()));
 
     p.run().waitUntilFinish();

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -274,6 +274,7 @@ class KafkaExactlyOnceSink<K, V>
 
     // Futures ignored as exceptions will be flushed out in the commitTxn
     @SuppressWarnings("FutureReturnValueIgnored")
+    @RequiresStableInput
     @ProcessElement
     public void processElement(
         @StateId(NEXT_ID) ValueState<Long> nextIdState,

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1141,7 +1141,8 @@ public class KafkaIO {
         String runner = options.getRunner().getName();
         if ("org.apache.beam.runners.direct.DirectRunner".equals(runner)
             || runner.startsWith("org.apache.beam.runners.dataflow.")
-            || runner.startsWith("org.apache.beam.runners.spark.")) {
+            || runner.startsWith("org.apache.beam.runners.spark.")
+            || runner.startsWith("org.apache.beam.runners.flink.")) {
           return;
         }
         throw new UnsupportedOperationException(


### PR DESCRIPTION
This enables exactly-once support for the KafkaIO sink when using the Flink
Runner. KafkaIO's KafkaExactlyOnceSink has been annotated with
@RequiresStableInput which forces the Flink Runner to buffer pending elements
until a checkpoint is completed.

CC @tweise @reuvenlax @kennknowles @rangadi 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
