### PR TITLE
[BEAM-2939] Add a new sdf E2E test without defer_remainder

### DIFF
--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -220,6 +220,9 @@ if __name__ == '__main__':
     def test_sdf(self):
       raise unittest.SkipTest("BEAM-2939")
 
+    def test_sdf_with_sdf_initiated_checkpointing(self):
+      raise unittest.SkipTest("BEAM-2939")
+
     def test_callbacks_with_exception(self):
       raise unittest.SkipTest("BEAM-6868")
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -364,23 +364,25 @@ class FnApiRunnerTest(unittest.TestCase):
 
   def test_sdf(self):
 
+    class ExpandingStringsDoFn(beam.DoFn):
+      def process(self, element, restriction_tracker=ExpandStringsProvider()):
+        assert isinstance(
+            restriction_tracker,
+            restriction_trackers.OffsetRestrictionTracker), restriction_tracker
+        for k in range(*restriction_tracker.current_restriction()):
+          yield element[k]
+
+    with self.create_pipeline() as p:
+      data = ['abc', 'defghijklmno', 'pqrstuv', 'wxyz']
+      actual = (
+          p
+          | beam.Create(data)
+          | beam.ParDo(ExpandingStringsDoFn()))
+      assert_that(actual, equal_to(list(''.join(data))))
+
+  def test_sdf_with_sdf_initiated_checkpointing(self):
+
     counter = beam.metrics.Metrics.counter('ns', 'my_counter')
-
-    class ExpandStringsProvider(beam.transforms.core.RestrictionProvider):
-      def initial_restriction(self, element):
-        return (0, len(element))
-
-      def create_tracker(self, restriction):
-        return restriction_trackers.OffsetRestrictionTracker(
-            restriction[0], restriction[1])
-
-      def split(self, element, restriction):
-        start, end = restriction
-        middle = (end - start) // 2
-        return [(start, middle), (middle, end)]
-
-      def restriction_size(self, element, restriction):
-        return restriction[1] - restriction[0]
 
     class ExpandStringsDoFn(beam.DoFn):
       def process(self, element, restriction_tracker=ExpandStringsProvider()):
@@ -1165,6 +1167,24 @@ class EventRecorder(object):
 
   def cleanup(self):
     shutil.rmtree(self.tmp_dir)
+
+
+class ExpandStringsProvider(beam.transforms.core.RestrictionProvider):
+  """A RestrictionProvider that used for sdf related tests."""
+  def initial_restriction(self, element):
+    return (0, len(element))
+
+  def create_tracker(self, restriction):
+    return restriction_trackers.OffsetRestrictionTracker(
+        restriction[0], restriction[1])
+
+  def split(self, element, restriction):
+    start, end = restriction
+    middle = (end - start) // 2
+    return [(start, middle), (middle, end)]
+
+  def restriction_size(self, element, restriction):
+    return restriction[1] - restriction[0]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The new test is partially taken from test_sdf. The difference is, test_sdf produces defer_remainder in DoFn.process(), verse the new test only yield elements within the range.
R: @lukecwik 
CC: @robertwb 