### PR TITLE
[BEAM-7076] Update Spark runner to use spark version 2.4.2

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -387,7 +387,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def proto_google_common_protos_version = "1.12.0"
     def protobuf_version = "3.6.0"
     def quickcheck_version = "0.8"
-    def spark_version = "2.4.1"
+    def spark_version = "2.4.2"
 
     // A map of maps containing common libraries used per language. To use:
     // dependencies {


### PR DESCRIPTION
Previous update was to 2.4.1 but there was a serious regression so better to pump up to 2.4.2
R: @jbonofre @aromanenko-dev 