### PR TITLE
[BEAM-6968] Deprecate MqttIO create with clientId constructor

### DIFF
--- a/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
+++ b/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
@@ -175,7 +175,10 @@ public class MqttIO {
      * @param topic The MQTT getTopic pattern.
      * @param clientId A client ID prefix, used to construct an unique client ID.
      * @return A connection configuration to the MQTT broker.
+     * @deprecated This constructor will be removed in a future version of Beam, please use
+     *     #create(String, String)} and {@link #withClientId(String)} instead.
      */
+    @Deprecated
     public static ConnectionConfiguration create(String serverUri, String topic, String clientId) {
       checkArgument(clientId != null, "clientId can not be null");
       return create(serverUri, topic).withClientId(clientId);

--- a/sdks/java/io/mqtt/src/test/java/org/apache/beam/sdk/io/mqtt/MqttIOTest.java
+++ b/sdks/java/io/mqtt/src/test/java/org/apache/beam/sdk/io/mqtt/MqttIOTest.java
@@ -150,8 +150,8 @@ public class MqttIOTest {
         pipeline.apply(
             MqttIO.read()
                 .withConnectionConfiguration(
-                    MqttIO.ConnectionConfiguration.create(
-                        "tcp://localhost:" + port, "READ_TOPIC", "READ_PIPELINE"))
+                    MqttIO.ConnectionConfiguration.create("tcp://localhost:" + port, "READ_TOPIC")
+                        .withClientId("READ_PIPELINE"))
                 .withMaxReadTime(Duration.standardSeconds(3)));
     PAssert.that(output)
         .containsInAnyOrder(
@@ -212,8 +212,8 @@ public class MqttIOTest {
     pipeline.apply(
         MqttIO.read()
             .withConnectionConfiguration(
-                MqttIO.ConnectionConfiguration.create(
-                    "tcp://localhost:" + port, "READ_TOPIC", "READ_PIPELINE"))
+                MqttIO.ConnectionConfiguration.create("tcp://localhost:" + port, "READ_TOPIC")
+                    .withClientId("READ_PIPELINE"))
             .withMaxReadTime(Duration.standardSeconds(2)));
 
     // should stop before the test timeout


### PR DESCRIPTION
R: @aromanenko-dev 