### PR TITLE
[BEAM-7002] Fix failures in SchemaCoder

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SchemaTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SchemaTranslation.java
@@ -112,6 +112,7 @@ public class SchemaTranslation {
       default:
         break;
     }
+    builder.setNullable(fieldType.getNullable());
     return builder.build();
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
@@ -95,4 +95,9 @@ public class SchemaCoder<T> extends CustomCoder<T> {
   public boolean consistentWithEquals() {
     return rowCoder.consistentWithEquals();
   }
+
+  @Override
+  public String toString() {
+    return "SchemaCoder: " + rowCoder.toString();
+  }
 }


### PR DESCRIPTION
There were two issues with Dataflow's proto representation of SchemaCoder:
   - It assumed that all schemas had a uuid, which was not true for nested schemas. This PR ensures that SchemaCoder gives nested schemas a uuid as well.
   - The nullable bit on FieldType was not being propagated to the proto. This caused the generated coder to do the incorrect thing, causing EOF exceptions to be thrown.