### PR TITLE
[BEAM-7234] GrpcWindmillServer improvements

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -404,7 +404,10 @@ public class GrpcWindmillServer extends WindmillServerStub {
       } catch (StatusRuntimeException e) {
         try {
           if (++rpcErrors % 20 == 0) {
-            LOG.warn("Many exceptions calling gRPC. Last exception: {}", e);
+            LOG.warn(
+                "Many exceptions calling gRPC. Last exception: {} with status {}",
+                e,
+                e.getStatus());
           }
           if (!BackOffUtils.next(Sleeper.DEFAULT, backoff)) {
             throw new WindmillServerStub.RpcException(e);
@@ -699,20 +702,22 @@ public class GrpcWindmillServer extends WindmillServerStub {
           }
         }
         if (t != null) {
+          Status status = null;
+          if (t instanceof StatusRuntimeException) {
+            status = ((StatusRuntimeException) t).getStatus();
+          }
           if (errorCount.incrementAndGet() % logEveryNStreamFailures == 0) {
             LOG.warn(
-                "{} streaming Windmill RPC errors for a stream, last was: {}",
+                "{} streaming Windmill RPC errors for a stream, last was: {} with status {}",
                 errorCount.get(),
-                t.toString());
+                t.toString(),
+                status);
           }
           // If the stream was stopped due to a resource exhausted error then we are throttled.
-          if (t instanceof StatusRuntimeException) {
-            StatusRuntimeException statusExc = (StatusRuntimeException) t;
-            if (statusExc.getStatus() != null
-                && statusExc.getStatus().getCode() == Status.Code.RESOURCE_EXHAUSTED) {
-              startThrottleTimer();
-            }
+          if (status != null && status.getCode() == Status.Code.RESOURCE_EXHAUSTED) {
+            startThrottleTimer();
           }
+
           try {
             long sleep = backoff.nextBackOffMillis();
             sleepUntil.set(Instant.now().getMillis() + sleep);
@@ -1067,24 +1072,22 @@ public class GrpcWindmillServer extends WindmillServerStub {
         batch.byteSize += request.byteSize;
       }
       if (responsibleForSend) {
-        // Wait for the previous batch to be sent if one existed.
         if (waitForSendLatch == null) {
           // If there was not a previous batch wait a little while to improve
           // batching.
           Thread.sleep(1);
-          synchronized (batches) {
-            Verify.verify(batch == batches.peekFirst());
-            batch.finalized = true;
-          }
         } else {
           waitForSendLatch.await();
+        }
+        // Finalize the batch so that no additional requests will be added.  Leave the batch in the
+        // queue so that a subsequent batch will wait for it's completion.
+        synchronized (batches) {
+          Verify.verify(batch == batches.peekFirst());
+          batch.finalized = true;
         }
         sendBatch(batch.requests);
         synchronized (batches) {
           Verify.verify(batch == batches.pollFirst());
-          if (!batches.isEmpty()) {
-            batches.getFirst().finalized = true;
-          }
         }
         // Notify all waiters with requests in this batch as well as the sender
         // of the next batch (if one exists).


### PR DESCRIPTION
- Log error statuses returned from grpc.
- Delay finalization of get data stream batch until just before sending.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
