### PR TITLE
[BEAM-7070] JOIN condition should accept field access

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRel.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.impl.transform.BeamJoinTransforms;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -60,6 +61,7 @@ import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -248,16 +250,24 @@ public class BeamJoinRel extends Join implements BeamRelNode {
       PCollection<Row> leftRows = pinput.get(0);
       PCollection<Row> rightRows = pinput.get(1);
 
+      int leftRowColumnCount = leftRelNode.getRowType().getFieldCount();
+
       // extract the join fields
-      List<Pair<Integer, Integer>> pairs =
-          extractJoinColumns(leftRelNode.getRowType().getFieldCount());
+      List<Pair<RexNode, RexNode>> pairs = extractJoinRexNodes();
 
       // build the extract key type
       // the name of the join field is not important
       Schema extractKeySchemaLeft =
-          pairs.stream().map(pair -> leftSchema.getField(pair.getKey())).collect(toSchema());
+          pairs.stream()
+              .map(pair -> BeamJoinRel.getFieldBasedOnRexNode(leftSchema, pair.getKey(), 0))
+              .collect(toSchema());
       Schema extractKeySchemaRight =
-          pairs.stream().map(pair -> rightSchema.getField(pair.getValue())).collect(toSchema());
+          pairs.stream()
+              .map(
+                  pair ->
+                      BeamJoinRel.getFieldBasedOnRexNode(
+                          rightSchema, pair.getValue(), leftRowColumnCount))
+              .collect(toSchema());
 
       SchemaCoder<Row> extractKeyRowCoder = SchemaCoder.of(extractKeySchemaLeft);
 
@@ -270,7 +280,8 @@ public class BeamJoinRel extends Join implements BeamRelNode {
               .apply(
                   "left_ExtractJoinFields",
                   MapElements.via(
-                      new BeamJoinTransforms.ExtractJoinFields(true, pairs, extractKeySchemaLeft)))
+                      new BeamJoinTransforms.ExtractJoinFields(
+                          true, pairs, extractKeySchemaLeft, 0)))
               .setCoder(KvCoder.of(extractKeyRowCoder, leftRows.getCoder()));
 
       PCollection<KV<Row, Row>> extractedRightRows =
@@ -282,7 +293,7 @@ public class BeamJoinRel extends Join implements BeamRelNode {
                   "right_ExtractJoinFields",
                   MapElements.via(
                       new BeamJoinTransforms.ExtractJoinFields(
-                          false, pairs, extractKeySchemaRight)))
+                          false, pairs, extractKeySchemaRight, leftRowColumnCount)))
               .setCoder(KvCoder.of(extractKeyRowCoder, rightRows.getCoder()));
 
       return PCollectionList.of(extractedLeftRows).and(extractedRightRows);
@@ -488,22 +499,38 @@ public class BeamJoinRel extends Join implements BeamRelNode {
     return kvs.setCoder(KvCoder.of(coder.getKeyCoder(), valueCoder));
   }
 
-  private List<Pair<Integer, Integer>> extractJoinColumns(int leftRowColumnCount) {
+  private static Field getFieldBasedOnRexNode(
+      Schema schema, RexNode rexNode, int leftRowColumnCount) {
+    if (rexNode instanceof RexInputRef) {
+      return schema.getField(((RexInputRef) rexNode).getIndex() - leftRowColumnCount);
+    } else if (rexNode instanceof RexFieldAccess) {
+      // need to extract field of Struct/Row.
+      RexFieldAccess fieldAccess = (RexFieldAccess) rexNode;
+      RexInputRef inputRef = (RexInputRef) fieldAccess.getReferenceExpr();
+      Field structField = schema.getField(inputRef.getIndex() - leftRowColumnCount);
+      // Should use RexFieldAccess to get field of Struct field.
+      return structField.getType().getRowSchema().getField(fieldAccess.getField().getIndex());
+    }
+
+    throw new UnsupportedOperationException("Does not support " + rexNode.getType() + " in JOIN.");
+  }
+
+  private List<Pair<RexNode, RexNode>> extractJoinRexNodes() {
     // it's a CROSS JOIN because: condition == true
     if (condition instanceof RexLiteral && (Boolean) ((RexLiteral) condition).getValue()) {
       throw new UnsupportedOperationException("CROSS JOIN is not supported!");
     }
 
     RexCall call = (RexCall) condition;
-    List<Pair<Integer, Integer>> pairs = new ArrayList<>();
+    List<Pair<RexNode, RexNode>> pairs = new ArrayList<>();
     if ("AND".equals(call.getOperator().getName())) {
       List<RexNode> operands = call.getOperands();
       for (RexNode rexNode : operands) {
-        Pair<Integer, Integer> pair = extractOneJoinColumn((RexCall) rexNode, leftRowColumnCount);
+        Pair<RexNode, RexNode> pair = extractJoinPairOfRexNodes((RexCall) rexNode);
         pairs.add(pair);
       }
     } else if ("=".equals(call.getOperator().getName())) {
-      pairs.add(extractOneJoinColumn(call, leftRowColumnCount));
+      pairs.add(extractJoinPairOfRexNodes(call));
     } else {
       throw new UnsupportedOperationException(
           "Operator " + call.getOperator().getName() + " is not supported in join condition");
@@ -512,19 +539,28 @@ public class BeamJoinRel extends Join implements BeamRelNode {
     return pairs;
   }
 
-  private Pair<Integer, Integer> extractOneJoinColumn(
-      RexCall oneCondition, int leftRowColumnCount) {
-    List<RexNode> operands = oneCondition.getOperands();
-    final int leftIndex =
-        Math.min(
-            ((RexInputRef) operands.get(0)).getIndex(), ((RexInputRef) operands.get(1)).getIndex());
+  private Pair<RexNode, RexNode> extractJoinPairOfRexNodes(RexCall rexCall) {
+    if (!rexCall.getOperator().getName().equals("=")) {
+      throw new UnsupportedOperationException("Non equi-join is not supported!");
+    }
 
-    final int rightIndex1 =
-        Math.max(
-            ((RexInputRef) operands.get(0)).getIndex(), ((RexInputRef) operands.get(1)).getIndex());
-    final int rightIndex = rightIndex1 - leftRowColumnCount;
+    int leftIndex = getColumnIndex(rexCall.getOperands().get(0));
+    int rightIndex = getColumnIndex(rexCall.getOperands().get(1));
+    if (leftIndex < rightIndex) {
+      return new Pair<>(rexCall.getOperands().get(0), rexCall.getOperands().get(1));
+    } else {
+      return new Pair<>(rexCall.getOperands().get(1), rexCall.getOperands().get(0));
+    }
+  }
 
-    return new Pair<>(leftIndex, rightIndex);
+  private int getColumnIndex(RexNode rexNode) {
+    if (rexNode instanceof RexInputRef) {
+      return ((RexInputRef) rexNode).getIndex();
+    } else if (rexNode instanceof RexFieldAccess) {
+      return ((RexInputRef) ((RexFieldAccess) rexNode).getReferenceExpr()).getIndex();
+    }
+
+    throw new UnsupportedOperationException("Cannot get column index from " + rexNode.getType());
   }
 
   /** check if {@code BeamRelNode} implements {@code BeamSeekableTable}. */

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.BeamSqlSeekableTable;
+import org.apache.beam.sdk.extensions.sql.impl.utils.SerializableRexInputRef;
+import org.apache.beam.sdk.extensions.sql.impl.utils.SerializableRexNode;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -44,25 +46,47 @@ public class BeamJoinTransforms {
 
   /** A {@code SimpleFunction} to extract join fields from the specified row. */
   public static class ExtractJoinFields extends SimpleFunction<Row, KV<Row, Row>> {
-    private final List<Integer> joinColumns;
+    private final List<SerializableRexNode> joinColumns;
     private final Schema schema;
+    private int leftRowColumnCount;
 
     public ExtractJoinFields(
-        boolean isLeft, List<Pair<Integer, Integer>> joinColumns, Schema schema) {
+        boolean isLeft,
+        List<Pair<RexNode, RexNode>> joinColumns,
+        Schema schema,
+        int leftRowColumnCount) {
       this.joinColumns =
-          joinColumns.stream().map(pair -> isLeft ? pair.left : pair.right).collect(toList());
+          joinColumns.stream()
+              .map(pair -> SerializableRexNode.builder(isLeft ? pair.left : pair.right).build())
+              .collect(toList());
       this.schema = schema;
+      this.leftRowColumnCount = leftRowColumnCount;
     }
 
     @Override
     public KV<Row, Row> apply(Row input) {
-      Row row = joinColumns.stream().map(input::getValue).collect(toRow(schema));
+      Row row =
+          joinColumns.stream()
+              .map(v -> getValue(v, input, leftRowColumnCount))
+              .collect(toRow(schema));
       return KV.of(row, input);
     }
 
+    @SuppressWarnings("unused")
     private Schema.Field toField(Schema schema, Integer fieldIndex) {
       Schema.Field original = schema.getField(fieldIndex);
       return original.withName("c" + fieldIndex);
+    }
+
+    private Object getValue(
+        SerializableRexNode serializableRexNode, Row input, int leftRowColumnCount) {
+      if (serializableRexNode instanceof SerializableRexInputRef) {
+        return input.getValue(serializableRexNode.getIndex() - leftRowColumnCount);
+      } else {
+        // It can only be SerializableFieldAccess.
+        Row rowField = input.getValue(serializableRexNode.getReferenceNode().getIndex());
+        return rowField.getValue(serializableRexNode.getIndex());
+      }
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexFieldAccess.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexFieldAccess.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.utils;
+
+import org.apache.calcite.rex.RexFieldAccess;
+
+/** SerializableRexFieldAccess. */
+public class SerializableRexFieldAccess extends SerializableRexNode {
+  private int index;
+
+  private SerializableRexNode serializableRexNode;
+
+  public SerializableRexFieldAccess(RexFieldAccess rexFieldAccess) {
+    index = rexFieldAccess.getField().getIndex();
+
+    serializableRexNode = SerializableRexNode.builder(rexFieldAccess.getReferenceExpr()).build();
+  }
+
+  @Override
+  public int getIndex() {
+    return index;
+  }
+
+  @Override
+  public SerializableRexNode getReferenceNode() {
+    return serializableRexNode;
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexInputRef.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexInputRef.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.utils;
+
+import org.apache.calcite.rex.RexInputRef;
+
+/** SerializableRexInputRef. */
+public class SerializableRexInputRef extends SerializableRexNode {
+  private int index;
+
+  public SerializableRexInputRef(RexInputRef rexInputRef) {
+    index = rexInputRef.getIndex();
+  }
+
+  @Override
+  public int getIndex() {
+    return index;
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexInputRef.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexInputRef.java
@@ -27,7 +27,6 @@ public class SerializableRexInputRef extends SerializableRexNode {
     index = rexInputRef.getIndex();
   }
 
-  @Override
   public int getIndex() {
     return index;
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexNode.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexNode.java
@@ -24,12 +24,6 @@ import org.apache.calcite.rex.RexNode;
 
 /** SerializableRexNode. */
 public abstract class SerializableRexNode implements Serializable {
-  public abstract int getIndex();
-
-  public SerializableRexNode getReferenceNode() {
-    throw new UnsupportedOperationException("No reference node in SerializableRexNode.");
-  }
-
   public static SerializableRexNode.Builder builder(RexNode rexNode) {
     return new SerializableRexNode.Builder(rexNode);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexNode.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SerializableRexNode.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.utils;
+
+import java.io.Serializable;
+import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+
+/** SerializableRexNode. */
+public abstract class SerializableRexNode implements Serializable {
+  public abstract int getIndex();
+
+  public SerializableRexNode getReferenceNode() {
+    throw new UnsupportedOperationException("No reference node in SerializableRexNode.");
+  }
+
+  public static SerializableRexNode.Builder builder(RexNode rexNode) {
+    return new SerializableRexNode.Builder(rexNode);
+  }
+
+  /** SerializableRexNode.Builder. */
+  public static class Builder {
+    private RexNode rexNode;
+
+    public Builder(RexNode rexNode) {
+      this.rexNode = rexNode;
+    }
+
+    public SerializableRexNode build() {
+      if (rexNode instanceof RexInputRef) {
+        return new SerializableRexInputRef((RexInputRef) rexNode);
+      } else if (rexNode instanceof RexFieldAccess) {
+        return new SerializableRexFieldAccess((RexFieldAccess) rexNode);
+      }
+
+      throw new UnsupportedOperationException(
+          "Does not support to convert " + rexNode.getType() + " to SerializableRexNode.");
+    }
+  }
+}

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/QueryTest.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/QueryTest.java
@@ -188,12 +188,14 @@ public class QueryTest {
 
   @Test
   @Category(NeedsRunner.class)
+  @Ignore("https://jira.apache.org/jira/browse/BEAM-7072")
   public void sqlQuery5MatchesModelBatch() {
     queryMatchesModel("SqlQuery5TestBatch", new SqlQuery5(CONFIG), new Query5Model(CONFIG), false);
   }
 
   @Test
   @Category(NeedsRunner.class)
+  @Ignore("https://jira.apache.org/jira/browse/BEAM-7072")
   public void sqlQuery5MatchesModelStreaming() {
     queryMatchesModel(
         "SqlQuery5TestStreaming", new SqlQuery5(CONFIG), new Query5Model(CONFIG), true);

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/sql/SqlQuery5Test.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/sql/SqlQuery5Test.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
 import org.joda.time.Instant;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,6 +61,7 @@ public class SqlQuery5Test {
   @Rule public TestPipeline testPipeline = TestPipeline.create();
 
   @Test
+  @Ignore("https://jira.apache.org/jira/browse/BEAM-7072")
   public void testBids() throws Exception {
     assertEquals(Long.valueOf(config.windowSizeSec), Long.valueOf(config.windowPeriodSec * 2));
 


### PR DESCRIPTION
Currently BeamSQL's join rel implementation has limitations:
1. only deal with RexInputRef and direct cast to RexInputRef without checking.
2. only check if join condition is `() [AND () AND ...]`
3. treat non equal operator (e.g. <) as equal operator (e.g. =)

and more

It's a big effort to improve join rel to make it work properly in every cases. In BeamSQL,  there is a also a lack if enough test cases and test utils.

This PR tries to kick off the party and
1. make JOIN condition work on field access. 
2. reject unsupported RexNode by an exception.

This PR is only an attempt to start to generalize join condition.

This PR also partially solves https://jira.apache.org/jira/browse/BEAM-7071.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
