### PR TITLE
[BEAM-7154] Updating Go SDK errors (Part 1)

### DIFF
--- a/sdks/go/pkg/beam/artifact/gcsproxy/retrieval.go
+++ b/sdks/go/pkg/beam/artifact/gcsproxy/retrieval.go
@@ -16,10 +16,10 @@
 package gcsproxy
 
 import (
-	"fmt"
 	"io"
 
 	"cloud.google.com/go/storage"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/gcsx"
 	"github.com/golang/protobuf/proto"
@@ -38,20 +38,20 @@ type RetrievalServer struct {
 func ReadProxyManifest(ctx context.Context, object string) (*pb.ProxyManifest, error) {
 	bucket, obj, err := gcsx.ParseObject(object)
 	if err != nil {
-		return nil, fmt.Errorf("invalid manifest object %v: %v", object, err)
+		return nil, errors.Wrapf(err, "invalid manifest object %v", object)
 	}
 
 	cl, err := gcsx.NewClient(ctx, storage.ScopeReadOnly)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create GCS client: %v", err)
+		return nil, errors.Wrap(err, "failed to create GCS client")
 	}
 	content, err := gcsx.ReadObject(ctx, cl, bucket, obj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read manifest %v: %v", object, err)
+		return nil, errors.Wrapf(err, "failed to read manifest %v", object)
 	}
 	var md pb.ProxyManifest
 	if err := proto.Unmarshal(content, &md); err != nil {
-		return nil, fmt.Errorf("invalid manifest %v: %v", object, err)
+		return nil, errors.Wrapf(err, "invalid manifest %v", object)
 	}
 	return &md, nil
 }
@@ -66,7 +66,7 @@ func NewRetrievalServer(md *pb.ProxyManifest) (*RetrievalServer, error) {
 	blobs := make(map[string]string)
 	for _, l := range md.GetLocation() {
 		if _, _, err := gcsx.ParseObject(l.GetUri()); err != nil {
-			return nil, fmt.Errorf("location %v is not a GCS object: %v", l.GetUri(), err)
+			return nil, errors.Wrapf(err, "location %v is not a GCS object", l.GetUri())
 		}
 		blobs[l.GetName()] = l.GetUri()
 	}
@@ -83,7 +83,7 @@ func (s *RetrievalServer) GetArtifact(req *pb.GetArtifactRequest, stream pb.Arti
 	key := req.GetName()
 	blob, ok := s.blobs[key]
 	if !ok {
-		return fmt.Errorf("artifact %v not found", key)
+		return errors.Errorf("artifact %v not found", key)
 	}
 
 	bucket, object := parseObject(blob)
@@ -91,13 +91,13 @@ func (s *RetrievalServer) GetArtifact(req *pb.GetArtifactRequest, stream pb.Arti
 	ctx := stream.Context()
 	client, err := gcsx.NewClient(ctx, storage.ScopeReadOnly)
 	if err != nil {
-		return fmt.Errorf("Failed to create client for %v: %v", key, err)
+		return errors.Wrapf(err, "Failed to create client for %v", key)
 	}
 
 	// Stream artifact in up to 1MB chunks.
 	r, err := client.Bucket(bucket).Object(object).NewReader(ctx)
 	if err != nil {
-		return fmt.Errorf("Failed to read object for %v: %v", key, err)
+		return errors.Wrapf(err, "Failed to read object for %v", key)
 	}
 	defer r.Close()
 
@@ -106,14 +106,14 @@ func (s *RetrievalServer) GetArtifact(req *pb.GetArtifactRequest, stream pb.Arti
 		n, err := r.Read(data)
 		if n > 0 {
 			if err := stream.Send(&pb.ArtifactChunk{Data: data[:n]}); err != nil {
-				return fmt.Errorf("chunk send failed: %v", err)
+				return errors.Wrap(err, "chunk send failed")
 			}
 		}
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("failed to read from %v: %v", blob, err)
+			return errors.Wrapf(err, "failed to read from %v", blob)
 		}
 	}
 	return nil
@@ -123,24 +123,24 @@ func validate(md *pb.ProxyManifest) error {
 	keys := make(map[string]bool)
 	for _, a := range md.GetManifest().GetArtifact() {
 		if _, seen := keys[a.Name]; seen {
-			return fmt.Errorf("multiple artifact with name %v", a.Name)
+			return errors.Errorf("multiple artifact with name %v", a.Name)
 		}
 		keys[a.Name] = true
 	}
 	for _, l := range md.GetLocation() {
 		fresh, seen := keys[l.Name]
 		if !seen {
-			return fmt.Errorf("no artifact named %v for location %v", l.Name, l.Uri)
+			return errors.Errorf("no artifact named %v for location %v", l.Name, l.Uri)
 		}
 		if !fresh {
-			return fmt.Errorf("multiple locations for %v:%v", l.Name, l.Uri)
+			return errors.Errorf("multiple locations for %v:%v", l.Name, l.Uri)
 		}
 		keys[l.Name] = false
 	}
 
 	for key, fresh := range keys {
 		if fresh {
-			return fmt.Errorf("no location for %v", key)
+			return errors.Errorf("no location for %v", key)
 		}
 	}
 	return nil

--- a/sdks/go/pkg/beam/artifact/stage.go
+++ b/sdks/go/pkg/beam/artifact/stage.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -30,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/errorx"
 )
@@ -103,7 +103,7 @@ func MultiStage(ctx context.Context, client pb.ArtifactStagingServiceClient, cpu
 					}
 					failures = append(failures, err.Error())
 					if len(failures) > attempts {
-						permErr.TrySetError(fmt.Errorf("failed to stage %v in %v attempts: %v", f.Filename, attempts, strings.Join(failures, "; ")))
+						permErr.TrySetError(errors.Errorf("failed to stage %v in %v attempts: %v", f.Filename, attempts, strings.Join(failures, "; ")))
 						break // give up
 					}
 					time.Sleep(time.Duration(rand.Intn(5)+1) * time.Second)
@@ -156,18 +156,18 @@ func Stage(ctx context.Context, client pb.ArtifactStagingServiceClient, key, fil
 	}
 	if err := stream.Send(header); err != nil {
 		stream.CloseAndRecv() // ignore error
-		return nil, fmt.Errorf("failed to send header for %v: %v", filename, err)
+		return nil, errors.Wrapf(err, "failed to send header for %v", filename)
 	}
 	stagedHash, err := stageChunks(stream, fd)
 	if err != nil {
 		stream.CloseAndRecv() // ignore error
-		return nil, fmt.Errorf("failed to send chunks for %v: %v", filename, err)
+		return nil, errors.Wrapf(err, "failed to send chunks for %v", filename)
 	}
 	if _, err := stream.CloseAndRecv(); err != nil && err != io.EOF {
-		return nil, fmt.Errorf("failed to close stream for %v: %v", filename, err)
+		return nil, errors.Wrapf(err, "failed to close stream for %v", filename)
 	}
 	if hash != stagedHash {
-		return nil, fmt.Errorf("unexpected SHA256 for sent chunks for %v: %v, want %v", filename, stagedHash, hash)
+		return nil, errors.Errorf("unexpected SHA256 for sent chunks for %v: %v, want %v", filename, stagedHash, hash)
 	}
 	return md, nil
 }
@@ -190,7 +190,7 @@ func stageChunks(stream pb.ArtifactStagingService_PutArtifactClient, r io.Reader
 				},
 			}
 			if err := stream.Send(chunk); err != nil {
-				return "", fmt.Errorf("chunk send failed: %v", err)
+				return "", errors.Wrap(err, "chunk send failed")
 			}
 		}
 		if err == io.EOF {
@@ -211,7 +211,7 @@ type KeyedFile struct {
 func scan(dir string) ([]KeyedFile, error) {
 	var ret []KeyedFile
 	if err := walk(dir, "", &ret); err != nil {
-		return nil, fmt.Errorf("failed to scan %v for artifacts to stage: %v", dir, err)
+		return nil, errors.Wrapf(err, "failed to scan %v for artifacts to stage", dir)
 	}
 	return ret, nil
 }

--- a/sdks/go/pkg/beam/testing/passert/hash.go
+++ b/sdks/go/pkg/beam/testing/passert/hash.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 )
 
 // Hash validates that the incoming PCollection<string> has the given size and
@@ -58,7 +59,7 @@ func (f *hashFn) ProcessElement(_ int, lines func(*string) bool) error {
 	hash := base64.StdEncoding.EncodeToString(md5W.Sum(nil))
 
 	if f.Size != len(col) || f.Hash != hash {
-		return fmt.Errorf("passert.Hash(%v) = (%v,%v), want (%v,%v)", f.Name, len(col), hash, f.Size, f.Hash)
+		return errors.Errorf("passert.Hash(%v) = (%v,%v), want (%v,%v)", f.Name, len(col), hash, f.Size, f.Hash)
 	}
 	return nil
 }

--- a/sdks/go/pkg/beam/testing/passert/passert.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/transforms/filter"
 )
 
@@ -135,7 +136,7 @@ func index(enc beam.ElementEncoder, iter func(*beam.T) bool) (map[string]indexEn
 	for iter(&val) {
 		var buf bytes.Buffer
 		if err := enc.Encode(val, &buf); err != nil {
-			return nil, fmt.Errorf("value %v not encodable with %v", val, enc)
+			return nil, errors.Errorf("value %v not encodable with %v", val, enc)
 		}
 		encoded := buf.String()
 
@@ -183,7 +184,7 @@ type failFn struct {
 }
 
 func (f *failFn) ProcessElement(x beam.X) error {
-	return fmt.Errorf(f.Format, x)
+	return errors.Errorf(f.Format, x)
 }
 
 type failKVFn struct {
@@ -191,7 +192,7 @@ type failKVFn struct {
 }
 
 func (f *failKVFn) ProcessElement(x beam.X, y beam.Y) error {
-	return fmt.Errorf(f.Format, fmt.Sprintf("(%v,%v)", x, y))
+	return errors.Errorf(f.Format, fmt.Sprintf("(%v,%v)", x, y))
 }
 
 type failGBKFn struct {
@@ -199,5 +200,5 @@ type failGBKFn struct {
 }
 
 func (f *failGBKFn) ProcessElement(x beam.X, _ func(*beam.Y) bool) error {
-	return fmt.Errorf(f.Format, fmt.Sprintf("(%v,*)", x))
+	return errors.Errorf(f.Format, fmt.Sprintf("(%v,*)", x))
 }

--- a/sdks/go/pkg/beam/testing/passert/sum.go
+++ b/sdks/go/pkg/beam/testing/passert/sum.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 )
 
 // Sum validates that the incoming PCollection<int> is a singleton
@@ -46,7 +47,7 @@ func (f *sumFn) ProcessElement(_ int, values func(*int) bool) error {
 	}
 
 	if f.Sum != sum || f.Size != count {
-		return fmt.Errorf("passert.Sum(%v) = {%v, size: %v}, want {%v, size:%v}", f.Name, sum, count, f.Sum, f.Size)
+		return errors.Errorf("passert.Sum(%v) = {%v, size: %v}, want {%v, size:%v}", f.Name, sum, count, f.Sum, f.Size)
 	}
 	return nil
 }

--- a/sdks/go/pkg/beam/transforms/top/top.go
+++ b/sdks/go/pkg/beam/transforms/top/top.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 )
 
 //go:generate go install github.com/apache/beam/sdks/go/cmd/starcgen
@@ -138,7 +139,7 @@ func (a *accum) unmarshal() error {
 	for _, val := range a.data {
 		element, err := a.dec.Decode(bytes.NewBuffer(val))
 		if err != nil {
-			return fmt.Errorf("top.accum: error unmarshal: %v", err)
+			return errors.WithContextf(err, "top.accum: unmarshalling")
 		}
 		a.list = append(a.list, element)
 	}
@@ -149,13 +150,13 @@ func (a *accum) unmarshal() error {
 // MarshalJSON uses the hook into the JSON encoder library to encode the accumulator.
 func (a accum) MarshalJSON() ([]byte, error) {
 	if a.enc == nil {
-		return nil, fmt.Errorf("top.accum: element encoder unspecified")
+		return nil, errors.Errorf("top.accum: element encoder unspecified")
 	}
 	var values [][]byte
 	for _, value := range a.list {
 		var buf bytes.Buffer
 		if err := a.enc.Encode(value, &buf); err != nil {
-			return nil, fmt.Errorf("top.accum: marshalling of %v failed: %v", value, err)
+			return nil, errors.WithContextf(err, "top.accum: marshalling %v", value)
 		}
 		values = append(values, buf.Bytes())
 	}

--- a/sdks/go/pkg/beam/util/gcsx/gcs.go
+++ b/sdks/go/pkg/beam/util/gcsx/gcs.go
@@ -25,6 +25,7 @@ import (
 	"path"
 
 	"cloud.google.com/go/storage"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"google.golang.org/api/option"
 )
 
@@ -111,10 +112,10 @@ func ParseObject(object string) (bucket, path string, err error) {
 	}
 
 	if parsed.Scheme != "gs" {
-		return "", "", fmt.Errorf("object %s must have 'gs' scheme", object)
+		return "", "", errors.Errorf("object %s must have 'gs' scheme", object)
 	}
 	if parsed.Host == "" {
-		return "", "", fmt.Errorf("object %s must have bucket", object)
+		return "", "", errors.Errorf("object %s must have bucket", object)
 	}
 	if parsed.Path == "" {
 		return parsed.Host, "", nil

--- a/sdks/go/pkg/beam/util/grpcx/dial.go
+++ b/sdks/go/pkg/beam/util/grpcx/dial.go
@@ -17,9 +17,9 @@ package grpcx
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"google.golang.org/grpc"
 )
 
@@ -35,7 +35,7 @@ func DefaultDial(ctx context.Context, endpoint string, timeout time.Duration) (*
 	cc, err := grpc.DialContext(ctx, endpoint, grpc.WithInsecure(), grpc.WithBlock(),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50<<20)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial server at %v: %v", endpoint, err)
+		return nil, errors.Wrapf(err, "failed to dial server at %v", endpoint)
 	}
 	return cc, nil
 }

--- a/sdks/go/pkg/beam/util/grpcx/metadata.go
+++ b/sdks/go/pkg/beam/util/grpcx/metadata.go
@@ -18,9 +18,8 @@ package grpcx
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -34,10 +33,10 @@ func ReadWorkerID(ctx context.Context) (string, error) {
 	}
 	id, ok := md[idKey]
 	if !ok || len(id) < 1 {
-		return "", fmt.Errorf("failed to find worker id in metadata %v", md)
+		return "", errors.Errorf("failed to find worker id in metadata %v", md)
 	}
 	if len(id) > 1 {
-		return "", fmt.Errorf("multiple worker ids in metadata: %v", id)
+		return "", errors.Errorf("multiple worker ids in metadata: %v", id)
 	}
 	return id[0], nil
 }

--- a/sdks/go/pkg/beam/util/pubsubx/pubsub.go
+++ b/sdks/go/pkg/beam/util/pubsubx/pubsub.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
 )
 
@@ -102,7 +103,7 @@ func Publish(ctx context.Context, project, topic string, messages ...string) (*p
 		}
 		id, err := t.Publish(ctx, m).Get(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to publish '%v': %v", msg, err)
+			return nil, errors.Wrapf(err, "failed to publish '%v'", msg)
 		}
 		log.Infof(ctx, "Published %v with id: %v", msg, id)
 	}

--- a/sdks/go/pkg/beam/util/starcgenx/starcgenx.go
+++ b/sdks/go/pkg/beam/util/starcgenx/starcgenx.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/shimx"
 )
 
@@ -151,7 +152,7 @@ func (e *Extractor) FromAsts(imp types.Importer, fset *token.FileSet, files []*a
 	}
 
 	if _, err := conf.Check(e.Package, fset, files, info); err != nil {
-		return fmt.Errorf("failed to type check package %s : %v", e.Package, err)
+		return errors.Wrapf(err, "failed to type check package %s : %v", e.Package)
 	}
 
 	e.Print("/*\n")
@@ -179,7 +180,7 @@ func (e *Extractor) FromAsts(imp types.Importer, fset *token.FileSet, files []*a
 		}
 	}
 	if len(notFound) > 0 {
-		return fmt.Errorf("couldn't find the following identifiers; please check for typos, or remove them: %v", strings.Join(notFound, ", "))
+		return errors.Errorf("couldn't find the following identifiers; please check for typos, or remove them: %v", strings.Join(notFound, ", "))
 	}
 	e.Print("*/\n")
 


### PR DESCRIPTION
Updating standard Go error functionality (`errors.New` and `fmt.Errorf`) to use the newly added Beam "errors" package. This PR covers the following subdirectories under `sdks/go/pkg/beam`: `artifact`, `testing`, `transforms`, and `util`.

I tried to keep the actual changes as straightforward as possible:

1. If a call isn't wrapping another error, replace it with `New` or `Errorf`. This should be functionally identical.
2. If a call is wrapping another error, replace it with either `Wrap` or `WithContext` using my best judgement. I generally used `Wrap` when the wrapped error originates from third-party code (i.e. any non-Beam package), and I tried to use `WithContext` otherwise.
3. `WithContext` messages make the most sense in present tense (e.g. "doing foo", "reading bar"). This means I had to adjust some messages slightly, as little as I could without losing any useful information.

This isn't the complete change of course. I still have other subdirectories to go through and change. But I wanted to try to keep each PR somewhat short since they can be merged independently and I don't want to have a really long, repetitive PR to review.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
