### PR TITLE
[BEAM-5115] Make ValueProvider API consistent between XmlIO and XmlSource

### DIFF
--- a/sdks/java/io/xml/src/test/java/org/apache/beam/sdk/io/xml/XmlIOTest.java
+++ b/sdks/java/io/xml/src/test/java/org/apache/beam/sdk/io/xml/XmlIOTest.java
@@ -128,7 +128,9 @@ public class XmlIOTest {
         PCollection<Bird> readBack =
             readPipeline.apply(
                 XmlIO.<Bird>read()
-                    .from(new File(tmpFolder.getRoot(), "birds").getAbsolutePath() + "*")
+                    .from(
+                        readPipeline.newProvider(
+                            new File(tmpFolder.getRoot(), "birds").getAbsolutePath() + "*"))
                     .withRecordClass(Bird.class)
                     .withRootElement("birds")
                     .withRecordElement("bird")


### PR DESCRIPTION
R: @aromanenko-dev 