### PR TITLE
[BEAM-6990] Use CoderTranslation for resolving coders in cross-language configuration

### DIFF
--- a/model/pipeline/src/main/proto/external_transforms.proto
+++ b/model/pipeline/src/main/proto/external_transforms.proto
@@ -31,7 +31,9 @@ option java_outer_classname = "ExternalTransforms";
 import "beam_runner_api.proto";
 
 message ConfigValue {
-  string coder_urn = 1;
+  // Coder and its components (in case of a compound Coder)
+  repeated string coder_urn = 1;
+  // The Payload which is decoded using the coder_urn
   bytes payload = 2;
 }
 

--- a/model/pipeline/src/main/proto/external_transforms.proto
+++ b/model/pipeline/src/main/proto/external_transforms.proto
@@ -38,5 +38,6 @@ message ConfigValue {
 // A configuration payload for an external transform.
 // Used as the payload of ExternalTransform as part of an ExpansionRequest.
 message ExternalConfigurationPayload {
+  // Configuration key => value
   map<string, ConfigValue> configuration = 1;
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/expansion/ExpansionService.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/expansion/ExpansionService.java
@@ -85,8 +85,7 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
    * Exposes Java transforms via {@link org.apache.beam.sdk.expansion.ExternalTransformRegistrar}.
    */
   @AutoService(ExpansionService.ExpansionServiceRegistrar.class)
-  public static class ExternalTransformRegistrarLoader<ConfigT>
-      implements ExpansionService.ExpansionServiceRegistrar {
+  public static class ExternalTransformRegistrarLoader implements ExpansionService.ExpansionServiceRegistrar {
 
     @Override
     public Map<String, ExpansionService.TransformProvider> knownTransforms() {
@@ -94,10 +93,10 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
           ImmutableMap.builder();
       for (ExternalTransformRegistrar registrar :
           ServiceLoader.load(ExternalTransformRegistrar.class)) {
-        for (Map.Entry<String, Class<? extends ExternalTransformBuilder<?, ?, ?>>> entry :
+        for (Map.Entry<String, Class<? extends ExternalTransformBuilder>> entry :
             registrar.knownBuilders().entrySet()) {
           String urn = entry.getKey();
-          Class<? extends ExternalTransformBuilder<?, ?, ?>> builderClass = entry.getValue();
+          Class<? extends ExternalTransformBuilder> builderClass = entry.getValue();
           builder.put(
               urn,
               spec -> {
@@ -117,7 +116,7 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
 
     private static PTransform translate(
         ExternalTransforms.ExternalConfigurationPayload payload,
-        Class<? extends ExternalTransformBuilder<?, ?, ?>> builderClass)
+        Class<? extends ExternalTransformBuilder> builderClass)
         throws Exception {
       Preconditions.checkState(
           ExternalTransformBuilder.class.isAssignableFrom(builderClass),
@@ -130,7 +129,7 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
     }
 
     private static Object initConfiguration(
-        Class<? extends ExternalTransformBuilder<?, ?, ?>> builderClass) throws Exception {
+        Class<? extends ExternalTransformBuilder> builderClass) throws Exception {
       for (Method method : builderClass.getMethods()) {
         if (method.getName().equals("buildExternal")) {
           Preconditions.checkState(
@@ -184,9 +183,9 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
     }
 
     private static PTransform buildTransform(
-        Class<? extends ExternalTransformBuilder<?, ?, ?>> builderClass, Object configObject)
+        Class<? extends ExternalTransformBuilder> builderClass, Object configObject)
         throws Exception {
-      Constructor<? extends ExternalTransformBuilder<?, ?, ?>> constructor =
+      Constructor<? extends ExternalTransformBuilder> constructor =
           builderClass.getDeclaredConstructor();
       constructor.setAccessible(true);
       ExternalTransformBuilder<?, ?, ?> externalTransformBuilder = constructor.newInstance();

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/expansion/ExpansionServiceTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/expansion/ExpansionServiceTest.java
@@ -18,24 +18,35 @@
 package org.apache.beam.runners.core.construction.expansion;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.auto.service.AutoService;
+import java.io.ByteArrayOutputStream;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.beam.model.expansion.v1.ExpansionApi;
 import org.apache.beam.model.pipeline.v1.ExternalTransforms;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.BeamUrns;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Impulse;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.grpc.v1p13p1.com.google.protobuf.ByteString;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Charsets;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterables;
 import org.hamcrest.Matchers;
@@ -105,13 +116,13 @@ public class ExpansionServiceTest {
             .putConfiguration(
                 "start",
                 ExternalTransforms.ConfigValue.newBuilder()
-                    .setCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.VARINT))
+                    .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.VARINT))
                     .setPayload(ByteString.copyFrom(new byte[] {0}))
                     .build())
             .putConfiguration(
                 "stop",
                 ExternalTransforms.ConfigValue.newBuilder()
-                    .setCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.VARINT))
+                    .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.VARINT))
                     .setPayload(ByteString.copyFrom(new byte[] {1}))
                     .build())
             .build();
@@ -135,6 +146,81 @@ public class ExpansionServiceTest {
     assertThat(expandedTransform.getInputsCount(), Matchers.is(0));
     assertThat(expandedTransform.getOutputsCount(), Matchers.is(1));
     assertThat(expandedTransform.getSubtransformsCount(), Matchers.greaterThan(0));
+  }
+
+  @Test
+  public void testCompoundCodersForExternalConfiguration() throws Exception {
+    ExternalTransforms.ExternalConfigurationPayload.Builder builder =
+        ExternalTransforms.ExternalConfigurationPayload.newBuilder();
+
+    builder.putConfiguration(
+        "config_key1",
+        ExternalTransforms.ConfigValue.newBuilder()
+            .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.VARINT))
+            .setPayload(ByteString.copyFrom(new byte[] {1}))
+            .build());
+
+    List<byte[]> byteList =
+        ImmutableList.of("testing", "compound", "coders").stream()
+            .map(str -> str.getBytes(Charsets.UTF_8))
+            .collect(Collectors.toList());
+    IterableCoder<byte[]> compoundCoder = IterableCoder.of(ByteArrayCoder.of());
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    compoundCoder.encode(byteList, baos);
+
+    builder.putConfiguration(
+        "config_key2",
+        ExternalTransforms.ConfigValue.newBuilder()
+            .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.ITERABLE))
+            .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.BYTES))
+            .setPayload(ByteString.copyFrom(baos.toByteArray()))
+            .build());
+
+    List<KV<byte[], Long>> byteKvList =
+        ImmutableList.of("testing", "compound", "coders").stream()
+            .map(str -> KV.of(str.getBytes(Charsets.UTF_8), (long) str.length()))
+            .collect(Collectors.toList());
+    IterableCoder<KV<byte[], Long>> compoundCoder2 =
+        IterableCoder.of(KvCoder.of(ByteArrayCoder.of(), VarLongCoder.of()));
+    ByteArrayOutputStream baos2 = new ByteArrayOutputStream();
+    compoundCoder2.encode(byteKvList, baos2);
+
+    builder.putConfiguration(
+        "config_key3",
+        ExternalTransforms.ConfigValue.newBuilder()
+            .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.ITERABLE))
+            .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.KV))
+            .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.BYTES))
+            .addCoderUrn(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.VARINT))
+            .setPayload(ByteString.copyFrom(baos2.toByteArray()))
+            .build());
+
+    ExternalTransforms.ExternalConfigurationPayload externalConfig = builder.build();
+    TestConfig config = new TestConfig();
+    ExpansionService.ExternalTransformRegistrarLoader.populateConfiguration(config, externalConfig);
+
+    assertThat(config.configKey1, Matchers.is(1L));
+    assertArrayEquals(Iterables.toArray(config.configKey2, byte[].class), byteList.toArray());
+    assertArrayEquals(Iterables.toArray(config.configKey3, KV.class), byteKvList.toArray());
+  }
+
+  private static class TestConfig {
+
+    private Long configKey1;
+    private Iterable<byte[]> configKey2;
+    private Iterable<KV<byte[], Long>> configKey3;
+
+    public void setConfigKey1(Long configKey1) {
+      this.configKey1 = configKey1;
+    }
+
+    public void setConfigKey2(Iterable<byte[]> configKey2) {
+      this.configKey2 = configKey2;
+    }
+
+    public void setConfigKey3(Iterable<KV<byte[], Long>> configKey3) {
+      this.configKey3 = configKey3;
+    }
   }
 
   public Set<String> allIds(RunnerApi.Components components) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/expansion/ExternalTransformRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/expansion/ExternalTransformRegistrar.java
@@ -27,5 +27,5 @@ import org.apache.beam.sdk.transforms.ExternalTransformBuilder;
 public interface ExternalTransformRegistrar {
 
   /** A mapping from URN to an {@link ExternalTransformBuilder} class. */
-  Map<String, Class<? extends ExternalTransformBuilder<?, ?, ?>>> knownBuilders();
+  Map<String, Class<? extends ExternalTransformBuilder>> knownBuilders();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/GenerateSequence.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/GenerateSequence.java
@@ -134,7 +134,7 @@ public abstract class GenerateSequence extends PTransform<PBegin, PCollection<Lo
     public static final String URN = "beam:external:java:generate_sequence:v1";
 
     @Override
-    public Map<String, Class<? extends ExternalTransformBuilder<?, ?, ?>>> knownBuilders() {
+    public Map<String, Class<? extends ExternalTransformBuilder>> knownBuilders() {
       return ImmutableMap.of(URN, AutoValue_GenerateSequence.Builder.class);
     }
 

--- a/sdks/python/apache_beam/io/external/generate_sequence.py
+++ b/sdks/python/apache_beam/io/external/generate_sequence.py
@@ -32,7 +32,7 @@ class GenerateSequence(ExternalTransform):
                elements_per_period=None, max_read_time=None,
                expansion_service=None):
     coder = VarIntCoder()
-    coder_urn = 'beam:coder:varint:v1'
+    coder_urn = ['beam:coder:varint:v1']
     args = {
         'start':
             ConfigValue(


### PR DESCRIPTION
This replaces the custom coder URN translation code in ExternalTransformRegistrarLoader with the usual CoderTranslation. This will allow to support all coders available across languages.

CC @tweise 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
