### PR TITLE
[BEAM-3344] Changes for serialize/deserialize PipelineOptions via jackson in DirectRunner

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -133,7 +133,6 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   private final DirectOptions options;
   private final Set<Enforcement> enabledEnforcements;
   private Supplier<Clock> clockSupplier = new NanosOffsetClockSupplier();
-  private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final ObjectMapper MAPPER_WITH_MODULES =
       new ObjectMapper()
           .registerModules(ObjectMapper.findModules(ReflectHelpers.findClassLoader()));

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -133,7 +133,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   private final DirectOptions options;
   private final Set<Enforcement> enabledEnforcements;
   private Supplier<Clock> clockSupplier = new NanosOffsetClockSupplier();
-  private static final ObjectMapper MAPPER_WITH_MODULES =
+  private static final ObjectMapper MAPPER =
       new ObjectMapper()
           .registerModules(ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -156,7 +156,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
     this.enabledEnforcements = Enforcement.enabled(options);
   }
 
-  /** For testing purpose only */
+  /** For testing purpose only. */
   @VisibleForTesting
   protected DirectOptions getPipelineOptions() {
     return options;

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.beam.runners.core.SplittableParDoViaKeyedWorkItems;
 import org.apache.beam.runners.core.construction.PTransformMatchers;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
@@ -41,6 +43,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.runners.PTransformOverride;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.util.UserCodeException;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Supplier;
@@ -130,9 +133,14 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   private final DirectOptions options;
   private final Set<Enforcement> enabledEnforcements;
   private Supplier<Clock> clockSupplier = new NanosOffsetClockSupplier();
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .registerModules(ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
+
 
   /** Construct a {@link DirectRunner} from the provided options. */
   public static DirectRunner fromOptions(PipelineOptions options) {
+    options = MAPPER.convertValue(MAPPER.valueToTree(options), DirectOptions.class);
     return new DirectRunner(options.as(DirectOptions.class));
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.direct;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -25,8 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.beam.runners.core.SplittableParDoViaKeyedWorkItems;
 import org.apache.beam.runners.core.construction.PTransformMatchers;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
@@ -136,7 +135,6 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   private static final ObjectMapper MAPPER =
       new ObjectMapper()
           .registerModules(ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
-
 
   /** Construct a {@link DirectRunner} from the provided options. */
   public static DirectRunner fromOptions(PipelineOptions options) {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -141,7 +141,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   public static DirectRunner fromOptions(PipelineOptions options) {
     try {
       options =
-          MAPPER.readValue(MAPPER_WITH_MODULES.writeValueAsBytes(options), DirectOptions.class);
+          MAPPER.readValue(MAPPER.writeValueAsBytes(options), PipelineOptions.class).as(DirectOptions.class);
     } catch (IOException e) {
       throw new IllegalArgumentException(
           "PipelineOptions specified failed to serialize to JSON.", e);

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -141,7 +141,9 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   public static DirectRunner fromOptions(PipelineOptions options) {
     try {
       options =
-          MAPPER.readValue(MAPPER.writeValueAsBytes(options), PipelineOptions.class).as(DirectOptions.class);
+          MAPPER
+              .readValue(MAPPER.writeValueAsBytes(options), PipelineOptions.class)
+              .as(DirectOptions.class);
     } catch (IOException e) {
       throw new IllegalArgumentException(
           "PipelineOptions specified failed to serialize to JSON.", e);

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -157,7 +157,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
 
   /** For testing purpose only. */
   @VisibleForTesting
-  protected DirectOptions getPipelineOptions() {
+  protected PipelineOptions getPipelineOptions() {
     return options;
   }
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -613,7 +613,6 @@ public class DirectRunnerTest implements Serializable {
     @JsonIgnore
     @Default.String("not overridden")
     String getIgnoredField();
-
     void setIgnoredField(String value);
   }
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -607,7 +607,6 @@ public class DirectRunnerTest implements Serializable {
    */
   public interface TestSerializationOfOptions extends PipelineOptions {
     String getFoo();
-
     void setFoo(String foo);
 
     @JsonIgnore

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -597,7 +597,7 @@ public class DirectRunnerTest implements Serializable {
     assertEquals("testValue", options.getFoo());
     assertEquals("overridden", options.getIgnoredField());
     options = DirectRunner.fromOptions(options).getPipelineOptions().as(TestSerializationOfOptions.class);
-    assertEquals("testValue", options.as(MyOptions.class).getFoo());
+    assertEquals("testValue", options.getFoo());
     assertEquals("not overridden", options.as(MyOptions.class).getIgnoredField());
   }
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -594,7 +594,7 @@ public class DirectRunnerTest implements Serializable {
         PipelineOptionsFactory.fromArgs("--foo=testValue", "--ignoredField=overridden")
             .as(TestSerializationOfOptions.class);
 
-    assertEquals("testValue", options.as(MyOptions.class).getFoo());
+    assertEquals("testValue", options.getFoo());
     assertEquals("overridden", options.as(MyOptions.class).getIgnoredField());
     options = DirectRunner.fromOptions(options).getPipelineOptions();
     assertEquals("testValue", options.as(MyOptions.class).getFoo());

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -596,7 +596,7 @@ public class DirectRunnerTest implements Serializable {
 
     assertEquals("testValue", options.getFoo());
     assertEquals("overridden", options.getIgnoredField());
-    options = DirectRunner.fromOptions(options).getPipelineOptions();
+    options = DirectRunner.fromOptions(options).getPipelineOptions().as(TestSerializationOfOptions.class);
     assertEquals("testValue", options.as(MyOptions.class).getFoo());
     assertEquals("not overridden", options.as(MyOptions.class).getIgnoredField());
   }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -22,9 +22,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -55,6 +57,7 @@ import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.Read;
+import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
@@ -579,6 +582,39 @@ public class DirectRunnerTest implements Serializable {
     thrown.expectCause(isA(CoderException.class));
     thrown.expectMessage("Cannot decode a long");
     p.run();
+  }
+
+  /**
+   * Tests that {@link DirectRunner#fromOptions(PipelineOptions)} drops {@link PipelineOptions}
+   * marked with {@link JsonIgnore} fields.
+   */
+  @Test
+  public void testFromOptionsIfIgnoredFieldsGettingDropped() {
+    PipelineOptions options =
+        PipelineOptionsFactory.fromArgs("--foo=testValue", "--ignoredField=overridden")
+            .as(MyOptions.class);
+
+    assertEquals("testValue", options.as(MyOptions.class).getFoo());
+    assertEquals("overridden", options.as(MyOptions.class).getIgnoredField());
+    options = DirectRunner.fromOptions(options).getPipelineOptions();
+    assertEquals("testValue", options.as(MyOptions.class).getFoo());
+    assertEquals("not overridden", options.as(MyOptions.class).getIgnoredField());
+  }
+
+  /**
+   * Options for testing if {@link DirectRunner} drops {@link PipelineOptions} marked with {@link
+   * JsonIgnore} fields.
+   */
+  private interface MyOptions extends DirectOptions {
+    String getFoo();
+
+    void setFoo(String foo);
+
+    @JsonIgnore
+    @Default.String("not overridden")
+    String getIgnoredField();
+
+    void setIgnoredField(String value);
   }
 
   private static class LongNoDecodeCoder extends AtomicCoder<Long> {

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -605,7 +605,7 @@ public class DirectRunnerTest implements Serializable {
    * Options for testing if {@link DirectRunner} drops {@link PipelineOptions} marked with {@link
    * JsonIgnore} fields.
    */
-  public interface MyOptions extends DirectOptions {
+  public interface TestSerializationOfOptions extends PipelineOptions {
     String getFoo();
 
     void setFoo(String foo);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -590,7 +590,7 @@ public class DirectRunnerTest implements Serializable {
    */
   @Test
   public void testFromOptionsIfIgnoredFieldsGettingDropped() {
-    PipelineOptions options =
+    TestSerializationOfOptions options =
         PipelineOptionsFactory.fromArgs("--foo=testValue", "--ignoredField=overridden")
             .as(MyOptions.class);
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -598,7 +598,7 @@ public class DirectRunnerTest implements Serializable {
     assertEquals("overridden", options.getIgnoredField());
     options = DirectRunner.fromOptions(options).getPipelineOptions().as(TestSerializationOfOptions.class);
     assertEquals("testValue", options.getFoo());
-    assertEquals("not overridden", options.as(MyOptions.class).getIgnoredField());
+    assertEquals("not overridden", options.getIgnoredField());
   }
 
   /**

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -592,7 +592,7 @@ public class DirectRunnerTest implements Serializable {
   public void testFromOptionsIfIgnoredFieldsGettingDropped() {
     TestSerializationOfOptions options =
         PipelineOptionsFactory.fromArgs("--foo=testValue", "--ignoredField=overridden")
-            .as(MyOptions.class);
+            .as(TestSerializationOfOptions.class);
 
     assertEquals("testValue", options.as(MyOptions.class).getFoo());
     assertEquals("overridden", options.as(MyOptions.class).getIgnoredField());

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -595,7 +595,7 @@ public class DirectRunnerTest implements Serializable {
             .as(TestSerializationOfOptions.class);
 
     assertEquals("testValue", options.getFoo());
-    assertEquals("overridden", options.as(MyOptions.class).getIgnoredField());
+    assertEquals("overridden", options.getIgnoredField());
     options = DirectRunner.fromOptions(options).getPipelineOptions();
     assertEquals("testValue", options.as(MyOptions.class).getFoo());
     assertEquals("not overridden", options.as(MyOptions.class).getIgnoredField());

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -605,7 +605,7 @@ public class DirectRunnerTest implements Serializable {
    * Options for testing if {@link DirectRunner} drops {@link PipelineOptions} marked with {@link
    * JsonIgnore} fields.
    */
-  private interface MyOptions extends DirectOptions {
+  public interface MyOptions extends DirectOptions {
     String getFoo();
 
     void setFoo(String foo);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -596,7 +596,8 @@ public class DirectRunnerTest implements Serializable {
 
     assertEquals("testValue", options.getFoo());
     assertEquals("overridden", options.getIgnoredField());
-    options = DirectRunner.fromOptions(options).getPipelineOptions().as(TestSerializationOfOptions.class);
+    options =
+        DirectRunner.fromOptions(options).getPipelineOptions().as(TestSerializationOfOptions.class);
     assertEquals("testValue", options.getFoo());
     assertEquals("not overridden", options.getIgnoredField());
   }
@@ -607,11 +608,13 @@ public class DirectRunnerTest implements Serializable {
    */
   public interface TestSerializationOfOptions extends PipelineOptions {
     String getFoo();
+
     void setFoo(String foo);
 
     @JsonIgnore
     @Default.String("not overridden")
     String getIgnoredField();
+
     void setIgnoredField(String value);
   }
 


### PR DESCRIPTION

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
