### PR TITLE
[BEAM-4152] Kinds & URNs for Session Windows

### DIFF
--- a/sdks/go/pkg/beam/core/graph/coder/windows.go
+++ b/sdks/go/pkg/beam/core/graph/coder/windows.go
@@ -21,6 +21,7 @@ type WindowKind string
 const (
 	GlobalWindow   WindowKind = "GWC"
 	IntervalWindow WindowKind = "IWC"
+	SessionWindow  WindowKind = "SWC"
 )
 
 // WindowCoder represents a Window coder.
@@ -44,4 +45,8 @@ func NewGlobalWindow() *WindowCoder {
 // NewIntervalWindow returns a window coder for interval windows.
 func NewIntervalWindow() *WindowCoder {
 	return &WindowCoder{Kind: IntervalWindow}
+}
+
+func NewSessionWindow() *WindowCoder {
+	return &WindowCoder{Kind: SessionWindow}
 }

--- a/sdks/go/pkg/beam/core/graph/coder/windows.go
+++ b/sdks/go/pkg/beam/core/graph/coder/windows.go
@@ -47,6 +47,7 @@ func NewIntervalWindow() *WindowCoder {
 	return &WindowCoder{Kind: IntervalWindow}
 }
 
+// NewSessionWindow returns a window coder for session windows.
 func NewSessionWindow() *WindowCoder {
 	return &WindowCoder{Kind: SessionWindow}
 }

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -39,6 +39,7 @@ const (
 
 	urnGlobalWindow   = "beam:coder:global_window:v1"
 	urnIntervalWindow = "beam:coder:interval_window:v1"
+	urnSessionWindow  = "beam:coder:session_window:v1"
 
 	// SDK constants
 
@@ -384,6 +385,8 @@ func (b *CoderMarshaller) AddWindowCoder(w *coder.WindowCoder) string {
 		return b.internBuiltInCoder(urnGlobalWindow)
 	case coder.IntervalWindow:
 		return b.internBuiltInCoder(urnIntervalWindow)
+	case coder.SessionWindow:
+		return b.internBuiltInCoder(urnSessionWindow)
 	default:
 		panic(fmt.Sprintf("Unexpected window kind: %v", w.Kind))
 	}

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -578,6 +578,8 @@ func makeWindowCoder(w *window.Fn) *coder.WindowCoder {
 		return coder.NewGlobalWindow()
 	case window.FixedWindows, window.SlidingWindows, URNSlidingWindowsWindowFn:
 		return coder.NewIntervalWindow()
+	case window.Sessions:
+		return coder.NewSessionWindow()
 	default:
 		panic(fmt.Sprintf("Unexpected windowing strategy: %v", w))
 	}


### PR DESCRIPTION
Added the `WindowKind` and coder things so that the already existing session
windowing would work.

Before, was getting the following panic when trying to use a session window (
with a gap time of 5 minutes ):

```
panic: Unexpected windowing strategy: SES[5m0s]
```

This PR still needs some work though -- now the error that I get is this:

```
panic: reflect.StructOf: StructOf does not allow unexported fields
```

After diving into the runtime package and doing some debugging, this seems to be coming from the encoder trying to encode a `time.Time` value and choking on the private `zone` struct. I'm at a loss there, as none of the structs in the pipeline I'm working on use `time.Time` ( or use a struct that uses `time.Time` somewhere )

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
