### PR TITLE
[BEAM-562] Add DoFn.setup and DoFn.teardown to Python SDK

### DIFF
--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -43,6 +43,8 @@ cdef class DoFnSignature(object):
   cdef public MethodWrapper process_method
   cdef public MethodWrapper start_bundle_method
   cdef public MethodWrapper finish_bundle_method
+  cdef public MethodWrapper setup_lifecycle_method
+  cdef public MethodWrapper teardown_lifecycle_method
   cdef public MethodWrapper initial_restriction_method
   cdef public MethodWrapper restriction_coder_method
   cdef public MethodWrapper create_tracker_method

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -210,6 +210,8 @@ class DoFnSignature(object):
     self.process_method = MethodWrapper(do_fn, 'process')
     self.start_bundle_method = MethodWrapper(do_fn, 'start_bundle')
     self.finish_bundle_method = MethodWrapper(do_fn, 'finish_bundle')
+    self.setup_lifecycle_method = MethodWrapper(do_fn, 'setup')
+    self.teardown_lifecycle_method = MethodWrapper(do_fn, 'teardown')
 
     restriction_provider = self.get_restriction_provider()
     self.initial_restriction_method = (
@@ -356,6 +358,11 @@ class DoFnInvoker(object):
     """
     raise NotImplementedError
 
+  def invoke_setup(self):
+    """Invokes the DoFn.setup() method
+    """
+    self.signature.setup_lifecycle_method.method_value()
+
   def invoke_start_bundle(self):
     """Invokes the DoFn.start_bundle() method.
     """
@@ -367,6 +374,11 @@ class DoFnInvoker(object):
     """
     self.output_processor.finish_bundle_outputs(
         self.signature.finish_bundle_method.method_value())
+
+  def invoke_teardown(self):
+    """Invokes the DoFn.teardown() method
+    """
+    self.signature.teardown_lifecycle_method.method_value()
 
   def invoke_user_timer(self, timer_spec, key, window, timestamp):
     self.output_processor.process_outputs(
@@ -778,6 +790,16 @@ class DoFnRunner(Receiver):
     except BaseException as exn:
       self._reraise_augmented(exn)
 
+  def _invoke_lifecycle_method(self, lifecycle_method):
+    try:
+      self.context.set_element(None)
+      lifecycle_method()
+    except BaseException as exn:
+      self._reraise_augmented(exn)
+
+  def setup(self):
+    self._invoke_lifecycle_method(self.do_fn_invoker.invoke_setup)
+
   def start(self):
     self._invoke_bundle_method(self.do_fn_invoker.invoke_start_bundle)
 
@@ -786,6 +808,9 @@ class DoFnRunner(Receiver):
 
   def finalize(self):
     self.bundle_finalizer_param.finalize_bundle()
+
+  def teardown(self):
+    self._invoke_lifecycle_method(self.do_fn_invoker.invoke_teardown)
 
   def _reraise_augmented(self, exn):
     if getattr(exn, '_tagged_with_step', False) or not self.step_name:

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -806,11 +806,11 @@ class DoFnRunner(Receiver):
   def finish(self):
     self._invoke_bundle_method(self.do_fn_invoker.invoke_finish_bundle)
 
-  def finalize(self):
-    self.bundle_finalizer_param.finalize_bundle()
-
   def teardown(self):
     self._invoke_lifecycle_method(self.do_fn_invoker.invoke_teardown)
+
+  def finalize(self):
+    self.bundle_finalizer_param.finalize_bundle()
 
   def _reraise_augmented(self, exn):
     if getattr(exn, '_tagged_with_step', False) or not self.step_name:

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -619,6 +619,7 @@ class _ParDoEvaluator(_TransformEvaluator):
         step_name=self._applied_ptransform.full_label,
         state=DoFnState(self._counter_factory),
         user_state_context=self.user_state_context)
+    self.runner.setup()
     self.runner.start()
 
   def process_timer(self, timer_firing):
@@ -634,6 +635,7 @@ class _ParDoEvaluator(_TransformEvaluator):
 
   def finish_bundle(self):
     self.runner.finish()
+    self.runner.teardown()
     bundles = list(self._tagged_receivers.values())
     result_counters = self._counter_factory.get_counters()
     if self.user_state_context:

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -619,7 +619,6 @@ class _ParDoEvaluator(_TransformEvaluator):
         step_name=self._applied_ptransform.full_label,
         state=DoFnState(self._counter_factory),
         user_state_context=self.user_state_context)
-    self.runner.setup()
     self.runner.start()
 
   def process_timer(self, timer_firing):
@@ -635,7 +634,6 @@ class _ParDoEvaluator(_TransformEvaluator):
 
   def finish_bundle(self):
     self.runner.finish()
-    self.runner.teardown()
     bundles = list(self._tagged_receivers.values())
     result_counters = self._counter_factory.get_counters()
     if self.user_state_context:

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -847,7 +847,7 @@ class EmbeddedWorkerHandler(WorkerHandler):
     pass
 
   def stop_worker(self):
-    pass
+    self.worker.teardown()
 
   def done(self):
     pass

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -847,7 +847,7 @@ class EmbeddedWorkerHandler(WorkerHandler):
     pass
 
   def stop_worker(self):
-    self.worker.teardown()
+    self.worker.stop()
 
   def done(self):
     pass
@@ -1134,7 +1134,7 @@ class WorkerHandlerManager(object):
       try:
         controller.close()
       except Exception:
-        logging.info("Error closing controller %s" % controller, exc_info=True)
+        logging.error("Error closing controller %s" % controller, exc_info=True)
     self._cached_handlers = {}
 
 

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -499,6 +499,8 @@ class BundleProcessor(object):
         'fnapi-step-%s' % self.process_bundle_descriptor.id,
         self.counter_factory)
     self.ops = self.create_execution_tree(self.process_bundle_descriptor)
+    for op in self.ops.values():
+      op.setup()
     self.splitting_lock = threading.Lock()
 
   def create_execution_tree(self, descriptor):

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -499,8 +499,6 @@ class BundleProcessor(object):
         'fnapi-step-%s' % self.process_bundle_descriptor.id,
         self.counter_factory)
     self.ops = self.create_execution_tree(self.process_bundle_descriptor)
-    for op in self.ops.values():
-      op.setup()
     self.splitting_lock = threading.Lock()
 
   def create_execution_tree(self, descriptor):
@@ -746,7 +744,7 @@ class BundleProcessor(object):
         monitoring_info.labels['TAG'] = actual_output_tags[0]
     return monitoring_info
 
-  def teardown(self):
+  def shutdown(self):
     for op in self.ops.values():
       op.teardown()
 

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -746,6 +746,10 @@ class BundleProcessor(object):
         monitoring_info.labels['TAG'] = actual_output_tags[0]
     return monitoring_info
 
+  def teardown(self):
+    for op in self.ops.values():
+      op.teardown()
+
 
 class ExecutionContext(object):
   def __init__(self):

--- a/sdks/python/apache_beam/runners/worker/operations.pxd
+++ b/sdks/python/apache_beam/runners/worker/operations.pxd
@@ -68,6 +68,7 @@ cdef class Operation(object):
   cpdef start(self)
   cpdef process(self, WindowedValue windowed_value)
   cpdef finish(self)
+  cpdef teardown(self)
   cpdef output(self, WindowedValue windowed_value, int output_index=*)
   cpdef execution_time_monitoring_infos(self, transform_id)
   cpdef user_monitoring_infos(self, transform_id)

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -240,6 +240,9 @@ class Operation(object):
     """Finish operation."""
     pass
 
+  def teardown(self):
+    pass
+
   def reset(self):
     self.metrics_container.reset()
 
@@ -569,6 +572,7 @@ class DoOperation(Operation):
           state=state,
           user_state_context=self.user_state_context,
           operation_name=self.name_context.metrics_name())
+      self.dofn_runner.setup()
 
       self.dofn_receiver = (self.dofn_runner
                             if isinstance(self.dofn_runner, Receiver)
@@ -603,6 +607,10 @@ class DoOperation(Operation):
       self.dofn_runner.finish()
       if self.user_state_context:
         self.user_state_context.commit()
+
+  def teardown(self):
+    with self.scoped_finish_state:
+      self.dofn_runner.teardown()
 
   def reset(self):
     super(DoOperation, self).reset()

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -198,6 +198,9 @@ class Operation(object):
     self.setup_done = False
 
   def setup(self):
+    """Set up operation.
+
+    This must be called before any other methods of the operation."""
     with self.scoped_start_state:
       self.debug_logging_enabled = logging.getLogger().isEnabledFor(
           logging.DEBUG)
@@ -241,6 +244,9 @@ class Operation(object):
     pass
 
   def teardown(self):
+    """Tear down operation.
+
+    No other methods of this operation should be called after this."""
     pass
 
   def reset(self):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -311,6 +311,7 @@ class BundleProcessorCache(object):
     return self.active_bundle_processors.get(instruction_id, (None, None))[-1]
 
   def discard(self, instruction_id):
+    self.active_bundle_processors[instruction_id].shutdown()
     del self.active_bundle_processors[instruction_id]
 
   def release(self, instruction_id):
@@ -319,7 +320,7 @@ class BundleProcessorCache(object):
     self.cached_bundle_processors[descriptor_id].append(processor)
 
   def shutdown(self):
-    for instruction_id in self.active_bundle_processors.keys():
+    for instruction_id in self.active_bundle_processors:
       self.active_bundle_processors[instruction_id].shutdown()
       del self.active_bundle_processors[instruction_id]
     for cached_bundle_processors in self.cached_bundle_processors.values():

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -150,6 +150,10 @@ class SdkHarness(object):
     # Stop all the workers and clean all the associated resources
     self._data_channel_factory.close()
     self._state_handler_factory.close()
+    while not self.workers.empty():
+      worker = self.workers.get()
+      worker.teardown()
+
     logging.info('Done consuming work.')
 
   def _execute(self, task, request):
@@ -424,6 +428,11 @@ class SdkWorker(object):
         yield
     else:
       yield
+
+  def teardown(self):
+    for processors in self.cached_bundle_processors.values():
+      for processor in processors:
+        processor.teardown()
 
 
 class StateHandlerFactory(with_metaclass(abc.ABCMeta, object)):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -311,7 +311,7 @@ class BundleProcessorCache(object):
     return self.active_bundle_processors.get(instruction_id, (None, None))[-1]
 
   def discard(self, instruction_id):
-    self.active_bundle_processors[instruction_id].shutdown()
+    self.active_bundle_processors[instruction_id][1].shutdown()
     del self.active_bundle_processors[instruction_id]
 
   def release(self, instruction_id):
@@ -321,7 +321,7 @@ class BundleProcessorCache(object):
 
   def shutdown(self):
     for instruction_id in self.active_bundle_processors:
-      self.active_bundle_processors[instruction_id].shutdown()
+      self.active_bundle_processors[instruction_id][1].shutdown()
       del self.active_bundle_processors[instruction_id]
     for cached_bundle_processors in self.cached_bundle_processors.values():
       while len(cached_bundle_processors) > 0:

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -472,6 +472,15 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
     """
     raise NotImplementedError
 
+  def setup(self):
+    """Called to prepare an instance for processing bundles of elements.
+
+    This is a good place to initialize transient in-memory resources, such as
+    network connections. The resources can then be disposed in
+    ``DoFn.teardown``.
+    """
+    pass
+
   def start_bundle(self):
     """Called before a bundle of elements is processed on a worker.
 
@@ -483,6 +492,24 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
 
   def finish_bundle(self):
     """Called after a bundle of elements is processed on a worker.
+    """
+    pass
+
+  def teardown(self):
+    """Called to use to clean up this instance before it is discarded.
+
+    A runner will do its best to call this method on any given instance to
+    prevent leaks of transient resources, however, there may be situations where
+    this is impossible (e.g. process crash, hardware failure, etc.) or
+    unnecessary (e.g. the pipeline is shutting down and the process is about to
+    be killed anyway, so all transient resources will be released automatically
+    by the OS). In these cases, the call may not happen. It will also not be
+    retried, because in such situations the DoFn instance no longer exists, so
+    there's no instance to retry it on.
+
+    Thus, all work that depends on input elements, and all externally important
+    side effects, must be performed in ``DoFn.process`` or
+    ``DoFn.finish_bundle``.
     """
     pass
 

--- a/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
+++ b/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
@@ -33,8 +33,6 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
     self._teardown_called = False
 
   def setup(self):
-    # Use assert instead of unittest.TestCase.assert* methods because
-    # this is not a TestCase
     assert not self._setup_called,'setup should not be called twice'
     assert self._start_bundle_calls == 0, 'setup should be called before start_bundle'
     assert self._finish_bundle_calls == 0, 'setup should be called before finish_bundle'
@@ -42,17 +40,13 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
     self._setup_called = True
 
   def start_bundle(self):
-    # Use assert instead of unittest.TestCase.assert* methods because
-    # this is not a TestCase
     assert self._setup_called, 'setup should have been called'
     assert self._start_bundle_calls == self._finish_bundle_calls , \
       'there should be as many start_bundle calls as finish_bundle calls'
     assert not self._teardown_called, 'teardown should not have been called'
     self._start_bundle_calls += 1
 
-  def process(self, element):
-    # Use assert instead of unittest.TestCase.assert* methods because
-    # this is not a TestCase
+  def process(self, element)
     assert self._setup_called, 'setup should have been called'
     assert self._start_bundle_calls > 0, 'start_bundle should have been called'
     assert self._start_bundle_calls == self._finish_bundle_calls + 1, \
@@ -61,8 +55,6 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
     return [element * element]
 
   def finish_bundle(self):
-    # Use assert instead of unittest.TestCase.assert* methods because
-    # this is not a TestCase
     assert self._setup_called, 'setup should have been called'
     assert self._start_bundle_calls > 0, 'start_bundle should have been called'
     assert self._start_bundle_calls == self._finish_bundle_calls + 1, \
@@ -71,8 +63,6 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
     self._finish_bundle_calls += 1
 
   def teardown(self):
-    # Use assert instead of unittest.TestCase.assert* methods because
-    # this is not a TestCase
     assert self._setup_called, 'setup should have been called'
     assert self._start_bundle_calls == self._finish_bundle_calls , \
       'there should be as many start_bundle calls as finish_bundle calls'

--- a/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
+++ b/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
@@ -25,8 +25,6 @@ from nose.plugins.attrib import attr
 import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline
 
-_global_teardown_called = False
-
 
 class CallSequenceEnforcingDoFn(beam.DoFn):
   def __init__(self):
@@ -73,8 +71,6 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
       'there should be as many start_bundle calls as finish_bundle calls'
     assert not self._teardown_called, 'teardown should not be called twice'
     self._teardown_called = True
-    global _global_teardown_called
-    _global_teardown_called = True
 
 
 @attr('ValidatesRunner')
@@ -87,7 +83,6 @@ class DoFnLifecycleTest(unittest.TestCase):
     result = p.run()
     result.wait_until_finish()
     # Assumes that the worker is run in the same process as the test.
-    self.assertTrue(_global_teardown_called)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
+++ b/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""UnitTests for DoFn lifecycle and bundle methods"""
+
+from __future__ import absolute_import
+
+import unittest
+
+from nose.plugins.attrib import attr
+
+import apache_beam as beam
+from apache_beam.testing.test_pipeline import TestPipeline
+
+class CallSequenceEnforcingDoFn(beam.DoFn):
+  def __init__(self):
+    self._setup_called = False
+    self._start_bundle_calls = 0
+    self._finish_bundle_calls = 0
+    self._teardown_called = False
+
+  def setup(self):
+    # Use assert instead of unittest.TestCase.assert* methods because
+    # this is not a TestCase
+    assert not self._setup_called,'setup should not be called twice'
+    assert self._start_bundle_calls == 0, 'setup should be called before start_bundle'
+    assert self._finish_bundle_calls == 0, 'setup should be called before finish_bundle'
+    assert not self._teardown_called, 'setup should be called before teardown'
+    self._setup_called = True
+
+  def start_bundle(self):
+    # Use assert instead of unittest.TestCase.assert* methods because
+    # this is not a TestCase
+    assert self._setup_called, 'setup should have been called'
+    assert self._start_bundle_calls == self._finish_bundle_calls , \
+      'there should be as many start_bundle calls as finish_bundle calls'
+    assert not self._teardown_called, 'teardown should not have been called'
+    self._start_bundle_calls += 1
+
+  def process(self, element):
+    # Use assert instead of unittest.TestCase.assert* methods because
+    # this is not a TestCase
+    assert self._setup_called, 'setup should have been called'
+    assert self._start_bundle_calls > 0, 'start_bundle should have been called'
+    assert self._start_bundle_calls == self._finish_bundle_calls + 1, \
+      'there should be one start_bundle call with no call to finish_bundle'
+    assert not self._teardown_called, 'teardown should not have been called'
+    return [element * element]
+
+  def finish_bundle(self):
+    # Use assert instead of unittest.TestCase.assert* methods because
+    # this is not a TestCase
+    assert self._setup_called, 'setup should have been called'
+    assert self._start_bundle_calls > 0, 'start_bundle should have been called'
+    assert self._start_bundle_calls == self._finish_bundle_calls + 1, \
+      'there should be one start_bundle call with no call to finish_bundle'
+    assert not self._teardown_called, 'teardown should not have been called'
+    self._finish_bundle_calls += 1
+
+  def teardown(self):
+    # Use assert instead of unittest.TestCase.assert* methods because
+    # this is not a TestCase
+    assert self._setup_called, 'setup should have been called'
+    assert self._start_bundle_calls == self._finish_bundle_calls , \
+      'there should be as many start_bundle calls as finish_bundle calls'
+    assert not self._teardown_called,'teardown should not be called twice'
+    # Unfortunately there is no way to assert that teardown was actually called.
+    # This is acceptable because teardown is best-effort.
+    self._teardown_called = True
+
+
+@attr('ValidatesRunner')
+class DoFnLifecycleTest(unittest.TestCase):
+  def test_dofn_lifecycle(self):
+    with TestPipeline() as p:
+      (p
+        | 'Start' >> beam.Create([1, 2, 3])
+        | 'Do' >> beam.ParDo(CallSequenceEnforcingDoFn()))

--- a/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
+++ b/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
@@ -23,10 +23,12 @@ import unittest
 from nose.plugins.attrib import attr
 
 import apache_beam as beam
+from apache_beam.metrics import Metrics
+from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.testing.test_pipeline import TestPipeline
 
-
 _global_teardown_called = False
+
 
 class CallSequenceEnforcingDoFn(beam.DoFn):
   def __init__(self):
@@ -34,17 +36,22 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
     self._start_bundle_calls = 0
     self._finish_bundle_calls = 0
     self._teardown_called = False
+    self._teardown_called_counter = Metrics.counter(
+        self.__class__, 'teardown_called')
 
   def setup(self):
-    assert not self._setup_called,'setup should not be called twice'
-    assert self._start_bundle_calls == 0, 'setup should be called before start_bundle'
-    assert self._finish_bundle_calls == 0, 'setup should be called before finish_bundle'
+    assert not self._setup_called, 'setup should not be called twice'
+    assert self._start_bundle_calls == 0, \
+      'setup should be called before start_bundle'
+    assert self._finish_bundle_calls == 0, \
+      'setup should be called before finish_bundle'
     assert not self._teardown_called, 'setup should be called before teardown'
     self._setup_called = True
+    self._teardown_called_counter.inc()
 
   def start_bundle(self):
     assert self._setup_called, 'setup should have been called'
-    assert self._start_bundle_calls == self._finish_bundle_calls , \
+    assert self._start_bundle_calls == self._finish_bundle_calls, \
       'there should be as many start_bundle calls as finish_bundle calls'
     assert not self._teardown_called, 'teardown should not have been called'
     self._start_bundle_calls += 1
@@ -67,9 +74,9 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
 
   def teardown(self):
     assert self._setup_called, 'setup should have been called'
-    assert self._start_bundle_calls == self._finish_bundle_calls , \
+    assert self._start_bundle_calls == self._finish_bundle_calls, \
       'there should be as many start_bundle calls as finish_bundle calls'
-    assert not self._teardown_called,'teardown should not be called twice'
+    assert not self._teardown_called, 'teardown should not be called twice'
     self._teardown_called = True
     global _global_teardown_called
     _global_teardown_called = True
@@ -79,10 +86,18 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
 class DoFnLifecycleTest(unittest.TestCase):
   def test_dofn_lifecycle(self):
     p = TestPipeline()
-    (p
-      | 'Start' >> beam.Create([1, 2, 3])
-      | 'Do' >> beam.ParDo(CallSequenceEnforcingDoFn()))
+    _ = (p
+         | 'Start' >> beam.Create([1, 2, 3])
+         | 'Do' >> beam.ParDo(CallSequenceEnforcingDoFn()))
     result = p.run()
     result.wait_until_finish()
     # Assumes that the worker is run in the same process as the test.
     self.assertTrue(_global_teardown_called)
+    metrics_filter = MetricsFilter().with_name('teardown_called')
+    metrics_query_result = result.metrics().query(metrics_filter)
+    self.assertEqual(len(metrics_query_result['counters']), 1)
+    self.assertEqual(metrics_query_result['counters'][0].result, 1)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
+++ b/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
@@ -36,8 +36,6 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
     self._start_bundle_calls = 0
     self._finish_bundle_calls = 0
     self._teardown_called = False
-    self._teardown_called_counter = Metrics.counter(
-        self.__class__, 'teardown_called')
 
   def setup(self):
     assert not self._setup_called, 'setup should not be called twice'
@@ -47,7 +45,6 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
       'setup should be called before finish_bundle'
     assert not self._teardown_called, 'setup should be called before teardown'
     self._setup_called = True
-    self._teardown_called_counter.inc()
 
   def start_bundle(self):
     assert self._setup_called, 'setup should have been called'
@@ -93,10 +90,6 @@ class DoFnLifecycleTest(unittest.TestCase):
     result.wait_until_finish()
     # Assumes that the worker is run in the same process as the test.
     self.assertTrue(_global_teardown_called)
-    metrics_filter = MetricsFilter().with_name('teardown_called')
-    metrics_query_result = result.metrics().query(metrics_filter)
-    self.assertEqual(len(metrics_query_result['counters']), 1)
-    self.assertEqual(metrics_query_result['counters'][0].result, 1)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
+++ b/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
@@ -23,8 +23,6 @@ import unittest
 from nose.plugins.attrib import attr
 
 import apache_beam as beam
-from apache_beam.metrics import Metrics
-from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.testing.test_pipeline import TestPipeline
 
 
@@ -36,7 +34,6 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
     self._start_bundle_calls = 0
     self._finish_bundle_calls = 0
     self._teardown_called = False
-    self._teardown_called_counter = Metrics.counter(self.__class__, 'teardown_called')
 
   def setup(self):
     assert not self._setup_called,'setup should not be called twice'
@@ -76,7 +73,6 @@ class CallSequenceEnforcingDoFn(beam.DoFn):
     self._teardown_called = True
     global _global_teardown_called
     _global_teardown_called = True
-    self._teardown_called_counter.inc()
 
 
 @attr('ValidatesRunner')
@@ -90,8 +86,3 @@ class DoFnLifecycleTest(unittest.TestCase):
     result.wait_until_finish()
     # Assumes that the worker is run in the same process as the test.
     self.assertTrue(_global_teardown_called)
-    metrics_filter = MetricsFilter().with_name('teardown_called')
-    metrics_query_result = result.metrics().query(metrics_filter)
-    self.assertEqual(len(metrics_query_result['counters']), 1)
-    self.assertEqual(metrics_query_result['counters'][0].result, 1)
-    

--- a/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
+++ b/sdks/python/apache_beam/transforms/dofn_lifecycle_test.py
@@ -23,8 +23,6 @@ import unittest
 from nose.plugins.attrib import attr
 
 import apache_beam as beam
-from apache_beam.metrics import Metrics
-from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.testing.test_pipeline import TestPipeline
 
 _global_teardown_called = False


### PR DESCRIPTION
DoFn.setup and DoFn.teardown is currently supported in Java but not Python. These methods are useful for performing expensive per-thread initialization. This change adds those methods to make the Python SDK more consistent with the Java SDK. It also modifies the direct runner to invoke these methods.

## Post-Commit Tests Status (on master branch)
Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
