### PR TITLE
[Beam-6627] add metrics to file based tests

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
@@ -72,7 +72,9 @@ def testsConfigurations = [
                 prCommitStatusName: 'Java AvroIO Performance Test',
                 prTriggerPhase    : 'Run Java AvroIO Performance Test',
                 extraPipelineArgs: [
-                        numberOfRecords: '1000000'
+                        numberOfRecords: '1000000',
+                        bigQueryDataset: 'beam_performance',
+                        bigQueryTable: 'avroioit_results',
                 ]
         ],
         [
@@ -83,6 +85,8 @@ def testsConfigurations = [
                 prCommitStatusName: 'Java TFRecordIO Performance Test',
                 prTriggerPhase    : 'Run Java TFRecordIO Performance Test',
                 extraPipelineArgs: [
+                        bigQueryDataset: 'beam_performance',
+                        bigQueryTable: 'tfrecordioit_results',
                         numberOfRecords: '1000000'
                 ]
         ],
@@ -94,6 +98,8 @@ def testsConfigurations = [
                 prCommitStatusName: 'Java XmlIOPerformance Test',
                 prTriggerPhase    : 'Run Java XmlIO Performance Test',
                 extraPipelineArgs: [
+                        bigQueryDataset: 'beam_performance',
+                        bigQueryTable: 'xmlioit_results',
                         numberOfRecords: '100000000',
                         charset: 'UTF-8'
                 ]
@@ -106,6 +112,8 @@ def testsConfigurations = [
                 prCommitStatusName: 'Java ParquetIOPerformance Test',
                 prTriggerPhase    : 'Run Java ParquetIO Performance Test',
                 extraPipelineArgs: [
+                        bigQueryDataset: 'beam_performance',
+                        bigQueryTable: 'parquetioit_results',
                         numberOfRecords: '100000000'
                 ]
         ]

--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT_HDFS.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT_HDFS.groovy
@@ -72,6 +72,8 @@ def testsConfigurations = [
                 prCommitStatusName: 'Java AvroIO Performance Test on HDFS',
                 prTriggerPhase    : 'Run Java AvroIO Performance Test HDFS',
                 extraPipelineArgs: [
+                        bigQueryDataset: 'beam_performance',
+                        bigQueryTable: 'avroioit_hdfs_results',
                         numberOfRecords: '1000000'
                 ]
         ],
@@ -96,6 +98,8 @@ def testsConfigurations = [
                 prCommitStatusName: 'Java XmlIOPerformance Test on HDFS',
                 prTriggerPhase    : 'Run Java XmlIO Performance Test HDFS',
                 extraPipelineArgs: [
+                        bigQueryDataset: 'beam_performance',
+                        bigQueryTable: 'xmlioit_hdfs_results',
                         numberOfRecords: '100000',
                         charset: 'UTF-8'
                 ]
@@ -108,6 +112,8 @@ def testsConfigurations = [
                 prCommitStatusName: 'Java ParquetIOPerformance Test on HDFS',
                 prTriggerPhase    : 'Run Java ParquetIO Performance Test HDFS',
                 extraPipelineArgs: [
+                        bigQueryDataset: 'beam_performance',
+                        bigQueryTable: 'parquetioit_hdfs_results',
                         numberOfRecords: '1000000'
                 ]
         ]

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/avro/AvroIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/avro/AvroIOIT.java
@@ -21,9 +21,15 @@ import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.appendTimestampS
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.getExpectedHashForLineCount;
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.readFileBasedIOITPipelineOptions;
 
+import com.google.cloud.Timestamp;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.io.AvroIO;
 import org.apache.beam.sdk.io.GenerateSequence;
@@ -31,8 +37,12 @@ import org.apache.beam.sdk.io.common.FileBasedIOITHelper;
 import org.apache.beam.sdk.io.common.FileBasedIOITHelper.DeleteFileFn;
 import org.apache.beam.sdk.io.common.FileBasedIOTestPipelineOptions;
 import org.apache.beam.sdk.io.common.HashingFn;
+import org.apache.beam.sdk.io.common.IOITMetrics;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testutils.NamedTestResult;
+import org.apache.beam.sdk.testutils.metrics.MetricsReader;
+import org.apache.beam.sdk.testutils.metrics.TimeMonitor;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -80,6 +90,9 @@ public class AvroIOIT {
 
   private static String filenamePrefix;
   private static Integer numberOfTextLines;
+  private static String bigQueryDataset;
+  private static String bigQueryTable;
+  private static final String AVRO_NAMESPACE = AvroIOIT.class.getName();
 
   @Rule public TestPipeline pipeline = TestPipeline.create();
 
@@ -89,6 +102,8 @@ public class AvroIOIT {
 
     numberOfTextLines = options.getNumberOfRecords();
     filenamePrefix = appendTimestampSuffix(options.getFilenamePrefix());
+    bigQueryDataset = options.getBigQueryDataset();
+    bigQueryTable = options.getBigQueryTable();
   }
 
   @Test
@@ -102,6 +117,7 @@ public class AvroIOIT {
                 ParDo.of(new FileBasedIOITHelper.DeterministicallyConstructTestTextLineFn()))
             .apply("Produce Avro records", ParDo.of(new DeterministicallyConstructAvroRecordsFn()))
             .setCoder(AvroCoder.of(AVRO_SCHEMA))
+            .apply("Collect start time", ParDo.of(new TimeMonitor<>(AVRO_NAMESPACE, "writeStart")))
             .apply(
                 "Write Avro records to files",
                 AvroIO.writeGenericRecords(AVRO_SCHEMA)
@@ -109,11 +125,14 @@ public class AvroIOIT {
                     .withOutputFilenames()
                     .withSuffix(".avro"))
             .getPerDestinationOutputFilenames()
+            .apply(
+                "Collect middle time", ParDo.of(new TimeMonitor<>(AVRO_NAMESPACE, "middlePoint")))
             .apply(Values.create());
 
     PCollection<String> consolidatedHashcode =
         testFilenames
             .apply("Read all files", AvroIO.readAllGenericRecords(AVRO_SCHEMA))
+            .apply("Collect end time", ParDo.of(new TimeMonitor<>(AVRO_NAMESPACE, "endPoint")))
             .apply("Parse Avro records to Strings", ParDo.of(new ParseAvroRecordsFn()))
             .apply("Calculate hashcode", Combine.globally(new HashingFn()));
 
@@ -125,7 +144,50 @@ public class AvroIOIT {
         ParDo.of(new DeleteFileFn())
             .withSideInputs(consolidatedHashcode.apply(View.asSingleton())));
 
-    pipeline.run().waitUntilFinish();
+    PipelineResult result = pipeline.run();
+    result.waitUntilFinish();
+    collectAndPublishMetrics(result);
+  }
+
+  private void collectAndPublishMetrics(PipelineResult result) {
+    String uuid = UUID.randomUUID().toString();
+    String timestamp = Timestamp.now().toString();
+
+    Set<Function<MetricsReader, NamedTestResult>> metricSuppliers =
+        fillMetricSuppliers(uuid, timestamp);
+    new IOITMetrics(metricSuppliers, result, AVRO_NAMESPACE, uuid, timestamp)
+        .publish(bigQueryDataset, bigQueryTable);
+  }
+
+  private Set<Function<MetricsReader, NamedTestResult>> fillMetricSuppliers(
+      String uuid, String timestamp) {
+    Set<Function<MetricsReader, NamedTestResult>> suppliers = new HashSet<>();
+
+    suppliers.add(
+        (reader) -> {
+          long writeStart = reader.getStartTimeMetric("writeStart");
+          long writeEnd = reader.getEndTimeMetric("middlePoint");
+          double writeTime = (writeEnd - writeStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "write_time", writeTime);
+        });
+
+    suppliers.add(
+        (reader) -> {
+          long readEnd = reader.getEndTimeMetric("endPoint");
+          long readStart = reader.getStartTimeMetric("middlePoint");
+          double readTime = (readEnd - readStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "read_time", readTime);
+        });
+
+    suppliers.add(
+        (reader) -> {
+          long readEnd = reader.getEndTimeMetric("endPoint");
+          long writeStart = reader.getStartTimeMetric("writeStart");
+          double runTime = (readEnd - writeStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "run_time", runTime);
+        });
+
+    return suppliers;
   }
 
   private static class DeterministicallyConstructAvroRecordsFn extends DoFn<String, GenericRecord> {

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/common/IOITMetrics.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/common/IOITMetrics.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.common;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.testutils.NamedTestResult;
+import org.apache.beam.sdk.testutils.metrics.MetricsReader;
+import org.apache.beam.sdk.testutils.publishing.BigQueryResultsPublisher;
+import org.apache.beam.sdk.testutils.publishing.ConsoleResultPublisher;
+
+/**
+ * Contains a flexible mechanism of publishing metrics to BQ and console using suppliers provided in
+ * test class using this object.
+ */
+public class IOITMetrics {
+
+  private final Set<Function<MetricsReader, NamedTestResult>> metricSuppliers;
+  private final PipelineResult result;
+  private final String namespace;
+  private String uuid;
+  private String timestamp;
+
+  public IOITMetrics(
+      Set<Function<MetricsReader, NamedTestResult>> metricSuppliers,
+      PipelineResult result,
+      String namespace,
+      String uuid,
+      String timestamp) {
+    this.metricSuppliers = metricSuppliers;
+    this.result = result;
+    this.namespace = namespace;
+    this.uuid = uuid;
+    this.timestamp = timestamp;
+  }
+
+  public void publish(String bigQueryDataset, String bigQueryTable) {
+    MetricsReader reader = new MetricsReader(result, namespace);
+    Collection<NamedTestResult> namedTestResults = reader.readAll(metricSuppliers);
+    if (bigQueryDataset != null && bigQueryTable != null) {
+      BigQueryResultsPublisher.create(bigQueryDataset, NamedTestResult.getSchema())
+          .publish(namedTestResults, bigQueryTable);
+    }
+    ConsoleResultPublisher.publish(namedTestResults, uuid, timestamp);
+  }
+}

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/parquet/ParquetIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/parquet/ParquetIOIT.java
@@ -22,17 +22,27 @@ import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.getExpectedHashF
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.readFileBasedIOITPipelineOptions;
 import static org.apache.beam.sdk.values.TypeDescriptors.strings;
 
+import com.google.cloud.Timestamp;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.common.FileBasedIOITHelper;
 import org.apache.beam.sdk.io.common.FileBasedIOTestPipelineOptions;
 import org.apache.beam.sdk.io.common.HashingFn;
+import org.apache.beam.sdk.io.common.IOITMetrics;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testutils.NamedTestResult;
+import org.apache.beam.sdk.testutils.metrics.MetricsReader;
+import org.apache.beam.sdk.testutils.metrics.TimeMonitor;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -82,8 +92,11 @@ public class ParquetIOIT {
 
   private static String filenamePrefix;
   private static Integer numberOfRecords;
+  private static String bigQueryDataset;
+  private static String bigQueryTable;
 
   @Rule public TestPipeline pipeline = TestPipeline.create();
+  private static final String PARQUET_NAMESPACE = ParquetIOIT.class.getName();
 
   @BeforeClass
   public static void setup() {
@@ -91,6 +104,8 @@ public class ParquetIOIT {
 
     numberOfRecords = options.getNumberOfRecords();
     filenamePrefix = appendTimestampSuffix(options.getFilenamePrefix());
+    bigQueryDataset = options.getBigQueryDataset();
+    bigQueryTable = options.getBigQueryTable();
   }
 
   @Test
@@ -104,16 +119,27 @@ public class ParquetIOIT {
             .apply("Produce Avro records", ParDo.of(new DeterministicallyConstructAvroRecordsFn()))
             .setCoder(AvroCoder.of(SCHEMA))
             .apply(
+                "Gather write start times",
+                ParDo.of(new TimeMonitor<>(PARQUET_NAMESPACE, "writeStart")))
+            .apply(
                 "Write Parquet files",
                 FileIO.<GenericRecord>write().via(ParquetIO.sink(SCHEMA)).to(filenamePrefix))
             .getPerDestinationOutputFilenames()
+            .apply(
+                "Gather write end times",
+                ParDo.of(new TimeMonitor<>(PARQUET_NAMESPACE, "writeEnd")))
             .apply("Get file names", Values.create());
 
     PCollection<String> consolidatedHashcode =
         testFiles
             .apply("Find files", FileIO.matchAll())
             .apply("Read matched files", FileIO.readMatches())
+            .apply(
+                "Gather read start time",
+                ParDo.of(new TimeMonitor<>(PARQUET_NAMESPACE, "readStart")))
             .apply("Read parquet files", ParquetIO.readFiles(SCHEMA))
+            .apply(
+                "Gather read end time", ParDo.of(new TimeMonitor<>(PARQUET_NAMESPACE, "readEnd")))
             .apply(
                 "Map records to strings",
                 MapElements.into(strings())
@@ -130,7 +156,48 @@ public class ParquetIOIT {
         ParDo.of(new FileBasedIOITHelper.DeleteFileFn())
             .withSideInputs(consolidatedHashcode.apply(View.asSingleton())));
 
-    pipeline.run().waitUntilFinish();
+    PipelineResult result = pipeline.run();
+    result.waitUntilFinish();
+    collectAndPublishMetrics(result);
+  }
+
+  private void collectAndPublishMetrics(PipelineResult result) {
+    String uuid = UUID.randomUUID().toString();
+    String timestamp = Timestamp.now().toString();
+    Set<Function<MetricsReader, NamedTestResult>> metricSuppliers =
+        fillMetricSuppliers(uuid, timestamp);
+    new IOITMetrics(metricSuppliers, result, PARQUET_NAMESPACE, uuid, timestamp)
+        .publish(bigQueryDataset, bigQueryTable);
+  }
+
+  private Set<Function<MetricsReader, NamedTestResult>> fillMetricSuppliers(
+      String uuid, String timestamp) {
+    Set<Function<MetricsReader, NamedTestResult>> metricSuppliers = new HashSet<>();
+    metricSuppliers.add(
+        reader -> {
+          long writeStart = reader.getStartTimeMetric("writeStart");
+          long writeEnd = reader.getEndTimeMetric("writeEnd");
+          double writeTime = (writeEnd - writeStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "write_time", writeTime);
+        });
+
+    metricSuppliers.add(
+        reader -> {
+          long readStart = reader.getStartTimeMetric("readStart");
+          long readEnd = reader.getEndTimeMetric("readEnd");
+          double readTime = (readEnd - readStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "read_time", readTime);
+        });
+
+    metricSuppliers.add(
+        reader -> {
+          long writeStart = reader.getStartTimeMetric("writeStart");
+          long readEnd = reader.getEndTimeMetric("readEnd");
+          double runTime = (readEnd - writeStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "run_time", runTime);
+        });
+
+    return metricSuppliers;
   }
 
   private static class DeterministicallyConstructAvroRecordsFn extends DoFn<String, GenericRecord> {

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
@@ -23,9 +23,10 @@ import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.getExpectedHashF
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.readFileBasedIOITPipelineOptions;
 
 import com.google.cloud.Timestamp;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.GenerateSequence;
@@ -34,13 +35,12 @@ import org.apache.beam.sdk.io.common.FileBasedIOITHelper;
 import org.apache.beam.sdk.io.common.FileBasedIOITHelper.DeleteFileFn;
 import org.apache.beam.sdk.io.common.FileBasedIOTestPipelineOptions;
 import org.apache.beam.sdk.io.common.HashingFn;
+import org.apache.beam.sdk.io.common.IOITMetrics;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testutils.NamedTestResult;
 import org.apache.beam.sdk.testutils.metrics.MetricsReader;
 import org.apache.beam.sdk.testutils.metrics.TimeMonitor;
-import org.apache.beam.sdk.testutils.publishing.BigQueryResultsPublisher;
-import org.apache.beam.sdk.testutils.publishing.ConsoleResultPublisher;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Values;
@@ -142,55 +142,61 @@ public class TextIOIT {
 
     PipelineResult result = pipeline.run();
     result.waitUntilFinish();
-    gatherAndPublishMetrics(result);
+
+    collectAndPublishMetrics(result);
   }
 
-  private void gatherAndPublishMetrics(PipelineResult result) {
+  private void collectAndPublishMetrics(PipelineResult result) {
     String uuid = UUID.randomUUID().toString();
     Timestamp timestamp = Timestamp.now();
-    List<NamedTestResult> namedTestResults = readMetrics(result, uuid, timestamp);
-    if (bigQueryDataset != null && bigQueryTable != null) {
-      BigQueryResultsPublisher.create(bigQueryDataset, NamedTestResult.getSchema())
-          .publish(namedTestResults, bigQueryTable);
-    }
-    ConsoleResultPublisher.publish(namedTestResults, uuid, timestamp.toString());
+
+    Set<Function<MetricsReader, NamedTestResult>> metricSuppliers =
+        fillMetricSuppliers(uuid, timestamp.toString());
+
+    new IOITMetrics(metricSuppliers, result, FILEIOIT_NAMESPACE, uuid, timestamp.toString())
+        .publish(bigQueryDataset, bigQueryTable);
   }
 
-  private List<NamedTestResult> readMetrics(
-      PipelineResult result, String uuid, Timestamp timestamp) {
-    List<NamedTestResult> results = new ArrayList<>();
+  private Set<Function<MetricsReader, NamedTestResult>> fillMetricSuppliers(
+      String uuid, String timestamp) {
+    Set<Function<MetricsReader, NamedTestResult>> metricSuppliers = new HashSet<>();
 
-    MetricsReader reader = new MetricsReader(result, FILEIOIT_NAMESPACE);
-    long writeStartTime = reader.getStartTimeMetric("startTime");
-    long writeEndTime = reader.getEndTimeMetric("middleTime");
-    long readStartTime = reader.getStartTimeMetric("middleTime");
-    long readEndTime = reader.getEndTimeMetric("endTime");
-    double writeTime = (writeEndTime - writeStartTime) / 1e3;
-    double readTime = (readEndTime - readStartTime) / 1e3;
-    double runTime = (readEndTime - writeStartTime) / 1e3;
+    metricSuppliers.add(
+        (reader) -> {
+          long writeStartTime = reader.getStartTimeMetric("startTime");
+          long writeEndTime = reader.getEndTimeMetric("middleTime");
+          double writeTime = (writeEndTime - writeStartTime) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "write_time", writeTime);
+        });
+
+    metricSuppliers.add(
+        (reader) -> {
+          long readStartTime = reader.getStartTimeMetric("middleTime");
+          long readEndTime = reader.getEndTimeMetric("endTime");
+          double readTime = (readEndTime - readStartTime) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "read_time", readTime);
+        });
+
+    metricSuppliers.add(
+        (reader) -> {
+          long writeStartTime = reader.getStartTimeMetric("startTime");
+          long readEndTime = reader.getEndTimeMetric("endTime");
+          double runTime = (readEndTime - writeStartTime) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "run_time", runTime);
+        });
+
     if (gatherGcsPerformanceMetrics) {
-      double copiesPerSec = calculateGcsCopies(result);
-
-      if (copiesPerSec > 0) {
-        results.add(
-            NamedTestResult.create(uuid, timestamp.toString(), "copies_per_sec", copiesPerSec));
-      }
+      metricSuppliers.add(
+          reader -> {
+            MetricsReader actualReader =
+                reader.withNamespace("org.apache.beam.sdk.extensions.gcp.storage.GcsFileSystem");
+            long numCopies = actualReader.getCounterMetric("num_copies");
+            long copyTimeMsec = actualReader.getCounterMetric("copy_time_msec");
+            double copiesPerSec =
+                (numCopies < 0 || copyTimeMsec < 0) ? -1 : numCopies / (copyTimeMsec / 1e3);
+            return NamedTestResult.create(uuid, timestamp, "copies_per_sec", copiesPerSec);
+          });
     }
-    results.add(NamedTestResult.create(uuid, timestamp.toString(), "read_time", readTime));
-    results.add(NamedTestResult.create(uuid, timestamp.toString(), "write_time", writeTime));
-    results.add(NamedTestResult.create(uuid, timestamp.toString(), "run_time", runTime));
-
-    return results;
-  }
-
-  private double calculateGcsCopies(PipelineResult result) {
-    MetricsReader metricsReader =
-        new MetricsReader(result, "org.apache.beam.sdk.extensions.gcp.storage.GcsFileSystem");
-    long numCopies = metricsReader.getCounterMetric("num_copies");
-    long copyTimeMsec = metricsReader.getCounterMetric("copy_time_msec");
-    if (numCopies < 0 || copyTimeMsec < 0) {
-      return -1;
-    }
-    return numCopies / (copyTimeMsec / 1e3);
+    return metricSuppliers;
   }
 }

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/tfrecord/TFRecordIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/tfrecord/TFRecordIOIT.java
@@ -22,7 +22,13 @@ import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.appendTimestampS
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.getExpectedHashForLineCount;
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.readFileBasedIOITPipelineOptions;
 
+import com.google.cloud.Timestamp;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.TFRecordIO;
@@ -30,8 +36,12 @@ import org.apache.beam.sdk.io.common.FileBasedIOITHelper;
 import org.apache.beam.sdk.io.common.FileBasedIOITHelper.DeleteFileFn;
 import org.apache.beam.sdk.io.common.FileBasedIOTestPipelineOptions;
 import org.apache.beam.sdk.io.common.HashingFn;
+import org.apache.beam.sdk.io.common.IOITMetrics;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testutils.NamedTestResult;
+import org.apache.beam.sdk.testutils.metrics.MetricsReader;
+import org.apache.beam.sdk.testutils.metrics.TimeMonitor;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -67,10 +77,13 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class TFRecordIOIT {
+  private static final String TFRECORD_NAMESPACE = TFRecordIOIT.class.getName();
 
   private static String filenamePrefix;
   private static Integer numberOfTextLines;
   private static Compression compressionType;
+  private static String bigQueryDataset;
+  private static String bigQueryTable;
 
   @Rule public TestPipeline writePipeline = TestPipeline.create();
 
@@ -83,6 +96,8 @@ public class TFRecordIOIT {
     numberOfTextLines = options.getNumberOfRecords();
     filenamePrefix = appendTimestampSuffix(options.getFilenamePrefix());
     compressionType = Compression.valueOf(options.getCompressionType());
+    bigQueryDataset = options.getBigQueryDataset();
+    bigQueryTable = options.getBigQueryTable();
   }
 
   private static String createFilenamePattern() {
@@ -104,6 +119,9 @@ public class TFRecordIOIT {
             "Produce text lines",
             ParDo.of(new FileBasedIOITHelper.DeterministicallyConstructTestTextLineFn()))
         .apply("Transform strings to bytes", MapElements.via(new StringToByteArray()))
+        .apply(
+            "Record time before writing",
+            ParDo.of(new TimeMonitor<>(TFRECORD_NAMESPACE, "writeTime")))
         .apply("Write content to files", writeTransform);
 
     writePipeline.run().waitUntilFinish();
@@ -112,6 +130,9 @@ public class TFRecordIOIT {
     PCollection<String> consolidatedHashcode =
         readPipeline
             .apply(TFRecordIO.read().from(filenamePattern).withCompression(AUTO))
+            .apply(
+                "Record time after reading",
+                ParDo.of(new TimeMonitor<>(TFRECORD_NAMESPACE, "readTime")))
             .apply("Transform bytes to strings", MapElements.via(new ByteArrayToString()))
             .apply("Calculate hashcode", Combine.globally(new HashingFn()))
             .apply(Reshuffle.viaRandomKey());
@@ -125,7 +146,49 @@ public class TFRecordIOIT {
             "Delete test files",
             ParDo.of(new DeleteFileFn())
                 .withSideInputs(consolidatedHashcode.apply(View.asSingleton())));
-    readPipeline.run().waitUntilFinish();
+    PipelineResult result = readPipeline.run();
+    result.waitUntilFinish();
+    collectAndPublishMetrics(result);
+  }
+
+  private void collectAndPublishMetrics(PipelineResult result) {
+    String uuid = UUID.randomUUID().toString();
+    String timestamp = Timestamp.now().toString();
+
+    Set<Function<MetricsReader, NamedTestResult>> metricSuppliers =
+        fillMetricSuppliers(uuid, timestamp);
+    new IOITMetrics(metricSuppliers, result, TFRECORD_NAMESPACE, uuid, timestamp)
+        .publish(bigQueryDataset, bigQueryTable);
+  }
+
+  private Set<Function<MetricsReader, NamedTestResult>> fillMetricSuppliers(
+      String uuid, String timestamp) {
+    Set<Function<MetricsReader, NamedTestResult>> suppliers = new HashSet<>();
+    suppliers.add(
+        reader -> {
+          long writeStart = reader.getStartTimeMetric("writeTime");
+          long writeEnd = reader.getEndTimeMetric("writeTime");
+          double writeTime = (writeEnd - writeStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "write_time", writeTime);
+        });
+
+    suppliers.add(
+        reader -> {
+          long readStart = reader.getStartTimeMetric("readTime");
+          long readEnd = reader.getEndTimeMetric("readTime");
+          double readTime = (readEnd - readStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "read_time", readTime);
+        });
+
+    suppliers.add(
+        reader -> {
+          long writeStart = reader.getStartTimeMetric("writeTime");
+          long readEnd = reader.getEndTimeMetric("readTime");
+          double runTime = (readEnd - writeStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "run_time", runTime);
+        });
+
+    return suppliers;
   }
 
   static class StringToByteArray extends SimpleFunction<String, byte[]> {

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/xml/XmlIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/xml/XmlIOIT.java
@@ -21,20 +21,30 @@ import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.appendTimestampS
 import static org.apache.beam.sdk.io.common.IOITHelper.getHashForRecordCount;
 import static org.apache.beam.sdk.io.common.IOITHelper.readIOTestPipelineOptions;
 
+import com.google.cloud.Timestamp;
 import java.io.Serializable;
 import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.common.FileBasedIOITHelper;
 import org.apache.beam.sdk.io.common.FileBasedIOTestPipelineOptions;
 import org.apache.beam.sdk.io.common.HashingFn;
+import org.apache.beam.sdk.io.common.IOITMetrics;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testutils.NamedTestResult;
+import org.apache.beam.sdk.testutils.metrics.MetricsReader;
+import org.apache.beam.sdk.testutils.metrics.TimeMonitor;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -89,6 +99,10 @@ public class XmlIOIT {
   private static Integer numberOfRecords;
 
   private static String filenamePrefix;
+  private static String bigQueryDataset;
+  private static String bigQueryTable;
+
+  private static final String XMLIOIT_NAMESPACE = XmlIOIT.class.getName();
 
   private static Charset charset;
 
@@ -101,6 +115,8 @@ public class XmlIOIT {
     filenamePrefix = appendTimestampSuffix(options.getFilenamePrefix());
     numberOfRecords = options.getNumberOfRecords();
     charset = Charset.forName(options.getCharset());
+    bigQueryDataset = options.getBigQueryDataset();
+    bigQueryTable = options.getBigQueryTable();
   }
 
   @Test
@@ -110,6 +126,9 @@ public class XmlIOIT {
             .apply("Generate sequence", GenerateSequence.from(0).to(numberOfRecords))
             .apply("Create xml records", MapElements.via(new LongToBird()))
             .apply(
+                "Gather write start time",
+                ParDo.of(new TimeMonitor<>(XMLIOIT_NAMESPACE, "writeStart")))
+            .apply(
                 "Write xml files",
                 FileIO.<Bird>write()
                     .via(XmlIO.sink(Bird.class).withRootElement("birds").withCharset(charset))
@@ -117,6 +136,8 @@ public class XmlIOIT {
                     .withPrefix("birds")
                     .withSuffix(".xml"))
             .getPerDestinationOutputFilenames()
+            .apply(
+                "Gather write end time", ParDo.of(new TimeMonitor<>(XMLIOIT_NAMESPACE, "writeEnd")))
             .apply("Get file names", Values.create());
 
     PCollection<Bird> birds =
@@ -124,12 +145,17 @@ public class XmlIOIT {
             .apply("Find files", FileIO.matchAll())
             .apply("Read matched files", FileIO.readMatches())
             .apply(
+                "Gather read start time",
+                ParDo.of(new TimeMonitor<>(XMLIOIT_NAMESPACE, "readStart")))
+            .apply(
                 "Read xml files",
                 XmlIO.<Bird>readFiles()
                     .withRecordClass(Bird.class)
                     .withRootElement("birds")
                     .withRecordElement("bird")
-                    .withCharset(charset));
+                    .withCharset(charset))
+            .apply(
+                "Gather read end time", ParDo.of(new TimeMonitor<>(XMLIOIT_NAMESPACE, "readEnd")));
 
     PCollection<String> consolidatedHashcode =
         birds
@@ -144,7 +170,48 @@ public class XmlIOIT {
         ParDo.of(new FileBasedIOITHelper.DeleteFileFn())
             .withSideInputs(consolidatedHashcode.apply(View.asSingleton())));
 
-    pipeline.run().waitUntilFinish();
+    PipelineResult result = pipeline.run();
+    result.waitUntilFinish();
+    collectAndPublishResults(result);
+  }
+
+  private void collectAndPublishResults(PipelineResult result) {
+    String uuid = UUID.randomUUID().toString();
+    String timestamp = Timestamp.now().toString();
+
+    Set<Function<MetricsReader, NamedTestResult>> metricSuppliers =
+        fillMetricSuppliers(uuid, timestamp);
+    new IOITMetrics(metricSuppliers, result, XMLIOIT_NAMESPACE, uuid, timestamp)
+        .publish(bigQueryDataset, bigQueryTable);
+  }
+
+  private Set<Function<MetricsReader, NamedTestResult>> fillMetricSuppliers(
+      String uuid, String timestamp) {
+    Set<Function<MetricsReader, NamedTestResult>> suppliers = new HashSet<>();
+    suppliers.add(
+        reader -> {
+          long writeStart = reader.getStartTimeMetric("writeStart");
+          long writeEnd = reader.getEndTimeMetric("writeEnd");
+          double writeTime = (writeEnd - writeStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "write_time", writeTime);
+        });
+
+    suppliers.add(
+        reader -> {
+          long readStart = reader.getStartTimeMetric("readStart");
+          long readEnd = reader.getEndTimeMetric("readEnd");
+          double readTime = (readEnd - readStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "read_time", readTime);
+        });
+
+    suppliers.add(
+        reader -> {
+          long writeStart = reader.getStartTimeMetric("writeStart");
+          long readEnd = reader.getEndTimeMetric("readEnd");
+          double runTime = (readEnd - writeStart) / 1e3;
+          return NamedTestResult.create(uuid, timestamp, "run_time", runTime);
+        });
+    return suppliers;
   }
 
   private static class LongToBird extends SimpleFunction<Long, Bird> {

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/ConsoleResultPublisher.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/ConsoleResultPublisher.java
@@ -19,13 +19,13 @@ package org.apache.beam.sdk.testutils.publishing;
 
 import static java.lang.String.format;
 
-import java.util.List;
+import java.util.Collection;
 import org.apache.beam.sdk.testutils.NamedTestResult;
 
 /** Writes load test metrics results to console. */
 public class ConsoleResultPublisher {
 
-  public static void publish(List<NamedTestResult> results, String testId, String timestamp) {
+  public static void publish(Collection<NamedTestResult> results, String testId, String timestamp) {
     final String textTemplate = "%24s  %24s";
 
     System.out.println(


### PR DESCRIPTION
Similarly as in my earlier [PR](https://github.com/apache/beam/pull/7772), I added metric reporting to the rest of file based IO tests.

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
