### PR TITLE
[BEAM-6125] Update jedis to version 3.0.1

### DIFF
--- a/sdks/java/io/redis/build.gradle
+++ b/sdks/java/io/redis/build.gradle
@@ -25,7 +25,7 @@ ext.summary ="IO to read and write on a Redis keystore."
 dependencies {
   shadow library.java.vendored_guava_20_0
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
-  shadow "redis.clients:jedis:2.9.0"
+  shadow "redis.clients:jedis:3.0.1"
   testCompile project(path: ":beam-runners-direct-java", configuration: "shadow")
   testCompile library.java.junit
   testCompile library.java.slf4j_jdk14

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
@@ -319,7 +319,7 @@ public class RedisIO {
         for (String k : keys) {
           processContext.output(k);
         }
-        cursor = scanResult.getStringCursor();
+        cursor = scanResult.getCursor();
         if (cursor.equals(ScanParams.SCAN_POINTER_START)) {
           finished = true;
         }


### PR DESCRIPTION
Jedis released a major version on December 2018 with improved API and support for more recent features/versions of Redis. This is a step towards the future Streams support on RedisIO [BEAM-3012](https://issues.apache.org/jira/browse/BEAM-3012).

R: @aromanenko-dev 