### PR TITLE
[BEAM-7174] Add schema modification transforms

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldAccessDescriptor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldAccessDescriptor.java
@@ -229,7 +229,7 @@ public abstract class FieldAccessDescriptor implements Serializable {
     return builder().setFieldsAccessed(Sets.newLinkedHashSet(fields)).build();
   }
 
-  // Union a set of FieldAccessDescriptors. This function currenty only supports descriptors with
+  // Union a set of FieldAccessDescriptors. This function currently only supports descriptors with
   // containing named fields, not those containing ids.
   private static FieldAccessDescriptor union(
       Iterable<FieldAccessDescriptor> fieldAccessDescriptors) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldAccessDescriptor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldAccessDescriptor.java
@@ -325,12 +325,30 @@ public abstract class FieldAccessDescriptor implements Serializable {
   }
 
   /**
+   * Return the field names accessed. Should not be called until after {@link #resolve} is called.
+   */
+  public Set<String> fieldNamesAccessed() {
+    return getFieldsAccessed().stream()
+        .map(FieldDescriptor::getFieldName)
+        .collect(Collectors.toSet());
+  }
+
+  /**
    * Return the nested fields keyed by field ids. Should not be called until after {@link #resolve}
    * is called.
    */
   public Map<Integer, FieldAccessDescriptor> nestedFieldsById() {
     return getNestedFieldsAccessed().entrySet().stream()
         .collect(Collectors.toMap(f -> f.getKey().getFieldId(), f -> f.getValue()));
+  }
+
+  /**
+   * Return the nested fields keyed by field name. Should not be called until after {@link #resolve}
+   * is called.
+   */
+  public Map<String, FieldAccessDescriptor> nestedFieldsByName() {
+    return getNestedFieldsAccessed().entrySet().stream()
+        .collect(Collectors.toMap(f -> f.getKey().getFieldName(), f -> f.getValue()));
   }
 
   /** Returns true if this descriptor references only a single, non-wildcard field. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -196,6 +196,10 @@ public class Schema implements Serializable {
       return this;
     }
 
+    public int getLastFieldId() {
+      return fields.size() - 1;
+    }
+
     public Schema build() {
       return new Schema(fields);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/AddFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/AddFields.java
@@ -17,17 +17,27 @@
  */
 package org.apache.beam.sdk.schemas.transforms;
 
-import com.google.common.collect.Lists;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterables;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Multimap;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Multimaps;
 
 /**
  * A transform to add new nullable fields to a PCollection's schema. Elements are extended to have
@@ -42,37 +52,299 @@ import org.apache.beam.sdk.values.Row;
  * }</pre>
  */
 public class AddFields {
-  /** Add all specified fields to the schema. */
-  public static <T> Inner<T> fields(Field... fields) {
-    return fields(Arrays.asList(fields));
-  }
-
-  /** Add all specified fields to the schema. */
-  public static <T> Inner<T> fields(List<Field> fields) {
-    for (Field field : fields) {
-      if (!field.getType().getNullable()) {
-        throw new IllegalArgumentException(
-            "Only nullable fields can be added to an existing schema.");
-      }
-    }
-    return new Inner<>(fields);
+  public static <T> Inner<T> create() {
+    return new Inner<>();
   }
 
   /** Inner PTransform for AddFields. */
   public static class Inner<T> extends PTransform<PCollection<T>, PCollection<Row>> {
-    private final List<Field> newFields;
-    private final List<Object> nullValues;
+    @AutoValue
+    abstract static class NewField implements Serializable {
+      abstract String getName();
 
-    private Inner(List<Field> newFields) {
+      abstract FieldAccessDescriptor getDescriptor();
+
+      abstract Schema.FieldType getFieldType();
+
+      @Nullable
+      abstract Object getDefaultValue();
+
+      @AutoValue.Builder
+      abstract static class Builder {
+        abstract Builder setName(String name);
+
+        abstract Builder setDescriptor(FieldAccessDescriptor descriptor);
+
+        abstract Builder setFieldType(Schema.FieldType fieldType);
+
+        abstract Builder setDefaultValue(@Nullable Object defaultValue);
+
+        abstract NewField build();
+      }
+
+      abstract Builder toBuilder();
+
+      static NewField of(
+          FieldAccessDescriptor fieldAccessDescriptor,
+          Schema.FieldType fieldType,
+          Object defaultValue) {
+        return new AutoValue_AddFields_Inner_NewField.Builder()
+            .setName(getName(fieldAccessDescriptor))
+            .setDescriptor(fieldAccessDescriptor)
+            .setFieldType(fieldType)
+            .setDefaultValue(defaultValue)
+            .build();
+      }
+
+      NewField descend() {
+        FieldAccessDescriptor descriptor =
+            Iterables.getOnlyElement(getDescriptor().getNestedFieldsAccessed().values());
+        return toBuilder().setDescriptor(descriptor).setName(getName(descriptor)).build();
+      }
+
+      static String getName(FieldAccessDescriptor descriptor) {
+        if (!descriptor.getFieldsAccessed().isEmpty()) {
+          return Iterables.getOnlyElement(descriptor.fieldNamesAccessed());
+        } else {
+          return Iterables.getOnlyElement(descriptor.nestedFieldsByName().keySet());
+        }
+      }
+    }
+
+    @AutoValue
+    abstract static class AddFieldsInformation implements Serializable {
+      @Nullable
+      abstract Schema.FieldType getOutputFieldType();
+
+      abstract List<Object> getNewValues();
+
+      abstract List<AddFieldsInformation> getNestedNewValues();
+
+      @AutoValue.Builder
+      abstract static class Builder {
+        abstract AddFieldsInformation.Builder setOutputFieldType(Schema.FieldType outputFieldType);
+
+        abstract AddFieldsInformation.Builder setNewValues(List<Object> newValues);
+
+        abstract AddFieldsInformation.Builder setNestedNewValues(List<AddFieldsInformation> nestedNewValues);
+
+        abstract AddFieldsInformation build();
+      }
+
+      abstract AddFieldsInformation.Builder toBuilder();
+
+      static AddFieldsInformation of(
+          Schema.FieldType outputFieldType,
+          List<Object> newValues,
+          List<AddFieldsInformation> nestedNewValues) {
+        return new AutoValue_AddFields_Inner_AddFieldsInformation.Builder()
+            .setOutputFieldType(outputFieldType)
+            .setNewValues(newValues)
+            .setNestedNewValues(nestedNewValues)
+            .build();
+      }
+    }
+
+    private final List<NewField> newFields;
+
+    private Inner() {
+      this.newFields = Collections.emptyList();
+    }
+
+    private Inner(List<NewField> newFields) {
       this.newFields = newFields;
-      this.nullValues = Collections.nCopies(newFields.size(), null);
+    }
+
+    public Inner<T> field(String fieldName, Schema.FieldType fieldType) {
+      return field(fieldName, fieldType.withNullable(true), null);
+    }
+
+    public Inner<T> field(String fieldName, Schema.FieldType fieldType, Object defaultValue) {
+      if (defaultValue == null) {
+        checkArgument(fieldType.getNullable());
+      }
+
+      FieldAccessDescriptor descriptor = FieldAccessDescriptor.withFieldNames(fieldName);
+      checkArgument(descriptor.referencesSingleField());
+      List<NewField> fields =
+          ImmutableList.<NewField>builder()
+              .addAll(newFields)
+              .add(NewField.of(descriptor, fieldType, defaultValue))
+              .build();
+      return new Inner<>(fields);
+    }
+
+    private AddFieldsInformation getAddFieldsInformation(
+        Schema inputSchema, Collection<NewField> fieldsToAdd) {
+      List<NewField> newTopLevelFields =
+          fieldsToAdd.stream()
+              .filter(n -> !n.getDescriptor().getFieldsAccessed().isEmpty())
+              .collect(Collectors.toList());
+      List<NewField> newNestedFields =
+          fieldsToAdd.stream()
+              .filter(n -> !n.getDescriptor().getNestedFieldsAccessed().isEmpty())
+              .collect(Collectors.toList());
+
+      Multimap<String, NewField> newNestedFieldsMap =
+          Multimaps.index(newNestedFields, NewField::getName);
+
+      Map<Integer, AddFieldsInformation> nestedNewValues = Maps.newHashMap();
+      Schema.Builder builder = Schema.builder();
+      for (int i = 0; i < inputSchema.getFieldCount(); ++i) {
+        Schema.Field field = inputSchema.getField(i);
+        Collection<NewField> nestedFields = newNestedFieldsMap.get(field.getName());
+
+        // If this field is a nested field and new subfields are added further down the tree, add
+        // those subfields before
+        // adding to the current schema. Otherwise we just add this field as is to the new schema.
+        if (!nestedFields.isEmpty()) {
+          nestedFields = nestedFields.stream().map(NewField::descend).collect(Collectors.toList());
+
+          AddFieldsInformation nestedInformation =
+              getAddFieldsInformation(field.getType(), nestedFields);
+          field = field.withType(nestedInformation.getOutputFieldType());
+          nestedNewValues.put(i, nestedInformation);
+        }
+        builder.addField(field);
+      }
+
+      // Add any new fields at this level.
+      List<Object> newValues = new ArrayList<>(newTopLevelFields.size());
+      for (NewField newField : newTopLevelFields) {
+        builder.addField(newField.getName(), newField.getFieldType());
+        newValues.add(newField.getDefaultValue());
+      }
+
+      // If there are any nested field additions left that are not already processed, that means
+      // that the root of the
+      // nested field doesn't exist in the schema. In this case we'll walk down the new nested
+      // fields and recursively
+      // create each nested level as necessary.
+      for (Map.Entry<String, Collection<NewField>> newNested :
+          newNestedFieldsMap.asMap().entrySet()) {
+        if (!inputSchema.hasField(newNested.getKey())) {
+          // This is a brand-new nested field with no matching field in the input schema. We will
+          // recursively create
+          // a nested schema to match it.
+          Collection<NewField> nestedNewFields =
+              newNested.getValue().stream().map(NewField::descend).collect(Collectors.toList());
+          AddFieldsInformation addFieldsInformation =
+              getAddFieldsInformation(
+                  Schema.FieldType.row(Schema.of()).withNullable(true), nestedNewFields);
+          builder.addField(newNested.getKey(), addFieldsInformation.getOutputFieldType());
+          nestedNewValues.put(builder.getLastFieldId(), addFieldsInformation);
+        }
+      }
+
+      Schema schema = builder.build();
+      List<AddFieldsInformation> nestedNewValueList =
+              new ArrayList<>(Collections.nCopies(schema.getFieldCount(), null));
+      for (Map.Entry<Integer, AddFieldsInformation> entry : nestedNewValues.entrySet()) {
+        nestedNewValueList.set(entry.getKey(), entry.getValue());
+      }
+      return AddFieldsInformation.of(
+          Schema.FieldType.row(schema), newValues, nestedNewValueList);
+    }
+
+    AddFieldsInformation getAddFieldsInformation(
+        Schema.FieldType inputFieldType, Collection<NewField> nestedFields) {
+      AddFieldsInformation addFieldsInformation;
+      Schema.FieldType fieldType;
+      switch (inputFieldType.getTypeName()) {
+        case ROW:
+          addFieldsInformation =
+              getAddFieldsInformation(inputFieldType.getRowSchema(), nestedFields);
+          fieldType = addFieldsInformation.getOutputFieldType();
+          break;
+
+        case ARRAY:
+          addFieldsInformation =
+              getAddFieldsInformation(inputFieldType.getCollectionElementType(), nestedFields);
+          fieldType = Schema.FieldType.array(addFieldsInformation.getOutputFieldType());
+          break;
+
+        case MAP:
+          addFieldsInformation =
+              getAddFieldsInformation(inputFieldType.getMapValueType(), nestedFields);
+          fieldType = Schema.FieldType.map(inputFieldType.getMapKeyType(), addFieldsInformation.getOutputFieldType());
+          break;
+
+        default:
+          throw new RuntimeException("Cannot select a subfield of a non-composite type.");
+      }
+      fieldType = fieldType.withNullable(inputFieldType.getNullable());
+      return addFieldsInformation.toBuilder().setOutputFieldType(fieldType).build();
+    }
+
+    Row fillNewFields(Row row, AddFieldsInformation addFieldsInformation) {
+      Schema outputSchema = checkNotNull(addFieldsInformation.getOutputFieldType().getRowSchema());
+
+      List<Object> newValues = Lists.newArrayListWithCapacity(outputSchema.getFieldCount());
+      for (int i = 0; i < row.getFieldCount(); ++i) {
+        AddFieldsInformation nested = addFieldsInformation.getNestedNewValues().get(i);
+        if (nested != null) {
+          Object newValue =
+              fillNewFields(row.getValue(i), row.getSchema().getField(i).getType(), nested);
+          newValues.add(newValue);
+        } else {
+          newValues.add(row.getValue(i));
+        }
+      }
+      newValues.addAll(addFieldsInformation.getNewValues());
+      for (int i = row.getFieldCount(); i < addFieldsInformation.getNestedNewValues().size(); ++i) {
+        AddFieldsInformation newNestedField = addFieldsInformation.getNestedNewValues().get(i);
+        if (newNestedField != null) {
+          newValues.add(fillNewFields(null, addFieldsInformation.getOutputFieldType(), newNestedField));
+        }
+      }
+
+      return Row.withSchema(outputSchema).attachValues(newValues).build();
+    }
+
+    Object fillNewFields(
+        Object original, Schema.FieldType fieldType, AddFieldsInformation addFieldsInformation) {
+      switch (fieldType.getTypeName()) {
+        case ROW:
+          if (original == null) {
+            original = Row.withSchema(fieldType.getRowSchema()).build();
+          }
+          return fillNewFields((Row) original, addFieldsInformation);
+
+        case ARRAY:
+          if (original == null) {
+            return Collections.emptyList();
+          }
+          List<Object> list = (List<Object>) original;
+          List<Object> filledList = new ArrayList<>(list.size());
+          for (Object element : list) {
+            filledList.add(
+                fillNewFields(element, fieldType.getCollectionElementType(), addFieldsInformation));
+          }
+          return filledList;
+
+        case MAP:
+          if (original == null) {
+            return Collections.emptyMap();
+          }
+          Map<Object, Object> originalMap = (Map<Object, Object>) original;
+          Map<Object, Object> filledMap = Maps.newHashMapWithExpectedSize(originalMap.size());
+          for (Map.Entry<Object, Object> entry : originalMap.entrySet()) {
+            filledMap.put(
+                entry.getKey(),
+                fillNewFields(entry.getValue(), fieldType.getMapValueType(), addFieldsInformation));
+          }
+          return filledMap;
+
+        default:
+          throw new RuntimeException("Unexpected field type");
+      }
     }
 
     @Override
     public PCollection<Row> expand(PCollection<T> input) {
-      Schema inputSchema = input.getSchema();
-      Schema outputSchema =
-          Schema.builder().addFields(inputSchema.getFields()).addFields(newFields).build();
+      final AddFieldsInformation addFieldsInformation =
+          getAddFieldsInformation(input.getSchema(), newFields);
+      Schema outputSchema = checkNotNull(addFieldsInformation.getOutputFieldType().getRowSchema());
 
       return input
           .apply(
@@ -80,12 +352,7 @@ public class AddFields {
                   new DoFn<T, Row>() {
                     @ProcessElement
                     public void processElement(@Element Row row, OutputReceiver<Row> o) {
-                      List<Object> values =
-                          Lists.newArrayListWithCapacity(outputSchema.getFieldCount());
-                      values.addAll(row.getValues());
-                      values.addAll(nullValues);
-                      Row newRow = Row.withSchema(outputSchema).attachValues(values).build();
-                      o.output(newRow);
+                      o.output(fillNewFields(row, addFieldsInformation));
                     }
                   }))
           .setRowSchema(outputSchema);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/AddFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/AddFields.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor.FieldDescriptor.Qualifier;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor.FieldDescriptor.Qualifier.Kind;
@@ -62,6 +63,7 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Multimaps;
  *       .field("userDetails.isSpecialUser", "FieldType.BOOLEAN", false));
  * }</pre>
  */
+@Experimental(Experimental.Kind.SCHEMAS)
 public class AddFields {
   public static <T> Inner<T> create() {
     return new Inner<>();
@@ -210,7 +212,7 @@ public class AddFields {
       return new Inner<>(fields);
     }
 
-    private AddFieldsInformation getAddFieldsInformation(
+    private static AddFieldsInformation getAddFieldsInformation(
         Schema inputSchema, Collection<NewField> fieldsToAdd) {
       List<NewField> newTopLevelFields =
           fieldsToAdd.stream()
@@ -222,7 +224,7 @@ public class AddFields {
               .collect(Collectors.toList());
       // Group all nested fields together by the field at the current level. For example, if adding
       // a.b, a.c, a.d
-      // this map will contain a -> {a.b, a.c, a.d}/
+      // this map will contain a -> {a.b, a.c, a.d}.
       Multimap<String, NewField> newNestedFieldsMap =
           Multimaps.index(newNestedFields, NewField::getName);
 
@@ -305,7 +307,7 @@ public class AddFields {
           Schema.FieldType.row(schema), newValuesThisLevel, nestedNewValueList);
     }
 
-    AddFieldsInformation getAddFieldsInformation(
+    private static AddFieldsInformation getAddFieldsInformation(
         Schema.FieldType inputFieldType, Collection<NewField> nestedFields) {
       AddFieldsInformation addFieldsInformation;
       Schema.FieldType fieldType;
@@ -337,7 +339,7 @@ public class AddFields {
       return addFieldsInformation.toBuilder().setOutputFieldType(fieldType).build();
     }
 
-    Row fillNewFields(Row row, AddFieldsInformation addFieldsInformation) {
+    private static Row fillNewFields(Row row, AddFieldsInformation addFieldsInformation) {
       Schema outputSchema = checkNotNull(addFieldsInformation.getOutputFieldType().getRowSchema());
 
       List<Object> newValues = Lists.newArrayListWithCapacity(outputSchema.getFieldCount());
@@ -356,7 +358,7 @@ public class AddFields {
       // If there are brand new simple (i.e. have no nested values) fields at this level, then add
       // the default values for all of them.
       newValues.addAll(addFieldsInformation.getDefaultValues());
-      // If we are creating new recursive fields, populate new values for the here.
+      // If we are creating new recursive fields, populate new values for them here.
       for (int i = newValues.size(); i < addFieldsInformation.getNestedNewValues().size(); ++i) {
         AddFieldsInformation newNestedField = addFieldsInformation.getNestedNewValues().get(i);
         if (newNestedField != null) {
@@ -367,7 +369,7 @@ public class AddFields {
       return Row.withSchema(outputSchema).attachValues(newValues).build();
     }
 
-    Object fillNewFields(
+    private static Object fillNewFields(
         Object original, Schema.FieldType fieldType, AddFieldsInformation addFieldsInformation) {
       switch (fieldType.getTypeName()) {
         case ROW:

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/AddFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/AddFields.java
@@ -22,7 +22,11 @@ import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Precondi
 
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/AddFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/AddFields.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+
+/**
+ * A transform to add new nullable fields to a PCollection's schema. Elements are extended to have
+ * the new schema, with null values used for the new fields. Any new fields added must be nullable.
+ *
+ * <p>Example use:
+ *
+ * <pre>{@code PCollection<Event> events = readEvents();
+ * PCollection<Row> augmentedEvents =
+ *   events.apply(AddFields.fields(Field.nullable("newField1", FieldType.STRING),
+ *                                 Field.nullable("newField2", FieldType.INT64)));
+ * }</pre>
+ */
+public class AddFields {
+  /** Add all specified fields to the schema. */
+  public static <T> Inner<T> fields(Field... fields) {
+    return fields(Arrays.asList(fields));
+  }
+
+  /** Add all specified fields to the schema. */
+  public static <T> Inner<T> fields(List<Field> fields) {
+    for (Field field : fields) {
+      if (!field.getType().getNullable()) {
+        throw new IllegalArgumentException(
+            "Only nullable fields can be added to an existing schema.");
+      }
+    }
+    return new Inner<>(fields);
+  }
+
+  /** Inner PTransform for AddFields. */
+  public static class Inner<T> extends PTransform<PCollection<T>, PCollection<Row>> {
+    private final List<Field> newFields;
+    private final List<Object> nullValues;
+
+    private Inner(List<Field> newFields) {
+      this.newFields = newFields;
+      this.nullValues = Collections.nCopies(newFields.size(), null);
+    }
+
+    @Override
+    public PCollection<Row> expand(PCollection<T> input) {
+      Schema inputSchema = input.getSchema();
+      Schema outputSchema =
+          Schema.builder().addFields(inputSchema.getFields()).addFields(newFields).build();
+
+      return input
+          .apply(
+              ParDo.of(
+                  new DoFn<T, Row>() {
+                    @ProcessElement
+                    public void processElement(@Element Row row, OutputReceiver<Row> o) {
+                      List<Object> values =
+                          Lists.newArrayListWithCapacity(outputSchema.getFieldCount());
+                      values.addAll(row.getValues());
+                      values.addAll(nullValues);
+                      Row newRow = Row.withSchema(outputSchema).attachValues(values).build();
+                      o.output(newRow);
+                    }
+                  }))
+          .setRowSchema(outputSchema);
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/DropFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/DropFields.java
@@ -17,9 +17,8 @@
  */
 package org.apache.beam.sdk.schemas.transforms;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -30,6 +29,8 @@ import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Sets;
 
 /**
  * A transform to drop fields from a schema.
@@ -71,6 +72,7 @@ public class DropFields {
     return new Inner<>(fieldsToDrop);
   }
 
+  /** Implementation class for DropFields. */
   public static class Inner<T> extends PTransform<PCollection<T>, PCollection<Row>> {
     private final FieldAccessDescriptor fieldsToDrop;
 
@@ -111,7 +113,7 @@ public class DropFields {
                 throw new RuntimeException("Unexpected field descriptor type.");
             }
           }
-          Preconditions.checkArgument(fieldType.getTypeName().isCompositeType());
+          checkArgument(fieldType.getTypeName().isCompositeType());
           FieldAccessDescriptor nestedDescriptor =
               input.getNestedFieldsAccessed().get(fieldDescriptor);
           nestedFieldsToSelect.put(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/DropFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/DropFields.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+
+/**
+ * A transform to drop fields from a schema.
+ *
+ * <p>This transform acts as the inverse of the {@link Select} transform. A list of fields to drop
+ * is specified, and all fields in the schema that are not specified are selected. For example:
+ *
+ * <pre>{@code @DefaultSchema(JavaFieldSchema.class)
+ * public class UserEvent {
+ *   public String userId;
+ *   public String eventId;
+ *   public int eventType;
+ *   public Location location;
+ * }}</pre>
+ *
+ * <pre>{@code @DefaultSchema(JavaFieldSchema.class)
+ * public class Location {
+ *   public double latitude;
+ *   public double longtitude;
+ * }
+ *
+ * PCollection<UserEvent> events = readUserEvents();
+ * // Drop the location field.
+ * PCollection<Row> noLocation = events.apply(DropFields.fields("location"));
+ * // Drop the latitude field.
+ * PCollection<Row> noLatitude = events.apply(DropFields.fields("location.latitude"));
+ * }</pre>
+ */
+public class DropFields {
+  public static <T> Inner<T> fields(String... fields) {
+    return fields(FieldAccessDescriptor.withFieldNames(fields));
+  }
+
+  public static <T> Inner<T> fields(Integer... fieldIds) {
+    return fields(FieldAccessDescriptor.withFieldIds(fieldIds));
+  }
+
+  public static <T> Inner<T> fields(FieldAccessDescriptor fieldsToDrop) {
+    return new Inner<>(fieldsToDrop);
+  }
+
+  public static class Inner<T> extends PTransform<PCollection<T>, PCollection<Row>> {
+    private final FieldAccessDescriptor fieldsToDrop;
+
+    private Inner(FieldAccessDescriptor fieldsToDrop) {
+      this.fieldsToDrop = fieldsToDrop;
+    }
+
+    FieldAccessDescriptor complement(Schema inputSchema, FieldAccessDescriptor input) {
+      Set<String> fieldNamesToSelect = Sets.newHashSet();
+      Map<FieldAccessDescriptor.FieldDescriptor, FieldAccessDescriptor> nestedFieldsToSelect =
+          Maps.newHashMap();
+      for (int i = 0; i < inputSchema.getFieldCount(); ++i) {
+        if (input.fieldIdsAccessed().contains(i)) {
+          // This field is selected, so exclude it from the complement.
+          continue;
+        }
+        Field field = inputSchema.getField(i);
+        Map<Integer, FieldAccessDescriptor.FieldDescriptor> nestedFields =
+            input.getNestedFieldsAccessed().entrySet().stream()
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toMap(k -> k.getFieldId(), k -> k));
+
+        FieldAccessDescriptor.FieldDescriptor fieldDescriptor = nestedFields.get(i);
+        if (fieldDescriptor != null) {
+          // Some subfields are selected, so recursively calculate the complementary subfields to
+          // select.
+          FieldType fieldType = inputSchema.getField(i).getType();
+          for (FieldAccessDescriptor.FieldDescriptor.Qualifier qualifier :
+              fieldDescriptor.getQualifiers()) {
+            switch (qualifier.getKind()) {
+              case LIST:
+                fieldType = fieldType.getCollectionElementType();
+                break;
+              case MAP:
+                fieldType = fieldType.getMapValueType();
+                break;
+              default:
+                throw new RuntimeException("Unexpected field descriptor type.");
+            }
+          }
+          Preconditions.checkArgument(fieldType.getTypeName().isCompositeType());
+          FieldAccessDescriptor nestedDescriptor =
+              input.getNestedFieldsAccessed().get(fieldDescriptor);
+          nestedFieldsToSelect.put(
+              fieldDescriptor, complement(fieldType.getRowSchema(), nestedDescriptor));
+        } else {
+          // Neither the field nor the subfield is selected. This means we should select it.
+          fieldNamesToSelect.add(field.getName());
+        }
+      }
+
+      FieldAccessDescriptor fieldAccess = FieldAccessDescriptor.withFieldNames(fieldNamesToSelect);
+      for (Map.Entry<FieldAccessDescriptor.FieldDescriptor, FieldAccessDescriptor> entry :
+          nestedFieldsToSelect.entrySet()) {
+        fieldAccess = fieldAccess.withNestedField(entry.getKey(), entry.getValue());
+      }
+      return fieldAccess.resolve(inputSchema);
+    }
+
+    @Override
+    public PCollection<Row> expand(PCollection<T> input) {
+      Schema inputSchema = input.getSchema();
+      FieldAccessDescriptor selectDescriptor =
+          complement(inputSchema, fieldsToDrop.resolve(inputSchema));
+
+      return Select.<T>fieldAccess(selectDescriptor).expand(input);
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/RenameFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/RenameFields.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
@@ -40,7 +42,8 @@ import org.apache.commons.compress.utils.Lists;
 
 /**
  * A transform for renaming fields inside an existing schema. Top level or nested fields can be
- * renamed.
+ * renamed. When renaming a nested field, the nested prefix does not need to be specified again when
+ * specifying the new name.
  *
  * <p>Example use:
  *
@@ -48,9 +51,10 @@ import org.apache.commons.compress.utils.Lists;
  * PCollection<Row> renamedEvents =
  *   events.apply(RenameFields.<Event>create()
  *       .rename("userName", "userId")
- *       .rename("location.country", "location.countryCode"));
+ *       .rename("location.country", "countryCode"));
  * }</pre>
  */
+@Experimental(Kind.SCHEMAS)
 public class RenameFields {
   /** Create an instance of this transform. */
   public static <T> Inner<T> create() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/RenameFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/RenameFields.java
@@ -17,9 +17,6 @@
  */
 package org.apache.beam.sdk.schemas.transforms;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
@@ -35,6 +32,9 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ArrayListMultimap;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterables;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Maps;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Multimap;
 import org.apache.commons.compress.utils.Lists;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/RenameFields.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/RenameFields.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ArrayListMultimap;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Multimap;
+import org.apache.commons.compress.utils.Lists;
+
+/**
+ * A transform for renaming fields inside an existing schema. Top level or nested fields can be
+ * renamed.
+ *
+ * <p>Example use:
+ *
+ * <pre>{@code PCollection<Event> events = readEvents();
+ * PCollection<Row> renamedEvents =
+ *   events.apply(RenameFields.<Event>create()
+ *       .rename("userName", "userId")
+ *       .rename("location.country", "location.countryCode"));
+ * }</pre>
+ */
+public class RenameFields {
+  /** Create an instance of this transform. */
+  public static <T> Inner<T> create() {
+    return new Inner<>();
+  }
+
+  // Describes a single renameSchema rule.
+  private static class RenamePair implements Serializable {
+    // The FieldAccessDescriptor describing the field to renameSchema. Must reference a singleton
+    // field.
+    private final FieldAccessDescriptor fieldAccessDescriptor;
+    // The new name for the field.
+    private final String newName;
+
+    RenamePair(FieldAccessDescriptor fieldAccessDescriptor, String newName) {
+      this.fieldAccessDescriptor = fieldAccessDescriptor;
+      this.newName = newName;
+    }
+
+    RenamePair resolve(Schema schema) {
+      FieldAccessDescriptor resolved = fieldAccessDescriptor.resolve(schema);
+      if (!resolved.referencesSingleField()) {
+        throw new IllegalArgumentException(resolved + " references multiple fields.");
+      }
+      return new RenamePair(resolved, newName);
+    }
+  }
+
+  private static FieldType renameFieldType(FieldType inputType, Collection<RenamePair> renames) {
+    switch (inputType.getTypeName()) {
+      case ROW:
+        return FieldType.row(renameSchema(inputType.getRowSchema(), renames));
+      case ARRAY:
+        return FieldType.array(renameFieldType(inputType.getCollectionElementType(), renames));
+      case MAP:
+        return FieldType.map(
+            renameFieldType(inputType.getMapKeyType(), renames),
+            renameFieldType(inputType.getMapValueType(), renames));
+      default:
+        return inputType;
+    }
+  }
+
+  // Apply the user-specified renames to the input schema.
+  private static Schema renameSchema(Schema inputSchema, Collection<RenamePair> renames) {
+    // The mapping of renames to apply at this level of the schema.
+    Map<Integer, String> topLevelRenames = Maps.newHashMap();
+    // For nested schemas, collect all applicable renames here.
+    Multimap<Integer, RenamePair> nestedRenames = ArrayListMultimap.create();
+
+    for (RenamePair rename : renames) {
+      FieldAccessDescriptor access = rename.fieldAccessDescriptor;
+      if (!access.fieldIdsAccessed().isEmpty()) {
+        // This references a field at this level of the schema.
+        Integer fieldId = Iterables.getOnlyElement(access.fieldIdsAccessed());
+        topLevelRenames.put(fieldId, rename.newName);
+      } else {
+        // This references a nested field.
+        Map.Entry<Integer, FieldAccessDescriptor> nestedAccess =
+            Iterables.getOnlyElement(access.nestedFieldsById().entrySet());
+        nestedRenames.put(
+            nestedAccess.getKey(), new RenamePair(nestedAccess.getValue(), rename.newName));
+      }
+    }
+
+    Schema.Builder builder = Schema.builder();
+    for (int i = 0; i < inputSchema.getFieldCount(); ++i) {
+      Field field = inputSchema.getField(i);
+      FieldType fieldType = field.getType();
+      String newName = topLevelRenames.getOrDefault(i, field.getName());
+      Collection<RenamePair> nestedFieldRenames = nestedRenames.asMap().get(i);
+      if (nestedFieldRenames != null) {
+        // There are nested field renames. Recursively renameSchema the rest of the schema.
+        builder.addField(newName, renameFieldType(fieldType, nestedFieldRenames));
+      } else {
+        // No renameSchema for this field. Just add it back as is, potentially with a new name.
+        builder.addField(newName, fieldType);
+      }
+    }
+    return builder.build();
+  }
+
+  /** The class implementing the actual PTransform. */
+  public static class Inner<T> extends PTransform<PCollection<T>, PCollection<Row>> {
+    private List<RenamePair> renames;
+
+    private Inner() {
+      renames = Lists.newArrayList();
+    }
+
+    private Inner(List<RenamePair> renames) {
+      this.renames = renames;
+    }
+
+    /** Rename a specific field. */
+    public Inner<T> rename(String field, String newName) {
+      return rename(FieldAccessDescriptor.withFieldNames(field), newName);
+    }
+
+    /** Rename a specific field. */
+    public Inner<T> rename(FieldAccessDescriptor field, String newName) {
+      List<RenamePair> newList =
+          ImmutableList.<RenamePair>builder()
+              .addAll(renames)
+              .add(new RenamePair(field, newName))
+              .build();
+
+      return new Inner<>(newList);
+    }
+
+    @Override
+    public PCollection<Row> expand(PCollection<T> input) {
+      Schema inputSchema = input.getSchema();
+
+      List<RenamePair> pairs =
+          renames.stream().map(r -> r.resolve(inputSchema)).collect(Collectors.toList());
+      final Schema outputSchema = renameSchema(inputSchema, pairs);
+      return input
+          .apply(
+              ParDo.of(
+                  new DoFn<T, Row>() {
+                    @ProcessElement
+                    public void processElement(@Element Row row, OutputReceiver<Row> o) {
+                      o.output(Row.withSchema(outputSchema).attachValues(row.getValues()).build());
+                    }
+                  }))
+          .setRowSchema(outputSchema);
+    }
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/AddFieldsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/AddFieldsTest.java
@@ -19,8 +19,6 @@ package org.apache.beam.sdk.schemas.transforms;
 
 import static junit.framework.TestCase.assertEquals;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.schemas.Schema;
@@ -31,11 +29,14 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
+/** Tests for {@link AddFields}. */
 public class AddFieldsTest {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule public transient ExpectedException thrown = ExpectedException.none();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/AddFieldsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/AddFieldsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import static junit.framework.TestCase.assertEquals;
+
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+
+public class AddFieldsTest {
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+  @Rule public transient ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void addSimpleFields() {
+    Schema schema = Schema.builder().addStringField("field1").build();
+    PCollection<Row> added =
+        pipeline
+            .apply(
+                Create.of(Row.withSchema(schema).addValue("value").build()).withRowSchema(schema))
+            .apply(
+                AddFields.fields(
+                    Schema.Field.nullable("field2", Schema.FieldType.INT16),
+                    Schema.Field.nullable(
+                        "field3", Schema.FieldType.array(Schema.FieldType.STRING))));
+
+    Schema expectedSchema =
+        Schema.builder()
+            .addStringField("field1")
+            .addNullableField("field2", Schema.FieldType.INT16)
+            .addNullableField("field3", Schema.FieldType.array(Schema.FieldType.STRING))
+            .build();
+    assertEquals(expectedSchema, added.getSchema());
+    Row expected = Row.withSchema(expectedSchema).addValues("value", null, null).build();
+    PAssert.that(added).containsInAnyOrder(expected);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void addDuplicateField() {
+    Schema schema = Schema.builder().addStringField("field1").build();
+    thrown.expect(IllegalArgumentException.class);
+    PCollection<Row> added =
+        pipeline
+            .apply(
+                Create.of(Row.withSchema(schema).addValue("value").build()).withRowSchema(schema))
+            .apply(AddFields.fields(Schema.Field.nullable("field1", Schema.FieldType.INT16)));
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void addNonNullableField() {
+    Schema schema = Schema.builder().addStringField("field1").build();
+    thrown.expect(IllegalArgumentException.class);
+    PCollection<Row> added =
+        pipeline
+            .apply(
+                Create.of(Row.withSchema(schema).addValue("value").build()).withRowSchema(schema))
+            .apply(AddFields.fields(Schema.Field.of("field2", Schema.FieldType.INT16)));
+    pipeline.run();
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/DropFieldsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/DropFieldsTest.java
@@ -132,7 +132,7 @@ public class DropFieldsTest {
     pipeline.run();
   }
 
-  // drop making sure a nested field remainsx
+  // drop making sure a nested field remains.
 
   @Test
   @Category(NeedsRunner.class)
@@ -158,7 +158,4 @@ public class DropFieldsTest {
     PAssert.that(result).containsInAnyOrder(expectedRows);
     pipeline.run();
   }
-
-  @Test
-  public void testDropAllFields() {}
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/DropFieldsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/DropFieldsTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/** Tests for {@link DropFields}. */
+public class DropFieldsTest {
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  private static final Schema SIMPLE_SCHEMA =
+      Schema.builder().addInt32Field("field1").addStringField("field2").build();
+
+  private static Row simpleRow(int field1, String field2) {
+    return Row.withSchema(SIMPLE_SCHEMA).addValues(field1, field2).build();
+  }
+
+  private static final Schema NESTED_SCHEMA =
+      Schema.builder().addRowField("nested", SIMPLE_SCHEMA).addStringField("string").build();
+
+  private static Row nestedRow(Row nested) {
+    return Row.withSchema(NESTED_SCHEMA).addValues(nested, "foo").build();
+  }
+
+  private static final Schema NESTED_ARRAY_SCHEMA =
+      Schema.builder().addArrayField("array", FieldType.row(SIMPLE_SCHEMA)).build();
+
+  private static Row nestedArray(Row... elements) {
+    return Row.withSchema(NESTED_ARRAY_SCHEMA).addArray((Object[]) elements).build();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testDropTopLevelField() {
+    Schema expectedSchema = Schema.builder().addStringField("field2").build();
+
+    PCollection<Row> result =
+        pipeline
+            .apply(
+                Create.of(simpleRow(1, "one"), simpleRow(2, "two"), simpleRow(3, "three"))
+                    .withRowSchema(SIMPLE_SCHEMA))
+            .apply(DropFields.fields("field1"));
+    assertEquals(expectedSchema, result.getSchema());
+
+    List<Row> expectedRows =
+        Lists.newArrayList(
+            Row.withSchema(expectedSchema).addValue("one").build(),
+            Row.withSchema(expectedSchema).addValue("two").build(),
+            Row.withSchema(expectedSchema).addValue("three").build());
+    PAssert.that(result).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testDropNestedField() {
+    Schema expectedSchema =
+        Schema.builder().addStringField("string").addStringField("field2").build();
+
+    PCollection<Row> result =
+        pipeline
+            .apply(
+                Create.of(
+                        nestedRow(simpleRow(1, "one")),
+                        nestedRow(simpleRow(2, "two")),
+                        nestedRow(simpleRow(3, "three")))
+                    .withRowSchema(NESTED_SCHEMA))
+            .apply(DropFields.fields("nested.field1"));
+    assertEquals(expectedSchema, result.getSchema());
+
+    List<Row> expectedRows =
+        Lists.newArrayList(
+            Row.withSchema(expectedSchema).addValues("foo", "one").build(),
+            Row.withSchema(expectedSchema).addValues("foo", "two").build(),
+            Row.withSchema(expectedSchema).addValues("foo", "three").build());
+
+    PAssert.that(result).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testDropNestedFieldKeepingOnlyNested() {
+    Schema expectedSchema = Schema.builder().addStringField("field2").build();
+
+    PCollection<Row> result =
+        pipeline
+            .apply(
+                Create.of(
+                        nestedRow(simpleRow(1, "one")),
+                        nestedRow(simpleRow(2, "two")),
+                        nestedRow(simpleRow(3, "three")))
+                    .withRowSchema(NESTED_SCHEMA))
+            .apply(DropFields.fields("string", "nested.field1"));
+    assertEquals(expectedSchema, result.getSchema());
+
+    List<Row> expectedRows =
+        Lists.newArrayList(
+            Row.withSchema(expectedSchema).addValue("one").build(),
+            Row.withSchema(expectedSchema).addValue("two").build(),
+            Row.withSchema(expectedSchema).addValue("three").build());
+    PAssert.that(result).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+
+  // drop making sure a nested field remainsx
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testDropNestedArrayField() {
+    Schema expectedSchema = Schema.builder().addArrayField("field2", FieldType.STRING).build();
+
+    PCollection<Row> result =
+        pipeline
+            .apply(
+                Create.of(
+                        nestedArray(simpleRow(1, "one1"), simpleRow(1, "one2")),
+                        nestedArray(simpleRow(2, "two1"), simpleRow(2, "two2")),
+                        nestedArray(simpleRow(3, "three1"), simpleRow(3, "three2")))
+                    .withRowSchema(NESTED_ARRAY_SCHEMA))
+            .apply(DropFields.fields("array[].field1"));
+    assertEquals(expectedSchema, result.getSchema());
+
+    List<Row> expectedRows =
+        Lists.newArrayList(
+            Row.withSchema(expectedSchema).addArray("one1", "one2").build(),
+            Row.withSchema(expectedSchema).addArray("two1", "two2").build(),
+            Row.withSchema(expectedSchema).addArray("three1", "three2").build());
+    PAssert.that(result).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+
+  @Test
+  public void testDropAllFields() {}
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/RenameFieldsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/RenameFieldsTest.java
@@ -19,8 +19,6 @@ package org.apache.beam.sdk.schemas.transforms;
 
 import static junit.framework.TestCase.assertEquals;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.NeedsRunner;
@@ -29,6 +27,8 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/RenameFieldsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/RenameFieldsTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import static junit.framework.TestCase.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/** Tests for {@link RenameFields}. */
+public class RenameFieldsTest {
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void renameTopLevelFields() {
+    Schema schema = Schema.builder().addStringField("field1").addInt32Field("field2").build();
+    PCollection<Row> renamed =
+        pipeline
+            .apply(
+                Create.of(
+                        Row.withSchema(schema).addValues("one", 1).build(),
+                        Row.withSchema(schema).addValues("two", 2).build())
+                    .withRowSchema(schema))
+            .apply(RenameFields.<Row>create().rename("field1", "new1").rename("field2", "new2"));
+    Schema expectedSchema = Schema.builder().addStringField("new1").addInt32Field("new2").build();
+    assertEquals(expectedSchema, renamed.getSchema());
+    List<Row> expectedRows =
+        ImmutableList.of(
+            Row.withSchema(expectedSchema).addValues("one", 1).build(),
+            Row.withSchema(expectedSchema).addValues("two", 2).build());
+    PAssert.that(renamed).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void renameNestedFields() {
+    Schema nestedSchema = Schema.builder().addStringField("field1").addInt32Field("field2").build();
+    Schema schema =
+        Schema.builder().addStringField("field1").addRowField("nested", nestedSchema).build();
+
+    PCollection<Row> renamed =
+        pipeline
+            .apply(
+                Create.of(
+                        Row.withSchema(schema)
+                            .addValues(
+                                "one", Row.withSchema(nestedSchema).addValues("one", 1).build())
+                            .build(),
+                        Row.withSchema(schema)
+                            .addValues(
+                                "two", Row.withSchema(nestedSchema).addValues("two", 1).build())
+                            .build())
+                    .withRowSchema(schema))
+            .apply(
+                RenameFields.<Row>create()
+                    .rename("nested.field1", "new1")
+                    .rename("nested.field2", "new2"));
+
+    Schema expectedNestedSchema =
+        Schema.builder().addStringField("new1").addInt32Field("new2").build();
+    Schema expectedSchema =
+        Schema.builder()
+            .addStringField("field1")
+            .addRowField("nested", expectedNestedSchema)
+            .build();
+    assertEquals(expectedSchema, renamed.getSchema());
+
+    List<Row> expectedRows =
+        ImmutableList.of(
+            Row.withSchema(expectedSchema)
+                .addValues("one", Row.withSchema(expectedNestedSchema).addValues("one", 1).build())
+                .build(),
+            Row.withSchema(expectedSchema)
+                .addValues("two", Row.withSchema(expectedNestedSchema).addValues("two", 1).build())
+                .build());
+
+    PAssert.that(renamed).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void renameTopLevelAndNestedFields() {
+    Schema nestedSchema = Schema.builder().addStringField("field1").addInt32Field("field2").build();
+    Schema schema =
+        Schema.builder().addStringField("field1").addRowField("nested", nestedSchema).build();
+
+    PCollection<Row> renamed =
+        pipeline
+            .apply(
+                Create.of(
+                        Row.withSchema(schema)
+                            .addValues(
+                                "one", Row.withSchema(nestedSchema).addValues("one", 1).build())
+                            .build(),
+                        Row.withSchema(schema)
+                            .addValues(
+                                "two", Row.withSchema(nestedSchema).addValues("two", 1).build())
+                            .build())
+                    .withRowSchema(schema))
+            .apply(
+                RenameFields.<Row>create()
+                    .rename("field1", "top1")
+                    .rename("nested", "newnested")
+                    .rename("nested.field1", "new1")
+                    .rename("nested.field2", "new2"));
+
+    Schema expectedNestedSchema =
+        Schema.builder().addStringField("new1").addInt32Field("new2").build();
+    Schema expectedSchema =
+        Schema.builder()
+            .addStringField("top1")
+            .addRowField("newnested", expectedNestedSchema)
+            .build();
+    assertEquals(expectedSchema, renamed.getSchema());
+
+    List<Row> expectedRows =
+        ImmutableList.of(
+            Row.withSchema(expectedSchema)
+                .addValues("one", Row.withSchema(expectedNestedSchema).addValues("one", 1).build())
+                .build(),
+            Row.withSchema(expectedSchema)
+                .addValues("two", Row.withSchema(expectedNestedSchema).addValues("two", 1).build())
+                .build());
+
+    PAssert.that(renamed).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void renameNestedInArrayFields() {
+    Schema nestedSchema = Schema.builder().addStringField("field1").addInt32Field("field2").build();
+    Schema schema =
+        Schema.builder().addArrayField("array", Schema.FieldType.row(nestedSchema)).build();
+
+    PCollection<Row> renamed =
+        pipeline
+            .apply(
+                Create.of(
+                        Row.withSchema(schema)
+                            .addValue(
+                                ImmutableList.of(
+                                    Row.withSchema(nestedSchema).addValues("one", 1).build()))
+                            .build(),
+                        Row.withSchema(schema)
+                            .addValue(
+                                ImmutableList.of(
+                                    Row.withSchema(nestedSchema).addValues("two", 1).build()))
+                            .build())
+                    .withRowSchema(schema))
+            .apply(
+                RenameFields.<Row>create()
+                    .rename("array.field1", "new1")
+                    .rename("array.field2", "new2"));
+
+    Schema expectedNestedSchema =
+        Schema.builder().addStringField("new1").addInt32Field("new2").build();
+    Schema expectedSchema =
+        Schema.builder().addArrayField("array", Schema.FieldType.row(expectedNestedSchema)).build();
+    assertEquals(expectedSchema, renamed.getSchema());
+
+    List<Row> expectedRows =
+        ImmutableList.of(
+            Row.withSchema(expectedSchema)
+                .addValue(
+                    ImmutableList.of(
+                        Row.withSchema(expectedNestedSchema).addValues("one", 1).build()))
+                .build(),
+            Row.withSchema(expectedSchema)
+                .addValue(
+                    ImmutableList.of(
+                        Row.withSchema(expectedNestedSchema).addValues("two", 1).build()))
+                .build());
+
+    PAssert.that(renamed).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void renameNestedInMapFields() {
+    Schema nestedSchema = Schema.builder().addStringField("field1").addInt32Field("field2").build();
+    Schema schema =
+        Schema.builder()
+            .addMapField("map", Schema.FieldType.STRING, Schema.FieldType.row(nestedSchema))
+            .build();
+
+    PCollection<Row> renamed =
+        pipeline
+            .apply(
+                Create.of(
+                        Row.withSchema(schema)
+                            .addValue(
+                                ImmutableMap.of(
+                                    "k1", Row.withSchema(nestedSchema).addValues("one", 1).build()))
+                            .build(),
+                        Row.withSchema(schema)
+                            .addValue(
+                                ImmutableMap.of(
+                                    "k2", Row.withSchema(nestedSchema).addValues("two", 1).build()))
+                            .build())
+                    .withRowSchema(schema))
+            .apply(
+                RenameFields.<Row>create()
+                    .rename("map.field1", "new1")
+                    .rename("map.field2", "new2"));
+
+    Schema expectedNestedSchema =
+        Schema.builder().addStringField("new1").addInt32Field("new2").build();
+    Schema expectedSchema =
+        Schema.builder()
+            .addMapField("map", Schema.FieldType.STRING, Schema.FieldType.row(expectedNestedSchema))
+            .build();
+    assertEquals(expectedSchema, renamed.getSchema());
+
+    List<Row> expectedRows =
+        ImmutableList.of(
+            Row.withSchema(expectedSchema)
+                .addValue(
+                    ImmutableMap.of(
+                        "k1", Row.withSchema(expectedNestedSchema).addValues("one", 1).build()))
+                .build(),
+            Row.withSchema(expectedSchema)
+                .addValue(
+                    ImmutableMap.of(
+                        "k2", Row.withSchema(expectedNestedSchema).addValues("two", 1).build()))
+                .build());
+
+    PAssert.that(renamed).containsInAnyOrder(expectedRows);
+    pipeline.run();
+  }
+}


### PR DESCRIPTION
Add three transforms for modifying schemas:
**AddFields** Add new fields to a schema. Existing rows are padded with null values in the position of these new fields (or alternatively the user can specify a default value)
**DropFields** Drop fields from a schema.
**RenameFields** Rename schema fields.