### PR TITLE
[BEAM-6962] Adds two existing cross-language tests to Python post-commit.

### DIFF
--- a/sdks/python/apache_beam/transforms/external_test.py
+++ b/sdks/python/apache_beam/transforms/external_test.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -29,7 +28,9 @@ from past.builtins import unicode
 
 import apache_beam as beam
 from apache_beam import Pipeline
-from apache_beam.io.external.generate_sequence import GenerateSequence
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.portability import python_urns
 from apache_beam.runners.portability import expansion_service
 from apache_beam.testing.util import assert_that
@@ -41,6 +42,7 @@ class ExternalTransformTest(unittest.TestCase):
 
   # This will be overwritten if set via a flag.
   expansion_service_jar = None
+  expansion_service_port = None
 
   def test_pipeline_generation(self):
 
@@ -191,58 +193,70 @@ class ExternalTransformTest(unittest.TestCase):
     with beam.Pipeline() as p:
       assert_that(p | FibTransform(6), equal_to([8]))
 
-  def test_java_expansion(self):
-    if not self.expansion_service_jar:
+  def test_java_expansion_portable_runner(self):
+    if not ExternalTransformTest.expansion_service_jar:
       raise unittest.SkipTest('No expansion service jar provided.')
 
+    # Run as cheaply as possible on the portable runner.
+    # TODO(robertwb): Support this directly in the direct runner.
+    pipeline_args = self.pipeline_args or (
+        ['--runner=PortableRunner',
+         '--experiments=beam_fn_api',
+         'environment_type=%s' % python_urns.EMBEDDED_PYTHON,
+         'job_endpoint=embed'])
+
+    pipeline_options = PipelineOptions(pipeline_args)
+    assert (
+        pipeline_options.view_as(StandardOptions).runner.lower()
+        == "portablerunner"), "Only PortableRunner is supported."
+
+    # We use the save_main_session option because one or more DoFn's in this
+    # workflow rely on global context (e.g., a module imported at module level).
+    pipeline_options.view_as(SetupOptions).save_main_session = True
+    self.run_pipelines(pipeline_options)
+
+  @staticmethod
+  def run_pipelines(pipeline_options):
     # The actual definitions of these transforms is in
     # org.apache.beam.runners.core.construction.TestExpansionService.
     TEST_COUNT_URN = "pytest:beam:transforms:count"
     TEST_FILTER_URN = "pytest:beam:transforms:filter_less_than"
 
-    # Run as cheaply as possible on the portable runner.
-    # TODO(robertwb): Support this directly in the direct runner.
-    options = beam.options.pipeline_options.PipelineOptions(
-        runner='PortableRunner',
-        experiments=['beam_fn_api'],
-        environment_type=python_urns.EMBEDDED_PYTHON,
-        job_endpoint='embed')
+    assert (
+        pipeline_options.view_as(StandardOptions).runner.lower()
+        == "portablerunner"), "Only PortableRunner is supported."
 
     try:
+
+      # Run a simple count-filtered-letters pipeline.
+      p = beam.Pipeline(options=pipeline_options)
+      p.runner.init_dockerized_job_server()
+
       # Start the java server and wait for it to be ready.
-      port = '8091'
+      port = str(ExternalTransformTest.expansion_service_port)
       address = 'localhost:%s' % port
-      server = subprocess.Popen(
-          ['java', '-jar', self.expansion_service_jar, port])
+      server = subprocess.Popen([
+          'java', '-jar', ExternalTransformTest.expansion_service_jar,
+          port])
+
       with grpc.insecure_channel(address) as channel:
         grpc.channel_ready_future(channel).result()
 
-      # Run a simple count-filtered-letters pipeline.
-      with beam.Pipeline(options=options) as p:
-        res = (
-            p
-            | beam.Create(list('aaabccxyyzzz'))
-            | beam.Map(unicode)
-            # TODO(BEAM-6587): Use strings directly rather than ints.
-            | beam.Map(lambda x: int(ord(x)))
-            | beam.ExternalTransform(TEST_FILTER_URN, b'middle', address)
-            | beam.ExternalTransform(TEST_COUNT_URN, None, address)
-            # TODO(BEAM-6587): Remove when above is removed.
-            | beam.Map(lambda kv: (chr(kv[0]), kv[1]))
-            | beam.Map(lambda kv: '%s: %s' % kv))
+      res = (
+          p
+          | beam.Create(list('aaabccxyyzzz'))
+          | beam.Map(unicode)
+          # TODO(BEAM-6587): Use strings directly rather than ints.
+          | beam.Map(lambda x: int(ord(x)))
+          | beam.ExternalTransform(TEST_FILTER_URN, b'middle', address)
+          | beam.ExternalTransform(TEST_COUNT_URN, None, address)
+          # # TODO(BEAM-6587): Remove when above is removed.
+          | beam.Map(lambda kv: (chr(kv[0]), kv[1]))
+          | beam.Map(lambda kv: '%s: %s' % kv))
 
-        assert_that(res, equal_to(['a: 3', 'b: 1', 'c: 2']))
+      assert_that(res, equal_to(['a: 3', 'b: 1', 'c: 2']))
 
-      # Test GenerateSequence Java transform
-      with beam.Pipeline(options=options) as p:
-        res = (
-            p
-            | GenerateSequence(start=1, stop=10,
-                               expansion_service=address)
-        )
-
-        assert_that(res, equal_to([i for i in range(1, 10)]))
-
+      p.run().wait_until_finish()
     finally:
       server.kill()
 
@@ -250,10 +264,16 @@ class ExternalTransformTest(unittest.TestCase):
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()
   parser.add_argument('--expansion_service_jar')
-  known_args, sys.argv = parser.parse_known_args(sys.argv)
+  parser.add_argument('--expansion_service_port')
+  known_args, pipeline_args = parser.parse_known_args(sys.argv)
 
   if known_args.expansion_service_jar:
     ExternalTransformTest.expansion_service_jar = (
         known_args.expansion_service_jar)
-
-  unittest.main()
+    ExternalTransformTest.expansion_service_port = int(
+        known_args.expansion_service_port)
+    pipeline_options = PipelineOptions(pipeline_args)
+    ExternalTransformTest.run_pipelines(pipeline_options)
+  else:
+    sys.argv = pipeline_args
+    unittest.main()

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -346,6 +346,7 @@ task javaReferenceRunnerValidatesRunner() {
 }
 
 task postCommit() {
+  dependsOn "crossLanguageTests"
   dependsOn "directRunnerIT"
   dependsOn "hdfsIntegrationTest"
   dependsOn "postCommitIT"
@@ -403,16 +404,27 @@ project.task('createProcessWorker') {
   }
 }
 
-project.task('crossLanguagePythonJava') {
+project.task('crossLanguagePythonJavaFlink') {
   dependsOn 'setupVirtualenv'
+  dependsOn ':beam-runners-flink_2.11-job-server-container:docker'
+  dependsOn ':beam-sdks-python-container:docker'
   dependsOn ':beam-sdks-java-container:docker'
   dependsOn ':beam-runners-core-construction-java:buildTestExpansionServiceJar'
 
   doLast {
     def testServiceExpansionJar = project(":beam-runners-core-construction-java:").buildTestExpansionServiceJar.archivePath
+    def options = [
+            "--runner=PortableRunner",
+            "--experiments=worker_threads=100",
+            "--parallelism=2",
+            "--shutdown_sources_on_final_watermark",
+            "--environment_cache_millis=10000",
+            "--expansion_service_port=8096",
+            "--expansion_service_jar=${testServiceExpansionJar}",
+    ]
     exec {
       executable 'sh'
-      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.transforms.external_test --expansion_service_jar=${testServiceExpansionJar}"
+      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.transforms.external_test ${options.join(' ')}"
     }
   }
 }
@@ -438,8 +450,13 @@ project.task('crossLanguagePortableWordCount') {
     ]
     exec {
       executable 'sh'
-      args '-c', ". ${project.ext.envdir}/bin/activate && python -m apache_beam.examples.wordcount_xlang ${options.join(' ')}"
+      args '-c', ". ${project.ext.envdir}/bin/activate && pip install -e .[test] && python -m apache_beam.examples.wordcount_xlang ${options.join(' ')}"
       // TODO: Check that the output file is generated and runs.
     }
   }
+}
+
+project.task('crossLanguageTests') {
+  dependsOn "crossLanguagePythonJavaFlink"
+  dependsOn "crossLanguagePortableWordCount"
 }


### PR DESCRIPTION
These cross-language tests use Java transforms from Python SDK and execute jobs using Flink runner.
Removed the second job that uses 'GenerateSequence' from 'test_java_expansion' since it's redundant and test expansion jar does not contain 'GenerateSequence' transform.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
