### PR TITLE
[BEAM-6777] Add HealthDaemon and tests

### DIFF
--- a/sdks/python/apache_beam/runners/worker/health_daemon.py
+++ b/sdks/python/apache_beam/runners/worker/health_daemon.py
@@ -17,12 +17,11 @@
 
 from __future__ import absolute_import
 
+import errno
 import http.client
 import logging
-import time
 import socket
-import errno
-
+import time
 from builtins import object
 
 
@@ -49,7 +48,7 @@ class HealthDaemon(object):
   """
 
   def __init__(self, health_http_port):
-    self.health_http_port = health_http_port
+    self._health_http_port = health_http_port
 
   @staticmethod
   def connect_to_server(health_http_port, timeout=5):
@@ -114,7 +113,7 @@ class HealthDaemon(object):
   def start(self):
     """Tries forever to send a health ping to the health server."""
 
-    conn = HealthDaemon.connect_to_server(self.health_http_port)
+    conn = HealthDaemon.connect_to_server(self._health_http_port)
     while True:
       HealthDaemon.try_health_ping(conn)
 

--- a/sdks/python/apache_beam/runners/worker/health_daemon.py
+++ b/sdks/python/apache_beam/runners/worker/health_daemon.py
@@ -101,13 +101,17 @@ class HealthDaemon(object):
     except socket.error as e:
       if e.errno == errno.ECONNREFUSED:
         logging.error('Connection refused by server')
-      health_server.close()
 
     # We want the HealthDaemon to always try to ping, otherwise the container
     # will be shut down.
     except Exception as e:
       logging.error('Unknown error while trying to send health ping: %s', e)
+
+    if not success:
+      logging.error('Trying to reconnect to localhost:%s.', health_server.port)
       health_server.close()
+      health_server = HealthDaemon.connect_to_server(health_server.port)
+
     return success
 
   def start(self):

--- a/sdks/python/apache_beam/runners/worker/health_daemon.py
+++ b/sdks/python/apache_beam/runners/worker/health_daemon.py
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import http.client
+import logging
+import time
+import socket
+import errno
+
+from builtins import object
+
+class HealthDaemon(object):
+    @staticmethod
+    def connect_to_server(health_http_port, timeout=5):
+        logging.info('Connecting to localhost:{}'.format(health_http_port))
+        return http.client.HTTPConnection('localhost', health_http_port, timeout=timeout)
+
+    @staticmethod
+    def try_health_ping(health_server):
+        success = False
+        try:
+            health_server.request('PUT', '/sdk')
+            resp = health_server.getresponse()
+            if resp.status == 200:
+                logging.info('Successfully sent health ping to localhost:{}'.format(health_server.port))
+                success = True
+            else:
+                logging.warning('Failed to send health ping to localhost:{} with: HTTP {} {}'.format(
+                    health_server.port, resp.status, resp.reason))
+
+            # Flush the response to close the connection.
+            resp.read()
+        except http.client.HTTPException as e:
+            logging.error('Could not send health ping to localhost:{} with exception: {}'.format(
+                health_server.port, e))
+        except socket.error as e:
+            if e.errno == errno.ECONNREFUSED:
+                logging.error('Connection refused by server')
+            health_server.close()
+        except:
+            logging.error('Unknown error while trying to send health ping. Continuing.')
+            health_server.close()
+        return success
+
+    @staticmethod
+    def start(health_http_port=8080):
+        """Executes the serving loop for the status server.
+
+        Args:
+          health_http_port(int): Binding port for the debug server.
+            Default is 0 which means any free unsecured port
+        """
+        conn = HealthDaemon.connect_to_server(health_http_port)
+        while True:
+            HealthDaemon.try_health_ping(conn)
+
+            logging.info('Health Client Daemon sleeping for 15 seconds...')
+            time.sleep(15)

--- a/sdks/python/apache_beam/runners/worker/health_daemon.py
+++ b/sdks/python/apache_beam/runners/worker/health_daemon.py
@@ -49,8 +49,9 @@ class HealthDaemon(object):
 
   HEALTH_CHECK_ENDPOINT = '/sdk'
 
-  def __init__(self, health_http_port):
+  def __init__(self, health_http_port, ping_interval_secs):
     self._health_http_port = health_http_port
+    self._ping_interval_secs = ping_interval_secs
 
   @staticmethod
   def connect_to_server(health_http_port, timeout=5):
@@ -126,4 +127,4 @@ class HealthDaemon(object):
       HealthDaemon.try_health_ping(conn)
 
       logging.debug('Health Client Daemon sleeping for 15 seconds...')
-      time.sleep(15)
+      time.sleep(self._ping_interval_secs)

--- a/sdks/python/apache_beam/runners/worker/health_daemon_test.py
+++ b/sdks/python/apache_beam/runners/worker/health_daemon_test.py
@@ -1,0 +1,178 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for apache_beam.runners.worker.health_daemon."""
+
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import http.server
+import logging
+import unittest
+import threading
+import time
+
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.runners.worker.health_daemon import HealthDaemon
+
+class MockHealthServer:
+    def __init__(self, listening_port, http_status_code=200):
+        self.listening_port = listening_port
+        self.http_status_code = http_status_code
+        self.httpd = None
+        self.ready = False
+        self.port = 0
+
+    def start(self):
+        http_status_code = self.http_status_code
+        class HttpHandler(http.server.BaseHTTPRequestHandler):
+            """HTTP handler for serving stacktraces of all threads."""
+
+            def do_PUT(self):  # pylint: disable=invalid-name
+                """Return all thread stacktraces information for GET request."""
+                self.send_response(http_status_code)
+                self.send_header('Content-Type', 'text/plain')
+                self.end_headers()
+
+            def do_GET(self):  # pylint: disable=invalid-name
+                """Return all thread stacktraces information for GET request."""
+                self.send_response(501)
+                self.send_header('Content-Type', 'text/plain')
+                self.end_headers()
+
+            def log_message(self, f, *args):
+                """Do not log any messages."""
+                pass
+
+        self.httpd = http.server.HTTPServer(('localhost', self.listening_port), HttpHandler)
+        logging.info('Health HTTP server running at %s:%s', self.httpd.server_name,
+                     self.httpd.server_port)
+        self.ready = True
+        self.port = self.httpd.server_port
+        self.httpd.serve_forever()
+        logging.info('Health HTTP server is now shutdown')
+
+    def wait_until_ready(self):
+        while not self.ready:
+            time.sleep(0.1)
+        logging.info('Health HTTP server is now ready')
+
+    def shutdown(self):
+        logging.info('Health HTTP server is shutting down')
+        if self.httpd:
+            self.httpd.shutdown()
+
+
+class MockLoggingHandler(logging.Handler):
+    """Mock logging handler to check for expected logs."""
+
+    def __init__(self, *args, **kwargs):
+        self.reset()
+        logging.Handler.__init__(self, *args, **kwargs)
+
+    def emit(self, record):
+        self.messages[record.levelname.lower()].append(record.getMessage())
+
+    def reset(self):
+        self.messages = {
+            'debug': [],
+            'info': [],
+            'warning': [],
+            'error': [],
+            'critical': [],
+        }
+
+
+class HealthDaemonTest(unittest.TestCase):
+
+    def setUp(self):
+        self.health_server = None
+        self.health_thread = None
+
+        self.addCleanup(self.shutDown)
+
+    def shutDown(self):
+        if self.health_server:
+            self.health_server.shutdown()
+            self.health_server = None
+
+        if self.health_thread:
+            self.health_thread.join()
+            self.health_thread = None
+
+    def start_mock_server(self, health_port, http_status_code):
+        # Set up a local HTTP server to server fake successful responses.
+        self.health_server = health_server = MockHealthServer(health_port,
+                                                              http_status_code=http_status_code)
+        self.health_thread = health_thread = threading.Thread(target=health_server.start)
+        health_thread.daemon = True
+        health_thread.setName('health-server-demon')
+        health_thread.start()
+
+
+        self.health_server.wait_until_ready()
+        return self.health_server.port
+
+    def test_ping_succeeds(self):
+        health_port = self.start_mock_server(health_port=0, http_status_code=200)
+
+        health_server_conn = HealthDaemon.connect_to_server(health_port)
+
+        # Create a timeout for 5 seconds from now.
+        timeout = time.time() + 5
+        result = False
+        while not result:
+            result = HealthDaemon.try_health_ping(health_server_conn)
+            time.sleep(0.5)
+            if result or time.time() > timeout:
+                break
+
+        # This fails if we could not connect to the server after 5 seconds.
+        self.assertTrue(result, 'Could not connect to server')
+
+    def test_ping_fails(self):
+        health_port = self.start_mock_server(health_port=0, http_status_code=501)
+
+        health_server_conn = HealthDaemon.connect_to_server(health_port)
+
+        # Create a timeout for 5 seconds from now.
+        timeout = time.time() + 1
+        result = False
+        while not result:
+            result = HealthDaemon.try_health_ping(health_server_conn)
+            time.sleep(0.5)
+            if result or time.time() > timeout:
+                break
+        self.assertFalse(result)
+
+    def test_no_server_fails(self):
+        health_port = 0
+
+        health_logger = MockLoggingHandler()
+        logging.getLogger().addHandler(health_logger)
+
+        health_server_conn = HealthDaemon.connect_to_server(health_port)
+        result = HealthDaemon.try_health_ping(health_server_conn)
+
+        self.assertFalse(result)
+        self.assertIn('Connection refused by server', health_logger.messages['error'])
+
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)
+    unittest.main()


### PR DESCRIPTION
Adds a HealthDaemon and tests. The HealthDaemon will be used to communicate to the Dataflow service that the container is healthy.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
