### PR TITLE
[BEAM-6820] Custom Row-Object mapper implementation for CassandraIO

### DIFF
--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/DefaultObjectMapper.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/DefaultObjectMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import com.datastax.driver.core.ResultSet;
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.concurrent.Future;
+
+/**
+ * Default Object mapper implementation that uses the <a
+ * href="https://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper">Cassandra
+ * Object Mapper</a> for mapping POJOs to CRUD events in Cassandra.
+ *
+ * @see org.apache.beam.sdk.io.cassandra.DefaultObjectMapperFactory
+ */
+class DefaultObjectMapper<T> implements Mapper<T>, Serializable {
+
+  private transient com.datastax.driver.mapping.Mapper<T> mapper;
+
+  public DefaultObjectMapper(com.datastax.driver.mapping.Mapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Iterator<T> map(ResultSet resultSet) {
+    return mapper.map(resultSet).iterator();
+  }
+
+  @Override
+  public Future<Void> deleteAsync(T entity) {
+    return mapper.deleteAsync(entity);
+  }
+
+  @Override
+  public Future<Void> saveAsync(T entity) {
+    return mapper.saveAsync(entity);
+  }
+}

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/DefaultObjectMapperFactory.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/DefaultObjectMapperFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.mapping.MappingManager;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+
+/**
+ * Factory implementation that CassandraIO uses to initialize the Default Object Mapper for mapping
+ * POJOs to CRUD events in Cassandra.
+ *
+ * @see org.apache.beam.sdk.io.cassandra.DefaultObjectMapper
+ */
+class DefaultObjectMapperFactory<T> implements SerializableFunction<Session, Mapper> {
+
+  private transient MappingManager mappingManager;
+  Class<T> entity;
+
+  DefaultObjectMapperFactory(Class<T> entity) {
+    this.entity = entity;
+  }
+
+  @Override
+  public Mapper apply(Session session) {
+    if (mappingManager == null) {
+      this.mappingManager = new MappingManager(session);
+    }
+
+    return new DefaultObjectMapper<T>(mappingManager.mapper(entity));
+  }
+}

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/Mapper.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/Mapper.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import com.datastax.driver.core.ResultSet;
+import java.util.Iterator;
+import java.util.concurrent.Future;
+
+/**
+ * The default behavior of {@link CassandraIO} is to use {@link DefaultObjectMapper} which in turn
+ * uses <a
+ * href="https://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper">Cassandra
+ * Object Mapper</a> to map POJOs to CRUD events in Cassandra. This interface allows you to
+ * implement a custom mapper.
+ *
+ * <p>To Implement a custom mapper you need to: <br>
+ * 1) Create a concrete implementation of {@link Mapper} <br>
+ * 2) Create a factory that implements SerializableFunction as in (see {@link
+ * DefaultObjectMapperFactory}) <br>
+ * 3) Pass the mapper-factory in 2) through withMapperFactoryFn() in the CassandraIO builder.
+ * Example:
+ *
+ * <pre>{@code
+ * SerializableFunction<Session, Mapper> factory = new MyCustomFactory();
+ * pipeline
+ *    .apply(...)
+ *    .apply(CassandraIO.<>read()
+ *        .withMapperFactoryFn(factory));
+ * }</pre>
+ */
+public interface Mapper<T> {
+
+  /**
+   * This method is called when reading data from Cassandra. The resultset will contain a subset of
+   * rows from the table specified in {@link CassandraIO}. If a where-clause is specified through
+   * withWhere() in {@link CassandraIO} the rows in the resultset would also be filtered given by
+   * the provided where statement.
+   *
+   * @param resultSet A resultset containing rows given by withTable() and withWhere() specified in
+   *     {@link CassandraIO}.
+   * @return Return an iterator containing the objects that you want to provide to your downstream
+   *     Beam pipeline.
+   */
+  Iterator<T> map(ResultSet resultSet);
+
+  /**
+   * This method gets called for each delete event. The input argument is the Object that should be
+   * deleted in Cassandra. The return value should be a future that completes when the delete action
+   * is completed.
+   *
+   * @param entity Entity to be deleted.
+   */
+  Future<Void> deleteAsync(T entity);
+
+  /**
+   * This method gets called for each save event. The input argument is the Object that should be
+   * saved or updated in Cassandra. The return value should be a future that completes when the save
+   * action is completed.
+   *
+   * @param entity Entity to be saved.
+   */
+  Future<Void> saveAsync(T entity);
+}


### PR DESCRIPTION
The current Cassandra source sink is tightly coupled to the Datastax Object Mapper. [This requires users](https://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper/) of the sink to provide a POJO describing  the table in Cassandra. Although the POJO is a easy and powerful way to describe the table it does requires users to always recompile the pipeline for each change in the table definition. 

I suggest adding a abstraction layer that allows users to inject their own mapper implementation. One example use would be a mapper that works with a generic [Row](https://beam.apache.org/releases/javadoc/2.4.0/org/apache/beam/sdk/values/Row.html) implementation rather than a compile-time POJO. 

This abstraction layer could be implemented by simply supplying a MapperFactory through the Sink/Source builder. 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
