### PR TITLE
[BEAM-6905] Add support for user distribution metrics.

### DIFF
--- a/model/pipeline/src/main/proto/metrics.proto
+++ b/model/pipeline/src/main/proto/metrics.proto
@@ -118,6 +118,13 @@ message MonitoringInfoSpecs {
         value: "The total estimated execution time of the ptransform"
       } ]
     }];
+
+    // TODO(ajamato): Add the PTRANSFORM name as a required label after
+    // upgrading the python SDK.
+    USER_DISTRIBUTION_COUNTER = 6 [(monitoring_info_spec) = {
+      urn: "beam:metric:user_distribution:",
+      type_urn: "beam:metrics:distribution_int_64",
+    }];
   }
 }
 
@@ -204,6 +211,10 @@ message MonitoringInfoUrns {
     TOTAL_MSECS = 5
         [(org.apache.beam.model.pipeline.v1.beam_urn) =
              "beam:metric:ptransform_execution_time:total_msecs:v1"];
+
+    USER_DISTRUBUTION_COUNTER_URN_PREFIX = 6
+        [(org.apache.beam.model.pipeline.v1.beam_urn) =
+            "beam:metric:user_distribution:"];
   }
 }
 

--- a/model/pipeline/src/main/proto/metrics.proto
+++ b/model/pipeline/src/main/proto/metrics.proto
@@ -59,7 +59,7 @@ message Annotation {
 // MonitoringInfo protos.
 message MonitoringInfoSpecs {
   enum Enum {
-    // TODO(ajamato): Add the PTRANSFORM name as a required label after
+    // TODO(BEAM-6926): Add the PTRANSFORM name as a required label after
     // upgrading the python SDK.
     USER_COUNTER = 0 [(monitoring_info_spec) = {
       urn: "beam:metric:user:",
@@ -119,7 +119,7 @@ message MonitoringInfoSpecs {
       } ]
     }];
 
-    // TODO(ajamato): Add the PTRANSFORM name as a required label after
+    // TODO(BEAM-6926): Add the PTRANSFORM name as a required label after
     // upgrading the python SDK.
     USER_DISTRIBUTION_COUNTER = 6 [(monitoring_info_spec) = {
       urn: "beam:metric:user_distribution:",
@@ -212,7 +212,7 @@ message MonitoringInfoUrns {
         [(org.apache.beam.model.pipeline.v1.beam_urn) =
              "beam:metric:ptransform_execution_time:total_msecs:v1"];
 
-    USER_DISTRUBUTION_COUNTER_URN_PREFIX = 6
+    USER_DISTRIBUTION_COUNTER_URN_PREFIX = 6
         [(org.apache.beam.model.pipeline.v1.beam_urn) =
             "beam:metric:user_distribution:"];
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/ElementCountMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/ElementCountMonitoringInfoToCounterUpdateTransformer.java
@@ -21,6 +21,7 @@ import com.google.api.services.dataflow.model.CounterUpdate;
 import com.google.api.services.dataflow.model.NameAndKind;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.runners.core.metrics.SpecMonitoringInfoValidator;
 import org.apache.beam.runners.dataflow.worker.counters.DataflowCounterUpdateExtractor;
@@ -84,6 +85,7 @@ public class ElementCountMonitoringInfoToCounterUpdateTransformer
    * @return CounterUpdate generated based on provided monitoringInfo
    */
   @Override
+  @Nullable
   public CounterUpdate transform(MonitoringInfo monitoringInfo) {
     Optional<String> validationResult = validate(monitoringInfo);
     if (validationResult.isPresent()) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/FnApiMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/FnApiMonitoringInfoToCounterUpdateTransformer.java
@@ -35,6 +35,7 @@ public class FnApiMonitoringInfoToCounterUpdateTransformer
     implements MonitoringInfoToCounterUpdateTransformer {
 
   final UserMonitoringInfoToCounterUpdateTransformer userCounterTransformer;
+  final UserDistributionMonitoringInfoToCounterUpdateTransformer userDistributionCounterTransformer;
   final Map<String, MonitoringInfoToCounterUpdateTransformer> counterTransformers = new HashMap<>();
 
   public FnApiMonitoringInfoToCounterUpdateTransformer(
@@ -43,6 +44,9 @@ public class FnApiMonitoringInfoToCounterUpdateTransformer
     SpecMonitoringInfoValidator specValidator = new SpecMonitoringInfoValidator();
     this.userCounterTransformer =
         new UserMonitoringInfoToCounterUpdateTransformer(specValidator, stepContextMap);
+
+    this.userDistributionCounterTransformer =
+        new UserDistributionMonitoringInfoToCounterUpdateTransformer(specValidator, stepContextMap);
 
     MSecMonitoringInfoToCounterUpdateTransformer msecTransformer =
         new MSecMonitoringInfoToCounterUpdateTransformer(specValidator, stepContextMap);
@@ -59,8 +63,10 @@ public class FnApiMonitoringInfoToCounterUpdateTransformer
   @VisibleForTesting
   public FnApiMonitoringInfoToCounterUpdateTransformer(
       UserMonitoringInfoToCounterUpdateTransformer userCounterTransformer,
+      UserDistributionMonitoringInfoToCounterUpdateTransformer userDistributionCounterTransformer,
       Map<String, MonitoringInfoToCounterUpdateTransformer> counterTransformers) {
     this.userCounterTransformer = userCounterTransformer;
+    this.userDistributionCounterTransformer = userDistributionCounterTransformer;
     this.counterTransformers.putAll(counterTransformers);
   }
 
@@ -69,6 +75,8 @@ public class FnApiMonitoringInfoToCounterUpdateTransformer
     String urn = src.getUrn();
     if (urn.startsWith(userCounterTransformer.getSupportedUrnPrefix())) {
       return userCounterTransformer.transform(src);
+    } else if (urn.startsWith(userDistributionCounterTransformer.getSupportedUrnPrefix())) {
+      return this.userDistributionCounterTransformer.transform(src);
     }
 
     MonitoringInfoToCounterUpdateTransformer transformer = counterTransformers.get(urn);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/FnApiMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/FnApiMonitoringInfoToCounterUpdateTransformer.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.dataflow.worker.fn.control;
 import com.google.api.services.dataflow.model.CounterUpdate;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.runners.core.metrics.SpecMonitoringInfoValidator;
 import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.DataflowStepContext;
@@ -71,6 +72,7 @@ public class FnApiMonitoringInfoToCounterUpdateTransformer
   }
 
   @Override
+  @Nullable
   public CounterUpdate transform(MonitoringInfo src) {
     String urn = src.getUrn();
     if (urn.startsWith(userCounterTransformer.getSupportedUrnPrefix())) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/MSecMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/MSecMonitoringInfoToCounterUpdateTransformer.java
@@ -24,6 +24,7 @@ import com.google.api.services.dataflow.model.CounterUpdate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.runners.core.metrics.SpecMonitoringInfoValidator;
 import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.DataflowStepContext;
@@ -108,6 +109,7 @@ public class MSecMonitoringInfoToCounterUpdateTransformer
   }
 
   @Override
+  @Nullable
   public CounterUpdate transform(MonitoringInfo monitoringInfo) {
     Optional<String> validationResult = validate(monitoringInfo);
     if (validationResult.isPresent()) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/MonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/MonitoringInfoToCounterUpdateTransformer.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.dataflow.worker.fn.control;
 
 import com.google.api.services.dataflow.model.CounterUpdate;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 
 interface MonitoringInfoToCounterUpdateTransformer {
@@ -29,5 +30,6 @@ interface MonitoringInfoToCounterUpdateTransformer {
    * @param src
    * @return CounterUpdate or null if MonitoringInfo is invalid/unsupported.
    */
+  @Nullable
   CounterUpdate transform(MonitoringInfo src);
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/UserDistributionMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/UserDistributionMonitoringInfoToCounterUpdateTransformer.java
@@ -26,6 +26,7 @@ import com.google.api.services.dataflow.model.CounterUpdate;
 import com.google.api.services.dataflow.model.DistributionUpdate;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.MetricsApi.IntDistributionData;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfoSpecs.Enum;
@@ -93,6 +94,7 @@ class UserDistributionMonitoringInfoToCounterUpdateTransformer
    * @return Relevant CounterUpdate or null if transformation failed.
    */
   @Override
+  @Nullable
   public CounterUpdate transform(MonitoringInfo monitoringInfo) {
     Optional<String> validationResult = validate(monitoringInfo);
     if (validationResult.isPresent()) {
@@ -111,6 +113,7 @@ class UserDistributionMonitoringInfoToCounterUpdateTransformer
     String nameWithNamespace =
         urn.substring(BEAM_METRICS_USER_DISTRIBUTION_PREFIX.length()).replace("^:", "");
 
+    // TODO(BEAM-6925) Extract common logic to separate class.
     final int lastColonIndex = nameWithNamespace.lastIndexOf(':');
     String counterName = nameWithNamespace.substring(lastColonIndex + 1);
     String counterNamespace =

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/UserDistributionMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/UserDistributionMonitoringInfoToCounterUpdateTransformer.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.fn.control;
+
+import static org.apache.beam.model.pipeline.v1.MetricsApi.monitoringInfoSpec;
+
+import com.google.api.services.dataflow.model.CounterMetadata;
+import com.google.api.services.dataflow.model.CounterStructuredName;
+import com.google.api.services.dataflow.model.CounterStructuredNameAndMetadata;
+import com.google.api.services.dataflow.model.CounterUpdate;
+import com.google.api.services.dataflow.model.DistributionUpdate;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.beam.model.pipeline.v1.MetricsApi.IntDistributionData;
+import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
+import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfoSpecs.Enum;
+import org.apache.beam.runners.core.metrics.SpecMonitoringInfoValidator;
+import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.DataflowStepContext;
+import org.apache.beam.runners.dataflow.worker.MetricsToCounterUpdateConverter.Origin;
+import org.apache.beam.runners.dataflow.worker.counters.DataflowCounterUpdateExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class for transforming MonitoringInfo's containing User counter values, to relevant CounterUpdate
+ * proto.
+ */
+class UserDistributionMonitoringInfoToCounterUpdateTransformer
+    implements MonitoringInfoToCounterUpdateTransformer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BeamFnMapTaskExecutor.class);
+
+  private final Map<String, DataflowStepContext> transformIdMapping;
+
+  private final SpecMonitoringInfoValidator specValidator;
+
+  public UserDistributionMonitoringInfoToCounterUpdateTransformer(
+      final SpecMonitoringInfoValidator specMonitoringInfoValidator,
+      final Map<String, DataflowStepContext> transformIdMapping) {
+    this.transformIdMapping = transformIdMapping;
+    this.specValidator = specMonitoringInfoValidator;
+  }
+
+  static final String BEAM_METRICS_USER_DISTRIBUTION_PREFIX =
+      Enum.USER_DISTRIBUTION_COUNTER
+          .getValueDescriptor()
+          .getOptions()
+          .getExtension(monitoringInfoSpec)
+          .getUrn();
+
+  private Optional<String> validate(MonitoringInfo monitoringInfo) {
+    Optional<String> validatorResult = specValidator.validate(monitoringInfo);
+    if (validatorResult.isPresent()) {
+      return validatorResult;
+    }
+
+    String urn = monitoringInfo.getUrn();
+    if (!urn.startsWith(BEAM_METRICS_USER_DISTRIBUTION_PREFIX)) {
+      throw new RuntimeException(
+          String.format(
+              "Received unexpected counter urn. Expected urn starting with: %s, received: %s",
+              BEAM_METRICS_USER_DISTRIBUTION_PREFIX, urn));
+    }
+
+    final String ptransform = monitoringInfo.getLabelsMap().get("PTRANSFORM");
+    DataflowStepContext stepContext = transformIdMapping.get(ptransform);
+    if (stepContext == null) {
+      return Optional.of(
+          "Encountered user-counter MonitoringInfo with unknown ptransformId: "
+              + monitoringInfo.toString());
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Transforms user counter MonitoringInfo to relevant CounterUpdate.
+   *
+   * @return Relevant CounterUpdate or null if transformation failed.
+   */
+  @Override
+  public CounterUpdate transform(MonitoringInfo monitoringInfo) {
+    Optional<String> validationResult = validate(monitoringInfo);
+    if (validationResult.isPresent()) {
+      LOG.info(validationResult.get());
+      return null;
+    }
+
+    IntDistributionData value =
+        monitoringInfo.getMetric().getDistributionData().getIntDistributionData();
+    String urn = monitoringInfo.getUrn();
+
+    final String ptransform = monitoringInfo.getLabelsMap().get("PTRANSFORM");
+
+    CounterStructuredNameAndMetadata name = new CounterStructuredNameAndMetadata();
+
+    String nameWithNamespace =
+        urn.substring(BEAM_METRICS_USER_DISTRIBUTION_PREFIX.length()).replace("^:", "");
+
+    final int lastColonIndex = nameWithNamespace.lastIndexOf(':');
+    String counterName = nameWithNamespace.substring(lastColonIndex + 1);
+    String counterNamespace =
+        lastColonIndex == -1 ? "" : nameWithNamespace.substring(0, lastColonIndex);
+
+    DataflowStepContext stepContext = transformIdMapping.get(ptransform);
+    name.setName(
+            new CounterStructuredName()
+                .setOrigin(Origin.USER.toString())
+                .setName(counterName)
+                .setOriginalStepName(stepContext.getNameContext().originalName())
+                .setOriginNamespace(counterNamespace))
+        .setMetadata(new CounterMetadata().setKind("DISTRIBUTION"));
+
+    return new CounterUpdate()
+        .setStructuredNameAndMetadata(name)
+        .setCumulative(true)
+        .setDistribution(
+            new DistributionUpdate()
+                .setMax(DataflowCounterUpdateExtractor.longToSplitInt(value.getMax()))
+                .setMin(DataflowCounterUpdateExtractor.longToSplitInt(value.getMin()))
+                .setSum(DataflowCounterUpdateExtractor.longToSplitInt(value.getSum()))
+                .setCount(DataflowCounterUpdateExtractor.longToSplitInt(value.getCount())));
+  }
+
+  /** @return MonitoringInfo urns prefix that this transformer can convert to CounterUpdates. */
+  public String getSupportedUrnPrefix() {
+    return BEAM_METRICS_USER_DISTRIBUTION_PREFIX;
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/UserMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/UserMonitoringInfoToCounterUpdateTransformer.java
@@ -25,6 +25,7 @@ import com.google.api.services.dataflow.model.CounterStructuredNameAndMetadata;
 import com.google.api.services.dataflow.model.CounterUpdate;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfoSpecs.Enum;
 import org.apache.beam.runners.core.metrics.SpecMonitoringInfoValidator;
@@ -87,6 +88,7 @@ class UserMonitoringInfoToCounterUpdateTransformer
    * @return Relevant CounterUpdate or null if transformation failed.
    */
   @Override
+  @Nullable
   public CounterUpdate transform(MonitoringInfo monitoringInfo) {
     Optional<String> validationResult = validate(monitoringInfo);
     if (validationResult.isPresent()) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/FnApiMonitoringInfoToCounterUpdateTransformerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/FnApiMonitoringInfoToCounterUpdateTransformerTest.java
@@ -35,6 +35,10 @@ public class FnApiMonitoringInfoToCounterUpdateTransformerTest {
 
   @Mock private UserMonitoringInfoToCounterUpdateTransformer mockUserCounterTransformer;
 
+  @Mock
+  private UserDistributionMonitoringInfoToCounterUpdateTransformer
+      mockUserDistributionCounterTransformer;
+
   @Mock private UserMonitoringInfoToCounterUpdateTransformer mockGenericTransformer1;
 
   @Before
@@ -48,7 +52,9 @@ public class FnApiMonitoringInfoToCounterUpdateTransformerTest {
         Collections.EMPTY_MAP;
     FnApiMonitoringInfoToCounterUpdateTransformer testObject =
         new FnApiMonitoringInfoToCounterUpdateTransformer(
-            mockUserCounterTransformer, genericTransformers);
+            mockUserCounterTransformer,
+            mockUserDistributionCounterTransformer,
+            genericTransformers);
 
     CounterUpdate expectedResult = new CounterUpdate();
     when(mockUserCounterTransformer.transform(any())).thenReturn(expectedResult);
@@ -72,10 +78,14 @@ public class FnApiMonitoringInfoToCounterUpdateTransformerTest {
     genericTransformers.put(validUrn, mockGenericTransformer1);
 
     when(mockUserCounterTransformer.getSupportedUrnPrefix()).thenReturn("invalid:prefix:");
+    when(mockUserDistributionCounterTransformer.getSupportedUrnPrefix())
+        .thenReturn("invalid:prefix2:");
 
     FnApiMonitoringInfoToCounterUpdateTransformer testObject =
         new FnApiMonitoringInfoToCounterUpdateTransformer(
-            mockUserCounterTransformer, genericTransformers);
+            mockUserCounterTransformer,
+            mockUserDistributionCounterTransformer,
+            genericTransformers);
 
     CounterUpdate expectedResult = new CounterUpdate();
     when(mockGenericTransformer1.transform(any())).thenReturn(expectedResult);

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/UserDistributionMonitoringInfoToCounterUpdateTransformerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/UserDistributionMonitoringInfoToCounterUpdateTransformerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.fn.control;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.api.services.dataflow.model.CounterUpdate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
+import org.apache.beam.runners.core.metrics.SpecMonitoringInfoValidator;
+import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.DataflowStepContext;
+import org.apache.beam.runners.dataflow.worker.counters.NameContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class UserDistributionMonitoringInfoToCounterUpdateTransformerTest {
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
+  @Mock private SpecMonitoringInfoValidator mockSpecValidator;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testTransformReturnsNullIfSpecValidationFails() {
+    Map<String, DataflowStepContext> stepContextMapping = new HashMap<>();
+    UserDistributionMonitoringInfoToCounterUpdateTransformer testObject =
+        new UserDistributionMonitoringInfoToCounterUpdateTransformer(
+            mockSpecValidator, stepContextMapping);
+    Optional<String> error = Optional.of("Error text");
+    when(mockSpecValidator.validate(any())).thenReturn(error);
+    assertEquals(null, testObject.transform(null));
+  }
+
+  @Test
+  public void testTransformThrowsIfMonitoringInfoWithWrongUrnPrefixReceived() {
+    Map<String, DataflowStepContext> stepContextMapping = new HashMap<>();
+    MonitoringInfo monitoringInfo =
+        MonitoringInfo.newBuilder().setUrn("beam:metric:element_count:v1").build();
+    UserDistributionMonitoringInfoToCounterUpdateTransformer testObject =
+        new UserDistributionMonitoringInfoToCounterUpdateTransformer(
+            mockSpecValidator, stepContextMapping);
+    when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
+
+    exception.expect(RuntimeException.class);
+    testObject.transform(monitoringInfo);
+  }
+
+  @Test
+  public void testTransformReturnsNullIfMonitoringInfoWithUnknownPTransformLabelPresent() {
+    Map<String, DataflowStepContext> stepContextMapping = new HashMap<>();
+    MonitoringInfo monitoringInfo =
+        MonitoringInfo.newBuilder()
+            .setUrn("beam:metric:user_distribution:anyNamespace:anyName")
+            .putLabels("PTRANSFORM", "anyValue")
+            .build();
+    UserDistributionMonitoringInfoToCounterUpdateTransformer testObject =
+        new UserDistributionMonitoringInfoToCounterUpdateTransformer(
+            mockSpecValidator, stepContextMapping);
+    when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
+    assertEquals(null, testObject.transform(monitoringInfo));
+  }
+
+  @Test
+  public void testTransformReturnsValidCounterUpdateWhenValidUserMonitoringInfoReceived() {
+    Map<String, DataflowStepContext> stepContextMapping = new HashMap<>();
+    NameContext nc =
+        NameContext.create("anyStageName", "anyOriginalName", "anySystemName", "anyUserName");
+    DataflowStepContext dsc = mock(DataflowStepContext.class);
+    when(dsc.getNameContext()).thenReturn(nc);
+    stepContextMapping.put("anyValue", dsc);
+
+    MonitoringInfo monitoringInfo =
+        MonitoringInfo.newBuilder()
+            .setUrn("beam:metric:user_distribution:anyNamespace:anyName")
+            .putLabels("PTRANSFORM", "anyValue")
+            .build();
+    UserDistributionMonitoringInfoToCounterUpdateTransformer testObject =
+        new UserDistributionMonitoringInfoToCounterUpdateTransformer(
+            mockSpecValidator, stepContextMapping);
+    when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
+
+    CounterUpdate result = testObject.transform(monitoringInfo);
+    assertNotEquals(null, result);
+
+    assertEquals(
+        "{cumulative=true, distribution={count={highBits=0, lowBits=0}, "
+            + "max={highBits=0, lowBits=0}, min={highBits=0, lowBits=0}, "
+            + "sum={highBits=0, lowBits=0}}, "
+            + "structuredNameAndMetadata={metadata={kind=DISTRIBUTION}, "
+            + "name={name=anyName, origin=USER, originNamespace=anyNamespace, "
+            + "originalStepName=anyOriginalName}}}",
+        result.toString());
+  }
+}

--- a/sdks/python/apache_beam/metrics/execution.py
+++ b/sdks/python/apache_beam/metrics/execution.py
@@ -40,6 +40,7 @@ from apache_beam.metrics import monitoring_infos
 from apache_beam.metrics.cells import CounterCell
 from apache_beam.metrics.cells import DistributionCell
 from apache_beam.metrics.cells import GaugeCell
+from apache_beam.metrics.monitoring_infos import user_distribution_metric_urn
 from apache_beam.metrics.monitoring_infos import user_metric_urn
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.runners.worker import statesampler
@@ -245,7 +246,7 @@ class MetricsContainer(object):
 
     for k, v in self.distributions.items():
       all_user_metrics.append(monitoring_infos.int64_distribution(
-          user_metric_urn(k.namespace, k.name),
+          user_distribution_metric_urn(k.namespace, k.name),
           v.get_cumulative().to_runner_api_monitoring_info(),
           ptransform=transform_id
       ))

--- a/sdks/python/apache_beam/metrics/monitoring_infos.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos.py
@@ -42,6 +42,8 @@ FINISH_BUNDLE_MSECS_URN = common_urns.monitoring_infos.FINISH_BUNDLE_MSECS.urn
 TOTAL_MSECS_URN = common_urns.monitoring_infos.TOTAL_MSECS.urn
 USER_COUNTER_URN_PREFIX = (
     common_urns.monitoring_infos.USER_COUNTER_URN_PREFIX.urn)
+USER_DISTRIBUTION_COUNTER_URN_PREFIX = (
+    common_urns.monitoring_infos.USER_DISTRUBUTION_COUNTER_URN_PREFIX.urn)
 
 # TODO(ajamato): Implement the remaining types, i.e. Double types
 # Extrema types, etc. See:
@@ -192,6 +194,17 @@ def user_metric_urn(namespace, name):
   return '%s%s:%s' % (USER_COUNTER_URN_PREFIX, namespace, name)
 
 
+def user_distribution_metric_urn(namespace, name):
+  """Returns the metric URN for a user distribution metric,
+  with a proper URN prefix.
+
+  Args:
+    namespace: The namespace of the metric.
+    name: The name of the metric.
+  """
+  return '%s%s:%s' % (USER_DISTRIBUTION_COUNTER_URN_PREFIX, namespace, name)
+
+
 def is_counter(monitoring_info_proto):
   """Returns true if the monitoring info is a coutner metric."""
   return monitoring_info_proto.type in COUNTER_TYPES
@@ -207,9 +220,22 @@ def is_gauge(monitoring_info_proto):
   return monitoring_info_proto.type in GAUGE_TYPES
 
 
+def _is_user_monitoring_info(monitoring_info_proto):
+  return monitoring_info_proto.urn.startswith(
+      USER_COUNTER_URN_PREFIX)
+
+
+def _is_user_distribution_monitoring_info(monitoring_info_proto):
+  return monitoring_info_proto.urn.startswith(
+      USER_DISTRIBUTION_COUNTER_URN_PREFIX)
+
+
 def is_user_monitoring_info(monitoring_info_proto):
   """Returns true if the monitoring info is a user metric."""
-  return monitoring_info_proto.urn.startswith(USER_COUNTER_URN_PREFIX)
+
+  return _is_user_monitoring_info(
+      monitoring_info_proto) or _is_user_distribution_monitoring_info(
+          monitoring_info_proto)
 
 
 def extract_metric_result_map_value(monitoring_info_proto):
@@ -235,9 +261,15 @@ def extract_metric_result_map_value(monitoring_info_proto):
 def parse_namespace_and_name(monitoring_info_proto):
   """Returns the (namespace, name) tuple of the URN in the monitoring info."""
   to_split = monitoring_info_proto.urn
-  if is_user_monitoring_info(monitoring_info_proto):
-    # Remove the URN prefix which indicates that it is a user counter.
-    to_split = monitoring_info_proto.urn[len(USER_COUNTER_URN_PREFIX):]
+
+  # Remove the URN prefix which indicates that it is a user counter.
+  prefix_len = 0
+  if _is_user_distribution_monitoring_info(monitoring_info_proto):
+    prefix_len = len(USER_DISTRIBUTION_COUNTER_URN_PREFIX)
+  elif _is_user_monitoring_info(monitoring_info_proto):
+    prefix_len = len(USER_COUNTER_URN_PREFIX)
+  to_split = monitoring_info_proto.urn[prefix_len:]
+
   # If it is not a user counter, just use the first part of the URN, i.e. 'beam'
   split = to_split.split(':')
   return split[0], ':'.join(split[1:])

--- a/sdks/python/apache_beam/metrics/monitoring_infos.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos.py
@@ -43,7 +43,7 @@ TOTAL_MSECS_URN = common_urns.monitoring_infos.TOTAL_MSECS.urn
 USER_COUNTER_URN_PREFIX = (
     common_urns.monitoring_infos.USER_COUNTER_URN_PREFIX.urn)
 USER_DISTRIBUTION_COUNTER_URN_PREFIX = (
-    common_urns.monitoring_infos.USER_DISTRUBUTION_COUNTER_URN_PREFIX.urn)
+    common_urns.monitoring_infos.USER_DISTRIBUTION_COUNTER_URN_PREFIX.urn)
 
 # TODO(ajamato): Implement the remaining types, i.e. Double types
 # Extrema types, etc. See:

--- a/sdks/python/apache_beam/metrics/monitoring_infos_test.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos_test.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+
+import unittest
+
+from apache_beam.metrics import monitoring_infos
+
+
+class MonitoringInfosTest(unittest.TestCase):
+
+  def test_parse_namespace_and_name_for_nonuser_metric(self):
+    input = monitoring_infos.create_monitoring_info("beam:dummy:metric",
+                                                    "typeurn", None)
+    namespace, name = monitoring_infos.parse_namespace_and_name(input)
+    self.assertEqual(namespace, "beam")
+    self.assertEqual(name, "dummy:metric")
+
+  def test_parse_namespace_and_name_for_user_metric(self):
+    urn = (monitoring_infos.USER_COUNTER_URN_PREFIX +
+           "counternamespace:countername")
+    input = monitoring_infos.create_monitoring_info(urn, "typeurn", None)
+    namespace, name = monitoring_infos.parse_namespace_and_name(input)
+    self.assertEqual(namespace, "counternamespace")
+    self.assertEqual(name, "countername")
+
+  def test_parse_namespace_and_name_for_user_distribution_metric(self):
+    urn = (monitoring_infos.USER_DISTRIBUTION_COUNTER_URN_PREFIX +
+           "counternamespace:countername")
+    input = monitoring_infos.create_monitoring_info(urn, "typeurn", None)
+    namespace, name = monitoring_infos.parse_namespace_and_name(input)
+    self.assertEqual(namespace, "counternamespace")
+    self.assertEqual(name, "countername")
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
[BEAM-6905](https://issues.apache.org/jira/browse/BEAM-6905)
---
1. It was decided to stick to current design and add a new monitoring
info type for distribution metric.

2. Updated python harness to report new metric urn.

3. Added UserDistributionMetric transformer to java. It is similar to
user metric transformer, but it is not worth to complicate code much
as of now.

4. Refactoring of code will be done in further commits.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
