### PR TITLE
[BEAM-7193] ParDoLifecycleTest: remove duplicated inner class

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoLifecycleTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoLifecycleTest.java
@@ -49,62 +49,6 @@ public class ParDoLifecycleTest implements Serializable {
 
   @Rule public final transient TestPipeline p = TestPipeline.create();
 
-  private static class CallSequenceEnforcingDoFn<T> extends DoFn<T, T> {
-    private boolean setupCalled = false;
-    private int startBundleCalls = 0;
-    private int finishBundleCalls = 0;
-    private boolean teardownCalled = false;
-
-    @Setup
-    public void setup() {
-      assertThat("setup should not be called twice", setupCalled, is(false));
-      assertThat("setup should be called before startBundle", startBundleCalls, equalTo(0));
-      assertThat("setup should be called before finishBundle", finishBundleCalls, equalTo(0));
-      assertThat("setup should be called before teardown", teardownCalled, is(false));
-      setupCalled = true;
-    }
-
-    @StartBundle
-    public void startBundle() {
-      assertThat("setup should have been called", setupCalled, is(true));
-      assertThat(
-          "Even number of startBundle and finishBundle calls in startBundle",
-          startBundleCalls,
-          equalTo(finishBundleCalls));
-      assertThat("teardown should not have been called", teardownCalled, is(false));
-      startBundleCalls++;
-    }
-
-    @ProcessElement
-    public void processElement(ProcessContext c) throws Exception {
-      assertThat("startBundle should have been called", startBundleCalls, greaterThan(0));
-      assertThat(
-          "there should be one startBundle call with no call to finishBundle",
-          startBundleCalls,
-          equalTo(finishBundleCalls + 1));
-      assertThat("teardown should not have been called", teardownCalled, is(false));
-    }
-
-    @FinishBundle
-    public void finishBundle() {
-      assertThat("startBundle should have been called", startBundleCalls, greaterThan(0));
-      assertThat(
-          "there should be one bundle that has been started but not finished",
-          startBundleCalls,
-          equalTo(finishBundleCalls + 1));
-      assertThat("teardown should not have been called", teardownCalled, is(false));
-      finishBundleCalls++;
-    }
-
-    @Teardown
-    public void teardown() {
-      assertThat(setupCalled, is(true));
-      assertThat(startBundleCalls, anyOf(equalTo(finishBundleCalls)));
-      assertThat(teardownCalled, is(false));
-      teardownCalled = true;
-    }
-  }
-
   @Test
   @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
   public void testFnCallSequence() {
@@ -201,7 +145,7 @@ public class ParDoLifecycleTest implements Serializable {
   }
 
   private static class CallSequenceEnforcingStatefulFn<K, V>
-      extends CallSequenceEnforcingDoFn<KV<K, V>> {
+      extends CallSequenceEnforcingFn<KV<K, V>> {
     private static final String STATE_ID = "foo";
 
     @StateId(STATE_ID)
@@ -211,7 +155,7 @@ public class ParDoLifecycleTest implements Serializable {
   @Test
   @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
   public void testTeardownCalledAfterExceptionInStartBundle() {
-    ExceptionThrowingOldFn fn = new ExceptionThrowingOldFn(MethodForException.START_BUNDLE);
+    ExceptionThrowingFn fn = new ExceptionThrowingFn(MethodForException.START_BUNDLE);
     p.apply(Create.of(1, 2, 3)).apply(ParDo.of(fn));
     try {
       p.run();
@@ -219,7 +163,7 @@ public class ParDoLifecycleTest implements Serializable {
     } catch (Exception e) {
       assertThat(
           "Function should have been torn down after exception",
-          ExceptionThrowingOldFn.teardownCalled.get(),
+          ExceptionThrowingFn.teardownCalled.get(),
           is(true));
     }
   }
@@ -227,7 +171,7 @@ public class ParDoLifecycleTest implements Serializable {
   @Test
   @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
   public void testTeardownCalledAfterExceptionInProcessElement() {
-    ExceptionThrowingOldFn fn = new ExceptionThrowingOldFn(MethodForException.PROCESS_ELEMENT);
+    ExceptionThrowingFn fn = new ExceptionThrowingFn(MethodForException.PROCESS_ELEMENT);
     p.apply(Create.of(1, 2, 3)).apply(ParDo.of(fn));
     try {
       p.run();
@@ -235,7 +179,7 @@ public class ParDoLifecycleTest implements Serializable {
     } catch (Exception e) {
       assertThat(
           "Function should have been torn down after exception",
-          ExceptionThrowingOldFn.teardownCalled.get(),
+          ExceptionThrowingFn.teardownCalled.get(),
           is(true));
     }
   }
@@ -243,7 +187,7 @@ public class ParDoLifecycleTest implements Serializable {
   @Test
   @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
   public void testTeardownCalledAfterExceptionInFinishBundle() {
-    ExceptionThrowingOldFn fn = new ExceptionThrowingOldFn(MethodForException.FINISH_BUNDLE);
+    ExceptionThrowingFn fn = new ExceptionThrowingFn(MethodForException.FINISH_BUNDLE);
     p.apply(Create.of(1, 2, 3)).apply(ParDo.of(fn));
     try {
       p.run();
@@ -251,7 +195,7 @@ public class ParDoLifecycleTest implements Serializable {
     } catch (Exception e) {
       assertThat(
           "Function should have been torn down after exception",
-          ExceptionThrowingOldFn.teardownCalled.get(),
+          ExceptionThrowingFn.teardownCalled.get(),
           is(true));
     }
   }
@@ -259,7 +203,7 @@ public class ParDoLifecycleTest implements Serializable {
   @Test
   @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
   public void testWithContextTeardownCalledAfterExceptionInSetup() {
-    ExceptionThrowingOldFn fn = new ExceptionThrowingOldFn(MethodForException.SETUP);
+    ExceptionThrowingFn fn = new ExceptionThrowingFn(MethodForException.SETUP);
     p.apply(Create.of(1, 2, 3)).apply(ParDo.of(fn));
     try {
       p.run();
@@ -267,7 +211,7 @@ public class ParDoLifecycleTest implements Serializable {
     } catch (Exception e) {
       assertThat(
           "Function should have been torn down after exception",
-          ExceptionThrowingOldFn.teardownCalled.get(),
+          ExceptionThrowingFn.teardownCalled.get(),
           is(true));
     }
   }
@@ -275,7 +219,7 @@ public class ParDoLifecycleTest implements Serializable {
   @Test
   @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
   public void testWithContextTeardownCalledAfterExceptionInStartBundle() {
-    ExceptionThrowingOldFn fn = new ExceptionThrowingOldFn(MethodForException.START_BUNDLE);
+    ExceptionThrowingFn fn = new ExceptionThrowingFn(MethodForException.START_BUNDLE);
     p.apply(Create.of(1, 2, 3)).apply(ParDo.of(fn));
     try {
       p.run();
@@ -283,7 +227,7 @@ public class ParDoLifecycleTest implements Serializable {
     } catch (Exception e) {
       assertThat(
           "Function should have been torn down after exception",
-          ExceptionThrowingOldFn.teardownCalled.get(),
+          ExceptionThrowingFn.teardownCalled.get(),
           is(true));
     }
   }
@@ -291,7 +235,7 @@ public class ParDoLifecycleTest implements Serializable {
   @Test
   @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
   public void testWithContextTeardownCalledAfterExceptionInProcessElement() {
-    ExceptionThrowingOldFn fn = new ExceptionThrowingOldFn(MethodForException.PROCESS_ELEMENT);
+    ExceptionThrowingFn fn = new ExceptionThrowingFn(MethodForException.PROCESS_ELEMENT);
     p.apply(Create.of(1, 2, 3)).apply(ParDo.of(fn));
     try {
       p.run();
@@ -299,7 +243,7 @@ public class ParDoLifecycleTest implements Serializable {
     } catch (Exception e) {
       assertThat(
           "Function should have been torn down after exception",
-          ExceptionThrowingOldFn.teardownCalled.get(),
+          ExceptionThrowingFn.teardownCalled.get(),
           is(true));
     }
   }
@@ -307,7 +251,7 @@ public class ParDoLifecycleTest implements Serializable {
   @Test
   @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
   public void testWithContextTeardownCalledAfterExceptionInFinishBundle() {
-    ExceptionThrowingOldFn fn = new ExceptionThrowingOldFn(MethodForException.FINISH_BUNDLE);
+    ExceptionThrowingFn fn = new ExceptionThrowingFn(MethodForException.FINISH_BUNDLE);
     p.apply(Create.of(1, 2, 3)).apply(ParDo.of(fn));
     try {
       p.run();
@@ -315,54 +259,8 @@ public class ParDoLifecycleTest implements Serializable {
     } catch (Exception e) {
       assertThat(
           "Function should have been torn down after exception",
-          ExceptionThrowingOldFn.teardownCalled.get(),
+          ExceptionThrowingFn.teardownCalled.get(),
           is(true));
-    }
-  }
-
-  private static class ExceptionThrowingOldFn extends DoFn<Object, Object> {
-    static AtomicBoolean teardownCalled = new AtomicBoolean(false);
-
-    private final MethodForException toThrow;
-    private boolean thrown;
-
-    private ExceptionThrowingOldFn(MethodForException toThrow) {
-      this.toThrow = toThrow;
-    }
-
-    @Setup
-    public void setup() throws Exception {
-      throwIfNecessary(MethodForException.SETUP);
-    }
-
-    @StartBundle
-    public void startBundle() throws Exception {
-      throwIfNecessary(MethodForException.START_BUNDLE);
-    }
-
-    @ProcessElement
-    public void processElement(ProcessContext c) throws Exception {
-      throwIfNecessary(MethodForException.PROCESS_ELEMENT);
-    }
-
-    @FinishBundle
-    public void finishBundle() throws Exception {
-      throwIfNecessary(MethodForException.FINISH_BUNDLE);
-    }
-
-    private void throwIfNecessary(MethodForException method) throws Exception {
-      if (toThrow == method && !thrown) {
-        thrown = true;
-        throw new Exception("Hasn't yet thrown");
-      }
-    }
-
-    @Teardown
-    public void teardown() {
-      if (!thrown) {
-        fail("Excepted to have a processing method throw an exception");
-      }
-      teardownCalled.set(true);
     }
   }
 


### PR DESCRIPTION
After migrating of OldDoFn and removal of corresponding tests, ParDoLifecycleTest is left with 2 apparently identical inner classes. This PR removes one of them.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
