### PR TITLE
[BEAM-3312] Improve the builder to MqttIO connection

### DIFF
--- a/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
+++ b/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
@@ -153,40 +153,26 @@ public class MqttIO {
       abstract ConnectionConfiguration build();
     }
 
-    /**
-     * Describe a connection configuration to the MQTT broker. This method creates an unique random
-     * MQTT client ID.
-     *
-     * @param serverUri The MQTT broker URI.
-     * @param topic The MQTT getTopic pattern.
-     * @return A connection configuration to the MQTT broker.
-     */
-    public static ConnectionConfiguration create(String serverUri, String topic) {
-      checkArgument(serverUri != null, "serverUri can not be null");
-      checkArgument(topic != null, "topic can not be null");
-      return new AutoValue_MqttIO_ConnectionConfiguration.Builder()
-          .setServerUri(serverUri)
-          .setTopic(topic)
-          .build();
+    public static ConnectionConfiguration create() {
+      return new AutoValue_MqttIO_ConnectionConfiguration.Builder().build();
     }
 
-    /**
-     * Describe a connection configuration to the MQTT broker.
-     *
-     * @param serverUri The MQTT broker URI.
-     * @param topic The MQTT getTopic pattern.
-     * @param clientId A client ID prefix, used to construct an unique client ID.
-     * @return A connection configuration to the MQTT broker.
-     */
-    public static ConnectionConfiguration create(String serverUri, String topic, String clientId) {
+    /** Set up the MQTT broker URI. */
+    public ConnectionConfiguration withUri(String serverUri) {
       checkArgument(serverUri != null, "serverUri can not be null");
+      return builder().setServerUri(serverUri).build();
+    }
+
+    /** Set up the MQTT getTopic pattern. */
+    public ConnectionConfiguration withTopic(String topic) {
       checkArgument(topic != null, "topic can not be null");
+      return builder().setTopic(topic).build();
+    }
+
+    /** Set up the client ID prefix, which is used to construct an unique client ID. */
+    public ConnectionConfiguration withClientId(String clientId) {
       checkArgument(clientId != null, "clientId can not be null");
-      return new AutoValue_MqttIO_ConnectionConfiguration.Builder()
-          .setServerUri(serverUri)
-          .setTopic(topic)
-          .setClientId(clientId)
-          .build();
+      return builder().setClientId(clientId).build();
     }
 
     public ConnectionConfiguration withUsername(String username) {

--- a/sdks/java/io/mqtt/src/test/java/org/apache/beam/sdk/io/mqtt/MqttIOTest.java
+++ b/sdks/java/io/mqtt/src/test/java/org/apache/beam/sdk/io/mqtt/MqttIOTest.java
@@ -87,7 +87,9 @@ public class MqttIOTest {
     Read mqttReader =
         MqttIO.read()
             .withConnectionConfiguration(
-                MqttIO.ConnectionConfiguration.create("tcp://localhost:" + port, topicName))
+                MqttIO.ConnectionConfiguration.create()
+                    .withUri("tcp://localhost:" + port)
+                    .withTopic(topicName))
             .withMaxNumRecords(10);
     PCollection<byte[]> output = pipeline.apply(mqttReader);
     PAssert.that(output)
@@ -150,8 +152,10 @@ public class MqttIOTest {
         pipeline.apply(
             MqttIO.read()
                 .withConnectionConfiguration(
-                    MqttIO.ConnectionConfiguration.create(
-                        "tcp://localhost:" + port, "READ_TOPIC", "READ_PIPELINE"))
+                    MqttIO.ConnectionConfiguration.create()
+                        .withUri("tcp://localhost:" + port)
+                        .withTopic("READ_TOPIC")
+                        .withClientId("READ_PIPELINE"))
                 .withMaxReadTime(Duration.standardSeconds(3)));
     PAssert.that(output)
         .containsInAnyOrder(
@@ -212,8 +216,10 @@ public class MqttIOTest {
     pipeline.apply(
         MqttIO.read()
             .withConnectionConfiguration(
-                MqttIO.ConnectionConfiguration.create(
-                    "tcp://localhost:" + port, "READ_TOPIC", "READ_PIPELINE"))
+                MqttIO.ConnectionConfiguration.create()
+                    .withUri("tcp://localhost:" + port)
+                    .withTopic("READ_TOPIC")
+                    .withClientId("READ_PIPELINE"))
             .withMaxReadTime(Duration.standardSeconds(2)));
 
     // should stop before the test timeout
@@ -255,8 +261,9 @@ public class MqttIOTest {
         .apply(
             MqttIO.write()
                 .withConnectionConfiguration(
-                    MqttIO.ConnectionConfiguration.create(
-                        "tcp://localhost:" + port, "WRITE_TOPIC")));
+                    MqttIO.ConnectionConfiguration.create()
+                        .withUri("tcp://localhost:" + port)
+                        .withTopic("WRITE_TOPIC")));
     pipeline.run();
     subscriber.join();
 


### PR DESCRIPTION
Hi all,

Here is the PR to add the builder methods allowing to configure the MqttIO connection. The idea is to stick to the builder style instead of putting the arguments directly in the constructor. 
Thanks in advance for the review. (R @iemejia )

Regards,
Guobao

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
