### PR TITLE
[BEAM-5663] Add Python 3.6 and Python 3.7 precommit test suites

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,7 @@ task pythonPreCommit() {
   dependsOn ":beam-sdks-python:preCommitPy2"
   dependsOn ":beam-sdks-python-test-suites-tox-py35:preCommitPy35"
   dependsOn ":beam-sdks-python-test-suites-tox-py36:preCommitPy36"
+  dependsOn ":beam-sdks-python-test-suites-tox-py37:preCommitPy37"
   dependsOn ":beam-sdks-python-test-suites-dataflow:preCommitIT"
 }
 

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1888,6 +1888,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     assert_that(d, equal_to([[10, 9, 8]]))
     self.p.run()
 
+  @unittest.skipIf(sys.version_info >= (3, 7, 0) and
+                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                   'This test still needs to be fixed on Python 3.7. '
+                   'See BEAM-6986')
   def test_top_of_runtime_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
 

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -19,6 +19,8 @@
 
 from __future__ import absolute_import
 
+import os
+import sys
 import typing
 import unittest
 
@@ -35,6 +37,10 @@ class _TestClass(object):
   pass
 
 
+@unittest.skipIf(sys.version_info >= (3, 7, 0) and
+                 os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                 'This test still needs to be fixed on Python 3.7. '
+                 'See BEAM-6985')
 class NativeTypeCompatibilityTest(unittest.TestCase):
 
   def test_convert_to_beam_type(self):

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -19,6 +19,8 @@
 
 from __future__ import absolute_import
 
+import os
+import sys
 import typing
 import unittest
 
@@ -46,6 +48,10 @@ class MainInputTest(unittest.TestCase):
     with self.assertRaises(typehints.TypeCheckError):
       [1, 2, 3] | beam.Map(repeat, 3)
 
+  @unittest.skipIf(sys.version_info >= (3, 7, 0) and
+                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                   'This test still needs to be fixed on Python 3.7. '
+                   'See BEAM-6988')
   def test_non_function(self):
     result = ['a', 'bb', 'c'] | beam.Map(str.upper)
     self.assertEqual(['A', 'BB', 'C'], sorted(result))
@@ -109,6 +115,10 @@ class MainInputTest(unittest.TestCase):
     self.assertEquals([1, 3], [1, 2, 3] | beam.Filter(filter_fn))
 
 
+@unittest.skipIf(sys.version_info >= (3, 7, 0) and
+                 os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                 'This test still needs to be fixed on Python 3.7. '
+                 'See BEAM-6987')
 class NativeTypesTest(unittest.TestCase):
 
   def test_good_main_input(self):

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -21,6 +21,8 @@ from __future__ import absolute_import
 
 import functools
 import inspect
+import os
+import sys
 import unittest
 from builtins import next
 from builtins import range
@@ -709,6 +711,10 @@ class IterableHintTestCase(TypeHintTestCase):
     self.assertIsNone(hint.type_check(l))
 
 
+@unittest.skipIf(sys.version_info >= (3, 7, 0) and
+                 os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                 'This test still needs to be fixed on Python 3.7. '
+                 'See BEAM-6986')
 class TestGeneratorWrapper(TypeHintTestCase):
 
   def test_functions_as_regular_generator(self):

--- a/sdks/python/test-suites/tox/py36/build.gradle
+++ b/sdks/python/test-suites/tox/py36/build.gradle
@@ -42,5 +42,6 @@ testPy36Cython.mustRunAfter testPython36, testPy36Gcp
 task preCommitPy36() {
     dependsOn "testPython36"
     dependsOn "testPy36Gcp"
-    dependsOn "testPy36Cython"
+    // TODO: Activate when Jenkins workers are updated with python3.6-dev
+    // dependsOn "testPy36Cython"
 }

--- a/sdks/python/test-suites/tox/py37/build.gradle
+++ b/sdks/python/test-suites/tox/py37/build.gradle
@@ -42,5 +42,6 @@ testPy37Cython.mustRunAfter testPython37, testPy37Gcp
 task preCommitPy37() {
     dependsOn "testPython37"
     dependsOn "testPy37Gcp"
-    dependsOn "testPy37Cython"
+    // TODO: Activate when Jenkins workers are updated with python3.7-dev
+    // dependsOn "testPy37Cython"
 }

--- a/sdks/python/test-suites/tox/py37/build.gradle
+++ b/sdks/python/test-suites/tox/py37/build.gradle
@@ -17,30 +17,30 @@
  */
 
 /**
- * Unit tests for Python 3.6
+ * Unit tests for Python 3.7
  */
 
 plugins { id 'org.apache.beam.module' }
 applyPythonNature()
 
 // Required to setup a Python 3 virtualenv.
-pythonVersion = '3.6'
+pythonVersion = '3.7'
 
-toxTask "testPython36", "py36"
-test.dependsOn testPython36
+toxTask "testPython37", "py37"
+test.dependsOn testPython37
 
-toxTask "testPy36Gcp", "py36-gcp"
-test.dependsOn testPy36Gcp
+toxTask "testPy37Gcp", "py37-gcp"
+test.dependsOn testPy37Gcp
 
-toxTask "testPy36Cython", "py36-cython"
-test.dependsOn testPy36Cython
-// Ensure that testPy36Cython runs exclusively to other tests. This line is not
+toxTask "testPy37Cython", "py37-cython"
+test.dependsOn testPy37Cython
+// Ensure that testPy37Cython runs exclusively to other tests. This line is not
 // actually required, since gradle doesn't do parallel execution within a
 // project.
-testPy36Cython.mustRunAfter testPython36, testPy36Gcp
+testPy37Cython.mustRunAfter testPython37, testPy37Gcp
 
-task preCommitPy36() {
-    dependsOn "testPython36"
-    dependsOn "testPy36Gcp"
-    dependsOn "testPy36Cython"
+task preCommitPy37() {
+    dependsOn "testPython37"
+    dependsOn "testPy37Gcp"
+    dependsOn "testPy37Cython"
 }

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -17,7 +17,7 @@
 
 [tox]
 # new environments will be excluded by default unless explicitly added to envlist.
-envlist = py27,py35,py36,py27-{gcp,cython,lint,lint3},py35-{gcp,cython,lint},docs
+envlist = py27,py35,py36,py37,py27-{gcp,cython,lint,lint3},py35-{gcp,cython,lint},py36-{gcp,cython},py37-{gcp,cython},docs
 toxworkdir = {toxinidir}/target/{env:ENV_NAME:.tox}
 
 [pycodestyle]
@@ -75,6 +75,17 @@ commands =
   python setup.py nosetests
   {toxinidir}/scripts/run_tox_cleanup.sh
 
+[testenv:py37]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python --version
+  pip --version
+  {toxinidir}/scripts/run_tox_cleanup.sh
+  python apache_beam/examples/complete/autocomplete_test.py
+  python setup.py nosetests
+  {toxinidir}/scripts/run_tox_cleanup.sh
+
 [testenv:py27-cython]
 # cython tests are only expected to work in linux (2.x and 3.x)
 # If we want to add other platforms in the future, it should be:
@@ -105,6 +116,38 @@ commands =
   python setup.py nosetests
   {toxinidir}/scripts/run_tox_cleanup.sh
 
+[testenv:py36-cython]
+# cython tests are only expected to work in linux (2.x and 3.x)
+# If we want to add other platforms in the future, it should be:
+# `platform = linux2|darwin|...`
+# See https://docs.python.org/2/library/sys.html#sys.platform for platform codes
+platform = linux
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python --version
+  pip --version
+  {toxinidir}/scripts/run_tox_cleanup.sh
+  python apache_beam/examples/complete/autocomplete_test.py
+  python setup.py nosetests
+  {toxinidir}/scripts/run_tox_cleanup.sh
+
+[testenv:py37-cython]
+# cython tests are only expected to work in linux (2.x and 3.x)
+# If we want to add other platforms in the future, it should be:
+# `platform = linux2|darwin|...`
+# See https://docs.python.org/2/library/sys.html#sys.platform for platform codes
+platform = linux
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python --version
+  pip --version
+  {toxinidir}/scripts/run_tox_cleanup.sh
+  python apache_beam/examples/complete/autocomplete_test.py
+  python setup.py nosetests
+  {toxinidir}/scripts/run_tox_cleanup.sh
+
 [testenv:py27-gcp]
 extras = test,gcp
 commands =
@@ -116,6 +159,17 @@ commands =
   {toxinidir}/scripts/run_tox_cleanup.sh
 
 [testenv:py35-gcp]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+extras = test,gcp
+commands =
+  python --version
+  pip --version
+  {toxinidir}/scripts/run_tox_cleanup.sh
+  python setup.py nosetests
+  {toxinidir}/scripts/run_tox_cleanup.sh
+
+[testenv:py37-gcp]
 setenv =
   RUN_SKIPPED_PY3_TESTS=0
 extras = test,gcp

--- a/settings.gradle
+++ b/settings.gradle
@@ -213,6 +213,8 @@ include "beam-sdks-python-test-suites-tox-py35"
 project(":beam-sdks-python-test-suites-tox-py35").dir = file("sdks/python/test-suites/tox/py35")
 include "beam-sdks-python-test-suites-tox-py36"
 project(":beam-sdks-python-test-suites-tox-py36").dir = file("sdks/python/test-suites/tox/py36")
+include "beam-sdks-python-test-suites-tox-py37"
+project(":beam-sdks-python-test-suites-tox-py37").dir = file("sdks/python/test-suites/tox/py37")
 include "beam-sdks-python-load-tests"
 project(":beam-sdks-python-load-tests").dir = file("sdks/python/apache_beam/testing/load_tests")
 include "beam-vendor-grpc-1_13_1"


### PR DESCRIPTION
This is is part of a series of PRs with goal to make Apache Beam PY3 compatible. The proposal with the outlined approach has been documented here: https://s.apache.org/beam-python-3.

This PR checks all unit tests for Python 3.6 and 3.7 to get an overview of remaining work.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
