### PR TITLE
Use self.assertEqual instead of self.assertEquals

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -844,7 +844,7 @@ class FnApiRunnerTest(unittest.TestCase):
 
     results = event_recorder.events()
     event_recorder.cleanup()
-    self.assertEquals(results, sorted(elements_list))
+    self.assertEqual(results, sorted(elements_list))
 
 
 class FnApiRunnerTestWithGrpc(FnApiRunnerTest):


### PR DESCRIPTION
self.assertEquals is deprecated and use self.assertEqual instead.
R: @aaltay 