### PR TITLE
[BEAM-3545] Support Metrics in Go SDK CombineFns- Part 2

### DIFF
--- a/sdks/go/pkg/beam/core/metrics/metrics.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics.go
@@ -123,12 +123,12 @@ func SetPTransformID(ctx context.Context, id string) context.Context {
 }
 
 const (
-	bundleIdUnset     = "(bundle id unset)"
-	ptransformIdUnset = "(ptransform id unset)"
+	bundleIDUnset     = "(bundle id unset)"
+	ptransformIDUnset = "(ptransform id unset)"
 )
 
 func getContextKey(ctx context.Context, n name) key {
-	key := key{name: n, bundle: bundleIdUnset, ptransform: ptransformIdUnset}
+	key := key{name: n, bundle: bundleIDUnset, ptransform: ptransformIDUnset}
 	if id := ctx.Value(bundleKey); id != nil {
 		key.bundle = id.(string)
 	}

--- a/sdks/go/pkg/beam/core/metrics/metrics_test.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics_test.go
@@ -41,8 +41,8 @@ func TestBeamContext(t *testing.T) {
 		ptID := "MY_TRANSFORM"
 		ctx := SetPTransformID(context.Background(), ptID)
 		key := getContextKey(ctx, name{})
-		if key.bundle != bundleIdUnset {
-			t.Errorf("bundleId = %q, want %q", key.bundle, bundleIdUnset)
+		if key.bundle != bundleIDUnset {
+			t.Errorf("bundleId = %q, want %q", key.bundle, bundleIDUnset)
 		}
 		if key.ptransform != ptID {
 			t.Errorf("ptransformId = %q, want %q", key.ptransform, ptID)
@@ -56,8 +56,8 @@ func TestBeamContext(t *testing.T) {
 		if key.bundle != bID {
 			t.Errorf("bundleId = %q, want %q", key.bundle, bID)
 		}
-		if key.ptransform != ptransformIdUnset {
-			t.Errorf("ptransformId = %q, want %q", key.ptransform, ptransformIdUnset)
+		if key.ptransform != ptransformIDUnset {
+			t.Errorf("ptransformId = %q, want %q", key.ptransform, ptransformIDUnset)
 		}
 	})
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/combine.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/combine.go
@@ -51,6 +51,11 @@ type Combine struct {
 	aiValConvert func(interface{}) interface{}
 }
 
+// GetPID returns the PTransformID for this CombineFn.
+func (n *Combine) GetPID() string {
+	return n.PID
+}
+
 // ID returns the UnitID for this node.
 func (n *Combine) ID() UnitID {
 	return n.UID

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo.go
@@ -66,7 +66,7 @@ func (n *ParDo) ID() UnitID {
 	return n.UID
 }
 
-// Up initializes this
+// Up initializes this ParDo and does one-time DoFn setup.
 func (n *ParDo) Up(ctx context.Context) error {
 	if n.status != Initializing {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Initializing", n.UID, n.status)
@@ -86,7 +86,7 @@ func (n *ParDo) Up(ctx context.Context) error {
 	return nil
 }
 
-// StartBundle starts processing for this bundle and does before bundle processing operations.
+// StartBundle does pre-bundle processing operation for the DoFn.
 func (n *ParDo) StartBundle(ctx context.Context, id string, data DataContext) error {
 	if n.status != Up {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Up", n.UID, n.status)
@@ -157,7 +157,9 @@ func mustExplodeWindows(fn *funcx.Fn, elm *FullValue, usesSideInput bool) bool {
 	return explode || usesSideInput
 }
 
-// FinishBundle finishes processing for this bundle and does post bundle processing operations.
+// FinishBundle does post-bundle processing operations for the DoFn.
+// Note: This is not a "FinalizeBundle" operation. Data is not yet durably
+// persisted at this point.
 func (n *ParDo) FinishBundle(ctx context.Context) error {
 	if n.status != Active {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Active", n.UID, n.status)
@@ -177,7 +179,7 @@ func (n *ParDo) FinishBundle(ctx context.Context) error {
 	return nil
 }
 
-// Down tearsdown DoFn resources.
+// Down performs best-effort teardown of DoFn resources. (May not run.)
 func (n *ParDo) Down(ctx context.Context) error {
 	if n.status == Down {
 		return n.err.Error()

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo.go
@@ -49,6 +49,11 @@ type ParDo struct {
 	err    errorx.GuardedError
 }
 
+// GetPID returns the PTransformID for this ParDo.
+func (n *ParDo) GetPID() string {
+	return n.PID
+}
+
 // cacheElm holds per-window cached information about side input.
 type cacheElm struct {
 	key       typex.Window
@@ -56,10 +61,12 @@ type cacheElm struct {
 	extra     []interface{}
 }
 
+// ID returns the UnitID for this ParDo.
 func (n *ParDo) ID() UnitID {
 	return n.UID
 }
 
+// Up initializes this
 func (n *ParDo) Up(ctx context.Context) error {
 	if n.status != Initializing {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Initializing", n.UID, n.status)
@@ -79,6 +86,7 @@ func (n *ParDo) Up(ctx context.Context) error {
 	return nil
 }
 
+// StartBundle starts processing for this bundle and does before bundle processing operations.
 func (n *ParDo) StartBundle(ctx context.Context, id string, data DataContext) error {
 	if n.status != Up {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Up", n.UID, n.status)
@@ -102,6 +110,7 @@ func (n *ParDo) StartBundle(ctx context.Context, id string, data DataContext) er
 	return nil
 }
 
+// ProcessElement processes each parallel element with the DoFn.
 func (n *ParDo) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	if n.status != Active {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Active", n.UID, n.status)
@@ -148,6 +157,7 @@ func mustExplodeWindows(fn *funcx.Fn, elm *FullValue, usesSideInput bool) bool {
 	return explode || usesSideInput
 }
 
+// FinishBundle finishes processing for this bundle and does post bundle processing operations.
 func (n *ParDo) FinishBundle(ctx context.Context) error {
 	if n.status != Active {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Active", n.UID, n.status)
@@ -167,6 +177,7 @@ func (n *ParDo) FinishBundle(ctx context.Context) error {
 	return nil
 }
 
+// Down tearsdown DoFn resources.
 func (n *ParDo) Down(ctx context.Context) error {
 	if n.status == Down {
 		return n.err.Error()


### PR DESCRIPTION
This PR cleans up a few things:
* transform.UniqueName appears to be -per bundle- in some instances, which defeats the point. Reverting until the runner I found that on changes behavior. Not caught earlier due to metrics being non-programmatically accessible at present.
* Fix a go lint on the "unset" constants I added. ID is prefered over Id.
* Actually add Combine PIDs to the list to pardos with which to export to the runner.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
