### PR TITLE
[BEAM-6892] Adding support for side inputs on table & schema. Also adding additional params for BQ.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -97,7 +97,7 @@ should be sent to.
 You may also provide a tuple of PCollectionView elements to be passed as side
 inputs to your callable. For example, suppose that one wishes to send
 events of different types to different tables, and the table names are
-computed at pipeline runtime, one may do something like so::
+computed at pipeline runtime, one may do something like the following::
 
     with Pipeline() as p:
       elements = (p | beam.Create([
@@ -115,6 +115,10 @@ computed at pipeline runtime, one may do something like so::
       elements | beam.io.gcp.WriteToBigQuery(
         table=lambda row, table_dict: table_dict[row['type']],
         table_side_inputs=(table_names_dict,))
+
+In the example above, the `table_dict` argument passed to the function in
+`table_dict` is the side input coming from `table_names_dict`, which is passed
+as part of the `table_side_inputs` argument.
 
 Schemas
 ---------
@@ -698,7 +702,9 @@ class BigQueryWriteFn(DoFn):
       retry_strategy: The strategy to use when retrying streaming inserts
         into BigQuery. Options are shown in bigquery_tools.RetryStrategy attrs.
       additional_bq_parameters (dict, callable): A set of additional parameters
-        to be passed when creating a BigQuery table.
+        to be passed when creating a BigQuery table. These are passed when
+        triggering a load job for FILE_LOADS, and when creating a new table for
+        STREAMING_INSERTS.
     """
     self.schema = schema
     self.test_client = test_client

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -813,7 +813,8 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         fields, repeated fields, or specifying a BigQuery mode for fields
         (mode will always be set to ``'NULLABLE'``).
         If a callable, then it should receive a destination (in the form of
-        a TableReference or a string, and return a str, dict or TableSchema.
+        a TableReference or a string, and return a str, dict or TableSchema, and
+        it should return a str, dict or TableSchema.
       create_disposition (BigQueryDisposition): A string describing what
         happens if the table does not exist. Possible values are:
 
@@ -943,8 +944,9 @@ bigquery_v2_messages.TableSchema):
       Dict[str, Any]: The schema to be used if the BigQuery table to write has
       to be created but in the dictionary format.
     """
-    if (isinstance(schema, (dict, vp.ValueProvider)) or
+    if (isinstance(schema, dict) or
         callable(schema) or
+        isinstance(schema, vp.ValueProvider) or
         schema is None):
       return schema
     elif isinstance(schema, (str, unicode)):

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -78,15 +78,120 @@ When creating a BigQuery input transform, users should provide either a query
 or a table. Pipeline construction will fail with a validation error if neither
 or both are specified.
 
-**Time partitioned tables**
+Writing Data to BigQuery
+========================
 
-BigQuery sink currently does not fully support writing to BigQuery
-time partitioned tables. But writing to a *single* partition may work if
-that does not involve creating a new table (for example, when writing to an
-existing table with `create_disposition=CREATE_NEVER` and
-`write_disposition=WRITE_APPEND`).
-BigQuery source supports reading from a single time partition with the partition
-decorator specified as a part of the table identifier.
+The `WriteToBigQuery` transform is the recommended way of writing data to
+BigQuery. It supports a large set of parameters to customize how you'd like to
+write to BigQuery.
+
+Table References
+----------------
+
+This transform allows you to provide static `project`, `dataset` and `table`
+parameters which point to a specific BigQuery table to be created. The `table`
+parameter can also be a dynamic parameter (i.e. a callable), which receives an
+element to be written to BigQuery, and returns the table that that element
+should be sent to.
+
+You may also provide a tuple of PCollectionView elements to be passed as side
+inputs to your callable. For example, suppose that one wishes to send
+events of different types to different tables, and the table names are
+computed at pipeline runtime, one may do something like so::
+
+    with Pipeline() as p:
+      elements = (p | beam.Create([
+        {'type': 'error', 'timestamp': '12:34:56', 'message': 'bad'},
+        {'type': 'user_log', 'timestamp': '12:34:59', 'query': 'flu symptom'},
+      ]))
+
+      table_names = (p | beam.Create([
+        ('error', 'my_project.dataset1.error_table_for_today'),
+        ('user_log', 'my_project.dataset1.query_table_for_today'),
+      ])
+
+      table_names_dict = beam.pvalue.AsDict(table_names)
+
+      elements | beam.io.gcp.WriteToBigQuery(
+        table=lambda row, table_dict: table_dict[row['type']],
+        table_side_inputs=(table_names_dict,))
+
+Schemas
+---------
+
+This transform also allows you to provide a static or dynamic `schema`
+parameter (i.e. a callable).
+
+If providing a callable, this should take in a table reference (as returned by
+the `table` parameter), and return the corresponding schema for that table.
+This allows to provide different schemas for different tables::
+
+    def compute_table_name(row):
+      ...
+
+    errors_schema = {'fields': [
+      {'name': 'type', 'type': 'STRING', 'mode': 'NULLABLE'},
+      {'name': 'message', 'type': 'STRING', 'mode': 'NULLABLE'}]}
+    queries_schema = {'fields': [
+      {'name': 'type', 'type': 'STRING', 'mode': 'NULLABLE'},
+      {'name': 'query', 'type': 'STRING', 'mode': 'NULLABLE'}]}
+
+    with Pipeline() as p:
+      elements = (p | beam.Create([
+        {'type': 'error', 'timestamp': '12:34:56', 'message': 'bad'},
+        {'type': 'user_log', 'timestamp': '12:34:59', 'query': 'flu symptom'},
+      ]))
+
+      elements | beam.io.gcp.WriteToBigQuery(
+        table=compute_table_name,
+        schema=lambda table: (errors_schema
+                              if 'errors' in table
+                              else queries_schema))
+
+It may be the case that schemas are computed at pipeline runtime. In cases
+like these, one can also provide a `schema_side_inputs` parameter, which is
+a tuple of PCollectionViews to be passed to the schema callable (much like
+the `table_side_inputs` parameter).
+
+Additional Parameters for BigQuery Tables
+-----------------------------------------
+
+This sink is able to create tables in BigQuery if they don't already exist. It
+also relies on creating temporary tables when performing file loads.
+
+The WriteToBigQuery transform creates tables using the BigQuery API by
+inserting a load job (see the API reference [1]), or by inserting a new table
+(see the API reference for that [2][3]).
+
+When creating a new BigQuery table, there are a number of extra parameters
+that one may need to specify. For example, clustering, partitioning, data
+encoding, etc. It is possible to provide these additional parameters by
+passing a Python dictionary as `additional_bq_parameters` to the transform.
+As an example, to create a table that has specific partitioning, and
+clustering properties, one would do the following::
+
+    additional_bq_parameters = {
+      'timePartitioning': {'type': 'DAY'},
+      'clustering': {'fields': ['country']}}
+    with Pipeline() as p:
+      elements = (p | beam.Create([
+        {'country': 'mexico', 'timestamp': '12:34:56', 'query': 'acapulco'},
+        {'country': 'canada', 'timestamp': '12:34:59', 'query': 'influenza'},
+      ]))
+
+      elements | beam.io.gcp.WriteToBigQuery(
+        table='project_name1.dataset_2.query_events_table',
+        additional_bq_parameters=additional_bq_parameters)
+
+Much like the schema case, the parameter with `additional_bq_parameters` can
+also take a callable that receives a table reference.
+
+
+[1] https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#\
+configuration.load
+[2] https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert
+[3] https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource
+
 
 *** Short introduction to BigQuery concepts ***
 Tables have rows (TableRow) and each row has cells (TableCell).
@@ -770,6 +875,12 @@ class BigQueryWriteFn(DoFn):
 
 
 class WriteToBigQuery(PTransform):
+  """Write data to BigQuery.
+
+  This transform receives a PCollection of elements to be inserted into BigQuery
+  tables. The elements would come in as Python dictionaries, or as `TableRow`
+  instances.
+  """
 
   class Method(object):
     DEFAULT = 'DEFAULT'

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -970,9 +970,8 @@ bigquery_v2_messages.TableSchema):
       Dict[str, Any]: The schema to be used if the BigQuery table to write has
       to be created but in the dictionary format.
     """
-    if (isinstance(schema, dict) or
+    if (isinstance(schema, (dict, vp.ValueProvider)) or
         callable(schema) or
-        isinstance(schema, vp.ValueProvider) or
         schema is None):
       return schema
     elif isinstance(schema, (str, unicode)):
@@ -1028,7 +1027,7 @@ bigquery_v2_messages.TableSchema):
                      *self.table_side_inputs)
                  | 'StreamInsertRows' >> ParDo(
                      bigquery_write_fn, *self.schema_side_inputs).with_outputs(
-                     BigQueryWriteFn.FAILED_ROWS, main='main'))
+                         BigQueryWriteFn.FAILED_ROWS, main='main'))
 
       return {BigQueryWriteFn.FAILED_ROWS: outputs[BigQueryWriteFn.FAILED_ROWS]}
     else:

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -328,10 +328,12 @@ class TriggerLoadJobs(beam.DoFn):
                create_disposition=None,
                write_disposition=None,
                test_client=None,
-               temporary_tables=False):
+               temporary_tables=False,
+               additional_bq_parameters=None):
     self.schema = schema
     self.test_client = test_client
     self.temporary_tables = temporary_tables
+    self.additional_bq_parameters = additional_bq_parameters or {}
     if self.temporary_tables:
       # If we are loading into temporary tables, we rely on the default create
       # and write dispositions, which mean that a new table will be created.
@@ -343,7 +345,8 @@ class TriggerLoadJobs(beam.DoFn):
 
   def display_data(self):
     result = {'create_disposition': str(self.create_disposition),
-              'write_disposition': str(self.write_disposition)}
+              'write_disposition': str(self.write_disposition),
+              'additional_bq_parameters': str(self.additional_bq_parameters)}
     if self.schema is not None:
       result['schema'] = str(self.schema)
     else:
@@ -354,16 +357,23 @@ class TriggerLoadJobs(beam.DoFn):
   def start_bundle(self):
     self.bq_wrapper = bigquery_tools.BigQueryWrapper(client=self.test_client)
 
-  def process(self, element, load_job_name_prefix):
+  def process(self, element, load_job_name_prefix, *schema_side_inputs):
     destination = element[0]
     files = iter(element[1])
 
     if callable(self.schema):
-      schema = self.schema(destination)
+      schema = self.schema(destination, *schema_side_inputs)
     elif isinstance(self.schema, vp.ValueProvider):
       schema = self.schema.get()
     else:
       schema = self.schema
+
+    if callable(self.additional_bq_parameters):
+      additional_parameters = self.additional_bq_parameters(destination)
+    elif isinstance(self.additional_bq_parameters, vp.ValueProvider):
+      additional_parameters = self.additional_bq_parameters.get()
+    else:
+      additional_parameters = self.additional_bq_parameters
 
     job_count = 0
     batch_of_files = list(itertools.islice(files, _MAXIMUM_SOURCE_URIS))
@@ -383,7 +393,7 @@ class TriggerLoadJobs(beam.DoFn):
                                  table_reference.datasetId,
                                  table_reference.tableId)),
           job_count)
-      logging.debug("Batch of files has %s files. Job name is %s",
+      logging.debug('Batch of files has %s files. Job name is %s.',
                     len(batch_of_files), job_name)
 
       if self.temporary_tables:
@@ -391,13 +401,16 @@ class TriggerLoadJobs(beam.DoFn):
         table_reference.tableId = job_name
         yield pvalue.TaggedOutput(TriggerLoadJobs.TEMP_TABLES, table_reference)
 
-      logging.info("Triggering job %s to load data to BigQuery table %s.",
-                   job_name, table_reference)
+      logging.info('Triggering job %s to load data to BigQuery table %s.'
+                   'Schema: %s. Additional parameters: %s',
+                   job_name, table_reference,
+                   schema, additional_parameters)
       job_reference = self.bq_wrapper.perform_load_job(
           table_reference, batch_of_files, job_name,
           schema=schema,
           write_disposition=self.write_disposition,
-          create_disposition=self.create_disposition)
+          create_disposition=self.create_disposition,
+          additional_load_parameters=additional_parameters)
       yield (destination, job_reference)
 
       # Prepare to trigger the next job
@@ -487,6 +500,9 @@ class BigQueryBatchFileLoads(beam.PTransform):
       coder=None,
       max_file_size=None,
       max_files_per_bundle=None,
+      additional_bq_parameters=None,
+      table_side_inputs=None,
+      schema_side_inputs=None,
       test_client=None,
       validate=True):
     self.destination = destination
@@ -505,6 +521,10 @@ class BigQueryBatchFileLoads(beam.PTransform):
     # If the destination is a single one, we assume that we will have only one
     # job to run - and thus we avoid using temporary tables
     self.temp_tables = True if callable(destination) else False
+
+    self.additional_bq_parameters = additional_bq_parameters or {}
+    self.table_side_inputs = table_side_inputs or ()
+    self.schema_side_inputs = schema_side_inputs or ()
 
     self._validate = validate
     if self._validate:
@@ -544,7 +564,7 @@ class BigQueryBatchFileLoads(beam.PTransform):
         pcoll
         | "ApplyGlobalWindow" >> beam.WindowInto(beam.window.GlobalWindows())
         | "AppendDestination" >> beam.ParDo(bigquery_tools.AppendDestinationsFn(
-            self.destination))
+            self.destination), *self.table_side_inputs)
         | beam.ParDo(
             WriteRecordsToFile(max_files_per_bundle=self.max_files_per_bundle,
                                max_file_size=self.max_file_size,
@@ -585,12 +605,15 @@ class BigQueryBatchFileLoads(beam.PTransform):
     # some of the load jobs would fail but not other.
     # If any of them fails, then copy jobs are not triggered.
     trigger_loads_outputs = (
-        grouped_files_pc | beam.ParDo(TriggerLoadJobs(
-            schema=self.schema,
-            write_disposition=self.write_disposition,
-            create_disposition=self.create_disposition,
-            test_client=self.test_client,
-            temporary_tables=self.temp_tables), load_job_name_pcv).with_outputs(
+        grouped_files_pc | beam.ParDo(
+            TriggerLoadJobs(
+                schema=self.schema,
+                write_disposition=self.write_disposition,
+                create_disposition=self.create_disposition,
+                test_client=self.test_client,
+                temporary_tables=self.temp_tables,
+                additional_bq_parameters=self.additional_bq_parameters),
+            load_job_name_pcv, *self.schema_side_inputs).with_outputs(
                 TriggerLoadJobs.TEMP_TABLES, main='main')
     )
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -361,7 +361,7 @@ class BigQueryFileLoadsIT(unittest.TestCase):
     logging.info("Created dataset %s in project %s",
                  self.dataset_id, self.project)
 
-  @attr('IT')
+  @attr('PABIT')
   def test_multiple_destinations_transform(self):
     output_table_1 = '%s%s' % (self.output_table, 1)
     output_table_2 = '%s%s' % (self.output_table, 2)
@@ -424,7 +424,7 @@ class BigQueryFileLoadsIT(unittest.TestCase):
                max_file_size=20,
                max_files_per_bundle=-1))
 
-  @attr('IT')
+  @attr('PABIT')
   def test_one_job_fails_all_jobs_fail(self):
 
     # If one of the import jobs fails, then other jobs must not be performed.

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -367,6 +367,15 @@ class BigQueryFileLoadsIT(unittest.TestCase):
     output_table_2 = '%s%s' % (self.output_table, 2)
     output_table_3 = '%s%s' % (self.output_table, 3)
     output_table_4 = '%s%s' % (self.output_table, 4)
+    schema1 = bigquery.WriteToBigQuery.get_dict_table_schema(
+        bigquery_tools.parse_table_schema_from_json(self.BIG_QUERY_SCHEMA))
+    schema2 = bigquery.WriteToBigQuery.get_dict_table_schema(
+        bigquery_tools.parse_table_schema_from_json(self.BIG_QUERY_SCHEMA_2))
+
+    schema_kv_pairs = [(output_table_1, schema1),
+                       (output_table_2, schema2),
+                       (output_table_3, schema1),
+                       (output_table_4, schema2)]
     pipeline_verifiers = [
         BigqueryFullResultMatcher(
             project=self.project,
@@ -400,6 +409,9 @@ class BigQueryFileLoadsIT(unittest.TestCase):
     with beam.Pipeline(argv=args) as p:
       input = p | beam.Create(_ELEMENTS)
 
+      schema_map_pcv = beam.pvalue.AsDict(
+          p | "MakeSchemas" >> beam.Create(schema_kv_pairs))
+
       # Get all input in same machine
       input = (input
                | beam.Map(lambda x: (None, x))
@@ -411,6 +423,8 @@ class BigQueryFileLoadsIT(unittest.TestCase):
                table=lambda x: (output_table_1
                                 if 'language' in x
                                 else output_table_2),
+               schema=lambda dest, schema_map: schema_map.get(dest, None),
+               schema_side_inputs=(schema_map_pcv,),
                create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
                write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY))
 
@@ -419,6 +433,8 @@ class BigQueryFileLoadsIT(unittest.TestCase):
                table=lambda x: (output_table_3
                                 if 'language' in x
                                 else output_table_4),
+               schema=lambda dest, schema_map: schema_map.get(dest, None),
+               schema_side_inputs=(schema_map_pcv,),
                create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
                write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY,
                max_file_size=20,

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -361,7 +361,7 @@ class BigQueryFileLoadsIT(unittest.TestCase):
     logging.info("Created dataset %s in project %s",
                  self.dataset_id, self.project)
 
-  @attr('PABIT')
+  @attr('IT')
   def test_multiple_destinations_transform(self):
     output_table_1 = '%s%s' % (self.output_table, 1)
     output_table_2 = '%s%s' % (self.output_table, 2)
@@ -424,7 +424,7 @@ class BigQueryFileLoadsIT(unittest.TestCase):
                max_file_size=20,
                max_files_per_bundle=-1))
 
-  @attr('PABIT')
+  @attr('IT')
   def test_one_job_fails_all_jobs_fail(self):
 
     # If one of the import jobs fails, then other jobs must not be performed.

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -492,7 +492,7 @@ class BigQueryStreamingInsertTransformIntegrationTests(unittest.TestCase):
     logging.info("Created dataset %s in project %s",
                  self.dataset_id, self.project)
 
-  @attr('PABIT')
+  @attr('IT')
   def test_value_provider_transform(self):
     output_table_1 = '%s%s' % (self.output_table, 1)
     output_table_2 = '%s%s' % (self.output_table, 2)

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -492,7 +492,7 @@ class BigQueryStreamingInsertTransformIntegrationTests(unittest.TestCase):
     logging.info("Created dataset %s in project %s",
                  self.dataset_id, self.project)
 
-  @attr('IT')
+  @attr('PABIT')
   def test_value_provider_transform(self):
     output_table_1 = '%s%s' % (self.output_table, 1)
     output_table_2 = '%s%s' % (self.output_table, 2)

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -38,6 +38,7 @@ from apache_beam.io.gcp.bigquery_file_loads_test import _ELEMENTS
 from apache_beam.io.gcp.bigquery_tools import JSON_COMPLIANCE_ERROR
 from apache_beam.io.gcp.internal.clients import bigquery
 from apache_beam.io.gcp.tests.bigquery_matcher import BigqueryFullResultMatcher
+from apache_beam.io.gcp.tests.bigquery_matcher import BigQueryTableMatcher
 from apache_beam.options import value_provider
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
@@ -500,7 +501,25 @@ class BigQueryStreamingInsertTransformIntegrationTests(unittest.TestCase):
         {'name': 'name', 'type': 'STRING', 'mode': 'NULLABLE'},
         {'name': 'language', 'type': 'STRING', 'mode': 'NULLABLE'}]}
 
+    additional_bq_parameters = {
+        'timePartitioning': {'type': 'DAY'},
+        'clustering': {'fields': ['language']}}
+
+    table_ref = bigquery_tools.parse_table_reference(output_table_1)
+    table_ref2 = bigquery_tools.parse_table_reference(output_table_2)
+
     pipeline_verifiers = [
+        # TODO(pabloem): Enable BQTableMatcher.
+        #BigQueryTableMatcher(
+        #    project=self.project,
+        #    dataset=table_ref.datasetId,
+        #    table=table_ref.tableId,
+        #    expected_properties=additional_bq_parameters),
+        #BigQueryTableMatcher(
+        #    project=self.project,
+        #    dataset=table_ref2.datasetId,
+        #    table=table_ref2.tableId,
+        #    expected_properties=additional_bq_parameters),
         BigqueryFullResultMatcher(
             project=self.project,
             query="SELECT * FROM %s" % output_table_1,
@@ -526,11 +545,13 @@ class BigQueryStreamingInsertTransformIntegrationTests(unittest.TestCase):
                table=value_provider.StaticValueProvider(
                    str, '%s:%s' % (self.project, output_table_1)),
                schema=value_provider.StaticValueProvider(dict, schema),
+               additional_bq_parameters=additional_bq_parameters,
                method='STREAMING_INSERTS'))
       _ = (input
            | "WriteWithMultipleDests2" >> beam.io.gcp.bigquery.WriteToBigQuery(
                table=value_provider.StaticValueProvider(
                    str, '%s:%s' % (self.project, output_table_2)),
+               additional_bq_parameters=lambda _: additional_bq_parameters,
                method='FILE_LOADS'))
 
   @attr('IT')
@@ -571,6 +592,10 @@ class BigQueryStreamingInsertTransformIntegrationTests(unittest.TestCase):
     with beam.Pipeline(argv=args) as p:
       input = p | beam.Create(_ELEMENTS)
 
+      schema_table_pcv = beam.pvalue.AsDict(
+          p | "MakeSchemas" >> beam.Create([(output_table_1, schema1),
+                                            (output_table_2, schema2)]))
+
       input2 = p | "Broken record" >> beam.Create([bad_record])
 
       input = (input, input2) | beam.Flatten()
@@ -579,10 +604,9 @@ class BigQueryStreamingInsertTransformIntegrationTests(unittest.TestCase):
            | "WriteWithMultipleDests" >> beam.io.gcp.bigquery.WriteToBigQuery(
                table=lambda x: (full_output_table_1
                                 if 'language' in x
-                                else full_output_table_2),
-               schema=lambda dest: (schema1
-                                    if dest == full_output_table_1
-                                    else schema2),
+                                else output_table_2),
+               schema=lambda dest, table_map: table_map.get(dest, None),
+               schema_side_inputs=(schema_table_pcv,),
                method='STREAMING_INSERTS'))
 
       assert_that(r[beam.io.gcp.bigquery.BigQueryWriteFn.FAILED_ROWS],

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -324,7 +324,9 @@ class BigQueryWrapper(object):
                        source_uris,
                        schema=None,
                        write_disposition=None,
-                       create_disposition=None):
+                       create_disposition=None,
+                       additional_load_parameters=None):
+    additional_load_parameters = additional_load_parameters or {}
     reference = bigquery.JobReference(jobId=job_id, projectId=project_id)
     request = bigquery.BigqueryJobsInsertRequest(
         projectId=project_id,
@@ -338,6 +340,7 @@ class BigQueryWrapper(object):
                     createDisposition=create_disposition,
                     sourceFormat='NEWLINE_DELIMITED_JSON',
                     autodetect=schema is None,
+                    **additional_load_parameters
                 )
             ),
             jobReference=reference,
@@ -421,11 +424,14 @@ class BigQueryWrapper(object):
     response = self.client.tables.Get(request)
     return response
 
-  def _create_table(self, project_id, dataset_id, table_id, schema):
+  def _create_table(self,
+      project_id, dataset_id, table_id, schema, additional_parameters=None):
+    additional_parameters = additional_parameters or {}
     table = bigquery.Table(
         tableReference=bigquery.TableReference(
             projectId=project_id, datasetId=dataset_id, tableId=table_id),
-        schema=schema)
+        schema=schema,
+        **additional_parameters)
     request = bigquery.BigqueryTablesInsertRequest(
         projectId=project_id, datasetId=dataset_id, table=table)
     response = self.client.tables.Insert(request)
@@ -566,7 +572,8 @@ class BigQueryWrapper(object):
                        job_id,
                        schema=None,
                        write_disposition=None,
-                       create_disposition=None):
+                       create_disposition=None,
+                       additional_load_parameters=None):
     """Starts a job to load data into BigQuery.
 
     Returns:
@@ -576,14 +583,15 @@ class BigQueryWrapper(object):
         destination.projectId, job_id, destination, files,
         schema=schema,
         create_disposition=create_disposition,
-        write_disposition=write_disposition)
+        write_disposition=write_disposition,
+        additional_load_parameters=additional_load_parameters)
 
   @retry.with_exponential_backoff(
       num_retries=MAX_RETRIES,
       retry_filter=retry.retry_on_server_errors_and_timeout_filter)
   def get_or_create_table(
       self, project_id, dataset_id, table_id, schema,
-      create_disposition, write_disposition):
+      create_disposition, write_disposition, additional_create_parameters=None):
     """Gets or creates a table based on create and write dispositions.
 
     The function mimics the behavior of BigQuery import jobs when using the
@@ -644,11 +652,14 @@ class BigQueryWrapper(object):
     if found_table and write_disposition != BigQueryDisposition.WRITE_TRUNCATE:
       return found_table
     else:
-      created_table = self._create_table(project_id=project_id,
-                                         dataset_id=dataset_id,
-                                         table_id=table_id,
-                                         schema=schema or found_table.schema)
-      logging.info('Created table %s.%s.%s with schema %s. Result: %s.',
+      created_table = self._create_table(
+          project_id=project_id,
+          dataset_id=dataset_id,
+          table_id=table_id,
+          schema=schema or found_table.schema,
+          additional_parameters=additional_create_parameters)
+      logging.info('Created table %s.%s.%s with schema %s. '
+                   'Result: %s.',
                    project_id, dataset_id, table_id,
                    schema or found_table.schema,
                    created_table)
@@ -1036,5 +1047,5 @@ class AppendDestinationsFn(DoFn):
       return lambda x: AppendDestinationsFn._value_provider_or_static_val(
           destination).get()
 
-  def process(self, element):
-    yield (self.destination(element), element)
+  def process(self, element, *side_inputs):
+    yield (self.destination(element, *side_inputs), element)

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -425,7 +425,11 @@ class BigQueryWrapper(object):
     return response
 
   def _create_table(self,
-      project_id, dataset_id, table_id, schema, additional_parameters=None):
+                    project_id,
+                    dataset_id,
+                    table_id,
+                    schema,
+                    additional_parameters=None):
     additional_parameters = additional_parameters or {}
     table = bigquery.Table(
         tableReference=bigquery.TableReference(

--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
@@ -27,7 +27,7 @@ from apache_beam.io.gcp import bigquery_tools
 from apache_beam.testing.test_utils import compute_hash
 from apache_beam.utils import retry
 
-__all__ = ['BigqueryMatcher']
+__all__ = ['BigqueryMatcher', 'BigQueryTableMatcher']
 
 
 # Protect against environments where bigquery library is not available.
@@ -202,7 +202,10 @@ class BigQueryTableMatcher(BaseMatcher):
     try:
       return obj.__getattribute__(attr)
     except AttributeError:
-      return None
+      try:
+        return obj.get(attr, None)
+      except TypeError:
+        return None
 
   @staticmethod
   def _match_property(expected, actual):

--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
@@ -23,6 +23,7 @@ import logging
 
 from hamcrest.core.base_matcher import BaseMatcher
 
+from apache_beam.io.gcp import bigquery_tools
 from apache_beam.testing.test_utils import compute_hash
 from apache_beam.utils import retry
 
@@ -162,3 +163,57 @@ class BigqueryFullResultMatcher(BaseMatcher):
     mismatch_description \
       .append_text("Actual data is ") \
       .append_text(self.actual_data)
+
+
+class BigQueryTableMatcher(BaseMatcher):
+  """Matcher that verifies the properties of a Table in BigQuery."""
+
+  def __init__(self, project, dataset, table, expected_properties):
+    if bigquery is None:
+      raise ImportError(
+          'Bigquery dependencies are not installed.')
+
+    self.project = project
+    self.dataset = dataset
+    self.table = table
+    self.expected_properties = expected_properties
+
+  @retry.with_exponential_backoff(
+      num_retries=MAX_RETRIES,
+      retry_filter=retry_on_http_and_value_error)
+  def _get_table_with_retry(self, bigquery_wrapper):
+    return bigquery_wrapper.get_table(self.project, self.dataset, self.table)
+
+  def _matches(self, _):
+    logging.info('Start verify Bigquery table properties.')
+    # Run query
+    bigquery_wrapper = bigquery_tools.BigQueryWrapper()
+
+    self.actual_table = self._get_table_with_retry(bigquery_wrapper)
+
+    logging.info('Table proto is %s', self.actual_table)
+
+    return (
+        sorted((k,v)
+               for k, v in self.expected_properties.iteritems()) ==
+        sorted((k, self._get_or_none(self.actual_table, k))
+               for k in self.expected_properties))
+
+  @staticmethod
+  def _get_or_none(obj, attr):
+    try:
+      return obj.__getattribute__(attr)
+    except AttributeError:
+      return None
+
+  def describe_to(self, description):
+    description \
+      .append_text("Expected table attributes are ") \
+      .append_text(sorted((k,v)
+                            for k, v in self.expected_properties.iteritems()))
+
+  def describe_mismatch(self, pipeline_result, mismatch_description):
+    mismatch_description \
+      .append_text("Actual table attributes are ") \
+      .append_text(sorted((k, self._get_or_none(self.actual_table, k))
+                          for k in self.expected_properties))

--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
@@ -195,7 +195,7 @@ class BigQueryTableMatcher(BaseMatcher):
 
     return all(
         self._match_property(v, self._get_or_none(self.actual_table, k))
-        for k, v in self.expected_properties.iteritems())
+        for k, v in self.expected_properties.items())
 
   @staticmethod
   def _get_or_none(obj, attr):
@@ -211,7 +211,7 @@ class BigQueryTableMatcher(BaseMatcher):
       return all(
           BigQueryTableMatcher._match_property(
               v, BigQueryTableMatcher._get_or_none(actual, k))
-          for k, v in expected.iteritems())
+          for k, v in expected.items())
     else:
       return expected == actual
 
@@ -219,7 +219,7 @@ class BigQueryTableMatcher(BaseMatcher):
     description \
       .append_text("Expected table attributes are ") \
       .append_text(sorted((k, v)
-                          for k, v in self.expected_properties.iteritems()))
+                          for k, v in self.expected_properties.items()))
 
   def describe_mismatch(self, pipeline_result, mismatch_description):
     mismatch_description \

--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
@@ -25,6 +25,7 @@ import unittest
 import mock
 from hamcrest import assert_that as hc_assert_that
 
+from apache_beam.io.gcp import bigquery_tools
 from apache_beam.io.gcp.tests import bigquery_matcher as bq_verifier
 from apache_beam.testing.test_utils import patch_retry
 
@@ -70,6 +71,43 @@ class BigqueryMatcherTest(unittest.TestCase):
                                           'mock_query',
                                           'mock_checksum')
     with self.assertRaises(NotFound):
+      hc_assert_that(self._mock_result, matcher)
+    self.assertEqual(bq_verifier.MAX_RETRIES + 1, mock_query.call_count)
+
+@unittest.skipIf(bigquery is None, 'Bigquery dependencies are not installed.')
+@mock.patch.object(bigquery_tools, 'BigQueryWrapper')
+class BigqueryTableMatcherTest(unittest.TestCase):
+
+  def setUp(self):
+    self._mock_result = mock.Mock()
+    patch_retry(self, bq_verifier)
+
+  def test_bigquery_table_matcher_success(self, mock_bigquery):
+    mock_query_result = mock.Mock(partitioning='a lot of partitioning',
+                                  clustering={'column': 'FRIENDS'})
+
+    mock_bigquery.return_value.get_table.return_value = mock_query_result
+
+    matcher = bq_verifier.BigQueryTableMatcher(
+        'mock_project',
+        'mock_dataset',
+        'mock_table',
+        {'partitioning': 'a lot of partitioning',
+         'clustering': {'column': 'FRIENDS'}})
+    hc_assert_that(self._mock_result, matcher)
+
+  def test_bigquery_table_matcher_query_error_retry(self, mock_bigquery):
+    mock_query = mock_bigquery.return_value.get_table
+    mock_query.side_effect = ValueError('table not found')
+
+    matcher = bq_verifier.BigQueryTableMatcher(
+        'mock_project',
+        'mock_dataset',
+        'mock_table',
+        {'partitioning': 'a lot of partitioning',
+         'clustering': {'column': 'FRIENDS'}})
+
+    with self.assertRaises(ValueError):
       hc_assert_that(self._mock_result, matcher)
     self.assertEqual(bq_verifier.MAX_RETRIES + 1, mock_query.call_count)
 

--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
@@ -74,6 +74,7 @@ class BigqueryMatcherTest(unittest.TestCase):
       hc_assert_that(self._mock_result, matcher)
     self.assertEqual(bq_verifier.MAX_RETRIES + 1, mock_query.call_count)
 
+
 @unittest.skipIf(bigquery is None, 'Bigquery dependencies are not installed.')
 @mock.patch.object(bigquery_tools, 'BigQueryWrapper')
 class BigqueryTableMatcherTest(unittest.TestCase):


### PR DESCRIPTION
r: @chamikaramj 
This will allow support for time partitioning, and for side inputs coming into the schema and table transforms. This is useful because schemas or table names may be computed during pipeline execution, and side inputs allow users the ability to access them when they're computed.