### PR TITLE
[BEAM-5663] Add issue links to failing Python 3.6 tests

### DIFF
--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -21,6 +21,8 @@
 from __future__ import absolute_import
 
 import logging
+import os
+import sys
 import unittest
 from builtins import object
 
@@ -109,6 +111,10 @@ class TestPubsubMessage(unittest.TestCase):
 @unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
 class TestReadFromPubSubOverride(unittest.TestCase):
 
+  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
+                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_expand_with_topic(self):
     options = PipelineOptions([])
     options.view_as(StandardOptions).streaming = True
@@ -133,6 +139,10 @@ class TestReadFromPubSubOverride(unittest.TestCase):
     self.assertEqual('a_topic', source.topic_name)
     self.assertEqual('a_label', source.id_label)
 
+  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
+                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_expand_with_subscription(self):
     options = PipelineOptions([])
     options.view_as(StandardOptions).streaming = True
@@ -169,6 +179,10 @@ class TestReadFromPubSubOverride(unittest.TestCase):
       ReadFromPubSub('a_topic', 'a_subscription', 'a_label',
                      with_attributes=False, timestamp_attribute=None)
 
+  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
+                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_expand_with_other_options(self):
     options = PipelineOptions([])
     options.view_as(StandardOptions).streaming = True

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -221,7 +221,8 @@ class FnApiRunnerTest(unittest.TestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6878')
   def test_multimap_side_input(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create(['a', 'b'])

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1474,7 +1474,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_combine_properly_pipeline_type_checks_using_decorator(self):
     @with_output_types(int)
     @with_input_types(ints=typehints.Iterable[int])
@@ -1637,7 +1638,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_mean_globally_pipeline_checking_satisfied(self):
     d = (self.p
          | 'C' >> beam.Create(range(5)).with_output_types(int)
@@ -1668,7 +1670,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_mean_globally_runtime_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
 
@@ -1779,7 +1782,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_count_globally_pipeline_type_checking_satisfied(self):
     d = (self.p
          | 'P' >> beam.Create(range(5)).with_output_types(int)
@@ -1791,7 +1795,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_count_globally_runtime_type_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
 
@@ -2082,7 +2087,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_pardo_type_inference(self):
     self.assertEqual(int,
                      beam.Filter(lambda x: False).infer_output_type(int))
@@ -2096,7 +2102,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_pipeline_inference(self):
     created = self.p | beam.Create(['a', 'b', 'c'])
     mapped = created | 'pair with 1' >> beam.Map(lambda x: (x, 1))
@@ -2108,7 +2115,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   @unittest.skipIf(sys.version_info >= (3, 6, 0) and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
+                   'This test still needs to be fixed on Python 3.6.'
+                   'See BEAM-6877')
   def test_inferred_bad_kv_type(self):
     with self.assertRaises(typehints.TypeCheckError) as e:
       _ = (self.p

--- a/sdks/python/apache_beam/typehints/trivial_inference_test.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference_test.py
@@ -29,37 +29,29 @@ from apache_beam.typehints import typehints
 global_int = 1
 
 
+@unittest.skipIf(sys.version_info >= (3, 6, 0) and
+                 os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+                 'This test still needs to be fixed on Python 3.6. '
+                 'See BEAM-6877')
 class TrivialInferenceTest(unittest.TestCase):
 
   def assertReturnType(self, expected, f, inputs=()):
     self.assertEquals(expected, trivial_inference.infer_return_type(f, inputs))
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testIdentity(self):
     self.assertReturnType(int, lambda x: x, [int])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testIndexing(self):
     self.assertReturnType(int, lambda x: x[0], [typehints.Tuple[int, str]])
     self.assertReturnType(str, lambda x: x[1], [typehints.Tuple[int, str]])
     self.assertReturnType(str, lambda x: x[1], [typehints.List[str]])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testTuples(self):
     self.assertReturnType(
         typehints.Tuple[typehints.Tuple[()], int], lambda x: ((), x), [int])
     self.assertReturnType(
         typehints.Tuple[str, int, float], lambda x: (x, 0, 1.0), [str])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testGetItem(self):
     def reverse(ab):
       return ab[-1], ab[0]
@@ -74,9 +66,6 @@ class TrivialInferenceTest(unittest.TestCase):
     self.assertReturnType(
         typehints.List[int], lambda v: v[::-1], [typehints.List[int]])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testUnpack(self):
     def reverse(a_b):
       (a, b) = a_b
@@ -99,9 +88,6 @@ class TrivialInferenceTest(unittest.TestCase):
     self.assertReturnType(any_tuple,
                           reverse, [trivial_inference.Const((1, 2, 3))])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testNoneReturn(self):
     def func(a):
       if a == 5:
@@ -109,9 +95,6 @@ class TrivialInferenceTest(unittest.TestCase):
       return None
     self.assertReturnType(typehints.Union[int, type(None)], func, [int])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testSimpleList(self):
     self.assertReturnType(
         typehints.List[int],
@@ -123,9 +106,6 @@ class TrivialInferenceTest(unittest.TestCase):
         lambda xs: list(xs), # List is a disallowed builtin
         [typehints.Tuple[int, ...]])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testListComprehension(self):
     self.assertReturnType(
         typehints.List[int],
@@ -134,7 +114,8 @@ class TrivialInferenceTest(unittest.TestCase):
 
   @unittest.skipIf(sys.version_info[0] == 3 and
                    os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.')
+                   'This test still needs to be fixed on Python 3. '
+                   'See BEAM-6877')
   def testTupleListComprehension(self):
     self.assertReturnType(
         typehints.List[int],
@@ -154,9 +135,6 @@ class TrivialInferenceTest(unittest.TestCase):
         lambda L: [(a, a or b, b) for a, b in L],
         [typehints.Iterable[typehints.Tuple[str, int]]])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testGenerator(self):
 
     def foo(x, y):
@@ -167,18 +145,12 @@ class TrivialInferenceTest(unittest.TestCase):
     self.assertReturnType(
         typehints.Iterable[typehints.Union[int, float]], foo, [int, float])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testGeneratorComprehension(self):
     self.assertReturnType(
         typehints.Iterable[int],
         lambda xs: (x for x in xs),
         [typehints.Tuple[int, ...]])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testBinOp(self):
     self.assertReturnType(int, lambda a, b: a + b, [int, int])
     self.assertReturnType(
@@ -187,9 +159,6 @@ class TrivialInferenceTest(unittest.TestCase):
         typehints.List[typehints.Union[int, str]], lambda a, b: a + b,
         [typehints.List[int], typehints.List[str]])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testCall(self):
     f = lambda x, *args: x
     self.assertReturnType(
@@ -198,37 +167,22 @@ class TrivialInferenceTest(unittest.TestCase):
     self.assertReturnType(
         typehints.Tuple[int, typehints.Any], lambda: (1, f(x=1.0)))
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testClosure(self):
     x = 1
     y = 1.0
     self.assertReturnType(typehints.Tuple[int, float], lambda: (x, y))
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testGlobals(self):
     self.assertReturnType(int, lambda: global_int)
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testBuiltins(self):
     self.assertReturnType(int, lambda x: len(x), [typehints.Any])
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testGetAttr(self):
     self.assertReturnType(
         typehints.Tuple[str, typehints.Any],
         lambda: (typehints.__doc__, typehints.fake))
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testMethod(self):
 
     class A(object):
@@ -238,9 +192,6 @@ class TrivialInferenceTest(unittest.TestCase):
     self.assertReturnType(int, lambda: A().m(3))
     self.assertReturnType(float, lambda: A.m(A(), 3.0))
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testAlwaysReturnsEarly(self):
 
     def some_fn(v):
@@ -250,9 +201,6 @@ class TrivialInferenceTest(unittest.TestCase):
 
     self.assertReturnType(int, some_fn)
 
-  @unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.6.')
   def testDict(self):
     self.assertReturnType(
         typehints.Dict[typehints.Any, typehints.Any], lambda: {})


### PR DESCRIPTION
This is is part of a series of PRs with goal to make Apache Beam PY3 compatible. The proposal with the outlined approach has been documented here: https://s.apache.org/beam-python-3.

This PR follows up on #7988 to add issue links to all skipped tests.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
