### PR TITLE
[BEAM-6695] Latest PTransform for Python SDK

### DIFF
--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -867,6 +867,8 @@ class PhasedCombineFnExecutor(object):
 class Latest(object):
   """Combiners for computing the latest element"""
 
+  @with_input_types(T)
+  @with_output_types(T)
   class Globally(ptransform.PTransform):
     """Compute the element with the latest timestamp from a
     PCollection."""
@@ -881,6 +883,8 @@ class Latest(object):
               .with_output_types(Tuple[T, TimestampType])
               | core.CombineGlobally(LatestCombineFn()))
 
+  @with_input_types(KV[K, V])
+  @with_output_types(KV[K, V])
   class PerKey(ptransform.PTransform):
     """Compute elements with the latest timestamp for each key
     from a keyed PCollection"""

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -45,7 +45,6 @@ from apache_beam.typehints import TypeVariable
 from apache_beam.typehints import Union
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
-from apache_beam.typehints.decorators import _check_instance_type
 from apache_beam.utils.timestamp import Duration
 from apache_beam.utils.timestamp import Timestamp
 
@@ -888,7 +887,6 @@ class Latest(object):
 
     @staticmethod
     def add_timestamp(element, timestamp=core.DoFn.TimestampParam):
-      _check_instance_type(KV[K, V], element)
       key, value = element
       return [(key, (value, timestamp))]
 

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -885,8 +885,8 @@ class Latest(object):
     @staticmethod
     def add_timestamp(element, timestamp=core.DoFn.TimestampParam):
       _check_instance_type(KV[T, T], element)
-      (K, V) = element
-      return [(K, (V, timestamp))]
+      key, value = element
+      return [(key, (value, timestamp))]
 
     def expand(self, pcoll):
       return (pcoll

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -888,14 +888,14 @@ class Latest(object):
 
     @staticmethod
     def add_timestamp(element, timestamp=core.DoFn.TimestampParam):
-      _check_instance_type(Tuple[T, T], element)
+      _check_instance_type(KV[K, V], element)
       key, value = element
       return [(key, (value, timestamp))]
 
     def expand(self, pcoll):
       return (pcoll
               | core.ParDo(self.add_timestamp)
-              .with_output_types(Tuple[T, Tuple[T, TimestampType]])
+              .with_output_types(KV[K, Tuple[T, TimestampType]])
               | core.CombinePerKey(LatestCombineFn()))
 
 

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -428,32 +428,6 @@ class LatestTest(unittest.TestCase):
       latest = pc | combine.Latest.PerKey()
       assert_that(latest, equal_to([]))
 
-  def test_per_key_add_timestamp_element_type_violation(self):
-    l_int = [window.GlobalWindows.windowed_value(1, 300),
-             window.GlobalWindows.windowed_value(6, 900),
-             window.GlobalWindows.windowed_value(8, 500)]
-    l_dict = [window.GlobalWindows.windowed_value({'a': 5}, 200),
-              window.GlobalWindows.windowed_value({'b': 3}, 300),
-              window.GlobalWindows.windowed_value({'a': 8}, 100)]
-    l_3_tuple = [window.GlobalWindows.windowed_value((1, 2, 3), 800),
-                 window.GlobalWindows.windowed_value((4, 5, 6), 200),
-                 window.GlobalWindows.windowed_value((7, 8, 9), 700)]
-
-    with self.assertRaises(TypeCheckError):
-      with TestPipeline() as p:
-        pc = p | Create(l_int)
-        _ = pc | beam.ParDo(combine.Latest.PerKey.add_timestamp)
-
-    with self.assertRaises(TypeCheckError):
-      with TestPipeline() as p:
-        pc = p | Create(l_dict)
-        _ = pc | beam.ParDo(combine.Latest.PerKey.add_timestamp)
-
-    with self.assertRaises(TypeCheckError):
-      with TestPipeline() as p:
-        pc = p | Create(l_3_tuple)
-        _ = pc | beam.ParDo(combine.Latest.PerKey.add_timestamp)
-
 
 class LatestCombineFnTest(unittest.TestCase):
 

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -417,7 +417,7 @@ class LatestTest(unittest.TestCase):
          window.GlobalWindows.windowed_value(('b', 3), 100),
          window.GlobalWindows.windowed_value(('a', 2), 200)]
     with TestPipeline() as p:
-      pc = p | Create(l)
+      pc = p | Create(l) | Map(lambda x: x)
       latest = pc | combine.Latest.PerKey()
       assert_that(latest, equal_to([('a', 1), ('b', 3)]))
 

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -397,13 +397,13 @@ class CombineTest(unittest.TestCase):
 class LatestTest(unittest.TestCase):
 
   def test_globally(self):
-    l = [window.GlobalWindows.windowed_value(1, 100),
-         window.GlobalWindows.windowed_value(2, 200),
-         window.GlobalWindows.windowed_value(3, 300)]
+    l = [window.GlobalWindows.windowed_value(3, 100),
+         window.GlobalWindows.windowed_value(1, 200),
+         window.GlobalWindows.windowed_value(2, 300)]
     with TestPipeline() as p:
       pc = p | Create(l)
       latest = pc | combine.Latest.Globally()
-      assert_that(latest, equal_to([3]))
+      assert_that(latest, equal_to([2]))
 
   def test_globally_empty(self):
     l = []
@@ -413,13 +413,13 @@ class LatestTest(unittest.TestCase):
       assert_that(latest, equal_to([None]))
 
   def test_per_key(self):
-    l = [window.GlobalWindows.windowed_value(('a', 1), 100),
-         window.GlobalWindows.windowed_value(('b', 2), 200),
-         window.GlobalWindows.windowed_value(('a', 3), 300)]
+    l = [window.GlobalWindows.windowed_value(('a', 1), 300),
+         window.GlobalWindows.windowed_value(('b', 3), 100),
+         window.GlobalWindows.windowed_value(('a', 2), 200)]
     with TestPipeline() as p:
       pc = p | Create(l)
       latest = pc | combine.Latest.PerKey()
-      assert_that(latest, equal_to([('a', 3), ('b', 2)]))
+      assert_that(latest, equal_to([('a', 1), ('b', 3)]))
 
   def test_per_key_empty(self):
     l = []
@@ -462,11 +462,9 @@ class LatestCombineFnTest(unittest.TestCase):
     self.assertEquals(new_accumulator, (1, 100))
 
   def test_merge_accumulators(self):
-    accumulators = [(1, 100),
-                    (2, 200),
-                    (3, 300)]
+    accumulators = [(2, 400), (5, 100), (9, 200)]
     merged_accumulator = self.fn.merge_accumulators(accumulators)
-    self.assertEquals(merged_accumulator, (3, 300))
+    self.assertEquals(merged_accumulator, (2, 400))
 
   def test_extract_output(self):
     accumulator = (1, 100)


### PR DESCRIPTION
Added Latest PTransform and Combine Fns for the Python SDK.
Latest PTransform is used to compute the element(s) with the
latest timestamp from a PCollection.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
