### PR TITLE
[BEAM-3072] updates to that the error handling and collected the fail…

### DIFF
--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -43,6 +43,12 @@ def call(*args, **kwargs):
     out = subprocess.call(*args, **kwargs)
   except OSError:
     raise RuntimeError("Executable {} not found".format(args[0]))
+  except subprocess.CalledProcessError:
+    if isinstance(args, tuple) and (args[0][2] == "pip"):
+      raise RuntimeError("Full traceback: {},Pip install failed for package {}"\
+        .format(traceback.format_exc(), args[0][6]))
+    else:
+      RuntimeError(traceback.format_exc())
   return out
 
 
@@ -54,7 +60,11 @@ def check_call(*args, **kwargs):
   except OSError:
     raise RuntimeError("Executable {} not found".format(args[0]))
   except subprocess.CalledProcessError:
-    raise RuntimeError(traceback.format_exc())
+    if isinstance(args, tuple) and (args[0][2] == "pip"):
+      raise RuntimeError("Full traceback: {},Pip install failed for package {}"\
+        .format(traceback.format_exc(), args[0][6]))
+    else:
+      RuntimeError(traceback.format_exc())
   return out
 
 
@@ -66,7 +76,11 @@ def check_output(*args, **kwargs):
   except OSError:
     raise RuntimeError("Executable {} not found".format(args[0]))
   except subprocess.CalledProcessError:
-    raise RuntimeError(traceback.format_exc())
+    if isinstance(args, tuple) and (args[0][2] == "pip"):
+      raise RuntimeError("Full traceback: {},Pip install failed for package {}"\
+        .format(traceback.format_exc(), args[0][6]))
+    else:
+      RuntimeError(traceback.format_exc())
   return out
 
 

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -73,11 +73,4 @@ def check_output(*args, **kwargs):
 def Popen(*args, **kwargs):  # pylint: disable=invalid-name
   if force_shell:
     kwargs['shell'] = True
-  try:
-    pipe = subprocess.Popen(["ls", "-l"], stdout=subprocess.PIPE,stderr=subprocess.PIPE,universal_newlines=True)
-    out,error=pipe.communicate()
-    if ""!=error:
-        raise RuntimeError(error)
-  except OSError:
-    raise RuntimeError("Executable: {}, not found".format("Hej"))
-  return output
+  return subprocess.Popen(*args,**kwargs)

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -40,7 +40,7 @@ def call(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
   try:
-    out =  subprocess.call(*args, **kwargs)
+    out = subprocess.call(*args, **kwargs)
   except OSError:
     raise RuntimeError("Executable {} not found".format(args[0]))
   return out
@@ -50,7 +50,7 @@ def check_call(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
   try:
-    out = subprocess.check_call(*args,**kwargs)
+    out = subprocess.check_call(*args, **kwargs)
   except OSError:
     raise RuntimeError("Executable {} not found".format(args[0]))
   except subprocess.CalledProcessError:
@@ -62,7 +62,7 @@ def check_output(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
   try:
-    out =  subprocess.check_output(*args, **kwargs)
+    out = subprocess.check_output(*args, **kwargs)
   except OSError:
     raise RuntimeError("Executable {} not found".format(args[0]))
   except subprocess.CalledProcessError:
@@ -73,4 +73,4 @@ def check_output(*args, **kwargs):
 def Popen(*args, **kwargs):  # pylint: disable=invalid-name
   if force_shell:
     kwargs['shell'] = True
-  return subprocess.Popen(*args,**kwargs)
+  return subprocess.Popen(*args, **kwargs)

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -74,9 +74,7 @@ def Popen(*args, **kwargs):  # pylint: disable=invalid-name
   if force_shell:
     kwargs['shell'] = True
   try:
-    pipe = subprocess.Popen(["ls", "-l"], stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                universal_newlines=True)
+    pipe = subprocess.Popen(["ls", "-l"], stdout=subprocess.PIPE,stderr=subprocess.PIPE,universal_newlines=True)
     out,error=pipe.communicate()
     if ""!=error:
         raise RuntimeError(error)

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -58,21 +58,20 @@ def call(*args, **kwargs):
 def check_call(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
-  return subprocess.check_output(*args, **kwargs)
-  # try:
-  #   out = subprocess.check_output(*args, **kwargs)
-  # except OSError:
-  #   raise RuntimeError("Executable {} not found".format(args[0]))
-  # except subprocess.CalledProcessError as error:
-  #   if isinstance(args, tuple) and (args[0][2] == "pip"):
-  #     raise RuntimeError( \
-  #       "Full traceback: {} \n Pip install failed for package: {} \
-  #       \n Output from execution of subprocess: {}" \
-  #       .format(traceback.format_exc(), args[0][6], error.output))
-  #   else:
-  #     RuntimeError("Full trace: {}\n Output of the failed child process: {}" \
-  #       .format(traceback.format_exc(), error.output))
-  # return out
+  try:
+    out = subprocess.check_call(*args, **kwargs)
+  except OSError:
+    raise RuntimeError("Executable {} not found".format(args[0]))
+  except subprocess.CalledProcessError as error:
+    if isinstance(args, tuple) and (args[0][2] == "pip"):
+      raise RuntimeError( \
+        "Full traceback: {} \n Pip install failed for package: {} \
+        \n Output from execution of subprocess: {}" \
+        .format(traceback.format_exc(), args[0][6], error.output))
+    else:
+      RuntimeError("Full trace: {}\n Output of the failed child process: {}" \
+        .format(traceback.format_exc(), error.output))
+  return out
 
 
 def check_output(*args, **kwargs):

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -43,29 +43,36 @@ def call(*args, **kwargs):
     out = subprocess.call(*args, **kwargs)
   except OSError:
     raise RuntimeError("Executable {} not found".format(args[0]))
-  except subprocess.CalledProcessError:
+  except subprocess.CalledProcessError as error:
     if isinstance(args, tuple) and (args[0][2] == "pip"):
-      raise RuntimeError("Full traceback: {},Pip install failed for package {}"\
-        .format(traceback.format_exc(), args[0][6]))
+      raise RuntimeError( \
+        "Full traceback: {}\n Pip install failed for package: {} \
+        \n Output from execution of subprocess: {}" \
+        .format(traceback.format_exc(), args[0][6], error. output))
     else:
-      RuntimeError(traceback.format_exc())
+      RuntimeError("Full trace: {} \n Output of the failed child process: {} "\
+        .format(traceback.format_exc(), error.output))
   return out
 
 
 def check_call(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
-  try:
-    out = subprocess.check_call(*args, **kwargs)
-  except OSError:
-    raise RuntimeError("Executable {} not found".format(args[0]))
-  except subprocess.CalledProcessError:
-    if isinstance(args, tuple) and (args[0][2] == "pip"):
-      raise RuntimeError("Full traceback: {},Pip install failed for package {}"\
-        .format(traceback.format_exc(), args[0][6]))
-    else:
-      RuntimeError(traceback.format_exc())
-  return out
+  return subprocess.check_output(*args, **kwargs)
+  # try:
+  #   out = subprocess.check_output(*args, **kwargs)
+  # except OSError:
+  #   raise RuntimeError("Executable {} not found".format(args[0]))
+  # except subprocess.CalledProcessError as error:
+  #   if isinstance(args, tuple) and (args[0][2] == "pip"):
+  #     raise RuntimeError( \
+  #       "Full traceback: {} \n Pip install failed for package: {} \
+  #       \n Output from execution of subprocess: {}" \
+  #       .format(traceback.format_exc(), args[0][6], error.output))
+  #   else:
+  #     RuntimeError("Full trace: {}\n Output of the failed child process: {}" \
+  #       .format(traceback.format_exc(), error.output))
+  # return out
 
 
 def check_output(*args, **kwargs):
@@ -75,16 +82,19 @@ def check_output(*args, **kwargs):
     out = subprocess.check_output(*args, **kwargs)
   except OSError:
     raise RuntimeError("Executable {} not found".format(args[0]))
-  except subprocess.CalledProcessError:
+  except subprocess.CalledProcessError as error:
     if isinstance(args, tuple) and (args[0][2] == "pip"):
-      raise RuntimeError("Full traceback: {},Pip install failed for package {}"\
-        .format(traceback.format_exc(), args[0][6]))
+      raise RuntimeError( \
+        "Full traceback: {} \n Pip install failed for package: {} \
+        \n Output from execution of subprocess: {}" \
+        .format(traceback.format_exc(), args[0][6], error.output))
     else:
-      RuntimeError(traceback.format_exc())
+      RuntimeError("Full trace: {}, output of the failed child process {} "\
+        .format(traceback.format_exc(), error.output))
   return out
 
 
-def Popen(*args, **kwargs):  # pylint: disable=invalid-name
+def Popen(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
   return subprocess.Popen(*args, **kwargs)

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 
 import platform
 import subprocess
+import traceback
 
 # On Windows, we need to use shell=True when creating subprocesses for binary
 # paths to be resolved correctly.
@@ -38,22 +39,47 @@ CalledProcessError = subprocess.CalledProcessError
 def call(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
-  return subprocess.call(*args, **kwargs)
+  try:
+    out =  subprocess.call(*args, **kwargs)
+  except OSError:
+    raise RuntimeError("Executable {} not found".format(args[0]))
+  return out
 
 
 def check_call(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
-  return subprocess.check_call(*args, **kwargs)
+  try:
+    out = subprocess.check_call(*args,**kwargs)
+  except OSError:
+    raise RuntimeError("Executable {} not found".format(args[0]))
+  except subprocess.CalledProcessError:
+    raise RuntimeError(traceback.format_exc())
+  return out
 
 
 def check_output(*args, **kwargs):
   if force_shell:
     kwargs['shell'] = True
-  return subprocess.check_output(*args, **kwargs)
+  try:
+    out =  subprocess.check_output(*args, **kwargs)
+  except OSError:
+    raise RuntimeError("Executable {} not found".format(args[0]))
+  except subprocess.CalledProcessError:
+    raise RuntimeError(traceback.format_exc())
+  return out
 
 
 def Popen(*args, **kwargs):  # pylint: disable=invalid-name
   if force_shell:
     kwargs['shell'] = True
-  return subprocess.Popen(*args, **kwargs)
+  try:
+    pipe = subprocess.Popen(["ls", "-l"], stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True)
+    out,error=pipe.communicate()
+    if ""!=error:
+        raise RuntimeError(error)
+  except OSError:
+    raise RuntimeError("Executable: {}, not found".format("Hej"))
+  return output

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -50,7 +50,8 @@ def call(*args, **kwargs):
         \n Output from execution of subprocess: {}" \
         .format(traceback.format_exc(), args[0][6], error. output))
     else:
-      RuntimeError("Full trace: {} \n Output of the failed child process: {} "\
+      raise RuntimeError("Full trace: {}\
+         \n Output of the failed child process: {} " \
         .format(traceback.format_exc(), error.output))
   return out
 
@@ -69,7 +70,8 @@ def check_call(*args, **kwargs):
         \n Output from execution of subprocess: {}" \
         .format(traceback.format_exc(), args[0][6], error.output))
     else:
-      RuntimeError("Full trace: {}\n Output of the failed child process: {}" \
+      raise RuntimeError("Full trace: {} \
+        \n Output of the failed child process: {}" \
         .format(traceback.format_exc(), error.output))
   return out
 
@@ -88,7 +90,8 @@ def check_output(*args, **kwargs):
         \n Output from execution of subprocess: {}" \
         .format(traceback.format_exc(), args[0][6], error.output))
     else:
-      RuntimeError("Full trace: {}, output of the failed child process {} "\
+      raise RuntimeError("Full trace: {}, \
+         output of the failed child process {} "\
         .format(traceback.format_exc(), error.output))
   return out
 

--- a/sdks/python/apache_beam/utils/processes_test.py
+++ b/sdks/python/apache_beam/utils/processes_test.py
@@ -125,10 +125,11 @@ class TestErrorHandlingCheckCall(unittest.TestCase):
     # Configure the mock to return a response with an OK status code.
     self.mock_get.side_effect = OSError()
     cmd = ["lls"]
-    with self.assertRaises(RuntimeError) as error:
+    try:
       processes.check_call(cmd)
-    self.assertEqual(error.exception.message,\
-      'Executable {} not found'.format(str(cmd)))
+    except RuntimeError as error:
+     self.assertIn('Executable {} not found'.format(str(cmd)),\
+     error.args[0])
 
   def test_check_call_pip_install_non_existing_package(self):
     returncode = 1
@@ -170,10 +171,11 @@ class TestErrorHandlingCheckOutput(unittest.TestCase):
   def test_oserror_check_output_message(self):
     self.mock_get.side_effect = OSError()
     cmd = ["lls"]
-    with self.assertRaises(RuntimeError) as error:
+    try:
       processes.check_output(cmd)
-    self.assertEqual(error.exception.message,\
-      'Executable {} not found'.format(str(cmd)))
+    except RuntimeError as error:
+     self.assertIn('Executable {} not found'.format(str(cmd)),\
+     error.args[0])
 
   def test_check_output_pip_install_non_existing_package(self):
     returncode = 1
@@ -205,10 +207,11 @@ class TestErrorHandlingCall(unittest.TestCase):
   def test_oserror_check_output_message(self):
     self.mock_get.side_effect = OSError()
     cmd = ["lls"]
-    with self.assertRaises(RuntimeError) as error:
+    try:
       processes.call(cmd)
-    self.assertEqual(error.exception.message,\
-      'Executable {} not found'.format(str(cmd)))
+    except RuntimeError as error:
+     self.assertIn('Executable {} not found'.format(str(cmd)),\
+     error.args[0])
 
   def test_check_output_pip_install_non_existing_package(self):
     returncode = 1

--- a/sdks/python/apache_beam/utils/processes_test.py
+++ b/sdks/python/apache_beam/utils/processes_test.py
@@ -139,12 +139,25 @@ class TestErrorHandlingCheckCall(unittest.TestCase):
     output = "Collecting {}".format(package)
     self.mock_get.side_effect = subprocess.CalledProcessError(returncode,\
       cmd, output=output)
-    with self.assertRaises(RuntimeError) as error:
+    # Since error.exception.message is removed from
+    # python3 and the self.assertRaises
+    # dont return error.args a try, except is used.
+    # Example of how it could be used with python 2.7
+    # with self.assertRaises(RuntimeError) as error:
+    #   output = processes.check_call(cmd)
+    # self.assertEqual(error.exception.message.split("\n")[-2].strip(),\
+    #   "Pip install failed for package: {}".format(package))
+    # self.assertEqual(error.exception.message.split("\n")[-1].strip(),\
+    #   "Output from execution of subprocess: " + output)
+    try:
       output = processes.check_call(cmd)
-    self.assertEqual(error.exception.message.split("\n")[-2].strip(),\
-      "Pip install failed for package: {}".format(package))
-    self.assertEqual(error.exception.message.split("\n")[-1].strip(),\
-      "Output from execution of subprocess: " + output)
+      self.fail("The test failed due to that\
+        no error was raised when calling process.check_call")
+    except RuntimeError as error:
+      self.assertIn("Output from execution of subprocess: {}".format(output),\
+        error.args[0])
+      self.assertIn("Pip install failed for package: {}".format(package),\
+        error.args[0])
 
 
 class TestErrorHandlingCheckOutput(unittest.TestCase):
@@ -171,12 +184,15 @@ class TestErrorHandlingCheckOutput(unittest.TestCase):
     output = "Collecting {}".format(package)
     self.mock_get.side_effect = subprocess.CalledProcessError(returncode,\
          cmd, output=output)
-    with self.assertRaises(RuntimeError) as error:
+    try:
       output = processes.check_output(cmd)
-    self.assertEqual(error.exception.message.split("\n")[-2].strip(),\
-      "Pip install failed for package: {}".format(package))
-    self.assertEqual(error.exception.message.split("\n")[-1].strip(),\
-      "Output from execution of subprocess: " + output)
+      self.fail("The test failed due to that\
+      no error was raised when calling process.check_call")
+    except RuntimeError as error:
+      self.assertIn("Output from execution of subprocess: {}".format(output),\
+        error.args[0])
+      self.assertIn("Pip install failed for package: {}".format(package),\
+        error.args[0])
 
 
 class TestErrorHandlingCall(unittest.TestCase):
@@ -203,12 +219,15 @@ class TestErrorHandlingCall(unittest.TestCase):
     output = "Collecting {}".format(package)
     self.mock_get.side_effect = subprocess.CalledProcessError(returncode,\
          cmd, output=output)
-    with self.assertRaises(RuntimeError) as error:
+    try:
       output = processes.call(cmd)
-    self.assertEqual(error.exception.message.split("\n")[-2].strip(),\
-      "Pip install failed for package: {}".format(package))
-    self.assertEqual(error.exception.message.split("\n")[-1].strip(),\
-      "Output from execution of subprocess: " + output)
+      self.fail("The test failed due to that\
+        no error was raised when calling process.check_call")
+    except RuntimeError as error:
+      self.assertIn("Output from execution of subprocess: {}".format(output),\
+        error.args[0])
+      self.assertIn("Pip install failed for package: {}".format(package),\
+        error.args[0])
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/utils/processes_test.py
+++ b/sdks/python/apache_beam/utils/processes_test.py
@@ -128,8 +128,8 @@ class TestErrorHandlingCheckCall(unittest.TestCase):
     try:
       processes.check_call(cmd)
     except RuntimeError as error:
-     self.assertIn('Executable {} not found'.format(str(cmd)),\
-     error.args[0])
+      self.assertIn('Executable {} not found'.format(str(cmd)),\
+      error.args[0])
 
   def test_check_call_pip_install_non_existing_package(self):
     returncode = 1
@@ -140,16 +140,6 @@ class TestErrorHandlingCheckCall(unittest.TestCase):
     output = "Collecting {}".format(package)
     self.mock_get.side_effect = subprocess.CalledProcessError(returncode,\
       cmd, output=output)
-    # Since error.exception.message is removed from
-    # python3 and the self.assertRaises
-    # dont return error.args a try, except is used.
-    # Example of how it could be used with python 2.7
-    # with self.assertRaises(RuntimeError) as error:
-    #   output = processes.check_call(cmd)
-    # self.assertEqual(error.exception.message.split("\n")[-2].strip(),\
-    #   "Pip install failed for package: {}".format(package))
-    # self.assertEqual(error.exception.message.split("\n")[-1].strip(),\
-    #   "Output from execution of subprocess: " + output)
     try:
       output = processes.check_call(cmd)
       self.fail("The test failed due to that\
@@ -174,8 +164,8 @@ class TestErrorHandlingCheckOutput(unittest.TestCase):
     try:
       processes.check_output(cmd)
     except RuntimeError as error:
-     self.assertIn('Executable {} not found'.format(str(cmd)),\
-     error.args[0])
+      self.assertIn('Executable {} not found'.format(str(cmd)),\
+      error.args[0])
 
   def test_check_output_pip_install_non_existing_package(self):
     returncode = 1
@@ -210,8 +200,8 @@ class TestErrorHandlingCall(unittest.TestCase):
     try:
       processes.call(cmd)
     except RuntimeError as error:
-     self.assertIn('Executable {} not found'.format(str(cmd)),\
-     error.args[0])
+      self.assertIn('Executable {} not found'.format(str(cmd)),\
+      error.args[0])
 
   def test_check_output_pip_install_non_existing_package(self):
     returncode = 1

--- a/sdks/python/scripts/run_pylint.sh
+++ b/sdks/python/scripts/run_pylint.sh
@@ -24,13 +24,6 @@
 # The exit-code of the script indicates success or a failure.
 
 # Check that the script is running in a known directory.
-echo "START"
-echo "START"
-echo "START"
-echo "START"
-echo "START"
-echo "START"
-
 if [[ $PWD != *sdks/python* ]]; then
   echo 'Unable to locate Apache Beam Python SDK root directory'
   exit 1

--- a/sdks/python/scripts/run_pylint.sh
+++ b/sdks/python/scripts/run_pylint.sh
@@ -24,6 +24,13 @@
 # The exit-code of the script indicates success or a failure.
 
 # Check that the script is running in a known directory.
+echo "START"
+echo "START"
+echo "START"
+echo "START"
+echo "START"
+echo "START"
+
 if [[ $PWD != *sdks/python* ]]; then
   echo 'Unable to locate Apache Beam Python SDK root directory'
   exit 1


### PR DESCRIPTION
Updates to collect more of the error message. This is done by tracing the error message and collect the output from the subprocess during failure.  In order to do this i have added a dependency on the package traceback. 

First contribution to Apache Beam, so feel free to give as much feedback as possible. 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.