### PR TITLE
[BEAM-6781] Changed -with- statement to run job in Python load tests.

### DIFF
--- a/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
@@ -210,36 +210,35 @@ class CoGroupByKeyTest(unittest.TestCase):
         yield i
 
   def testCoGroupByKey(self):
-    with self.pipeline as p:
-      pc1 = (p
-             | 'Read ' + INPUT_TAG >> beam.io.Read(
-                 synthetic_pipeline.SyntheticSource(
-                     self.parseTestPipelineOptions(self.input_options)))
-             | 'Make ' + INPUT_TAG + ' iterable' >> beam.Map(lambda x: (x, x))
-             | 'Measure time: Start pc1' >> beam.ParDo(
-                 MeasureTime(self.metrics_namespace))
-            )
+    pc1 = (self.pipeline
+           | 'Read ' + INPUT_TAG >> beam.io.Read(
+               synthetic_pipeline.SyntheticSource(
+                   self.parseTestPipelineOptions(self.input_options)))
+           | 'Make ' + INPUT_TAG + ' iterable' >> beam.Map(lambda x: (x, x))
+           | 'Measure time: Start pc1' >> beam.ParDo(
+               MeasureTime(self.metrics_namespace))
+          )
 
-      pc2 = (p
-             | 'Read ' + CO_INPUT_TAG >> beam.io.Read(
-                 synthetic_pipeline.SyntheticSource(
-                     self.parseTestPipelineOptions(self.co_input_options)))
-             | 'Make ' + CO_INPUT_TAG + ' iterable' >> beam.Map(
-                 lambda x: (x, x))
-             | 'Measure time: Start pc2' >> beam.ParDo(
-                 MeasureTime(self.metrics_namespace))
-            )
-      # pylint: disable=expression-not-assigned
-      ({INPUT_TAG: pc1, CO_INPUT_TAG: pc2}
-       | 'CoGroupByKey: ' >> beam.CoGroupByKey()
-       | 'Consume Joined Collections' >> beam.ParDo(self._Ungroup())
-       | 'Measure time: End' >> beam.ParDo(MeasureTime(self.metrics_namespace))
-      )
+    pc2 = (self.pipeline
+           | 'Read ' + CO_INPUT_TAG >> beam.io.Read(
+               synthetic_pipeline.SyntheticSource(
+                   self.parseTestPipelineOptions(self.co_input_options)))
+           | 'Make ' + CO_INPUT_TAG + ' iterable' >> beam.Map(
+               lambda x: (x, x))
+           | 'Measure time: Start pc2' >> beam.ParDo(
+               MeasureTime(self.metrics_namespace))
+          )
+    # pylint: disable=expression-not-assigned
+    ({INPUT_TAG: pc1, CO_INPUT_TAG: pc2}
+     | 'CoGroupByKey: ' >> beam.CoGroupByKey()
+     | 'Consume Joined Collections' >> beam.ParDo(self._Ungroup())
+     | 'Measure time: End' >> beam.ParDo(MeasureTime(self.metrics_namespace))
+    )
 
-      result = p.run()
-      result.wait_until_finish()
-      if self.metrics_monitor is not None:
-        self.metrics_monitor.send_metrics(result)
+    result = self.pipeline.run()
+    result.wait_until_finish()
+    if self.metrics_monitor is not None:
+      self.metrics_monitor.send_metrics(result)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/testing/load_tests/combine_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/combine_test.py
@@ -170,23 +170,22 @@ class CombineTest(unittest.TestCase):
       yield element
 
   def testCombineGlobally(self):
-    with self.pipeline as p:
-      # pylint: disable=expression-not-assigned
-      (p
-       | beam.io.Read(synthetic_pipeline.SyntheticSource(
-           self.parseTestPipelineOptions()))
-       | 'Measure time: Start' >> beam.ParDo(
-           MeasureTime(self.metrics_namespace))
-       | 'Combine with Top' >> beam.CombineGlobally(
-           beam.combiners.TopCombineFn(1000))
-       | 'Consume' >> beam.ParDo(self._GetElement())
-       | 'Measure time: End' >> beam.ParDo(MeasureTime(self.metrics_namespace))
-      )
+    # pylint: disable=expression-not-assigned
+    (self.pipeline
+     | beam.io.Read(synthetic_pipeline.SyntheticSource(
+         self.parseTestPipelineOptions()))
+     | 'Measure time: Start' >> beam.ParDo(
+         MeasureTime(self.metrics_namespace))
+     | 'Combine with Top' >> beam.CombineGlobally(
+         beam.combiners.TopCombineFn(1000))
+     | 'Consume' >> beam.ParDo(self._GetElement())
+     | 'Measure time: End' >> beam.ParDo(MeasureTime(self.metrics_namespace))
+    )
 
-      result = p.run()
-      result.wait_until_finish()
-      if self.metrics_monitor is not None:
-        self.metrics_monitor.send_metrics(result)
+    result = self.pipeline.run()
+    result.wait_until_finish()
+    if self.metrics_monitor is not None:
+      self.metrics_monitor.send_metrics(result)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
@@ -167,23 +167,22 @@ class GroupByKeyTest(unittest.TestCase):
                        'are empty.')
 
   def testGroupByKey(self):
-    with self.pipeline as p:
-      # pylint: disable=expression-not-assigned
-      (p
-       | beam.io.Read(synthetic_pipeline.SyntheticSource(
-           self.parseTestPipelineOptions()))
-       | 'Measure time: Start' >> beam.ParDo(
-           MeasureTime(self.metrics_namespace))
-       | 'GroupByKey' >> beam.GroupByKey()
-       | 'Ungroup' >> beam.FlatMap(
-           lambda elm: [(elm[0], v) for v in elm[1]])
-       | 'Measure time: End' >> beam.ParDo(MeasureTime(self.metrics_namespace))
-      )
+    # pylint: disable=expression-not-assigned
+    (self.pipeline
+     | beam.io.Read(synthetic_pipeline.SyntheticSource(
+         self.parseTestPipelineOptions()))
+     | 'Measure time: Start' >> beam.ParDo(
+         MeasureTime(self.metrics_namespace))
+     | 'GroupByKey' >> beam.GroupByKey()
+     | 'Ungroup' >> beam.FlatMap(
+         lambda elm: [(elm[0], v) for v in elm[1]])
+     | 'Measure time: End' >> beam.ParDo(MeasureTime(self.metrics_namespace))
+    )
 
-      result = p.run()
-      result.wait_until_finish()
-      if self.metrics_monitor is not None:
-        self.metrics_monitor.send_metrics(result)
+    result = self.pipeline.run()
+    result.wait_until_finish()
+    if self.metrics_monitor is not None:
+      self.metrics_monitor.send_metrics(result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bug fix - because of `with` python pipelines were run twice.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
