### PR TITLE
[BEAM-6861] Add support to specify a query in CassandraIO

### DIFF
--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
@@ -37,7 +37,11 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -219,12 +223,12 @@ public class CassandraIO {
       return builder().setTable(table).build();
     }
 
-    /** Specify select fields to reduce data or add computed fields * */
+    /** Specify select fields to reduce data or add computed fields. */
     public Read<T> withSelectFields(ValueProvider<List<String>> selectFields) {
       return builder().setSelectFields(selectFields).build();
     }
 
-    /** Specify select fields to reduce data or add computed fields * */
+    /** Specify select fields to reduce data or add computed fields. */
     public Read<T> withSelectFields(List<String> selectFields) {
       checkArgument(
           selectFields != null

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
@@ -219,16 +219,18 @@ public class CassandraIO {
       return builder().setTable(table).build();
     }
 
-    /** Specify select fields to reduce data or add computed fields **/
-    public Read<T> withSelectFields(ValueProvider<List<String>> selectFields){
+    /** Specify select fields to reduce data or add computed fields * */
+    public Read<T> withSelectFields(ValueProvider<List<String>> selectFields) {
       return builder().setSelectFields(selectFields).build();
     }
 
-    /** Specify select fields to reduce data or add computed fields **/
-    public Read<T> withSelectFields(List<String> selectFields){
-      checkArgument(selectFields != null && selectFields.size()>0 &&
-              selectFields.stream().allMatch(s->s==null || !s.isEmpty()),
-              "Select fields should be valid field names");
+    /** Specify select fields to reduce data or add computed fields * */
+    public Read<T> withSelectFields(List<String> selectFields) {
+      checkArgument(
+          selectFields != null
+              && selectFields.size() > 0
+              && selectFields.stream().allMatch(s -> s == null || !s.isEmpty()),
+          "Select fields should be valid field names");
       return builder().setSelectFields(ValueProvider.StaticValueProvider.of(selectFields)).build();
     }
 
@@ -455,8 +457,8 @@ public class CassandraIO {
               spec, desiredBundleSizeBytes, getEstimatedSizeBytes(pipelineOptions), cluster);
         } else {
           String selectFields = "*";
-          if(spec.selectFields()!=null){
-            selectFields = String.join(",",spec.selectFields().get());
+          if (spec.selectFields() != null) {
+            selectFields = String.join(",", spec.selectFields().get());
           }
           LOG.warn(
               "Only Murmur3Partitioner is supported for splitting, using an unique source for "
@@ -503,8 +505,8 @@ public class CassandraIO {
 
       List<BoundedSource<T>> sources = new ArrayList<>();
       String selectFields = "*";
-      if(spec.selectFields()!=null){
-        selectFields = String.join(",",spec.selectFields().get());
+      if (spec.selectFields() != null) {
+        selectFields = String.join(",", spec.selectFields().get());
       }
 
       for (List<RingRange> split : splits) {
@@ -553,7 +555,8 @@ public class CassandraIO {
       return sources;
     }
 
-    private static String generateRangeQuery(String selectFields,
+    private static String generateRangeQuery(
+        String selectFields,
         ValueProvider<String> keyspace,
         ValueProvider<String> table,
         ValueProvider<String> where,

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -23,7 +23,9 @@ import static org.apache.beam.sdk.io.cassandra.CassandraIO.CassandraSource.getEs
 import static org.apache.beam.sdk.io.cassandra.CassandraIO.CassandraSource.getRingFraction;
 import static org.apache.beam.sdk.io.cassandra.CassandraIO.CassandraSource.isMurmur3Partitioner;
 import static org.apache.beam.sdk.testing.SourceTestUtils.readFromSource;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -288,14 +288,15 @@ public class CassandraIOTest implements Serializable {
                 .withWhere(pipeline.newProvider("person_id=10")));
 
     PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(1L);
-    PAssert.that(output).satisfies(input -> {
-      for (Scientist sci: input) {
-        assertNotNull(sci.id);
-        assertNull(sci.name);
-
-      }
-      return null;
-    });
+    PAssert.that(output)
+        .satisfies(
+            input -> {
+              for (Scientist sci : input) {
+                assertNotNull(sci.id);
+                assertNull(sci.name);
+              }
+              return null;
+            });
 
     pipeline.run();
   }
@@ -305,27 +306,29 @@ public class CassandraIOTest implements Serializable {
     insertRecords();
 
     PCollection<Scientist> output =
-            pipeline.apply(
-                    CassandraIO.<Scientist>read()
-                            .withHosts(pipeline.newProvider(Arrays.asList(CASSANDRA_HOST)))
-                            .withPort(pipeline.newProvider(CASSANDRA_PORT))
-                            .withKeyspace(pipeline.newProvider(CASSANDRA_KEYSPACE))
-                            .withTable(pipeline.newProvider(CASSANDRA_TABLE))
-                            .withSelectFields(pipeline.newProvider(Arrays.asList("person_id","writetime(person_name)")))
-                            .withCoder(SerializableCoder.of(Scientist.class))
-                            .withEntity(Scientist.class)
-                            .withWhere(pipeline.newProvider("person_id=10")));
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(pipeline.newProvider(Arrays.asList(CASSANDRA_HOST)))
+                .withPort(pipeline.newProvider(CASSANDRA_PORT))
+                .withKeyspace(pipeline.newProvider(CASSANDRA_KEYSPACE))
+                .withTable(pipeline.newProvider(CASSANDRA_TABLE))
+                .withSelectFields(
+                    pipeline.newProvider(Arrays.asList("person_id", "writetime(person_name)")))
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class)
+                .withWhere(pipeline.newProvider("person_id=10")));
 
     PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(1L);
-    PAssert.that(output).satisfies(input -> {
-      for (Scientist sci: input) {
-        assertNotNull(sci.id);
-        assertNull(sci.name);
-        assertTrue(sci.nameTs!=null && sci.nameTs>0);
-
-      }
-      return null;
-    });
+    PAssert.that(output)
+        .satisfies(
+            input -> {
+              for (Scientist sci : input) {
+                assertNotNull(sci.id);
+                assertNull(sci.name);
+                assertTrue(sci.nameTs != null && sci.nameTs > 0);
+              }
+              return null;
+            });
 
     pipeline.run();
   }
@@ -335,15 +338,15 @@ public class CassandraIOTest implements Serializable {
     insertRecords();
 
     PCollection<Scientist> output =
-            pipeline.apply(
-                    CassandraIO.<Scientist>read()
-                            .withHosts(pipeline.newProvider(Arrays.asList(CASSANDRA_HOST)))
-                            .withPort(pipeline.newProvider(CASSANDRA_PORT))
-                            .withKeyspace(pipeline.newProvider(CASSANDRA_KEYSPACE))
-                            .withTable(pipeline.newProvider(CASSANDRA_TABLE))
-                            .withCoder(SerializableCoder.of(Scientist.class))
-                            .withEntity(Scientist.class)
-                            .withWhere(pipeline.newProvider("person_id=10")));
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(pipeline.newProvider(Arrays.asList(CASSANDRA_HOST)))
+                .withPort(pipeline.newProvider(CASSANDRA_PORT))
+                .withKeyspace(pipeline.newProvider(CASSANDRA_KEYSPACE))
+                .withTable(pipeline.newProvider(CASSANDRA_TABLE))
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class)
+                .withWhere(pipeline.newProvider("person_id=10")));
 
     PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(1L);
 


### PR DESCRIPTION
CassandraIO.Read currently selects all fields and maps them to POJO. 
With this change it is possible to select only subset of fields or added computed fields to allow reading things like write Timestamp or other functions. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
