### PR TITLE
Datastore dependencies update

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -139,9 +139,9 @@ REQUIRED_TEST_PACKAGES = [
 GCP_REQUIREMENTS = [
     # google-apitools 0.5.23 and above has important Python 3 supports.
     'google-apitools>=0.5.26,<0.5.27',
-    'proto-google-cloud-datastore-v1>=0.90.0,<=0.90.4',
     # [BEAM-4543] Datastore IO is not supported in Python 3.
     'googledatastore>=7.0.1,<7.1; python_version < "3.0"',
+    'google-cloud-datastore==1.7.1',
     'google-cloud-pubsub==0.39.0',
     # GCP packages required by tests
     'google-cloud-bigquery>=1.6.0,<1.7.0',

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -48,6 +48,7 @@ list_dependencies_command = {envbindir}/python {envbindir}/pip freeze
 commands =
   python --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests
@@ -59,6 +60,7 @@ setenv =
 commands =
   python --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests
@@ -73,6 +75,7 @@ platform = linux2
 commands =
   python --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests
@@ -89,6 +92,7 @@ setenv =
 commands =
   python --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests
@@ -99,6 +103,7 @@ extras = test,gcp
 commands =
   python --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests
@@ -111,6 +116,7 @@ extras = test,gcp
 commands =
   python --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   python setup.py nosetests
   {toxinidir}/scripts/run_tox_cleanup.sh
@@ -125,6 +131,7 @@ deps =
 commands =
   pylint --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   time {toxinidir}/scripts/run_pylint.sh
 
@@ -139,6 +146,7 @@ deps =
 commands =
   pylint --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   time {toxinidir}/scripts/run_pylint_2to3.sh
 
@@ -153,6 +161,7 @@ deps =
 commands =
   pylint --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   time {toxinidir}/scripts/run_mini_py3lint.sh
 
@@ -164,6 +173,7 @@ deps =
 commands =
   python --version
   pip --version
+  pip check
   time {toxinidir}/scripts/generate_pydoc.sh
 
 [testenv:cover]
@@ -173,6 +183,7 @@ deps =
 commands =
   python --version
   pip --version
+  pip check
   {toxinidir}/scripts/run_tox_cleanup.sh
   # Clean up previously collected data.
   coverage erase


### PR DESCRIPTION
First step in migrating from googledatstore to google-cloud-datastore.

Remove unused proto-google-cloud-datastore-v1 package.
Add `pip check` to all tox environments to makes sure there are no
dependency conflicts.
Add `google-cloud-datastore==1.7.1` to gcp dependencies (later versions
need newer google-cloud-core packages which conflicts with other
packages).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
