### PR TITLE
[BEAM-6892] Schemas and destinations are provided to WriteToBigQuery separately

### DIFF
--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes.py
@@ -99,7 +99,7 @@ def run(argv=None):
         schema='month:INTEGER, tornado_count:INTEGER',
         create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
         write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
-        gs_location=location)
+        custom_gcs_temp_location=location)
 
     # Run the pipeline (all operations are deferred until run() is called).
 

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes.py
@@ -87,19 +87,13 @@ def run(argv=None):
     rows = p | 'read' >> beam.io.Read(beam.io.BigQuerySource(known_args.input))
     counts = count_tornadoes(rows)
 
-    if 'temp_location' in p.options.get_all_options():
-      location = p.options.get_all_options()['temp_location']
-    else:
-      location = known_args.gcs_location
-
     # Write the output using a "Write" transform that has side effects.
     # pylint: disable=expression-not-assigned
     counts | 'Write' >> beam.io.WriteToBigQuery(
         known_args.output,
         schema='month:INTEGER, tornado_count:INTEGER',
         create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
-        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
-        custom_gcs_temp_location=location)
+        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE)
 
     # Run the pipeline (all operations are deferred until run() is called).
 

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_it_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_it_test.py
@@ -60,10 +60,8 @@ class BigqueryTornadoesIT(unittest.TestCase):
                               project=project,
                               query=query,
                               checksum=self.DEFAULT_CHECKSUM)]
-    custom_gcs_temp_location = 'gs://temp-storage-for-upload-tests/%s' % table
     extra_opts = {'output': output_table,
-                  'on_success_matcher': all_of(*pipeline_verifiers),
-                  'gcs_location': custom_gcs_temp_location}
+                  'on_success_matcher': all_of(*pipeline_verifiers)}
 
     # Register cleanup before pipeline execution.
     # Note that actual execution happens in reverse order.

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_it_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_it_test.py
@@ -60,10 +60,10 @@ class BigqueryTornadoesIT(unittest.TestCase):
                               project=project,
                               query=query,
                               checksum=self.DEFAULT_CHECKSUM)]
-    gs_location = 'gs://temp-storage-for-upload-tests/%s' % table
+    custom_gcs_temp_location = 'gs://temp-storage-for-upload-tests/%s' % table
     extra_opts = {'output': output_table,
                   'on_success_matcher': all_of(*pipeline_verifiers),
-                  'gcs_location': gs_location}
+                  'gcs_location': custom_gcs_temp_location}
 
     # Register cleanup before pipeline execution.
     # Note that actual execution happens in reverse order.

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -131,10 +131,11 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         query=verify_query,
         checksum=expected_checksum)]
 
-    gs_location = 'gs://temp-storage-for-upload-tests/%s' % self.output_table
+    custom_gcs_temp_location = (
+        'gs://temp-storage-for-upload-tests/%s' % self.output_table)
     extra_opts = {'query': LEGACY_QUERY,
                   'output': self.output_table,
-                  'bq_temp_location': gs_location,
+                  'bq_temp_location': custom_gcs_temp_location,
                   'output_schema': DIALECT_OUTPUT_SCHEMA,
                   'use_standard_sql': False,
                   'on_success_matcher': all_of(*pipeline_verifiers)}
@@ -149,10 +150,11 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         project=self.project,
         query=verify_query,
         checksum=expected_checksum)]
-    gs_location = 'gs://temp-storage-for-upload-tests/%s' % self.output_table
+    custom_gcs_temp_location = (
+        'gs://temp-storage-for-upload-tests/%s' % self.output_table)
     extra_opts = {'query': STANDARD_QUERY,
                   'output': self.output_table,
-                  'bq_temp_location': gs_location,
+                  'bq_temp_location': custom_gcs_temp_location,
                   'output_schema': DIALECT_OUTPUT_SCHEMA,
                   'use_standard_sql': True,
                   'on_success_matcher': all_of(*pipeline_verifiers)}
@@ -197,11 +199,12 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         query=verify_query,
         checksum=expected_checksum)]
     self._setup_new_types_env()
-    gs_location = 'gs://temp-storage-for-upload-tests/%s' % self.output_table
+    custom_gcs_temp_location = (
+        'gs://temp-storage-for-upload-tests/%s' % self.output_table)
     extra_opts = {
         'query': NEW_TYPES_QUERY % (self.dataset_id, NEW_TYPES_INPUT_TABLE),
         'output': self.output_table,
-        'bq_temp_location': gs_location,
+        'bq_temp_location': custom_gcs_temp_location,
         'output_schema': NEW_TYPES_OUTPUT_SCHEMA,
         'use_standard_sql': False,
         'on_success_matcher': all_of(*pipeline_verifiers)}

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -181,10 +181,6 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         self.project, self.dataset_id, 'output_table')
     self.assertEqual(KMS_KEY, table.encryptionConfiguration.kmsKeyName)
 
-  @unittest.skipIf(sys.version_info[0] == 3 and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3'
-                   'TODO: BEAM-6769')
   @attr('IT')
   def test_big_query_new_types(self):
     expected_checksum = test_utils.compute_hash(NEW_TYPES_OUTPUT_EXPECTED)

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -131,11 +131,8 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         query=verify_query,
         checksum=expected_checksum)]
 
-    custom_gcs_temp_location = (
-        'gs://temp-storage-for-upload-tests/%s' % self.output_table)
     extra_opts = {'query': LEGACY_QUERY,
                   'output': self.output_table,
-                  'bq_temp_location': custom_gcs_temp_location,
                   'output_schema': DIALECT_OUTPUT_SCHEMA,
                   'use_standard_sql': False,
                   'on_success_matcher': all_of(*pipeline_verifiers)}
@@ -150,11 +147,9 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         project=self.project,
         query=verify_query,
         checksum=expected_checksum)]
-    custom_gcs_temp_location = (
-        'gs://temp-storage-for-upload-tests/%s' % self.output_table)
+
     extra_opts = {'query': STANDARD_QUERY,
                   'output': self.output_table,
-                  'bq_temp_location': custom_gcs_temp_location,
                   'output_schema': DIALECT_OUTPUT_SCHEMA,
                   'use_standard_sql': True,
                   'on_success_matcher': all_of(*pipeline_verifiers)}
@@ -199,12 +194,9 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         query=verify_query,
         checksum=expected_checksum)]
     self._setup_new_types_env()
-    custom_gcs_temp_location = (
-        'gs://temp-storage-for-upload-tests/%s' % self.output_table)
     extra_opts = {
         'query': NEW_TYPES_QUERY % (self.dataset_id, NEW_TYPES_INPUT_TABLE),
         'output': self.output_table,
-        'bq_temp_location': custom_gcs_temp_location,
         'output_schema': NEW_TYPES_OUTPUT_SCHEMA,
         'use_standard_sql': False,
         'on_success_matcher': all_of(*pipeline_verifiers)}

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -181,6 +181,10 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         self.project, self.dataset_id, 'output_table')
     self.assertEqual(KMS_KEY, table.encryptionConfiguration.kmsKeyName)
 
+  @unittest.skipIf(sys.version_info[0] == 3 and
+                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                   'This test still needs to be fixed on Python 3'
+                   'TODO: BEAM-6769')
   @attr('IT')
   def test_big_query_new_types(self):
     expected_checksum = test_utils.compute_hash(NEW_TYPES_OUTPUT_EXPECTED)

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
@@ -50,10 +50,7 @@ def run_bq_pipeline(argv=None):
                       help='Output BQ table to write results to.')
   parser.add_argument('--kms_key', default=None,
                       help='Use this Cloud KMS key with BigQuery.')
-  parser.add_argument('--bq_temp_location',
-                      default=None,
-                      help=('GCS bucket to use to store files for '
-                            'loading data into BigQuery.'))
+
   known_args, pipeline_args = parser.parse_known_args(argv)
 
   table_schema = parse_table_schema_from_json(known_args.output_schema)
@@ -61,10 +58,6 @@ def run_bq_pipeline(argv=None):
 
   p = TestPipeline(options=PipelineOptions(pipeline_args))
 
-  if 'temp_location' in p.options.get_all_options():
-    location = p.options.get_all_options()['temp_location']
-  else:
-    location = known_args.bq_temp_location
   # pylint: disable=expression-not-assigned
   # pylint: disable=bad-continuation
   (p | 'read' >> beam.io.Read(beam.io.BigQuerySource(
@@ -74,8 +67,7 @@ def run_bq_pipeline(argv=None):
            known_args.output,
            schema=table_schema,
            create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
-           write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY,
-           custom_gcs_temp_location=location))
+           write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY))
 
   result = p.run()
   result.wait_until_finish()

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
@@ -75,7 +75,7 @@ def run_bq_pipeline(argv=None):
            schema=table_schema,
            create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
            write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY,
-           gs_location=location))
+           custom_gcs_temp_location=location))
 
   result = p.run()
   result.wait_until_finish()

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -687,9 +687,11 @@ class BigQueryWriteFn(DoFn):
     else:
       schema = self.schema
 
-    self._create_table_if_needed(
-        bigquery_tools.parse_table_reference(destination),
-        schema)
+    table_ref = bigquery_tools.parse_table_reference(destination)
+    if not table_ref.projectId:
+      table_ref.projectId = vp.RuntimeValueProvider.get_value('project',
+                                                              str, '')
+    self._create_table_if_needed(table_ref, schema)
 
     row = element[1]
     self._rows_buffer[destination].append(row)

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -851,7 +851,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         FILE_LOADS on Batch pipelines.
       insert_retry_strategy: The strategy to use when retrying streaming inserts
         into BigQuery. Options are shown in bigquery_tools.RetryStrategy attrs.
-      validate (boolean): Indicates whether to perform validation checks on
+      validate: Indicates whether to perform validation checks on
         inputs. This parameter is primarily used for testing.
     """
     self.table_reference = bigquery_tools.parse_table_reference(

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -809,7 +809,8 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         type of the field. Single string based schemas do not support nested
         fields, repeated fields, or specifying a BigQuery mode for fields
         (mode will always be set to ``'NULLABLE'``).
-        If a callable, then it should return a str, dict or TableSchema.
+        If a callable, then it should receive a destination (in the form of
+        a TableReference or a string, and return a str, dict or TableSchema.
       create_disposition (BigQueryDisposition): A string describing what
         happens if the table does not exist. Possible values are:
 
@@ -864,6 +865,8 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
     self.batch_size = batch_size
     self.kms_key = kms_key
     self.test_client = test_client
+
+    # TODO(pabloem): Consider handling ValueProvider for this location.
     self.custom_gcs_temp_location = custom_gcs_temp_location
     self.max_file_size = max_file_size
     self.max_files_per_bundle = max_files_per_bundle

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -687,11 +687,9 @@ class BigQueryWriteFn(DoFn):
     else:
       schema = self.schema
 
-    table_ref = bigquery_tools.parse_table_reference(destination)
-    if not table_ref.projectId:
-      table_ref.projectId = vp.RuntimeValueProvider.get_value('project',
-                                                              str, '')
-    self._create_table_if_needed(table_ref, schema)
+    self._create_table_if_needed(
+        bigquery_tools.parse_table_reference(destination),
+        schema)
 
     row = element[1]
     self._rows_buffer[destination].append(row)

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -933,9 +933,8 @@ bigquery_v2_messages.TableSchema):
       Dict[str, Any]: The schema to be used if the BigQuery table to write has
       to be created but in the dictionary format.
     """
-    if (isinstance(schema, dict) or
+    if (isinstance(schema, (dict, vp.ValueProvider)) or
         callable(schema) or
-        isinstance(schema, vp.ValueProvider) or
         schema is None):
       return schema
     elif isinstance(schema, (str, unicode)):

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -590,7 +590,8 @@ class BigQueryBatchFileLoads(beam.PTransform):
          | "RemoveTempTables/PassTables" >> beam.FlatMap(
              lambda x, deleting_tables: deleting_tables,
              pvalue.AsIter(temp_tables_pc))
-         | "RemoveTempTables/DeduplicateTables" >> Count.PerElement()
+         | "RemoveTempTables/AddUselessValue" >> beam.Map(lambda x: (x, None))
+         | "RemoveTempTables/DeduplicateTables" >> beam.GroupByKey()
          | "RemoveTempTables/GetTableNames" >> beam.Map(lambda elm: elm[0])
          | "RemoveTempTables/Delete" >> beam.ParDo(DeleteTablesFn()))
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -350,6 +350,13 @@ class TriggerLoadJobs(beam.DoFn):
     destination = element[0]
     files = iter(element[1])
 
+    if callable(self.schema):
+      schema = self.schema(destination)
+    elif isinstance(self.schema, vp.ValueProvider):
+      schema = self.schema.get()
+    else:
+      schema = self.schema
+
     job_count = 0
     batch_of_files = list(itertools.islice(files, _MAXIMUM_SOURCE_URIS))
     while batch_of_files:
@@ -380,7 +387,7 @@ class TriggerLoadJobs(beam.DoFn):
                    job_name, table_reference)
       job_reference = self.bq_wrapper.perform_load_job(
           table_reference, batch_of_files, job_name,
-          schema=self.schema,
+          schema=schema,
           write_disposition=self.write_disposition,
           create_disposition=self.create_disposition)
       yield (destination, job_reference)

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -44,7 +44,6 @@ from apache_beam.io import filesystems as fs
 from apache_beam.io.gcp import bigquery_tools
 from apache_beam.io.gcp.internal.clients import bigquery as bigquery_api
 from apache_beam.options import value_provider as vp
-from apache_beam.transforms.combiners import Count
 
 ONE_TERABYTE = (1 << 40)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -361,10 +361,6 @@ class BigQueryFileLoadsIT(unittest.TestCase):
     logging.info("Created dataset %s in project %s",
                  self.dataset_id, self.project)
 
-  @unittest.skipIf(sys.version_info[0] == 3 and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3'
-                   'TODO: BEAM-6711')
   @attr('IT')
   def test_multiple_destinations_transform(self):
     output_table_1 = '%s%s' % (self.output_table, 1)

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -295,8 +295,9 @@ class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
 
     transform = bigquery.WriteToBigQuery(
         destination,
-        gs_location=self._new_tempdir(),
-        test_client=bq_client)
+        custom_gcs_temp_location=self._new_tempdir(),
+        test_client=bq_client,
+        validate=False)
 
     # Need to test this with the DirectRunner to avoid serializing mocks
     with TestPipeline('DirectRunner') as p:

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -23,7 +23,6 @@ import json
 import logging
 import os
 import random
-import sys
 import time
 import unittest
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -39,7 +39,6 @@ from apache_beam.io.gcp.bigquery_tools import JSON_COMPLIANCE_ERROR
 from apache_beam.io.gcp.internal.clients import bigquery
 from apache_beam.io.gcp.tests.bigquery_matcher import BigqueryFullResultMatcher
 from apache_beam.options import value_provider
-from apache_beam.options.pipeline_options import GoogleCloudOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
@@ -531,9 +530,7 @@ class BigQueryStreamingInsertTransformIntegrationTests(unittest.TestCase):
            | "WriteWithMultipleDests2" >> beam.io.gcp.bigquery.WriteToBigQuery(
                table=value_provider.StaticValueProvider(
                    str, '%s:%s' % (self.project, output_table_2)),
-               method='FILE_LOADS',
-               custom_gcs_temp_location=(
-                   p.options.view_as(GoogleCloudOptions).temp_location)))
+               method='FILE_LOADS'))
 
   @attr('IT')
   def test_multiple_destinations_transform(self):

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -997,8 +997,8 @@ class AppendDestinationsFn(DoFn):
   Experimental; no backwards compatibility guarantees.
   """
 
-  def __init__(self, destination, schema=None):
-    self.destination = AppendDestinationsFn._get_table_fn(destination, schema)
+  def __init__(self, destination):
+    self.destination = AppendDestinationsFn._get_table_fn(destination)
 
   @staticmethod
   def _value_provider_or_static_val(elm):
@@ -1010,13 +1010,9 @@ class AppendDestinationsFn(DoFn):
       return value_provider.StaticValueProvider(lambda x: x, value=elm)
 
   @staticmethod
-  def _get_table_fn(destination, schema=None):
+  def _get_table_fn(destination):
     if callable(destination):
       return destination
-    elif not callable(destination) and schema is not None:
-      return lambda x: (
-          AppendDestinationsFn._value_provider_or_static_val(destination).get(),
-          AppendDestinationsFn._value_provider_or_static_val(schema).get())
     else:
       return lambda x: AppendDestinationsFn._value_provider_or_static_val(
           destination).get()


### PR DESCRIPTION
This is an improvement in the design for schemas and destinations. They used to be provided together, but that cannot scale. Separating them now.
r: @chamikaramj 
cc: @Juta @tvalentyn 