### PR TITLE
[BEAM-7046] Restore os.environ in HttpClientTest

### DIFF
--- a/sdks/python/apache_beam/internal/http_client_test.py
+++ b/sdks/python/apache_beam/internal/http_client_test.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 import os
 import unittest
 
+import mock
 from httplib2 import ProxyInfo
 
 from apache_beam.internal.http_client import DEFAULT_HTTP_TIMEOUT_SECONDS
@@ -31,52 +32,52 @@ from apache_beam.internal.http_client import proxy_info_from_environment_var
 class HttpClientTest(unittest.TestCase):
 
   def test_proxy_from_env_http_with_port(self):
-    os.environ['http_proxy'] = 'http://localhost:9000'
-    proxy_info = proxy_info_from_environment_var('http_proxy')
-    expected = ProxyInfo(3, 'localhost', 9000)
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, http_proxy='http://localhost:9000'):
+      proxy_info = proxy_info_from_environment_var('http_proxy')
+      expected = ProxyInfo(3, 'localhost', 9000)
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_https_with_port(self):
-    os.environ['https_proxy'] = 'https://localhost:9000'
-    proxy_info = proxy_info_from_environment_var('https_proxy')
-    expected = ProxyInfo(3, 'localhost', 9000)
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, https_proxy='https://localhost:9000'):
+      proxy_info = proxy_info_from_environment_var('https_proxy')
+      expected = ProxyInfo(3, 'localhost', 9000)
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_http_without_port(self):
-    os.environ['http_proxy'] = 'http://localhost'
-    proxy_info = proxy_info_from_environment_var('http_proxy')
-    expected = ProxyInfo(3, 'localhost', 80)
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, http_proxy='http://localhost'):
+      proxy_info = proxy_info_from_environment_var('http_proxy')
+      expected = ProxyInfo(3, 'localhost', 80)
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_https_without_port(self):
-    os.environ['https_proxy'] = 'https://localhost'
-    proxy_info = proxy_info_from_environment_var('https_proxy')
-    expected = ProxyInfo(3, 'localhost', 443)
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, https_proxy='https://localhost'):
+      proxy_info = proxy_info_from_environment_var('https_proxy')
+      expected = ProxyInfo(3, 'localhost', 443)
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_http_without_method(self):
-    os.environ['http_proxy'] = 'localhost:8000'
-    proxy_info = proxy_info_from_environment_var('http_proxy')
-    expected = ProxyInfo(3, 'localhost', 8000)
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, http_proxy='localhost:8000'):
+      proxy_info = proxy_info_from_environment_var('http_proxy')
+      expected = ProxyInfo(3, 'localhost', 8000)
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_https_without_method(self):
-    os.environ['https_proxy'] = 'localhost:8000'
-    proxy_info = proxy_info_from_environment_var('https_proxy')
-    expected = ProxyInfo(3, 'localhost', 8000)
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, https_proxy='localhost:8000'):
+      proxy_info = proxy_info_from_environment_var('https_proxy')
+      expected = ProxyInfo(3, 'localhost', 8000)
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_http_without_port_without_method(self):
-    os.environ['http_proxy'] = 'localhost'
-    proxy_info = proxy_info_from_environment_var('http_proxy')
-    expected = ProxyInfo(3, 'localhost', 80)
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, http_proxy='localhost'):
+      proxy_info = proxy_info_from_environment_var('http_proxy')
+      expected = ProxyInfo(3, 'localhost', 80)
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_https_without_port_without_method(self):
-    os.environ['https_proxy'] = 'localhost'
-    proxy_info = proxy_info_from_environment_var('https_proxy')
-    expected = ProxyInfo(3, 'localhost', 443)
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, https_proxy='localhost'):
+      proxy_info = proxy_info_from_environment_var('https_proxy')
+      expected = ProxyInfo(3, 'localhost', 443)
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_invalid_var(self):
     proxy_info = proxy_info_from_environment_var('http_proxy_host')
@@ -84,21 +85,21 @@ class HttpClientTest(unittest.TestCase):
     self.assertEquals(str(expected), str(proxy_info))
 
   def test_proxy_from_env_wrong_method_in_var_name(self):
-    os.environ['smtp_proxy'] = 'localhost'
-    with self.assertRaises(KeyError):
-      proxy_info_from_environment_var('smtp_proxy')
+    with mock.patch.dict(os.environ, smtp_proxy='localhost'):
+      with self.assertRaises(KeyError):
+        proxy_info_from_environment_var('smtp_proxy')
 
   def test_proxy_from_env_wrong_method_in_url(self):
-    os.environ['http_proxy'] = 'smtp://localhost:8000'
-    proxy_info = proxy_info_from_environment_var('http_proxy')
-    expected = ProxyInfo(3, 'smtp', 80) # wrong proxy info generated
-    self.assertEquals(str(expected), str(proxy_info))
+    with mock.patch.dict(os.environ, http_proxy='smtp://localhost:8000'):
+      proxy_info = proxy_info_from_environment_var('http_proxy')
+      expected = ProxyInfo(3, 'smtp', 80) # wrong proxy info generated
+      self.assertEquals(str(expected), str(proxy_info))
 
   def test_get_new_http_proxy_info(self):
-    os.environ['http_proxy'] = 'localhost'
-    http = get_new_http()
-    expected = ProxyInfo(3, 'localhost', 80)
-    self.assertEquals(str(http.proxy_info), str(expected))
+    with mock.patch.dict(os.environ, http_proxy='localhost'):
+      http = get_new_http()
+      expected = ProxyInfo(3, 'localhost', 80)
+      self.assertEquals(str(http.proxy_info), str(expected))
 
   def test_get_new_http_timeout(self):
     http = get_new_http()


### PR DESCRIPTION
This was causing warnings about parsing http_proxy in other tests that
use grpc.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
