### PR TITLE
[BEAM-6892] Adding support for auto-creating buckets for BigQuery file loads

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -1137,7 +1137,8 @@ def model_bigqueryio(p, write_project='', write_dataset='', write_table=''):
       table_spec,
       schema=table_schema,
       write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
-      create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED)
+      create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
+      validate=False)
   # [END model_bigqueryio_write]
 
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -675,7 +675,8 @@ class BigQueryWriteFn(DoFn):
         table_reference.datasetId,
         table_reference.tableId,
         table_schema,
-        self.create_disposition, self.write_disposition)
+        self.create_disposition, self.write_disposition,
+        kms_key=self.kms_key)
     self._observed_tables.add(str_table_reference)
 
   def process(self, element, unused_create_fn_output=None):
@@ -1016,6 +1017,7 @@ bigquery_v2_messages.TableSchema):
                   max_files_per_bundle=self.max_files_per_bundle,
                   custom_gcs_temp_location=self.custom_gcs_temp_location,
                   test_client=self.test_client,
+                  kms_key=self.kms_key,
                   validate=self._validate))
 
   def display_data(self):

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -42,7 +42,6 @@ import apache_beam as beam
 from apache_beam import pvalue
 from apache_beam.io import filesystems as fs
 from apache_beam.io.gcp import bigquery_tools
-from apache_beam.io.gcp import gcsio
 from apache_beam.io.gcp.internal.clients import bigquery as bigquery_api
 from apache_beam.options import value_provider as vp
 from apache_beam.options.pipeline_options import GoogleCloudOptions
@@ -566,6 +565,7 @@ class BigQueryBatchFileLoads(beam.PTransform):
 
     bucket_name = DEFAULT_BUCKET_NAME % (region, project_number)
 
+    from apache_beam.io.gcp import gcsio
     gcs = gcsio.GcsIO()
     bucket = gcs.get_bucket(bucket_name)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -583,7 +583,7 @@ class BigQueryBatchFileLoads(beam.PTransform):
 
       if not bucket:
         raise ValueError(
-          'Unable to create default bucket for BigQuery File Loads.')
+            'Unable to create default bucket for BigQuery File Loads.')
 
     if int(bucket.projectNumber) != int(project_number):
       raise ValueError(

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -152,6 +152,37 @@ class GcsIO(object):
     """
     self._rewrite_cb = callback
 
+  def get_bucket(self, bucket_name):
+    """Returns an object bucket from its name, or None if it does not exist."""
+    try:
+      request = storage.StorageBucketsGetRequest(bucket=bucket_name)
+      return self.client.buckets.Get(request)
+    except HttpError:
+      return None
+
+  def insert_bucket(self,
+                    bucket_name,
+                    project,
+                    kms_key=None,
+                    location=None):
+    """Create and return a GCS bucket in a specific project."""
+    encryption = None
+    if kms_key:
+      encryption = storage.Bucket.EncryptionValue(kms_key)
+
+    request = storage.StorageBucketsInsertRequest(
+        bucket=storage.Bucket(
+            name=bucket_name,
+            location=location,
+            encryption=encryption
+        ),
+        project=project,
+    )
+    try:
+      return self.client.buckets.Insert(request)
+    except HttpError:
+      return None
+
   def open(self,
            filename,
            mode='r',

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -143,10 +143,11 @@ GCP_REQUIREMENTS = [
     # [BEAM-4543] Datastore IO is not supported in Python 3.
     'googledatastore>=7.0.1,<7.1; python_version < "3.0"',
     'google-cloud-pubsub==0.39.0',
+    'google-cloud-resource-manager',
     # GCP packages required by tests
     'google-cloud-bigquery>=1.6.0,<1.7.0',
-    'google-cloud-core==0.28.1',
-    'google-cloud-bigtable==0.31.1',
+    'google-cloud-core>=0.29.0',
+    'google-cloud-bigtable>=0.32.0',
 ]
 
 


### PR DESCRIPTION
This change does the following:
- Add a validation step at pipeline expansion, which is able to create a default bucket to run the pipeline.
- Bump a few dependency versions for google-cloud deps to add google-cloud-resource-manager.
- Pass around kms_key arguments.

r: @udim 
cc: @tvalentyn @chamikaramj 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
