### PR TITLE
[BEAM-7121] Add deterministic proto coder

### DIFF
--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -282,6 +282,13 @@ class ProtoCoderImpl(SimpleCoderImpl):
     return proto_message
 
 
+class DeterministicProtoCoderImpl(ProtoCoderImpl):
+  """For internal use only; no backwards-compatibility guarantees."""
+
+  def encode(self, value):
+    return value.SerializeToString(deterministic=True)
+
+
 UNKNOWN_TYPE = 0xFF
 NONE_TYPE = 0
 INT_TYPE = 1

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -751,6 +751,9 @@ class ProtoCoder(FastCoder):
     # a Map.
     return False
 
+  def as_deterministic_coder(self, step_label, error_message=None):
+    return DeterministicProtoCoder(self.proto_message_type)
+
   def __eq__(self, other):
     return (type(self) == type(other)
             and self.proto_message_type == other.proto_message_type)
@@ -765,6 +768,29 @@ class ProtoCoder(FastCoder):
     else:
       raise ValueError(('Expected a subclass of google.protobuf.message.Message'
                         ', but got a %s' % typehint))
+
+
+class DeterministicProtoCoder(ProtoCoder):
+  """A Coder for Google Protocol Buffers.
+
+  It supports both Protocol Buffers syntax versions 2 and 3. However,
+  the runtime version of the python protobuf library must exactly match the
+  version of the protoc compiler what was used to generate the protobuf
+  messages.
+
+  ProtoCoder is registered in the global CoderRegistry as the default coder for
+  any protobuf Message object.
+
+  """
+
+  def _create_impl(self):
+    return coder_impl.DeterministicProtoCoderImpl(self.proto_message_type)
+
+  def is_deterministic(self):
+    return True
+
+  def as_deterministic_coder(self, step_label, error_message=None):
+    return self
 
 
 class TupleCoder(FastCoder):

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -771,16 +771,12 @@ class ProtoCoder(FastCoder):
 
 
 class DeterministicProtoCoder(ProtoCoder):
-  """A Coder for Google Protocol Buffers.
+  """A deterministic Coder for Google Protocol Buffers.
 
   It supports both Protocol Buffers syntax versions 2 and 3. However,
   the runtime version of the python protobuf library must exactly match the
   version of the protoc compiler what was used to generate the protobuf
   messages.
-
-  ProtoCoder is registered in the global CoderRegistry as the default coder for
-  any protobuf Message object.
-
   """
 
   def _create_impl(self):

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -99,13 +99,16 @@ class DeterministicProtoCoderTest(unittest.TestCase):
     self.assertEqual(ma, real_coder.decode(real_coder.encode(ma)))
 
   def test_deterministic_proto_coder_determinism(self):
-    mm = test_message.MessageWithMap()
-    for i in range(10):
-      mm.field1['key_%s' % i].field1 = 'Hello world %s' % i
-    coder = coders.DeterministicProtoCoder(mm.__class__)
-    expected_encoded = coder.encode(mm)
-    for _ in range(5):
-      self.assertEqual(expected_encoded, coder.encode(mm))
+    for _ in xrange(10):
+      keys = range(20)
+      mm_forward = test_message.MessageWithMap()
+      for key in keys:
+        mm_forward.field1[str(key)].field1 = str(key)
+      mm_reverse = test_message.MessageWithMap()
+      for key in reversed(keys):
+        mm_reverse.field1[str(key)].field1 = str(key)
+      coder = coders.DeterministicProtoCoder(mm_forward.__class__)
+      self.assertEqual(coder.encode(mm_forward), coder.encode(mm_reverse))
 
 
 class DummyClass(object):

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -100,8 +100,8 @@ class DeterministicProtoCoderTest(unittest.TestCase):
     self.assertEqual(ma, real_coder.decode(real_coder.encode(ma)))
 
   def test_deterministic_proto_coder_determinism(self):
-    for _ in xrange(10):
-      keys = range(20)
+    for _ in range(10):
+      keys = list(range(20))
       mm_forward = test_message.MessageWithMap()
       for key in keys:
         mm_forward.field1[str(key)].field1 = str(key)

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -100,11 +100,11 @@ class DeterministicProtoCoderTest(unittest.TestCase):
 
   def test_deterministic_proto_coder_determinism(self):
     mm = test_message.MessageWithMap()
-    for i in xrange(10):
+    for i in range(10):
       mm.field1['key_%s' % i].field1 = 'Hello world %s' % i
     coder = coders.DeterministicProtoCoder(mm.__class__)
     expected_encoded = coder.encode(mm)
-    for _ in xrange(10):
+    for _ in range(5):
       self.assertEqual(expected_encoded, coder.encode(mm))
 
 

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -84,6 +84,30 @@ class ProtoCoderTest(unittest.TestCase):
     self.assertEqual(ma, real_coder.decode(real_coder.encode(ma)))
 
 
+class DeterministicProtoCoderTest(unittest.TestCase):
+
+  def test_deterministic_proto_coder(self):
+    ma = test_message.MessageA()
+    mb = ma.field2.add()
+    mb.field1 = True
+    ma.field1 = u'hello world'
+    expected_coder = coders.DeterministicProtoCoder(ma.__class__)
+    real_coder = (coders_registry.get_coder(ma.__class__).as_deterministic_coder(step_label='unused'))
+    self.assertTrue(real_coder.is_deterministic())
+    self.assertEqual(expected_coder, real_coder)
+    self.assertEqual(real_coder.encode(ma), expected_coder.encode(ma))
+    self.assertEqual(ma, real_coder.decode(real_coder.encode(ma)))
+
+  def test_deterministic_proto_coder_determinism(self):
+    mm = test_message.MessageWithMap()
+    for i in xrange(10):
+      mm.field1['key_%s' % i].field1 = 'Hello world %s' % i
+    coder = coders.DeterministicProtoCoder(mm.__class__)
+    expected_encoded = coder.encode(mm)
+    for _ in xrange(10):
+      self.assertEqual(expected_encoded, coder.encode(mm))
+
+
 class DummyClass(object):
   """A class with no registered coder."""
   def __init__(self):

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -92,7 +92,8 @@ class DeterministicProtoCoderTest(unittest.TestCase):
     mb.field1 = True
     ma.field1 = u'hello world'
     expected_coder = coders.DeterministicProtoCoder(ma.__class__)
-    real_coder = (coders_registry.get_coder(ma.__class__).as_deterministic_coder(step_label='unused'))
+    real_coder = (coders_registry.get_coder(ma.__class__)
+                  .as_deterministic_coder(step_label='unused'))
     self.assertTrue(real_coder.is_deterministic())
     self.assertEqual(expected_coder, real_coder)
     self.assertEqual(real_coder.encode(ma), expected_coder.encode(ma))

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -68,6 +68,7 @@ class CodersTest(unittest.TestCase):
                    if isinstance(c, type) and issubclass(c, coders.Coder) and
                    'Base' not in c.__name__)
     standard -= set([coders.Coder,
+                     coders.DeterministicProtoCoder,
                      coders.FastCoder,
                      coders.ProtoCoder,
                      coders.RunnerAPICoderHolder,

--- a/sdks/python/apache_beam/tools/coders_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/coders_microbenchmark.py
@@ -40,6 +40,7 @@ import sys
 from past.builtins import unicode
 
 from apache_beam.coders import coders
+from apache_beam.coders import proto2_coder_test_messages_pb2 as test_message
 from apache_beam.tools import utils
 from apache_beam.transforms import window
 from apache_beam.utils import windowed_value
@@ -131,6 +132,23 @@ def large_iterable():
     yield k
 
 
+def random_message_with_map(size):
+  message = test_message.MessageWithMap()
+  keys = list_int(size)
+  random.shuffle(keys)
+  for key in keys:
+    message.field1[str(key)].field1 = small_string()
+  return message
+
+
+def small_message_with_map():
+  return random_message_with_map(5)
+
+
+def large_message_with_map():
+  return random_message_with_map(20)
+
+
 def globally_windowed_value():
   return windowed_value.WindowedValue(
       value=small_int(),
@@ -198,6 +216,18 @@ def run_coder_benchmarks(
       coder_benchmark_factory(
           coders.FastPrimitivesCoder(),
           large_dict),
+      coder_benchmark_factory(
+          coders.ProtoCoder(test_message.MessageWithMap),
+          small_message_with_map),
+      coder_benchmark_factory(
+          coders.ProtoCoder(test_message.MessageWithMap),
+          large_message_with_map),
+      coder_benchmark_factory(
+          coders.DeterministicProtoCoder(test_message.MessageWithMap),
+          small_message_with_map),
+      coder_benchmark_factory(
+          coders.DeterministicProtoCoder(test_message.MessageWithMap),
+          large_message_with_map),
       coder_benchmark_factory(
           coders.WindowedValueCoder(coders.FastPrimitivesCoder()),
           wv_with_one_window),

--- a/sdks/python/apache_beam/tools/coders_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/coders_microbenchmark.py
@@ -39,8 +39,8 @@ import sys
 
 from past.builtins import unicode
 
-from apache_beam.coders import coders
 from apache_beam.coders import proto2_coder_test_messages_pb2 as test_message
+from apache_beam.coders import coders
 from apache_beam.tools import utils
 from apache_beam.transforms import window
 from apache_beam.utils import windowed_value


### PR DESCRIPTION
Implement DeterministicProtoCoder, a deterministic coder for protos.

Beam currently uses Protobuf 3.5.0 or later, which supports deterministic serialization if [`deterministic=True` is passed to SerializeToString()](https://github.com/protocolbuffers/protobuf/blob/2761122b810fe8861004ae785cc3ab39f384d342/python/google/protobuf/message.py#L193-L194).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
