### PR TITLE
[BEAM-7102] Adding `jar_packages` experiment option for Python SDK

### DIFF
--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -58,6 +58,7 @@ import pkg_resources
 from apache_beam.internal import pickler
 from apache_beam.internal.http_client import get_new_http
 from apache_beam.io.filesystems import FileSystems
+from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.options.pipeline_options import WorkerOptions
 # TODO(angoenka): Remove reference to dataflow internal names
@@ -196,6 +197,15 @@ class Stager(object):
               setup_options.extra_packages, staging_location,
               temp_dir=temp_dir))
 
+    # Handle jar packages that should be staged for Java SDK Harness.
+    jar_packages = options.view_as(
+        DebugOptions).lookup_experiment('jar_packages')
+    if jar_packages is not None:
+      resources.extend(
+          self._stage_jar_packages(
+              jar_packages.split(':'), staging_location,
+              temp_dir=temp_dir))
+
     # Pickle the main session if requested.
     # We will create the pickled main session locally and then copy it to the
     # staging location because the staging location is a remote path and the
@@ -307,6 +317,56 @@ class Stager(object):
   @staticmethod
   def _is_remote_path(path):
     return path.find('://') != -1
+
+  def _stage_jar_packages(self, jar_packages, staging_location, temp_dir):
+    """Stages a list of local jar packages for Java SDK Harness.
+
+    :param jar_packages: Ordered list of local paths to jar packages to be
+      staged. Only packages on localfile system and GCS are supported.
+    :param staging_location: Staging location for the packages.
+    :param temp_dir: Temporary folder where the resource building can happen.
+    :return: A list of file names (no paths) for the resource staged. All the
+      files are assumed to be staged in staging_location.
+    :raises:
+      RuntimeError: If files specified are not found or do not have expected
+        name patterns.
+    """
+    resources = []
+    staging_temp_dir = tempfile.mkdtemp(dir=temp_dir)
+    local_packages = []
+    for package in jar_packages:
+      if not os.path.basename(package).endswith('.jar'):
+        raise RuntimeError(
+            'The --experiment=\'jar_packages=\' option expects a full path '
+            'ending with ".jar" instead of %s' % package)
+
+      if not os.path.isfile(package):
+        if Stager._is_remote_path(package):
+          # Download remote package.
+          logging.info('Downloading jar package: %s locally before staging',
+                       package)
+          _, last_component = FileSystems.split(package)
+          local_file_path = FileSystems.join(staging_temp_dir, last_component)
+          Stager._download_file(package, local_file_path)
+        else:
+          raise RuntimeError(
+              'The file %s cannot be found. It was specified in the '
+              '--experiment=\'jar_packages=\' command line option.' % package)
+      else:
+        local_packages.append(package)
+
+    local_packages.extend([
+        FileSystems.join(staging_temp_dir, f)
+        for f in os.listdir(staging_temp_dir)
+    ])
+
+    for package in local_packages:
+      basename = os.path.basename(package)
+      staged_path = FileSystems.join(staging_location, basename)
+      self.stage_artifact(package, staged_path)
+      resources.append(basename)
+
+    return resources
 
   def _stage_extra_packages(self, extra_packages, staging_location, temp_dir):
     """Stages a list of local extra packages.

--- a/sdks/python/apache_beam/runners/portability/stager_test.py
+++ b/sdks/python/apache_beam/runners/portability/stager_test.py
@@ -28,6 +28,7 @@ import unittest
 import mock
 
 from apache_beam.io.filesystems import FileSystems
+from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.runners.dataflow.internal import names
@@ -59,6 +60,26 @@ class StagerTest(unittest.TestCase):
     with open(path, 'w') as f:
       f.write(contents)
       return f.name
+
+  # We can not rely on actual remote file systems paths hence making
+  # '/tmp/remote/' a new remote path.
+  def is_remote_path(self, path):
+    return path.startswith('/tmp/remote/')
+
+  remote_copied_files = []
+
+  def file_copy(self, from_path, to_path):
+    if self.is_remote_path(from_path):
+      self.remote_copied_files.append(from_path)
+      _, from_name = os.path.split(from_path)
+      if os.path.isdir(to_path):
+        to_path = os.path.join(to_path, from_name)
+      self.create_temp_file(to_path, 'nothing')
+      logging.info('Fake copied remote file: %s to %s', from_path, to_path)
+    elif self.is_remote_path(to_path):
+      logging.info('Faking upload_file(%s, %s)', from_path, to_path)
+    else:
+      shutil.copyfile(from_path, to_path)
 
   def populate_requirements_cache(self, requirements_file, cache_dir):
     _ = requirements_file
@@ -422,14 +443,9 @@ class StagerTest(unittest.TestCase):
     self.update_options(options)
     options.view_as(SetupOptions).sdk_location = sdk_location
 
-    # We can not rely on actual remote file systems paths hence making
-    # '/tmp/remote/' a new remote path.
-    def is_remote_path(path):
-      return path.startswith('/tmp/remote/')
-
     with mock.patch(
         'apache_beam.runners.portability.stager_test'
-        '.stager.Stager._is_remote_path', staticmethod(is_remote_path)):
+        '.stager.Stager._is_remote_path', staticmethod(self.is_remote_path)):
       self.assertEqual([sdk_filename],
                        self.stager.stage_job_resources(
                            options, staging_location=staging_dir)[1])
@@ -477,32 +493,14 @@ class StagerTest(unittest.TestCase):
         os.path.join(source_dir, 'whl.whl'), '/tmp/remote/remote_file.tar.gz'
     ]
 
-    remote_copied_files = []
-
-    # We can not rely on actual remote file systems paths hence making
-    # '/tmp/remote/' a new remote path.
-    def is_remote_path(path):
-      return path.startswith('/tmp/remote/')
-
-    def file_copy(from_path, to_path):
-      if is_remote_path(from_path):
-        remote_copied_files.append(from_path)
-        _, from_name = os.path.split(from_path)
-        if os.path.isdir(to_path):
-          to_path = os.path.join(to_path, from_name)
-        self.create_temp_file(to_path, 'nothing')
-        logging.info('Fake copied remote file: %s to %s', from_path, to_path)
-      elif is_remote_path(to_path):
-        logging.info('Faking upload_file(%s, %s)', from_path, to_path)
-      else:
-        shutil.copyfile(from_path, to_path)
+    self.remote_copied_files = []
 
     with mock.patch(
         'apache_beam.runners.portability.stager_test'
-        '.stager.Stager._download_file', staticmethod(file_copy)):
+        '.stager.Stager._download_file', staticmethod(self.file_copy)):
       with mock.patch(
           'apache_beam.runners.portability.stager_test'
-          '.stager.Stager._is_remote_path', staticmethod(is_remote_path)):
+          '.stager.Stager._is_remote_path', staticmethod(self.is_remote_path)):
         self.assertEqual([
             'abc.tar.gz', 'xyz.tar.gz', 'xyz2.tar', 'whl.whl',
             'remote_file.tar.gz', stager.EXTRA_PACKAGES_FILE
@@ -513,7 +511,8 @@ class StagerTest(unittest.TestCase):
           'abc.tar.gz\n', 'xyz.tar.gz\n', 'xyz2.tar\n', 'whl.whl\n',
           'remote_file.tar.gz\n'
       ], f.readlines())
-    self.assertEqual(['/tmp/remote/remote_file.tar.gz'], remote_copied_files)
+    self.assertEqual(
+        ['/tmp/remote/remote_file.tar.gz'], self.remote_copied_files)
 
   def test_with_extra_packages_missing_files(self):
     staging_dir = self.make_temp_dir()
@@ -545,6 +544,70 @@ class StagerTest(unittest.TestCase):
         'The --extra_package option expects a full path ending with '
         '".tar", ".tar.gz", ".whl" or ".zip" '
         'instead of %s' % os.path.join(source_dir, 'abc.tgz'))
+
+  def test_with_jar_packages_missing_files(self):
+    staging_dir = self.make_temp_dir()
+    with self.assertRaises(RuntimeError) as cm:
+
+      options = PipelineOptions()
+      self.update_options(options)
+      options.view_as(DebugOptions).experiments = [
+          'jar_packages=nosuchfile.jar'
+      ]
+      self.stager.stage_job_resources(options, staging_location=staging_dir)
+    self.assertEqual(
+        cm.exception.args[0],
+        'The file %s cannot be found. It was specified in the '
+        '--experiment=\'jar_packages=\' command line option.' %
+        'nosuchfile.jar')
+
+  def test_with_jar_packages_invalid_file_name(self):
+    staging_dir = self.make_temp_dir()
+    source_dir = self.make_temp_dir()
+    self.create_temp_file(os.path.join(source_dir, 'abc.tgz'), 'nothing')
+    with self.assertRaises(RuntimeError) as cm:
+      options = PipelineOptions()
+      self.update_options(options)
+      options.view_as(DebugOptions).experiments = [
+          'jar_packages='+os.path.join(source_dir, 'abc.tgz')
+      ]
+      self.stager.stage_job_resources(options, staging_location=staging_dir)
+    self.assertEqual(
+        cm.exception.args[0],
+        'The --experiment=\'jar_packages=\' option expects a full path ending '
+        'with ".jar" instead of %s' % os.path.join(source_dir, 'abc.tgz'))
+
+  def test_with_jar_packages(self):
+    staging_dir = self.make_temp_dir()
+    source_dir = self.make_temp_dir()
+    self.create_temp_file(os.path.join(source_dir, 'abc.jar'), 'nothing')
+    self.create_temp_file(os.path.join(source_dir, 'xyz.jar'), 'nothing')
+    self.create_temp_file(os.path.join(source_dir, 'ijk.jar'), 'nothing')
+
+    options = PipelineOptions()
+    self.update_options(options)
+    options.view_as(DebugOptions).experiments = [
+        'jar_packages=%s:%s:%s:%s' % (
+            os.path.join(source_dir, 'abc.jar'),
+            os.path.join(source_dir, 'xyz.jar'),
+            os.path.join(source_dir, 'ijk.jar'),
+            '/tmp/remote/remote.jar'
+        )
+    ]
+
+    self.remote_copied_files = []
+
+    with mock.patch(
+        'apache_beam.runners.portability.stager_test'
+        '.stager.Stager._download_file', staticmethod(self.file_copy)):
+      with mock.patch(
+          'apache_beam.runners.portability.stager_test'
+          '.stager.Stager._is_remote_path', staticmethod(self.is_remote_path)):
+        self.assertEqual([
+            'abc.jar', 'xyz.jar', 'ijk.jar', 'remote.jar'
+        ], self.stager.stage_job_resources(
+            options, staging_location=staging_dir)[1])
+    self.assertEqual(['/tmp/remote/remote.jar'], self.remote_copied_files)
 
 
 class TestStager(stager.Stager):


### PR DESCRIPTION
Adding `jar_packages` experiment option for Python SDK

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
