### PR TITLE
[BEAM-4684] Disable support of @RequiresStableInput on Dataflow runner for now

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -411,22 +411,24 @@ task examplesJavaFnApiWorkerIntegrationTest(type: Test) {
 }
 
 task coreSDKJavaLegacyWorkerIntegrationTest(type: Test) {
-  group = "Verification"
-  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
+    group = "Verification"
+    dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
 
-  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
-          "--runner=TestDataflowRunner",
-          "--project=${dataflowProject}",
-          "--tempRoot=${dataflowPostCommitTempRoot}",
-          "--dataflowWorkerJar=${dataflowLegacyWorkerJar}",
-          "--workerHarnessContainerImage=",
-  ])
+    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+            "--runner=TestDataflowRunner",
+            "--project=${dataflowProject}",
+            "--tempRoot=${dataflowPostCommitTempRoot}",
+            "--dataflowWorkerJar=${dataflowLegacyWorkerJar}",
+            "--workerHarnessContainerImage=",
+    ])
 
-  include '**/*IT.class'
-  maxParallelForks 4
-  classpath = configurations.coreSDKJavaIntegrationTest
-  testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
-  useJUnit { }
+    include '**/*IT.class'
+    // TODO[Beam-4684]: Support @RequiresStableInput on Dataflow in a more intelligent way
+    exclude '**/RequiresStableInputIT.class'
+    maxParallelForks 4
+    classpath = configurations.coreSDKJavaIntegrationTest
+    testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
+    useJUnit { }
 }
 
 task coreSDKJavaFnApiWorkerIntegrationTest(type: Test) {
@@ -441,6 +443,8 @@ task coreSDKJavaFnApiWorkerIntegrationTest(type: Test) {
     )
 
     include '**/*IT.class'
+    // TODO[Beam-4684]: Support @RequiresStableInput on Dataflow in a more intelligent way
+    exclude '**/RequiresStableInputIT.class'
     maxParallelForks 4
     classpath = configurations.coreSDKJavaIntegrationTest
     testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -123,9 +123,9 @@ def fnapiExperiments = project.findProperty('useExecutableStage') ? 'beam_fn_api
 ext.dockerImageName = "${dockerImageContainer}:${dockerTag}"
 
 def fnApiPipelineOptions = [
-      "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
-      "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
-      "--experiments=${fnapiExperiments}",
+  "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
+  "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
+  "--experiments=${fnapiExperiments}",
 ]
 
 def commonExcludeCategories = [
@@ -162,7 +162,6 @@ task validatesRunnerLegacyWorkerTest(type: Test) {
           "--tempRoot=${dataflowValidatesTempRoot}",
           "--dataflowWorkerJar=${dataflowLegacyWorkerJar}",
           "--workerHarnessContainerImage=",
-
   ])
 
   // Increase test parallelism up to the number of Gradle workers. By default this is equal
@@ -206,75 +205,75 @@ afterEvaluate {
 }
 
 task printFnApiPipelineOptions {
-    group = "Help"
-    description = "Prints to the console extra pipeline options needed to run a Dataflow pipeline using portability"
+  group = "Help"
+  description = "Prints to the console extra pipeline options needed to run a Dataflow pipeline using portability"
 
-    dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
-    dependsOn buildAndPushDockerContainer
+  dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
+  dependsOn buildAndPushDockerContainer
 
-    doLast {
-      println "To run a Dataflow job with portability, add the following pipeline options to your command-line:"
-      println fnApiPipelineOptions.join(' ')
-    }
+  doLast {
+    println "To run a Dataflow job with portability, add the following pipeline options to your command-line:"
+    println fnApiPipelineOptions.join(' ')
+  }
 }
 
 task validatesRunnerFnApiWorkerTest(type: Test) {
-    group = "Verification"
-    dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
-    dependsOn buildAndPushDockerContainer
-    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
-            "--runner=TestDataflowRunner",
-            "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
-    )
+  group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
+  dependsOn buildAndPushDockerContainer
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+          "--runner=TestDataflowRunner",
+          "--project=${dataflowProject}",
+          "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
+  )
 
-    // Increase test parallelism up to the number of Gradle workers. By default this is equal
-    // to the number of CPU cores, but can be increased by setting --max-workers=N.
-    maxParallelForks Integer.MAX_VALUE
-    classpath = configurations.validatesRunner
-    testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
-    useJUnit {
-      includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
-      commonExcludeCategories.each {
-        excludeCategories it
-      }
-      fnApiWorkerExcludeCategories.each {
-        excludeCategories it
-      }
+  // Increase test parallelism up to the number of Gradle workers. By default this is equal
+  // to the number of CPU cores, but can be increased by setting --max-workers=N.
+  maxParallelForks Integer.MAX_VALUE
+  classpath = configurations.validatesRunner
+  testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
+  useJUnit {
+    includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+    commonExcludeCategories.each {
+      excludeCategories it
     }
+    fnApiWorkerExcludeCategories.each {
+      excludeCategories it
+    }
+  }
 }
 
 task validatesRunnerFnApiWorkerExecutableStageTest(type: Test) {
-    group = "Verification"
-    description "Validates Dataflow PortabilityApi runner"
-    dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
-    dependsOn buildAndPushDockerContainer
+  group = "Verification"
+  description "Validates Dataflow PortabilityApi runner"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
+  dependsOn buildAndPushDockerContainer
 
-    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
-            "--runner=TestDataflowRunner",
-            "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}",
-            "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
-            "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
-            "--experiments=beam_fn_api,use_executable_stage_bundle_execution"]
-    )
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+          "--runner=TestDataflowRunner",
+          "--project=${dataflowProject}",
+          "--tempRoot=${dataflowPostCommitTempRoot}",
+          "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
+          "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
+          "--experiments=beam_fn_api,use_executable_stage_bundle_execution"]
+  )
 
-    // Increase test parallelism up to the number of Gradle workers. By default this is equal
-    // to the number of CPU cores, but can be increased by setting --max-workers=N.
-    maxParallelForks Integer.MAX_VALUE
-    classpath = configurations.validatesRunner
-    testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
-    useJUnit {
-        includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
-        commonExcludeCategories.each {
-            excludeCategories it
-        }
-        fnApiWorkerExcludeCategories.each {
-            excludeCategories it
-        }
-        // TODO(BEAM-6233): Support timer and state.
-        excludeCategories 'org.apache.beam.sdk.testing.UsesStatefulParDo'
+  // Increase test parallelism up to the number of Gradle workers. By default this is equal
+  // to the number of CPU cores, but can be increased by setting --max-workers=N.
+  maxParallelForks Integer.MAX_VALUE
+  classpath = configurations.validatesRunner
+  testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
+  useJUnit {
+    includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+    commonExcludeCategories.each {
+      excludeCategories it
     }
+    fnApiWorkerExcludeCategories.each {
+      excludeCategories it
+    }
+    // TODO(BEAM-6233): Support timer and state.
+    excludeCategories 'org.apache.beam.sdk.testing.UsesStatefulParDo'
+  }
 }
 
 task validatesRunner {
@@ -306,55 +305,55 @@ task googleCloudPlatformLegacyWorkerIntegrationTest(type: Test) {
 }
 
 task googleCloudPlatformLegacyWorkerKmsIntegrationTest(type: Test) {
-    group = "Verification"
-    dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
-    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
-            "--runner=TestDataflowRunner",
-            "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}",
-            "--dataflowWorkerJar=${dataflowLegacyWorkerJar}",
-            "--workerHarnessContainerImage=",
-            "--dataflowKmsKey=${dataflowKmsKey}",
-    ])
+  group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+          "--runner=TestDataflowRunner",
+          "--project=${dataflowProject}",
+          "--tempRoot=${dataflowPostCommitTempRoot}",
+          "--dataflowWorkerJar=${dataflowLegacyWorkerJar}",
+          "--workerHarnessContainerImage=",
+          "--dataflowKmsKey=${dataflowKmsKey}",
+  ])
 
-    include '**/*KmsKeyIT.class'
-    exclude '**/BigQueryKmsKeyIT.class'  // Only needs to run on direct runner.
-    maxParallelForks 4
-    classpath = configurations.googleCloudPlatformIntegrationTest
-    testClassesDirs = files(project(":beam-sdks-java-io-google-cloud-platform").sourceSets.test.output.classesDirs)
-    useJUnit { }
+  include '**/*KmsKeyIT.class'
+  exclude '**/BigQueryKmsKeyIT.class'  // Only needs to run on direct runner.
+  maxParallelForks 4
+  classpath = configurations.googleCloudPlatformIntegrationTest
+  testClassesDirs = files(project(":beam-sdks-java-io-google-cloud-platform").sourceSets.test.output.classesDirs)
+  useJUnit { }
 }
 
 task googleCloudPlatformFnApiWorkerIntegrationTest(type: Test) {
-    group = "Verification"
-    dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
-    dependsOn buildAndPushDockerContainer
+  group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
+  dependsOn buildAndPushDockerContainer
 
-    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
-            "--runner=TestDataflowRunner",
-            "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
-    )
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+          "--runner=TestDataflowRunner",
+          "--project=${dataflowProject}",
+          "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
+  )
 
-    include '**/*IT.class'
-    exclude '**/BigQueryIOReadIT.class'
-    exclude '**/BigQueryIOStorageReadIT.class'
-    exclude '**/BigQueryIOStorageReadTableRowIT.class'
-    exclude '**/PubsubReadIT.class'
-    exclude '**/SpannerReadIT.class'
-    exclude '**/BigtableReadIT.class'
-    exclude '**/V1ReadIT.class'
-    exclude '**/SpannerWriteIT.class'
-    exclude '**/BigQueryNestedRecordsIT.class'
-    exclude '**/SplitQueryFnIT.class'
-    exclude '**/*KmsKeyIT.class'
+  include '**/*IT.class'
+  exclude '**/BigQueryIOReadIT.class'
+  exclude '**/BigQueryIOStorageReadIT.class'
+  exclude '**/BigQueryIOStorageReadTableRowIT.class'
+  exclude '**/PubsubReadIT.class'
+  exclude '**/SpannerReadIT.class'
+  exclude '**/BigtableReadIT.class'
+  exclude '**/V1ReadIT.class'
+  exclude '**/SpannerWriteIT.class'
+  exclude '**/BigQueryNestedRecordsIT.class'
+  exclude '**/SplitQueryFnIT.class'
+  exclude '**/*KmsKeyIT.class'
 
-    maxParallelForks 4
-    classpath = configurations.googleCloudPlatformIntegrationTest
-    testClassesDirs = files(project(":beam-sdks-java-io-google-cloud-platform").sourceSets.test.output.classesDirs)
-    useJUnit {
-      excludeCategories 'org.apache.beam.sdk.testing.DataflowPortabilityApiUnsupported'
-    }
+  maxParallelForks 4
+  classpath = configurations.googleCloudPlatformIntegrationTest
+  testClassesDirs = files(project(":beam-sdks-java-io-google-cloud-platform").sourceSets.test.output.classesDirs)
+  useJUnit {
+    excludeCategories 'org.apache.beam.sdk.testing.DataflowPortabilityApiUnsupported'
+  }
 }
 
 task examplesJavaLegacyWorkerIntegrationTest(type: Test) {
@@ -383,72 +382,72 @@ task examplesJavaLegacyWorkerIntegrationTest(type: Test) {
 // For fn-api runner, only run the IT can be passed for now.
 // Should support more ITs in the future.
 task examplesJavaFnApiWorkerIntegrationTest(type: Test) {
-    group = "Verification"
-    dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
-    dependsOn buildAndPushDockerContainer
+  group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
+  dependsOn buildAndPushDockerContainer
 
-    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
-            "--runner=TestDataflowRunner",
-            "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
-    )
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+          "--runner=TestDataflowRunner",
+          "--project=${dataflowProject}",
+          "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
+  )
 
-    // The examples/java preCommit task already covers running WordCountIT/WindowedWordCountIT so
-    // this postCommit integration test excludes them.
-    include '**/*IT.class'
-    exclude '**/WordCountIT.class'
-    exclude '**/WindowedWordCountIT.class'
-    exclude '**/TopWikipediaSessionsIT.class'
-    exclude '**/TfIdfIT.class'
-    exclude '**/AutoCompleteIT.class'
-    exclude '**/TrafficMaxLaneFlowIT.class'
-    exclude '**/TrafficRoutesIT.class'
+  // The examples/java preCommit task already covers running WordCountIT/WindowedWordCountIT so
+  // this postCommit integration test excludes them.
+  include '**/*IT.class'
+  exclude '**/WordCountIT.class'
+  exclude '**/WindowedWordCountIT.class'
+  exclude '**/TopWikipediaSessionsIT.class'
+  exclude '**/TfIdfIT.class'
+  exclude '**/AutoCompleteIT.class'
+  exclude '**/TrafficMaxLaneFlowIT.class'
+  exclude '**/TrafficRoutesIT.class'
 
-    maxParallelForks 4
-    classpath = configurations.examplesJavaIntegrationTest
-    testClassesDirs = files(project(":beam-examples-java").sourceSets.test.output.classesDirs)
-    useJUnit { }
+  maxParallelForks 4
+  classpath = configurations.examplesJavaIntegrationTest
+  testClassesDirs = files(project(":beam-examples-java").sourceSets.test.output.classesDirs)
+  useJUnit { }
 }
 
 task coreSDKJavaLegacyWorkerIntegrationTest(type: Test) {
-    group = "Verification"
-    dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
+  group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
 
-    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
-            "--runner=TestDataflowRunner",
-            "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}",
-            "--dataflowWorkerJar=${dataflowLegacyWorkerJar}",
-            "--workerHarnessContainerImage=",
-    ])
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+          "--runner=TestDataflowRunner",
+          "--project=${dataflowProject}",
+          "--tempRoot=${dataflowPostCommitTempRoot}",
+          "--dataflowWorkerJar=${dataflowLegacyWorkerJar}",
+          "--workerHarnessContainerImage=",
+  ])
 
-    include '**/*IT.class'
-    // TODO[Beam-4684]: Support @RequiresStableInput on Dataflow in a more intelligent way
-    exclude '**/RequiresStableInputIT.class'
-    maxParallelForks 4
-    classpath = configurations.coreSDKJavaIntegrationTest
-    testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
-    useJUnit { }
+  include '**/*IT.class'
+  // TODO[Beam-4684]: Support @RequiresStableInput on Dataflow in a more intelligent way
+  exclude '**/RequiresStableInputIT.class'
+  maxParallelForks 4
+  classpath = configurations.coreSDKJavaIntegrationTest
+  testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
+  useJUnit { }
 }
 
 task coreSDKJavaFnApiWorkerIntegrationTest(type: Test) {
-    group = "Verification"
-    dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
-    dependsOn buildAndPushDockerContainer
+  group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
+  dependsOn buildAndPushDockerContainer
 
-    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
-            "--runner=TestDataflowRunner",
-            "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
-    )
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+          "--runner=TestDataflowRunner",
+          "--project=${dataflowProject}",
+          "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
+  )
 
-    include '**/*IT.class'
-    // TODO[Beam-4684]: Support @RequiresStableInput on Dataflow in a more intelligent way
-    exclude '**/RequiresStableInputIT.class'
-    maxParallelForks 4
-    classpath = configurations.coreSDKJavaIntegrationTest
-    testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
-    useJUnit { }
+  include '**/*IT.class'
+  // TODO[Beam-4684]: Support @RequiresStableInput on Dataflow in a more intelligent way
+  exclude '**/RequiresStableInputIT.class'
+  maxParallelForks 4
+  classpath = configurations.coreSDKJavaIntegrationTest
+  testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
+  useJUnit { }
 }
 
 task postCommit {
@@ -502,8 +501,8 @@ createJavaExamplesArchetypeValidationTask(type: 'MobileGaming',
 
 // Standalone task for testing GCS upload, use with -PfilesToStage and -PdataflowTempRoot.
 task GCSUpload(type: JavaExec) {
-   main = 'org.apache.beam.runners.dataflow.util.GCSUploadMain'
-   classpath = sourceSets.test.runtimeClasspath
-   args "--stagingLocation=${dataflowUploadTemp}/staging",
-        "--filesToStage=${testFilesToStage}"
+  main = 'org.apache.beam.runners.dataflow.util.GCSUploadMain'
+  classpath = sourceSets.test.runtimeClasspath
+  args "--stagingLocation=${dataflowUploadTemp}/staging",
+       "--filesToStage=${testFilesToStage}"
 }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -456,6 +456,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
                         BatchViewOverrides.BatchViewAsIterable.class, this)));
       }
     }
+    /* TODO[Beam-4684]: Support @RequiresStableInput on Dataflow in a more intelligent way
     // Uses Reshuffle, so has to be before the Reshuffle override
     overridesBuilder.add(
         PTransformOverride.of(
@@ -466,6 +467,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         PTransformOverride.of(
             PTransformMatchers.requiresStableInputParDoMulti(),
             RequiresStableInputParDoOverrides.multiOutputOverrideFactory()));
+    */
     // Expands into Reshuffle and single-output ParDo, so has to be before the overrides below.
     if (fnApiEnabled) {
       overridesBuilder.add(


### PR DESCRIPTION
Disable support of @RequiresStableInput on Dataflow runner for now, until we have a more intelligent implementation, as discussed in PR #7991 .

cc: @kennknowles @reuvenlax @rangadi @tweise @mxm 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
