### PR TITLE
Allow Schema field selections in DoFn using NewDoFn injection

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDoNaiveBounded.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDoNaiveBounded.java
@@ -238,7 +238,7 @@ public class SplittableParDoNaiveBounded {
       }
 
       @Override
-      public Object schemaElement(DoFn<InputT, OutputT> doFn) {
+      public Object schemaElement(int index) {
         throw new UnsupportedOperationException();
       }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -121,7 +121,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
               }
 
               @Override
-              public Object schemaElement(DoFn<InputT, OutputT> doFn) {
+              public Object schemaElement(int index) {
                 throw new UnsupportedOperationException("Not supported in SplittableDoFn");
               }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.transforms.DoFn.MultiOutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFnOutputReceivers;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
@@ -301,7 +302,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public Object schemaElement(DoFn<InputT, OutputT> doFn) {
+    public Object schemaElement(int index) {
       throw new UnsupportedOperationException(
           "Element parameters are not supported outside of @ProcessElement method.");
     }
@@ -415,7 +416,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public Object schemaElement(DoFn<InputT, OutputT> doFn) {
+    public Object schemaElement(int index) {
       throw new UnsupportedOperationException(
           "Cannot access element outside of @ProcessElement method.");
     }
@@ -631,9 +632,9 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public Object schemaElement(DoFn<InputT, OutputT> doFn) {
-      Row row = schemaCoder.getToRowFunction().apply(element());
-      return doFnSchemaInformation.getElementParameterSchema().getFromRowFunction().apply(row);
+    public Object schemaElement(int index) {
+      SerializableFunction converter = doFnSchemaInformation.getElementConverters().get(index);
+      return converter.apply(element());
     }
 
     @Override
@@ -781,7 +782,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public Object schemaElement(DoFn<InputT, OutputT> doFn) {
+    public Object schemaElement(int index) {
       throw new UnsupportedOperationException("Element parameters are not supported.");
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
@@ -78,22 +78,52 @@ public class SchemaRegistry {
     @Nullable
     @Override
     public <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
-      SchemaProvider schemaProvider = providers.get(typeDescriptor);
-      return (schemaProvider != null) ? schemaProvider.schemaFor(typeDescriptor) : null;
+      TypeDescriptor<?> type = typeDescriptor;
+      do {
+        SchemaProvider schemaProvider = providers.get(type);
+        if (schemaProvider != null) {
+          return schemaProvider.schemaFor(type);
+        }
+        Class<?> superClass = type.getRawType().getSuperclass();
+        if (superClass == null || superClass.equals(Object.class)) {
+          return null;
+        }
+        type = TypeDescriptor.of(superClass);
+      } while (true);
     }
 
     @Nullable
     @Override
     public <T> SerializableFunction<T, Row> toRowFunction(TypeDescriptor<T> typeDescriptor) {
-      SchemaProvider schemaProvider = providers.get(typeDescriptor);
-      return (schemaProvider != null) ? schemaProvider.toRowFunction(typeDescriptor) : null;
+      TypeDescriptor<?> type = typeDescriptor;
+      do {
+        SchemaProvider schemaProvider = providers.get(type);
+        if (schemaProvider != null) {
+          return (SerializableFunction<T, Row>) schemaProvider.toRowFunction(type);
+        }
+        Class<?> superClass = type.getRawType().getSuperclass();
+        if (superClass == null || superClass.equals(Object.class)) {
+          return null;
+        }
+        type = TypeDescriptor.of(superClass);
+      } while (true);
     }
 
     @Nullable
     @Override
     public <T> SerializableFunction<Row, T> fromRowFunction(TypeDescriptor<T> typeDescriptor) {
-      SchemaProvider schemaProvider = providers.get(typeDescriptor);
-      return (schemaProvider != null) ? schemaProvider.fromRowFunction(typeDescriptor) : null;
+      TypeDescriptor<?> type = typeDescriptor;
+      do {
+        SchemaProvider schemaProvider = providers.get(type);
+        if (schemaProvider != null) {
+          return (SerializableFunction<Row, T>) schemaProvider.fromRowFunction(type);
+        }
+        Class<?> superClass = type.getRawType().getSuperclass();
+        if (superClass == null || superClass.equals(Object.class)) {
+          return null;
+        }
+        type = TypeDescriptor.of(superClass);
+      } while (true);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/annotations/DefaultSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/annotations/DefaultSchema.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.schemas.annotations;
 
 import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
 
+import java.io.Serializable;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -73,7 +74,7 @@ public @interface DefaultSchema {
   class DefaultSchemaProvider implements SchemaProvider {
     final Map<TypeDescriptor, ProviderAndDescriptor> cachedProviders = Maps.newConcurrentMap();
 
-    private static final class ProviderAndDescriptor {
+    private static final class ProviderAndDescriptor implements Serializable {
       final SchemaProvider schemaProvider;
       final TypeDescriptor<?> typeDescriptor;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
@@ -20,15 +20,13 @@ package org.apache.beam.sdk.schemas.transforms;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
-import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
-import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.schemas.SchemaRegistry;
+import org.apache.beam.sdk.schemas.utils.ConvertHelpers;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -99,7 +97,6 @@ public class Convert {
   private static class ConvertTransform<InputT, OutputT>
       extends PTransform<PCollection<InputT>, PCollection<OutputT>> {
     TypeDescriptor<OutputT> outputTypeDescriptor;
-    Schema unboxedSchema = null;
 
     ConvertTransform(TypeDescriptor<OutputT> outputTypeDescriptor) {
       this.outputTypeDescriptor = outputTypeDescriptor;
@@ -124,62 +121,34 @@ public class Convert {
         throw new RuntimeException("Convert requires a schema on the input.");
       }
 
-      final SchemaCoder<OutputT> outputSchemaCoder;
-      boolean toRow = outputTypeDescriptor.equals(TypeDescriptor.of(Row.class));
-      if (toRow) {
-        // If the output is of type Row, then just forward the schema of the input type to the
-        // output.
-        outputSchemaCoder =
-            (SchemaCoder<OutputT>)
-                SchemaCoder.of(
-                    input.getSchema(),
-                    SerializableFunctions.identity(),
-                    SerializableFunctions.identity());
-      } else {
-        // Otherwise, try to find a schema for the output type in the schema registry.
-        SchemaRegistry registry = input.getPipeline().getSchemaRegistry();
-        try {
-          outputSchemaCoder =
-              SchemaCoder.of(
-                  registry.getSchema(outputTypeDescriptor),
-                  registry.getToRowFunction(outputTypeDescriptor),
-                  registry.getFromRowFunction(outputTypeDescriptor));
-
-          Schema outputSchema = outputSchemaCoder.getSchema();
-          if (!outputSchema.assignableToIgnoreNullable(input.getSchema())) {
-            // We also support unboxing nested Row schemas, so attempt that.
-            // TODO: Support unboxing to primitive types as well.
-            unboxedSchema = getBoxedNestedSchema(input.getSchema());
-            if (unboxedSchema == null || !outputSchema.assignableToIgnoreNullable(unboxedSchema)) {
-              Schema checked = (unboxedSchema == null) ? input.getSchema() : unboxedSchema;
-              throw new RuntimeException(
-                  "Cannot convert between types that don't have equivalent schemas."
-                      + " input schema: "
-                      + checked
-                      + " output schema: "
-                      + outputSchemaCoder.getSchema());
-            }
-          }
-        } catch (NoSuchSchemaException e) {
-          throw new RuntimeException("No schema registered for " + outputTypeDescriptor);
-        }
-      }
-
-      return input
-          .apply(
+      SchemaRegistry registry = input.getPipeline().getSchemaRegistry();
+      ConvertHelpers.ConvertedSchemaInformation<OutputT> converted =
+          ConvertHelpers.getConvertedSchemaInformation(
+              input.getSchema(), outputTypeDescriptor, registry);
+      boolean unbox = converted.unboxedType != null;
+      PCollection<OutputT> output =
+          input.apply(
               ParDo.of(
                   new DoFn<InputT, OutputT>() {
                     @ProcessElement
                     public void processElement(@Element Row row, OutputReceiver<OutputT> o) {
                       // Read the row, potentially unboxing if necessary.
-                      Row input = (unboxedSchema == null) ? row : row.getValue(0);
-                      o.output(outputSchemaCoder.getFromRowFunction().apply(input));
+                      Object input = unbox ? row : row.getValue(0);
+                      // The output has a schema, so we need to convert to the appropriate type.
+                      o.output(converted.outputSchemaCoder.getFromRowFunction().apply((Row) input));
                     }
-                  }))
-          .setSchema(
-              outputSchemaCoder.getSchema(),
-              outputSchemaCoder.getToRowFunction(),
-              outputSchemaCoder.getFromRowFunction());
+                  }));
+      if (converted.outputSchemaCoder != null) {
+        output =
+            output.setSchema(
+                converted.outputSchemaCoder.getSchema(),
+                converted.outputSchemaCoder.getToRowFunction(),
+                converted.outputSchemaCoder.getFromRowFunction());
+      } else {
+        // TODO: Support full unboxing and boxing in Create.
+        throw new RuntimeException("Unboxing is not yet supported in the Create transform");
+      }
+      return output;
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
@@ -133,7 +133,7 @@ public class Convert {
                     @ProcessElement
                     public void processElement(@Element Row row, OutputReceiver<OutputT> o) {
                       // Read the row, potentially unboxing if necessary.
-                      Object input = unbox ? row : row.getValue(0);
+                      Object input = unbox ? row.getValue(0) : row;
                       // The output has a schema, so we need to convert to the appropriate type.
                       o.output(converted.outputSchemaCoder.getFromRowFunction().apply((Row) input));
                     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Select.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Select.java
@@ -64,7 +64,7 @@ import org.apache.beam.sdk.values.Row;
  *
  * <pre>{@code
  * PCollection<UserEvent> events = readUserEvents();
- * PCollection<Row> rows = event.apply(Select.fieldNames("location")
+ * PCollection<Location> rows = event.apply(Select.fieldNames("location")
  *                              .apply(Convert.to(Location.class));
  * }</pre>
  */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import javax.annotation.Nullable;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.dynamic.scaffold.InstrumentedType;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.ByteCodeAppender;
+import net.bytebuddy.implementation.bytecode.ByteCodeAppender.Size;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.member.MethodReturn;
+import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.beam.sdk.schemas.JavaFieldSchema.JavaFieldTypeSupplier;
+import org.apache.beam.sdk.schemas.NoSuchSchemaException;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.SchemaRegistry;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertType;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertValueForSetter;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SerializableFunctions;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.primitives.Primitives;
+
+/** Helper functions for converting between equivalent schema types. */
+public class ConvertHelpers {
+  /** Return value after converting a schema. */
+  public static class ConvertedSchemaInformation<T> {
+    // If the output type is a composite type, this is the schema coder.
+    @Nullable public final SchemaCoder<T> outputSchemaCoder;
+    @Nullable public final FieldType unboxedType;
+
+    public ConvertedSchemaInformation(
+        @Nullable SchemaCoder<T> outputSchemaCoder, @Nullable FieldType unboxedType) {
+      this.outputSchemaCoder = outputSchemaCoder;
+      this.unboxedType = unboxedType;
+    }
+  }
+
+  /** Get the coder used for converting from an inputSchema to a given type. */
+  public static <T> ConvertedSchemaInformation<T> getConvertedSchemaInformation(
+      Schema inputSchema, TypeDescriptor<T> outputType, SchemaRegistry schemaRegistry) {
+    ConvertedSchemaInformation<T> convertedSchema = null;
+    boolean toRow = outputType.equals(TypeDescriptor.of(Row.class));
+    if (toRow) {
+      // If the output is of type Row, then just forward the schema of the input type to the
+      // output.
+      convertedSchema =
+          new ConvertedSchemaInformation<>(
+              (SchemaCoder<T>)
+                  SchemaCoder.of(
+                      inputSchema,
+                      SerializableFunctions.identity(),
+                      SerializableFunctions.identity()),
+              null);
+    } else {
+      // Otherwise, try to find a schema for the output type in the schema registry.
+      Schema outputSchema = null;
+      SchemaCoder<T> outputSchemaCoder = null;
+      try {
+        outputSchema = schemaRegistry.getSchema(outputType);
+        outputSchemaCoder =
+            SchemaCoder.of(
+                outputSchema,
+                schemaRegistry.getToRowFunction(outputType),
+                schemaRegistry.getFromRowFunction(outputType));
+      } catch (NoSuchSchemaException e) {
+
+      }
+      FieldType unboxedType = null;
+      // TODO: Properly handle nullable.
+      if (outputSchema == null || !outputSchema.assignableToIgnoreNullable(inputSchema)) {
+        // The schema is not convertible directly. Attempt to unbox it and see if the schema matches then.
+        Schema checkedSchema = inputSchema;
+        if (inputSchema.getFieldCount() == 1) {
+          unboxedType = inputSchema.getField(0).getType();
+          if (unboxedType.getTypeName().isCompositeType()
+              && !outputSchema.assignableToIgnoreNullable(unboxedType.getRowSchema())) {
+            checkedSchema = unboxedType.getRowSchema();
+          } else {
+            checkedSchema = null;
+          }
+        }
+        if (checkedSchema != null) {
+          throw new RuntimeException(
+              "Cannot convert between types that don't have equivalent schemas."
+                  + " input schema: "
+                  + checkedSchema
+                  + " output schema: "
+                  + outputSchema);
+        }
+      }
+      convertedSchema = new ConvertedSchemaInformation<T>(outputSchemaCoder, unboxedType);
+    }
+    return convertedSchema;
+  }
+
+  /**
+   * Returns a function to convert a Row into a primitive type. This only works when the row schema
+   * contains a single field, and that field is convertible to the primitive type.
+   */
+  @SuppressWarnings("unchecked")
+  public static <OutputT> SerializableFunction<?, OutputT> getConvertPrimitive(
+      FieldType fieldType, TypeDescriptor<?> outputTypeDescriptor) {
+    FieldType expectedFieldType =
+        StaticSchemaInference.fieldFromType(outputTypeDescriptor, JavaFieldTypeSupplier.INSTANCE);
+    if (!expectedFieldType.equals(fieldType)) {
+      throw new IllegalArgumentException(
+          "Element argument type "
+              + outputTypeDescriptor
+              + " does not work with expected schema field type "
+              + fieldType);
+    }
+
+    Type expectedInputType = new ConvertType(true).convert(outputTypeDescriptor);
+
+    TypeDescriptor<?> outputType = outputTypeDescriptor;
+    if (outputType.getRawType().isPrimitive()) {
+      // A SerializableFunction can only return an Object type, so if the DoFn parameter is a
+      // primitive type, then box it for the return. The return type will be unboxed before being
+      // forwarded to the DoFn parameter.
+      outputType = TypeDescriptor.of(Primitives.wrap(outputType.getRawType()));
+    }
+
+    TypeDescription.Generic genericType =
+        TypeDescription.Generic.Builder.parameterizedType(
+                SerializableFunction.class, expectedInputType, outputType.getType())
+            .build();
+    DynamicType.Builder<SerializableFunction> builder =
+        (DynamicType.Builder<SerializableFunction>) new ByteBuddy().subclass(genericType);
+    try {
+      return builder
+          .method(ElementMatchers.named("apply"))
+          .intercept(new ConvertPrimitiveInstruction(outputType))
+          .make()
+          .load(ReflectHelpers.findClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+          .getLoaded()
+          .getDeclaredConstructor()
+          .newInstance();
+    } catch (InstantiationException
+        | IllegalAccessException
+        | NoSuchMethodException
+        | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static class ConvertPrimitiveInstruction implements Implementation {
+    private final TypeDescriptor<?> outputFieldType;
+
+    public ConvertPrimitiveInstruction(TypeDescriptor<?> outputFieldType) {
+      this.outputFieldType = outputFieldType;
+    }
+
+    @Override
+    public InstrumentedType prepare(InstrumentedType instrumentedType) {
+      return instrumentedType;
+    }
+
+    @Override
+    public ByteCodeAppender appender(final Target implementationTarget) {
+      return (methodVisitor, implementationContext, instrumentedMethod) -> {
+        int numLocals = 1 + instrumentedMethod.getParameters().size();
+
+        // Method param is offset 1 (offset 0 is the this parameter).
+        StackManipulation readValue = MethodVariableAccess.REFERENCE.loadFrom(1);
+        StackManipulation stackManipulation =
+            new StackManipulation.Compound(
+                new ConvertValueForSetter(readValue).convert(outputFieldType),
+                MethodReturn.REFERENCE);
+
+        StackManipulation.Size size = stackManipulation.apply(methodVisitor, implementationContext);
+        return new Size(size.getMaximalSize(), numLocals);
+      };
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
@@ -95,7 +95,8 @@ public class ConvertHelpers {
       FieldType unboxedType = null;
       // TODO: Properly handle nullable.
       if (outputSchema == null || !outputSchema.assignableToIgnoreNullable(inputSchema)) {
-        // The schema is not convertible directly. Attempt to unbox it and see if the schema matches then.
+        // The schema is not convertible directly. Attempt to unbox it and see if the schema matches
+        // then.
         Schema checkedSchema = inputSchema;
         if (inputSchema.getFieldCount() == 1) {
           unboxedType = inputSchema.getField(0).getType();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.schemas.utils;
 
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
@@ -50,7 +51,7 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.primitives.Primitive
 /** Helper functions for converting between equivalent schema types. */
 public class ConvertHelpers {
   /** Return value after converting a schema. */
-  public static class ConvertedSchemaInformation<T> {
+  public static class ConvertedSchemaInformation<T> implements Serializable {
     // If the output type is a composite type, this is the schema coder.
     @Nullable public final SchemaCoder<T> outputSchemaCoder;
     @Nullable public final FieldType unboxedType;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
@@ -91,8 +91,8 @@ public class StaticSchemaInference {
     return builder.build();
   }
 
-  // Map a Java field type to a Beam Schema FieldType.
-  private static Schema.FieldType fieldFromType(
+  /** Map a Java field type to a Beam Schema FieldType. */
+  public static Schema.FieldType fieldFromType(
       TypeDescriptor type, FieldValueTypeSupplier fieldValueTypeSupplier) {
     FieldType primitiveType = PRIMITIVE_TYPES.get(type.getRawType());
     if (primitiveType != null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -251,7 +251,7 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
             }
 
             @Override
-            public InputT schemaElement(DoFn<InputT, OutputT> doFn) {
+            public InputT schemaElement(int index) {
               throw new UnsupportedOperationException("Schemas are not supported by DoFnTester");
             }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -39,6 +39,8 @@ import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.schemas.SchemaRegistry;
+import org.apache.beam.sdk.schemas.utils.ConvertHelpers;
+import org.apache.beam.sdk.schemas.utils.SelectHelpers;
 import org.apache.beam.sdk.state.StateSpec;
 import org.apache.beam.sdk.transforms.DoFn.WindowedContext;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -59,7 +61,6 @@ import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
 import org.apache.beam.sdk.values.PValue;
-import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -435,7 +436,7 @@ public class ParDo {
     }
   }
 
-  private static void validateFieldAccessParameter(
+  private static FieldAccessDescriptor getFieldAccessDescriptorFromParameter(
       @Nullable String fieldAccessString,
       Schema inputSchema,
       Map<String, FieldAccessDeclaration> fieldAccessDeclarations,
@@ -448,25 +449,25 @@ public class ParDo {
     // here as well to catch these errors.
     FieldAccessDescriptor fieldAccessDescriptor = null;
     if (fieldAccessString == null) {
-      // This is the case where no FieldId is defined, just an @Element Row row. Default to all
-      // fields accessed.
+      // This is the case where no FieldId is defined. Default to all fields accessed.
       fieldAccessDescriptor = FieldAccessDescriptor.withAllFields();
     } else {
-      // In this case, we expect to have a FieldAccessDescriptor defined in the class.
+      // If there is a FieldAccessDescriptor in the class with this id, use that.
       FieldAccessDeclaration fieldAccessDeclaration =
           fieldAccessDeclarations.get(fieldAccessString);
-      checkArgument(
-          fieldAccessDeclaration != null,
-          "No FieldAccessDeclaration  defined with id",
-          fieldAccessString);
-      checkArgument(fieldAccessDeclaration.field().getType().equals(FieldAccessDescriptor.class));
-      try {
-        fieldAccessDescriptor = (FieldAccessDescriptor) fieldAccessDeclaration.field().get(fn);
-      } catch (IllegalAccessException e) {
-        throw new RuntimeException(e);
+      if (fieldAccessDeclaration != null) {
+        checkArgument(fieldAccessDeclaration.field().getType().equals(FieldAccessDescriptor.class));
+        try {
+          fieldAccessDescriptor = (FieldAccessDescriptor) fieldAccessDeclaration.field().get(fn);
+        } catch (IllegalAccessException e) {
+          throw new RuntimeException(e);
+        }
+      } else {
+        // Otherwise, interpret the string as a field-name expression.
+        fieldAccessDescriptor = FieldAccessDescriptor.withFieldNames(fieldAccessString);
       }
     }
-    fieldAccessDescriptor.resolve(inputSchema);
+    return fieldAccessDescriptor.resolve(inputSchema);
   }
 
   /**
@@ -571,64 +572,44 @@ public class ParDo {
       DoFn<?, ?> fn, PCollection<?> input) {
     DoFnSignature signature = DoFnSignatures.getSignature(fn.getClass());
     DoFnSignature.ProcessElementMethod processElementMethod = signature.processElement();
-    SchemaElementParameter elementParameter = processElementMethod.getSchemaElementParameter();
-    boolean validateInputSchema = elementParameter != null;
-    TypeDescriptor<?> elementT = null;
-    if (validateInputSchema) {
-      elementT = (TypeDescriptor<?>) elementParameter.elementT();
-    }
-
-    DoFnSchemaInformation doFnSchemaInformation = DoFnSchemaInformation.create();
-    if (validateInputSchema) {
-      // Element type doesn't match input type, so we need to covnert.
+    if (!processElementMethod.getSchemaElementParameters().isEmpty()) {
       if (!input.hasSchema()) {
         throw new IllegalArgumentException("Type of @Element must match the DoFn type" + input);
       }
+    }
 
-      validateFieldAccessParameter(
-          elementParameter.fieldAccessString(),
-          input.getSchema(),
-          signature.fieldAccessDeclarations(),
-          fn);
-
-      boolean toRow = elementT.equals(TypeDescriptor.of(Row.class));
-      if (toRow) {
+    SchemaRegistry schemaRegistry = input.getPipeline().getSchemaRegistry();
+    DoFnSchemaInformation doFnSchemaInformation = DoFnSchemaInformation.create();
+    for (SchemaElementParameter parameter : processElementMethod.getSchemaElementParameters()) {
+      TypeDescriptor<?> elementT = parameter.elementT();
+      FieldAccessDescriptor accessDescriptor =
+          getFieldAccessDescriptorFromParameter(
+              parameter.fieldAccessString(),
+              input.getSchema(),
+              signature.fieldAccessDeclarations(),
+              fn);
+      Schema selectedSchema = SelectHelpers.getOutputSchema(input.getSchema(), accessDescriptor);
+      ConvertHelpers.ConvertedSchemaInformation converted =
+          ConvertHelpers.getConvertedSchemaInformation(selectedSchema, elementT, schemaRegistry);
+      if (converted.outputSchemaCoder != null) {
         doFnSchemaInformation =
             doFnSchemaInformation.withElementParameterSchema(
-                SchemaCoder.of(
-                    input.getSchema(),
-                    SerializableFunctions.identity(),
-                    SerializableFunctions.identity()));
+                (SchemaCoder<?>) input.getCoder(),
+                accessDescriptor,
+                selectedSchema,
+                converted.outputSchemaCoder,
+                converted.unboxedType != null);
       } else {
-        // For now we assume the parameter is not of type Row (TODO: change this)
-        SchemaRegistry schemaRegistry = input.getPipeline().getSchemaRegistry();
-        try {
-          Schema schema = schemaRegistry.getSchema(elementT);
-          SerializableFunction toRowFunction = schemaRegistry.getToRowFunction(elementT);
-          SerializableFunction fromRowFunction = schemaRegistry.getFromRowFunction(elementT);
-          doFnSchemaInformation =
-              doFnSchemaInformation.withElementParameterSchema(
-                  SchemaCoder.of(schema, toRowFunction, fromRowFunction));
-
-          // assert matches input schema.
-          // TODO: Properly handle nullable.
-          if (!doFnSchemaInformation
-              .getElementParameterSchema()
-              .getSchema()
-              .assignableToIgnoreNullable(input.getSchema())) {
-            throw new IllegalArgumentException(
-                "Input to DoFn has schema: "
-                    + input.getSchema()
-                    + " However @ElementParameter of type "
-                    + elementT
-                    + " has incompatible schema "
-                    + doFnSchemaInformation.getElementParameterSchema().getSchema());
-          }
-        } catch (NoSuchSchemaException e) {
-          throw new RuntimeException("No schema registered for " + elementT);
-        }
+        // If the selected schema is a Row containing a single primitive type (which is the output
+        // of Select when selecting a primitive), attempt to unbox it and match against the
+        // parameter.
+        checkArgument(converted.unboxedType != null);
+        doFnSchemaInformation =
+            doFnSchemaInformation.withUnboxParameter(
+                (SchemaCoder<?>) input.getCoder(), accessDescriptor, selectedSchema, elementT);
       }
     }
+
     return doFnSchemaInformation;
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -593,7 +593,7 @@ public class ParDo {
           ConvertHelpers.getConvertedSchemaInformation(selectedSchema, elementT, schemaRegistry);
       if (converted.outputSchemaCoder != null) {
         doFnSchemaInformation =
-            doFnSchemaInformation.withElementParameterSchema(
+            doFnSchemaInformation.withSelectFromSchemaParameter(
                 (SchemaCoder<?>) input.getCoder(),
                 accessDescriptor,
                 selectedSchema,
@@ -605,7 +605,7 @@ public class ParDo {
         // parameter.
         checkArgument(converted.unboxedType != null);
         doFnSchemaInformation =
-            doFnSchemaInformation.withUnboxParameter(
+            doFnSchemaInformation.withUnboxPrimitiveParameter(
                 (SchemaCoder<?>) input.getCoder(), accessDescriptor, selectedSchema, elementT);
       }
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -132,16 +132,19 @@ public interface DoFnInvoker<InputT, OutputT> {
     /** Provide a {@link DoFn.OnTimerContext} to use with the given {@link DoFn}. */
     DoFn<InputT, OutputT>.OnTimerContext onTimerContext(DoFn<InputT, OutputT> doFn);
 
-    /** Provide a link to the input element. */
+    /** Provide a reference to the input element. */
     InputT element(DoFn<InputT, OutputT> doFn);
 
-    /** Provide a link to the input element. */
+    /**
+     * Provide a reference to the selected schema field corresponding to the input argument
+     * specified by index.
+     */
     Object schemaElement(int index);
 
-    /** Provide a link to the input element timestamp. */
+    /** Provide a reference to the input element timestamp. */
     Instant timestamp(DoFn<InputT, OutputT> doFn);
 
-    /** Provide a link to the time domain for a timer firing. */
+    /** Provide a reference to the time domain for a timer firing. */
     TimeDomain timeDomain(DoFn<InputT, OutputT> doFn);
 
     /** Provide a {@link OutputReceiver} for outputting to the default output. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -136,7 +136,7 @@ public interface DoFnInvoker<InputT, OutputT> {
     InputT element(DoFn<InputT, OutputT> doFn);
 
     /** Provide a link to the input element. */
-    Object schemaElement(DoFn<InputT, OutputT> doFn);
+    Object schemaElement(int index);
 
     /** Provide a link to the input element timestamp. */
     Instant timestamp(DoFn<InputT, OutputT> doFn);
@@ -188,7 +188,7 @@ public interface DoFnInvoker<InputT, OutputT> {
     }
 
     @Override
-    public InputT schemaElement(DoFn<InputT, OutputT> doFn) {
+    public InputT schemaElement(int index) {
       throw new UnsupportedOperationException(
           String.format(
               "Should never call non-overridden methods of %s",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -398,8 +399,12 @@ public abstract class DoFnSignature {
     }
 
     public static SchemaElementParameter schemaElementParameter(
-        TypeDescriptor<?> elementT, @Nullable String fieldAccessId) {
-      return new AutoValue_DoFnSignature_Parameter_SchemaElementParameter(elementT, fieldAccessId);
+        TypeDescriptor<?> elementT, @Nullable String fieldAccessString, int index) {
+      return new AutoValue_DoFnSignature_Parameter_SchemaElementParameter.Builder()
+          .setElementT(elementT)
+          .setFieldAccessString(fieldAccessString)
+          .setIndex(index)
+          .build();
     }
 
     public static TimestampParameter timestampParameter() {
@@ -511,6 +516,22 @@ public abstract class DoFnSignature {
 
       @Nullable
       public abstract String fieldAccessString();
+
+      public abstract int index();
+
+      /** Builder class. */
+      @AutoValue.Builder
+      public abstract static class Builder {
+        public abstract Builder setElementT(TypeDescriptor<?> elementT);
+
+        public abstract Builder setFieldAccessString(@Nullable String fieldAccess);
+
+        public abstract Builder setIndex(int index);
+
+        public abstract SchemaElementParameter build();
+      }
+
+      public abstract Builder toBuilder();
     }
 
     /**
@@ -691,12 +712,11 @@ public abstract class DoFnSignature {
     }
 
     @Nullable
-    public SchemaElementParameter getSchemaElementParameter() {
-      Optional<Parameter> parameter =
-          extraParameters().stream()
-              .filter(Predicates.instanceOf(SchemaElementParameter.class)::apply)
-              .findFirst();
-      return parameter.isPresent() ? ((SchemaElementParameter) parameter.get()) : null;
+    public List<SchemaElementParameter> getSchemaElementParameters() {
+      return extraParameters().stream()
+          .filter(Predicates.instanceOf(SchemaElementParameter.class)::apply)
+          .map(SchemaElementParameter.class::cast)
+          .collect(Collectors.toList());
     }
 
     /** The {@link OutputReceiverParameter} for a main output, or null if there is none. */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
@@ -556,7 +556,7 @@ public class ParDoSchemaTest implements Serializable {
                           FieldAccessDescriptor.withFieldNames("integerField");
 
                       @FieldAccess("intsSelector")
-                      final FieldAccessDescriptor stringsSelector =
+                      final FieldAccessDescriptor intsSelector =
                           FieldAccessDescriptor.withFieldNames("ints");
 
                       @ProcessElement

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
@@ -25,6 +25,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -66,6 +68,7 @@ import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.joda.time.Instant;
@@ -181,7 +184,35 @@ public class DoFnSignaturesTest {
               @ProcessElement
               public void process(@Element Row row) {}
             }.getClass());
-    assertThat(sig.processElement().getSchemaElementParameter(), notNullValue());
+    assertFalse(sig.processElement().getSchemaElementParameters().isEmpty());
+  }
+
+  @Test
+  public void testMultipleSchemaParameters() {
+    DoFnSignature sig =
+        DoFnSignatures.getSignature(
+            new DoFn<String, String>() {
+              @ProcessElement
+              public void process(
+                  @Element Row row1,
+                  @Timestamp Instant ts,
+                  @Element Row row2,
+                  OutputReceiver<String> o,
+                  @Element Integer intParameter) {}
+            }.getClass());
+    assertEquals(3, sig.processElement().getSchemaElementParameters().size());
+    assertEquals(0, sig.processElement().getSchemaElementParameters().get(0).index());
+    assertEquals(
+        TypeDescriptors.rows(),
+        sig.processElement().getSchemaElementParameters().get(0).elementT());
+    assertEquals(1, sig.processElement().getSchemaElementParameters().get(1).index());
+    assertEquals(
+        TypeDescriptors.rows(),
+        sig.processElement().getSchemaElementParameters().get(1).elementT());
+    assertEquals(2, sig.processElement().getSchemaElementParameters().get(2).index());
+    assertEquals(
+        TypeDescriptors.integers(),
+        sig.processElement().getSchemaElementParameters().get(2).elementT());
   }
 
   @Test
@@ -202,7 +233,7 @@ public class DoFnSignaturesTest {
     assertThat(field.getName(), equalTo("fieldAccess"));
     assertThat(field.get(doFn), equalTo(descriptor));
 
-    assertThat(sig.processElement().getSchemaElementParameter(), notNullValue());
+    assertFalse(sig.processElement().getSchemaElementParameters().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
This change enables selecting fields out of input schemas directly in a DoFn. Fields can automatically be converted to user types if the types match.

For example, if a input schema contained a latitude and a longitude field, you could write:

ParDo.of(new DoFn<>() {
   @ProcessElement public void process(
      @FieldAccess("latitude") double latitude, @FieldAccess('longitude") double longitude) {
   }               
});

And Beam will automatically extract those fields from the input schema and inject just them into the dofn.

Beam will also automatically convert to user types. If the input schema has a nested row that matches a custom user type's schema, the user can use that Java type in their DoFn parameter and Beam will convert the field to that type.

R: @TheNeuralBit 