### PR TITLE
[BEAM-6851] Support recursive globs in HadoopFileSystem.

### DIFF
--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
@@ -29,7 +29,9 @@ import java.nio.file.FileAlreadyExistsException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.fs.CreateOptions;
 import org.apache.beam.sdk.io.fs.MatchResult;
@@ -87,31 +89,85 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
     ImmutableList.Builder<MatchResult> resultsBuilder = ImmutableList.builder();
     for (String spec : specs) {
       try {
-        FileStatus[] fileStatuses = fileSystem.globStatus(new Path(spec));
-        if (fileStatuses == null) {
-          resultsBuilder.add(MatchResult.create(Status.NOT_FOUND, Collections.emptyList()));
-          continue;
-        }
+        Set<Metadata> metadata = new HashSet<>();
 
-        List<Metadata> metadata = new ArrayList<>();
-        for (FileStatus fileStatus : fileStatuses) {
-          if (fileStatus.isFile()) {
-            URI uri = dropEmptyAuthority(fileStatus.getPath().toUri().toString());
-            metadata.add(
-                Metadata.builder()
-                    .setResourceId(new HadoopResourceId(uri))
-                    .setIsReadSeekEfficient(true)
-                    .setSizeBytes(fileStatus.getLen())
-                    .setLastModifiedMillis(fileStatus.getModificationTime())
-                    .build());
+        FileStatus[] fileStatuses = fileSystem.globStatus(new Path(spec));
+        if (fileStatuses != null) {
+          for (FileStatus fileStatus : fileStatuses) {
+            if (fileStatus.isFile()) {
+              metadata.add(toMetadata(fileStatus));
+            }
           }
         }
-        resultsBuilder.add(MatchResult.create(Status.OK, metadata));
+
+        if (spec.contains("**")) {
+          int index = spec.indexOf("**");
+          metadata.addAll(
+              matchRecursiveGlob(spec.substring(0, index + 1), spec.substring(index + 1)));
+        }
+
+        if (metadata.isEmpty()) {
+          resultsBuilder.add(MatchResult.create(Status.NOT_FOUND, Collections.emptyList()));
+        } else {
+          resultsBuilder.add(MatchResult.create(Status.OK, new ArrayList<>(metadata)));
+        }
       } catch (IOException e) {
         resultsBuilder.add(MatchResult.create(Status.ERROR, e));
       }
     }
     return resultsBuilder.build();
+  }
+
+  private Set<Metadata> matchRecursiveGlob(String directorySpec, String fileSpec)
+      throws IOException {
+    Set<Metadata> metadata = new HashSet<>();
+    if (directorySpec.contains("*")) {
+      // An abstract directory with a wildcard is converted to concrete directories to search.
+      FileStatus[] directoryStatuses = fileSystem.globStatus(new Path(directorySpec));
+      for (FileStatus directoryStatus : directoryStatuses) {
+        if (directoryStatus.isDirectory()) {
+          metadata.addAll(
+              matchRecursiveGlob(directoryStatus.getPath().toUri().toString(), fileSpec));
+        }
+      }
+    } else {
+      // A concrete directory is searched.
+      FileStatus[] fileStatuses = fileSystem.globStatus(new Path(directorySpec + "/" + fileSpec));
+      for (FileStatus fileStatus : fileStatuses) {
+        if (fileStatus.isFile()) {
+          metadata.add(toMetadata(fileStatus));
+        }
+      }
+
+      // All sub-directories of a concrete directory are searched.
+      FileStatus[] directoryStatuses = fileSystem.globStatus(new Path(directorySpec + "/*"));
+      for (FileStatus directoryStatus : directoryStatuses) {
+        if (directoryStatus.isDirectory()) {
+          metadata.addAll(
+              matchRecursiveGlob(directoryStatus.getPath().toUri().toString(), fileSpec));
+        }
+      }
+
+      // Handle additional instances of recursive globs.
+      if (fileSpec.contains("**")) {
+        int index = fileSpec.indexOf("**");
+        metadata.addAll(
+            matchRecursiveGlob(
+                directorySpec + "/" + fileSpec.substring(0, index + 1),
+                fileSpec.substring(index + 1)));
+      }
+    }
+    return metadata;
+  }
+
+  private Metadata toMetadata(FileStatus fileStatus) {
+    URI uri = dropEmptyAuthority(fileStatus.getPath().toUri().toString());
+    return Metadata.builder()
+        .setResourceId(new HadoopResourceId(uri))
+        .setIsReadSeekEfficient(true)
+        .setSizeBytes(fileStatus.getLen())
+        .setLastModifiedMillis(fileStatus.getModificationTime())
+        .build();
   }
 
   @Override


### PR DESCRIPTION
Add support for the use of recursive globs `**` to HadoopFileSystem.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
