### PR TITLE
[BEAM-6934] Fixing timer firing timing issue

### DIFF
--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -789,7 +789,7 @@ class DoFnRunner(Receiver):
 
   def _reraise_augmented(self, exn):
     if getattr(exn, '_tagged_with_step', False) or not self.step_name:
-      raise exn
+      raise
     step_annotation = " [while running '%s']" % self.step_name
     # To emulate exception chaining (not available in Python 2).
     try:

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -789,7 +789,7 @@ class DoFnRunner(Receiver):
 
   def _reraise_augmented(self, exn):
     if getattr(exn, '_tagged_with_step', False) or not self.step_name:
-      raise
+      raise exn
     step_annotation = " [while running '%s']" % self.step_name
     # To emulate exception chaining (not available in Python 2).
     try:

--- a/sdks/python/apache_beam/runners/direct/watermark_manager.py
+++ b/sdks/python/apache_beam/runners/direct/watermark_manager.py
@@ -160,6 +160,8 @@ class WatermarkManager(object):
     for applied_ptransform, tw in self._transform_to_watermarks.items():
       fired_timers, had_realtime_timer = tw.extract_transform_timers()
       if fired_timers:
+        # We should sort the timer firings, so they are fired in order.
+        fired_timers.sort(key=lambda ft: ft.timestamp)
         all_timers.append((applied_ptransform, fired_timers))
       if (had_realtime_timer
           and tw.output_watermark < WatermarkManager.WATERMARK_POS_INF):

--- a/sdks/python/apache_beam/transforms/userstate.py
+++ b/sdks/python/apache_beam/transforms/userstate.py
@@ -131,7 +131,12 @@ def on_timer(timer_spec):
 
 
 def get_dofn_specs(dofn):
-  """Gets the state and timer specs for a DoFn, if any."""
+  """Gets the state and timer specs for a DoFn, if any.
+
+  Args:
+    dofn (apache_beam.transforms.core.DoFn): The DoFn instance to introspect for
+      timer and state specs.
+  """
 
   # Avoid circular import.
   from apache_beam.runners.common import MethodWrapper

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -388,6 +388,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
       def emit_values(self, bag_state=beam.DoFn.StateParam(BAG_STATE)):
         for value in bag_state.read():
           yield value
+        yield 'extra'
 
       @on_timer(CLEAR_TIMER)
       def clear_values(self, bag_state=beam.DoFn.StateParam(BAG_STATE)):
@@ -405,7 +406,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
            | beam.ParDo(self.record_dofn()))
 
     self.assertEqual(
-        [],
+        ['extra'],
         StatefulDoFnOnDirectRunnerTest.all_records)
 
   def test_stateful_dofn_nonkeyed_input(self):


### PR DESCRIPTION
What is odd about this problem is that:
- We would expect the timer set to `100` to fire when the watermark advances to 100 - but instead, it fires together with the timer set to `1000` when the watermark advances to infinity.

On the other hand, if we set `advance_watermark_to(101)`, the test behaves properly without any need for modifications.

BUT, what's even more odd is that when doing the actual check in trigger.py as to whether the timer should be fired, we do check for `<=`. Strange.:
https://github.com/apache/beam/blob/master/sdks/python/apache_beam/transforms/trigger.py#L1273

Nonetheless, this change does fix the new test (which was previously failing) - and I believe it does correct the behavior. So. Yes.

I'll keep hunting for bugs.

r: @aaltay 
cc: @tweise 