### PR TITLE
[BEAM-6935] Spark portable runner: implement side inputs

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
@@ -54,6 +54,7 @@ import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandlers;
+import org.apache.beam.runners.fnexecution.translation.BatchSideInputHandlerFactory;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.io.FileSystems;
@@ -167,7 +168,8 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
       RuntimeContext runtimeContext) {
     final StateRequestHandler sideInputHandler;
     StateRequestHandlers.SideInputHandlerFactory sideInputHandlerFactory =
-        FlinkBatchSideInputHandlerFactory.forStage(executableStage, runtimeContext);
+        BatchSideInputHandlerFactory.forStage(
+            executableStage, runtimeContext::getBroadcastVariable);
     try {
       sideInputHandler =
           StateRequestHandlers.forSideInputHandlerFactory(

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/BoundedDataset.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/BoundedDataset.java
@@ -46,6 +46,7 @@ public class BoundedDataset<T> implements Dataset {
   private Iterable<WindowedValue<T>> windowedValues;
   private Coder<T> coder;
   private JavaRDD<WindowedValue<T>> rdd;
+  private List<byte[]> clientBytes;
 
   BoundedDataset(JavaRDD<WindowedValue<T>> rdd) {
     this.rdd = rdd;
@@ -67,6 +68,14 @@ public class BoundedDataset<T> implements Dataset {
               .map(CoderHelpers.fromByteFunction(windowCoder));
     }
     return rdd;
+  }
+
+  List<byte[]> getBytes(WindowedValue.WindowedValueCoder<T> wvCoder) {
+    if (clientBytes == null) {
+      JavaRDDLike<byte[], ?> bytesRDD = rdd.map(CoderHelpers.toByteFunction(wvCoder));
+      clientBytes = bytesRDD.collect();
+    }
+    return clientBytes;
   }
 
   Iterable<WindowedValue<T>> getValues(PCollection<T> pcollection) {

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkBatchPortablePipelineTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkBatchPortablePipelineTranslator.java
@@ -22,10 +22,12 @@ import static org.apache.beam.runners.fnexecution.translation.PipelineTranslator
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ExecutableStagePayload.SideInputId;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.runners.core.SystemReduceFn;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
@@ -54,6 +56,8 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterables;
 import org.apache.spark.HashPartitioner;
 import org.apache.spark.Partitioner;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.broadcast.Broadcast;
+import scala.Tuple2;
 
 /** Translates a bounded portable pipeline into a Spark job. */
 public class SparkBatchPortablePipelineTranslator {
@@ -163,7 +167,7 @@ public class SparkBatchPortablePipelineTranslator {
     context.pushDataset(getOutputId(transformNode), new BoundedDataset<>(groupedByKeyAndWindow));
   }
 
-  private static <InputT, OutputT> void translateExecutableStage(
+  private static <InputT, OutputT, SideInputT> void translateExecutableStage(
       PTransformNode transformNode, RunnerApi.Pipeline pipeline, SparkTranslationContext context) {
 
     RunnerApi.ExecutableStagePayload stagePayload;
@@ -180,8 +184,22 @@ public class SparkBatchPortablePipelineTranslator {
     Map<String, String> outputs = transformNode.getTransform().getOutputsMap();
     BiMap<String, Integer> outputMap = createOutputMap(outputs.values());
 
-    SparkExecutableStageFunction<InputT> function =
-        new SparkExecutableStageFunction<>(stagePayload, context.jobInfo, outputMap);
+    ImmutableMap.Builder<String, Tuple2<Broadcast<List<byte[]>>, WindowedValueCoder<SideInputT>>>
+        broadcastVariablesBuilder = ImmutableMap.builder();
+    for (SideInputId sideInputId : stagePayload.getSideInputsList()) {
+      RunnerApi.Components components = stagePayload.getComponents();
+      String collectionId =
+          components
+              .getTransformsOrThrow(sideInputId.getTransformId())
+              .getInputsOrThrow(sideInputId.getLocalName());
+      Tuple2<Broadcast<List<byte[]>>, WindowedValueCoder<SideInputT>> tuple2 =
+          broadcastSideInput(collectionId, components, context);
+      broadcastVariablesBuilder.put(collectionId, tuple2);
+    }
+
+    SparkExecutableStageFunction<InputT, SideInputT> function =
+        new SparkExecutableStageFunction<>(
+            stagePayload, context.jobInfo, outputMap, broadcastVariablesBuilder.build());
     JavaRDD<RawUnionValue> staged = inputRdd.mapPartitions(function);
 
     for (String outputId : outputs.values()) {
@@ -189,6 +207,29 @@ public class SparkBatchPortablePipelineTranslator {
           staged.flatMap(new SparkExecutableStageExtractionFunction<>(outputMap.get(outputId)));
       context.pushDataset(outputId, new BoundedDataset<>(outputRdd));
     }
+  }
+
+  /**
+   * Collect and serialize the data and then broadcast the result. *This can be expensive.*
+   *
+   * @return Spark broadcast variable and coder to decode its contents
+   */
+  private static <T> Tuple2<Broadcast<List<byte[]>>, WindowedValueCoder<T>> broadcastSideInput(
+      String collectionId, RunnerApi.Components components, SparkTranslationContext context) {
+    PCollection collection = components.getPcollectionsOrThrow(collectionId);
+    @SuppressWarnings("unchecked")
+    BoundedDataset<T> dataset = (BoundedDataset<T>) context.popDataset(collectionId);
+    PCollectionNode collectionNode = PipelineNode.pCollection(collectionId, collection);
+    WindowedValueCoder<T> coder;
+    try {
+      coder =
+          (WindowedValueCoder<T>) WireCoders.instantiateRunnerWireCoder(collectionNode, components);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    List<byte[]> bytes = dataset.getBytes(coder);
+    Broadcast<List<byte[]>> broadcast = context.getSparkContext().broadcast(bytes);
+    return new Tuple2<>(broadcast, coder);
   }
 
   @Nullable

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunctionTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunctionTest.java
@@ -89,14 +89,14 @@ public class SparkExecutableStageFunctionTest {
 
   @Test(expected = Exception.class)
   public void sdkErrorsSurfaceOnClose() throws Exception {
-    SparkExecutableStageFunction<Integer> function = getFunction(Collections.emptyMap());
+    SparkExecutableStageFunction<Integer, ?> function = getFunction(Collections.emptyMap());
     doThrow(new Exception()).when(remoteBundle).close();
     function.call(Collections.emptyIterator());
   }
 
   @Test
   public void expectedInputsAreSent() throws Exception {
-    SparkExecutableStageFunction<Integer> function = getFunction(Collections.emptyMap());
+    SparkExecutableStageFunction<Integer, ?> function = getFunction(Collections.emptyMap());
 
     RemoteBundle bundle = Mockito.mock(RemoteBundle.class);
     when(stageBundleFactory.getBundle(any(), any(), any())).thenReturn(bundle);
@@ -178,7 +178,7 @@ public class SparkExecutableStageFunctionTest {
         };
     when(jobBundleFactory.forStage(any())).thenReturn(stageBundleFactory);
 
-    SparkExecutableStageFunction<Integer> function = getFunction(outputTagMap);
+    SparkExecutableStageFunction<Integer, ?> function = getFunction(outputTagMap);
     Iterator<RawUnionValue> iterator = function.call(Collections.emptyIterator());
     Iterable<RawUnionValue> iterable = () -> iterator;
 
@@ -190,14 +190,17 @@ public class SparkExecutableStageFunctionTest {
 
   @Test
   public void testStageBundleClosed() throws Exception {
-    SparkExecutableStageFunction<Integer> function = getFunction(Collections.emptyMap());
+    SparkExecutableStageFunction<Integer, ?> function = getFunction(Collections.emptyMap());
     function.call(Collections.emptyIterator());
     verify(stageBundleFactory).getBundle(any(), any(), any());
+    verify(stageBundleFactory).getProcessBundleDescriptor();
     verify(stageBundleFactory).close();
     verifyNoMoreInteractions(stageBundleFactory);
   }
 
-  private <T> SparkExecutableStageFunction<T> getFunction(Map<String, Integer> outputMap) {
-    return new SparkExecutableStageFunction<>(stagePayload, outputMap, jobBundleFactoryCreator);
+  private <InputT, SideInputT> SparkExecutableStageFunction<InputT, SideInputT> getFunction(
+      Map<String, Integer> outputMap) {
+    return new SparkExecutableStageFunction<>(
+        stagePayload, outputMap, jobBundleFactoryCreator, Collections.emptyMap());
   }
 }


### PR DESCRIPTION
1. During translation, convert each side input's corresponding RDD into bytes, which bytes are then broadcast to the Spark context. (This is necessary because in Spark we cannot broadcast an RDD directly like how we can broadcast a Dataset in Flink.)
2. Pass reference to the resulting Spark broadcast variable along with a decoder for those bytes to the executable stage function.
3. When the executable stage function needs to read the side inputs, it gets the broadcasted bytes value, then uses the decoder to convert the bytes to the side input value.

Notes:
- Converted `FlinkBatchSideInputHandlerFactory` to a pluggable `BatchSideInputHandlerFactory` to connect Spark implementation with portability framework.
- For now, testing is still just a log statement with the side input value. More formal verification is still a few PRs away.
- It is quite possible we will want to improve performance in the future; this is just a starting point.

R: @angoenka @iemejia 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
