### PR TITLE
[BEAM-6894] Support for constructing a Dataflow job request that includes cross-language transforms

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -280,10 +280,17 @@ class Coder(object):
     Prefer registering a urn with its parameter type and constructor.
     """
     parameter_type, constructor = cls._known_urns[coder_proto.spec.spec.urn]
-    return constructor(
-        proto_utils.parse_Bytes(coder_proto.spec.spec.payload, parameter_type),
-        [context.coders.get_by_id(c) for c in coder_proto.component_coder_ids],
-        context)
+    try:
+      return constructor(
+          proto_utils.parse_Bytes(
+              coder_proto.spec.spec.payload, parameter_type),
+          [context.coders.get_by_id(c)
+           for c in coder_proto.component_coder_ids],
+          context)
+    except Exception:
+      if context.allow_proto_holders:
+        return RunnerAPICoderHolder(coder_proto)
+      raise
 
   def to_runner_api_parameter(self, context):
     return (
@@ -1140,3 +1147,25 @@ class StateBackedIterableCoder(FastCoder):
         read_state=context.iterable_state_read,
         write_state=context.iterable_state_write,
         write_state_threshold=int(payload))
+
+
+class RunnerAPICoderHolder(Coder):
+  """A `Coder` that holds a runner API `Coder` proto.
+
+  This is used for coders for which corresponding objects cannot be
+  initialized in Python SDK. For example, coders for remote SDKs that may
+  be available in Python SDK transform graph when expanding a cross-language
+  transform.
+  """
+
+  def __init__(self, proto):
+    self._proto = proto
+
+  def proto(self):
+    return self._proto
+
+  def to_runner_api(self, context):
+    return self._proto
+
+  def to_type_hint(self):
+    return typehints.Any

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -70,6 +70,7 @@ class CodersTest(unittest.TestCase):
     standard -= set([coders.Coder,
                      coders.FastCoder,
                      coders.ProtoCoder,
+                     coders.RunnerAPICoderHolder,
                      coders.ToStringCoder])
     assert not standard - cls.seen, standard - cls.seen
     assert not standard - cls.seen_nested, standard - cls.seen_nested

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -659,11 +659,13 @@ class Pipeline(object):
       return proto
 
   @staticmethod
-  def from_runner_api(proto, runner, options, return_context=False):
+  def from_runner_api(proto, runner, options, return_context=False,
+                      allow_proto_holders=False):
     """For internal use only; no backwards-compatibility guarantees."""
     p = Pipeline(runner=runner, options=options)
     from apache_beam.runners import pipeline_context
-    context = pipeline_context.PipelineContext(proto.components)
+    context = pipeline_context.PipelineContext(
+        proto.components, allow_proto_holders=allow_proto_holders)
     root_transform_id, = proto.root_transform_ids
     p.transforms_stack = [
         context.transforms.get_by_id(root_transform_id)]

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -243,10 +243,40 @@ class DataflowRunner(PipelineRunner):
               pcoll.element_type, transform_node.full_label)
           key_type, value_type = pcoll.element_type.tuple_types
           if transform_node.outputs:
-            transform_node.outputs[None].element_type = typehints.KV[
+            from apache_beam.runners.portability.fn_api_runner_transforms import \
+              only_element
+            key = (
+                None if None in transform_node.outputs.keys()
+                else only_element(transform_node.outputs.keys()))
+            transform_node.outputs[key].element_type = typehints.KV[
                 key_type, typehints.Iterable[value_type]]
 
     return GroupByKeyInputVisitor()
+
+  @staticmethod
+  def _set_pdone_visitor(pipeline):
+    # Imported here to avoid circular dependencies.
+    from apache_beam.pipeline import PipelineVisitor
+
+    class SetPDoneVisitor(PipelineVisitor):
+
+      def __init__(self, pipeline):
+        self._pipeline = pipeline
+
+      @staticmethod
+      def _maybe_fix_output(transform_node, pipeline):
+        if not transform_node.outputs:
+          pval = pvalue.PDone(pipeline)
+          pval.producer = transform_node
+          transform_node.outputs = {None: pval}
+
+      def enter_composite_transform(self, transform_node):
+        SetPDoneVisitor._maybe_fix_output(transform_node, self._pipeline)
+
+      def visit_transform(self, transform_node):
+        SetPDoneVisitor._maybe_fix_output(transform_node, self._pipeline)
+
+    return SetPDoneVisitor(pipeline)
 
   @staticmethod
   def side_input_visitor():
@@ -345,6 +375,23 @@ class DataflowRunner(PipelineRunner):
     # Snapshot the pipeline in a portable proto.
     self.proto_pipeline, self.proto_context = pipeline.to_runner_api(
         return_context=True)
+
+    if apiclient._use_fnapi(options):
+      # Cross language transform require using a pipeline object constructed
+      # from the full pipeline proto to make sure that expanded version of
+      # external transforms are reflected in the Pipeline job graph.
+      from apache_beam import Pipeline
+      pipeline = Pipeline.from_runner_api(
+          self.proto_pipeline, pipeline.runner, options,
+          allow_proto_holders=True)
+
+      # Pipelines generated from proto do not have output set to PDone set for
+      # leaf elements.
+      pipeline.visit(self._set_pdone_visitor(pipeline))
+
+      # We need to generate a new context that maps to the new pipeline object.
+      self.proto_pipeline, self.proto_context = pipeline.to_runner_api(
+          return_context=True)
 
     # Add setup_options for all the BeamPlugin imports
     setup_options = options.view_as(SetupOptions)
@@ -461,18 +508,24 @@ class DataflowRunner(PipelineRunner):
 
   def _get_encoded_output_coder(self, transform_node, window_value=True):
     """Returns the cloud encoding of the coder for the output of a transform."""
-    if (len(transform_node.outputs) == 1
-        and transform_node.outputs[None].element_type is not None):
+    from apache_beam.runners.portability.fn_api_runner_transforms import \
+      only_element
+    if len(transform_node.outputs) == 1:
+      output_tag = only_element(transform_node.outputs.keys())
       # TODO(robertwb): Handle type hints for multi-output transforms.
-      element_type = transform_node.outputs[None].element_type
+      element_type = transform_node.outputs[output_tag].element_type
     else:
       # TODO(silviuc): Remove this branch (and assert) when typehints are
       # propagated everywhere. Returning an 'Any' as type hint will trigger
       # usage of the fallback coder (i.e., cPickler).
       element_type = typehints.Any
     if window_value:
+      # All outputs have the same windowing. So getting the coder from an
+      # arbitrary window is fine.
+      output_tag = next(iter(transform_node.outputs.keys()))
       window_coder = (
-          transform_node.outputs[None].windowing.windowfn.get_window_coder())
+          transform_node.outputs[
+              output_tag].windowing.windowfn.get_window_coder())
     else:
       window_coder = None
     from apache_beam.runners.dataflow.internal import apiclient
@@ -490,7 +543,14 @@ class DataflowRunner(PipelineRunner):
     self.job.proto.steps.append(step.proto)
     step.add_property(PropertyNames.USER_NAME, step_label)
     # Cache the node/step association for the main output of the transform node.
-    self._cache.cache_output(transform_node, None, step)
+
+    # Main output key of external transforms can be ambiguous, so we only tag if
+    # there's only one tag instead of None.
+    from apache_beam.runners.portability.fn_api_runner_transforms import only_element
+    output_tag = (only_element(transform_node.outputs.keys())
+                  if len(transform_node.outputs.keys()) == 1 else None)
+
+    self._cache.cache_output(transform_node, output_tag, step)
     # If side_tags is not () then this is a multi-output transform node and we
     # need to cache the (node, tag, step) for each of the tags used to access
     # the outputs. This is essential because the keys used to search in the
@@ -647,6 +707,24 @@ class DataflowRunner(PipelineRunner):
         PropertyNames.SERIALIZED_FN,
         self.serialize_windowing_strategy(windowing))
 
+  def run_RunnerAPIPTransformHolder(self, transform_node, options):
+    """Adding Dataflow runner job description for transform holder objects.
+
+    These holder transform objects are generated for some of the transforms that
+    become available after a cross-language transform expansion, usually if the
+    corresponding transform object cannot be generated in Python SDK (for
+    example, a python `ParDo` transform cannot be generated without a serialized
+    Python `DoFn` object).
+    """
+    urn = transform_node.transform.proto().urn
+    assert urn
+    # TODO(chamikara): support other transforms that requires holder objects in
+    #  Python SDk.
+    if common_urns.primitives.PAR_DO.urn == urn:
+      self.run_ParDo(transform_node, options)
+    else:
+      NotImplementedError(urn)
+
   def run_ParDo(self, transform_node, options):
     transform = transform_node.transform
     input_tag = transform_node.inputs[0].tag
@@ -770,13 +848,11 @@ class DataflowRunner(PipelineRunner):
 
     # Add the restriction encoding if we are a splittable DoFn
     # and are using the Fn API on the unified worker.
-    from apache_beam.runners.common import DoFnSignature
-    signature = DoFnSignature(transform_node.transform.fn)
-    if (use_fnapi and use_unified_worker and signature.is_splittable_dofn()):
-      restriction_coder = (
-          signature.get_restriction_provider().restriction_coder())
+    restriction_coder = transform.get_restriction_coder()
+    if (use_fnapi and use_unified_worker and restriction_coder):
       step.add_property(PropertyNames.RESTRICTION_ENCODING,
-                        self._get_cloud_encoding(restriction_coder, use_fnapi))
+                        self._get_cloud_encoding(
+                            restriction_coder, use_fnapi))
 
   @staticmethod
   def _pardo_fn_data(transform_node, get_label):

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -116,7 +116,7 @@ class Step(object):
       ValueError: if the tag does not exist within outputs.
     """
     outputs = self._get_outputs()
-    if tag is None:
+    if tag is None or len(outputs) == 1:
       return outputs[0]
     else:
       name = '%s_%s' % (PropertyNames.OUT, tag)

--- a/sdks/python/apache_beam/runners/pipeline_context.py
+++ b/sdks/python/apache_beam/runners/pipeline_context.py
@@ -130,7 +130,7 @@ class PipelineContext(object):
   def __init__(
       self, proto=None, default_environment=None, use_fake_coders=False,
       iterable_state_read=None, iterable_state_write=None,
-      namespace='ref'):
+      namespace='ref', allow_proto_holders=False):
     if isinstance(proto, beam_fn_api_pb2.ProcessBundleDescriptor):
       proto = beam_runner_api_pb2.Components(
           coders=dict(proto.coders.items()),
@@ -148,6 +148,7 @@ class PipelineContext(object):
     self.use_fake_coders = use_fake_coders
     self.iterable_state_read = iterable_state_read
     self.iterable_state_write = iterable_state_write
+    self.allow_proto_holders = allow_proto_holders
 
   # If fake coders are requested, return a pickled version of the element type
   # rather than an actual coder. The element type is required for some runners,

--- a/sdks/python/apache_beam/transforms/external_test.py
+++ b/sdks/python/apache_beam/transforms/external_test.py
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -24,18 +25,26 @@ import sys
 import unittest
 
 import grpc
+from mock import patch
 from past.builtins import unicode
 
 import apache_beam as beam
 from apache_beam import Pipeline
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.portability import python_urns
 from apache_beam.runners.portability import expansion_service
 from apache_beam.runners.portability.expansion_service_test import FibTransform
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+
+# Protect against environments where apitools library is not available.
+# pylint: disable=wrong-import-order, wrong-import-position
+try:
+  from apache_beam.runners.dataflow.internal import apiclient
+except ImportError:
+  apiclient = None
+# pylint: enable=wrong-import-order, wrong-import-position
 
 
 class ExternalTransformTest(unittest.TestCase):
@@ -43,6 +52,29 @@ class ExternalTransformTest(unittest.TestCase):
   # This will be overwritten if set via a flag.
   expansion_service_jar = None
   expansion_service_port = None
+
+  class _RunWithExpansion(object):
+
+    def __init__(self, port, expansion_service_jar):
+      self._port = port
+      self._expansion_service_jar = expansion_service_jar
+
+    def __enter__(self):
+      if not ExternalTransformTest.expansion_service_jar:
+        raise unittest.SkipTest('No expansion service jar provided.')
+
+      # Start the java server and wait for it to be ready.
+      self._server = subprocess.Popen(
+          ['java', '-jar', self._expansion_service_jar, str(self._port)])
+
+      port = ExternalTransformTest.expansion_service_port or 8091
+      address = 'localhost:%s' % str(port)
+
+      with grpc.insecure_channel(address) as channel:
+        grpc.channel_ready_future(channel).result()
+
+    def __exit__(self, type, value, traceback):
+      self._server.kill()
 
   def test_pipeline_generation(self):
     pipeline = beam.Pipeline()
@@ -105,71 +137,86 @@ class ExternalTransformTest(unittest.TestCase):
       assert_that(p | FibTransform(6), equal_to([8]))
 
   def test_java_expansion_portable_runner(self):
-    if not ExternalTransformTest.expansion_service_jar:
-      raise unittest.SkipTest('No expansion service jar provided.')
-
-    # Run as cheaply as possible on the portable runner.
-    # TODO(robertwb): Support this directly in the direct runner.
-    pipeline_args = self.pipeline_args or (
+    pipeline_options = PipelineOptions(
         ['--runner=PortableRunner',
          '--experiments=beam_fn_api',
-         'environment_type=%s' % python_urns.EMBEDDED_PYTHON,
-         'job_endpoint=embed'])
-
-    pipeline_options = PipelineOptions(pipeline_args)
-    assert (
-        pipeline_options.view_as(StandardOptions).runner.lower()
-        == "portablerunner"), "Only PortableRunner is supported."
+         '--environment_type=%s' % python_urns.EMBEDDED_PYTHON,
+         '--job_endpoint=embed'])
 
     # We use the save_main_session option because one or more DoFn's in this
     # workflow rely on global context (e.g., a module imported at module level).
     pipeline_options.view_as(SetupOptions).save_main_session = True
-    self.run_pipelines(pipeline_options)
+
+    ExternalTransformTest.run_pipeline_with_portable_runner(pipeline_options)
+
+  @unittest.skipIf(apiclient is None, 'GCP dependencies are not installed')
+  def test_java_expansion_dataflow(self):
+    # This test does not actually running the pipeline in Dataflow. It just
+    # tests the translation to a Dataflow job request.
+
+    with patch.object(
+        apiclient.DataflowApplicationClient, 'create_job') as mock_create_job:
+      port = ExternalTransformTest.expansion_service_port or 8091
+      with self._RunWithExpansion(port, self.expansion_service_jar):
+        pipeline_options = PipelineOptions(
+            ['--runner=DataflowRunner',
+             '--project=dummyproject',
+             '--experiments=beam_fn_api',
+             '--temp_location=gs://dummybucket/'])
+
+        # We use the save_main_session option because one or more DoFn's in this
+        # workflow rely on global context (e.g., a module imported at module
+        # level).
+        pipeline_options.view_as(SetupOptions).save_main_session = True
+
+        # Run a simple count-filtered-letters pipeline.
+        self.run_pipeline(pipeline_options, port, False)
+
+        mock_args = mock_create_job.call_args_list
+        assert mock_args
+        args, kwargs = mock_args[0]
+        job = args[0]
+        job_str = '%s' % job
+        self.assertIn('pytest:beam:transforms:filter_less_than', job_str)
 
   @staticmethod
-  def run_pipelines(pipeline_options):
+  def run_pipeline_with_portable_runner(pipeline_options):
+
+    port = ExternalTransformTest.expansion_service_port or 8091
+
+    with ExternalTransformTest._RunWithExpansion(
+        port, ExternalTransformTest.expansion_service_jar):
+      # Run a simple count-filtered-letters pipeline.
+      ExternalTransformTest.run_pipeline(pipeline_options, port, True)
+
+  @staticmethod
+  def run_pipeline(
+      pipeline_options, expansion_service_port, wait_until_finish=True):
     # The actual definitions of these transforms is in
     # org.apache.beam.runners.core.construction.TestExpansionService.
     TEST_COUNT_URN = "pytest:beam:transforms:count"
     TEST_FILTER_URN = "pytest:beam:transforms:filter_less_than"
 
-    assert (
-        pipeline_options.view_as(StandardOptions).runner.lower()
-        == "portablerunner"), "Only PortableRunner is supported."
+    # Run a simple count-filtered-letters pipeline.
+    p = beam.Pipeline(options=pipeline_options)
+    address = 'localhost:%s' % str(expansion_service_port)
+    res = (
+        p
+        | beam.Create(list('aaabccxyyzzz'))
+        | beam.Map(unicode)
+        # TODO(BEAM-6587): Use strings directly rather than ints.
+        | beam.Map(lambda x: int(ord(x)))
+        | beam.ExternalTransform(TEST_FILTER_URN, b'middle', address)
+        | beam.ExternalTransform(TEST_COUNT_URN, None, address)
+        # # TODO(BEAM-6587): Remove when above is removed.
+        | beam.Map(lambda kv: (chr(kv[0]), kv[1]))
+        | beam.Map(lambda kv: '%s: %s' % kv))
 
-    try:
+    assert_that(res, equal_to(['a: 3', 'b: 1', 'c: 2']))
 
-      # Run a simple count-filtered-letters pipeline.
-      p = beam.Pipeline(options=pipeline_options)
-      p.runner.init_dockerized_job_server()
-
-      # Start the java server and wait for it to be ready.
-      port = str(ExternalTransformTest.expansion_service_port)
-      address = 'localhost:%s' % port
-      server = subprocess.Popen([
-          'java', '-jar', ExternalTransformTest.expansion_service_jar,
-          port])
-
-      with grpc.insecure_channel(address) as channel:
-        grpc.channel_ready_future(channel).result()
-
-      res = (
-          p
-          | beam.Create(list('aaabccxyyzzz'))
-          | beam.Map(unicode)
-          # TODO(BEAM-6587): Use strings directly rather than ints.
-          | beam.Map(lambda x: int(ord(x)))
-          | beam.ExternalTransform(TEST_FILTER_URN, b'middle', address)
-          | beam.ExternalTransform(TEST_COUNT_URN, None, address)
-          # # TODO(BEAM-6587): Remove when above is removed.
-          | beam.Map(lambda kv: (chr(kv[0]), kv[1]))
-          | beam.Map(lambda kv: '%s: %s' % kv))
-
-      assert_that(res, equal_to(['a: 3', 'b: 1', 'c: 2']))
-
-      p.run().wait_until_finish()
-    finally:
-      server.kill()
+    result = p.run()
+    if wait_until_finish:
+      result.wait_until_finish()
 
 
 if __name__ == '__main__':
@@ -184,7 +231,7 @@ if __name__ == '__main__':
     ExternalTransformTest.expansion_service_port = int(
         known_args.expansion_service_port)
     pipeline_options = PipelineOptions(pipeline_args)
-    ExternalTransformTest.run_pipelines(pipeline_options)
+    ExternalTransformTest.run_pipeline_with_portable_runner(pipeline_options)
   else:
     sys.argv = pipeline_args
     unittest.main()


### PR DESCRIPTION
This is done by rebuilding the Pipeline object from the runner API proto if experiment 'cross_language_pipeline' is set.
This rebuilding fails for some of the pipeline constructs, for example ParDos due to Python ParDo object expecting a serialized Python DoFn object, coders that are not available in local (Python) SDK.
I get around this by introducing holder objects that will hold pipeline constructs that cannot be locally built from their proto representations.
At the Dataflow runner, I added a new 'run_XX' method for such holder PTransform where we'll do the proper runner API proto to Dataflow API proto conversion.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
