### PR TITLE
[BEAM-6605] Deprecate TextIO.readAll and TextIO.ReadAll transform

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -71,7 +71,7 @@ import org.joda.time.Duration;
  * <p>To read a {@link PCollection} from one or more text files, use {@code TextIO.read()} to
  * instantiate a transform and use {@link TextIO.Read#from(String)} to specify the path of the
  * file(s) to be read. Alternatively, if the filenames to be read are themselves in a {@link
- * PCollection}, apply {@link TextIO#readAll()} or {@link TextIO#readFiles}.
+ * PCollection} you can use {@link FileIO} to match them and {@link TextIO#readFiles} to read them.
  *
  * <p>{@link #read} returns a {@link PCollection} of {@link String Strings}, each corresponding to
  * one line of an input UTF-8 text file (split into lines delimited by '\n', '\r', or '\r\n', or
@@ -79,13 +79,15 @@ import org.joda.time.Duration;
  *
  * <h3>Filepattern expansion and watching</h3>
  *
- * <p>By default, the filepatterns are expanded only once. {@link Read#watchForNewFiles} and {@link
- * ReadAll#watchForNewFiles} allow streaming of new files matching the filepattern(s).
+ * <p>By default, the filepatterns are expanded only once. {@link Read#watchForNewFiles} or the
+ * combination of {@link FileIO.Match#continuously(Duration, TerminationCondition)} and {@link
+ * #readFiles()} allow streaming of new files matching the filepattern(s).
  *
- * <p>By default, {@link #read} prohibits filepatterns that match no files, and {@link #readAll}
+ * <p>By default, {@link #read} prohibits filepatterns that match no files, and {@link #readFiles()}
  * allows them in case the filepattern contains a glob wildcard character. Use {@link
- * TextIO.Read#withEmptyMatchTreatment} and {@link TextIO.ReadAll#withEmptyMatchTreatment} to
- * configure this behavior.
+ * Read#withEmptyMatchTreatment} or {@link
+ * FileIO.Match#withEmptyMatchTreatment(EmptyMatchTreatment)} plus {@link #readFiles()} to configure
+ * this behavior.
  *
  * <p>Example 1: reading a file or filepattern.
  *
@@ -106,7 +108,11 @@ import org.joda.time.Duration;
  * PCollection<String> filenames = ...;
  *
  * // Read all files in the collection.
- * PCollection<String> lines = filenames.apply(TextIO.readAll());
+ * PCollection<String> lines =
+ *     filenames
+ *         .apply(FileIO.matchAll())
+ *         .apply(FileIO.readMatches())
+ *         .apply(TextIO.readFiles());
  * }</pre>
  *
  * <p>Example 3: streaming new files matching a filepattern.
@@ -195,7 +201,13 @@ public class TextIO {
    * filepattern is expanded once at the moment it is processed, rather than watched for new files
    * matching the filepattern to appear. Likewise, every file is read once, rather than watched for
    * new entries.
+   *
+   * @deprecated You can achieve The functionality of {@link #readAll()} using {@link FileIO}
+   *     matching plus {@link #readFiles()}. This is the preferred method to make composition
+   *     explicit. {@link ReadAll} will not receive upgrades and will be removed in a future version
+   *     of Beam.
    */
+  @Deprecated
   public static ReadAll readAll() {
     return new AutoValue_TextIO_ReadAll.Builder()
         .setCompression(Compression.AUTO)
@@ -424,7 +436,12 @@ public class TextIO {
 
   /////////////////////////////////////////////////////////////////////////////
 
-  /** Implementation of {@link #readAll}. */
+  /**
+   * Implementation of {@link #readAll}.
+   *
+   * @deprecated See {@link #readAll()} for details.
+   */
+  @Deprecated
   @AutoValue
   public abstract static class ReadAll
       extends PTransform<PCollection<String>, PCollection<String>> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOReadTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOReadTest.java
@@ -162,6 +162,7 @@ public class TextIOReadTest {
    * <ul>
    *   <li>TextIO.read().from(filename).withCompression(compressionType)
    *   <li>TextIO.read().from(filename).withCompression(compressionType) .withHintMatchesManyFiles()
+   *   <li>TextIO.readFiles().withCompression(compressionType)
    *   <li>TextIO.readAll().withCompression(compressionType)
    * </ul>
    */
@@ -172,17 +173,24 @@ public class TextIOReadTest {
 
     PAssert.that(p.apply("Read_" + file + "_" + compression.toString(), read))
         .containsInAnyOrder(expected);
-
     PAssert.that(
             p.apply(
                 "Read_" + file + "_" + compression.toString() + "_many",
                 read.withHintMatchesManyFiles()))
         .containsInAnyOrder(expected);
 
-    TextIO.ReadAll readAll = TextIO.readAll().withCompression(compression);
     PAssert.that(
-            p.apply("Create_" + file, Create.of(file.getPath()))
-                .apply("Read_" + compression.toString(), readAll))
+            p.apply("Create_Paths_ReadFiles_" + file, Create.of(file.getPath()))
+                .apply("Match_" + file, FileIO.matchAll())
+                .apply("ReadMatches_" + file, FileIO.readMatches().withCompression(compression))
+                .apply("ReadFiles_" + compression.toString(), TextIO.readFiles()))
+        .containsInAnyOrder(expected);
+
+    PAssert.that(
+            p.apply("Create_Paths_ReadAll_" + file, Create.of(file.getPath()))
+                .apply(
+                    "ReadAll_" + compression.toString(),
+                    TextIO.readAll().withCompression(compression)))
         .containsInAnyOrder(expected);
   }
 

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.sdk.io.text;
 
-import static org.apache.beam.sdk.io.Compression.AUTO;
+import static org.apache.beam.sdk.io.FileIO.ReadMatches.DirectoryTreatment;
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.appendTimestampSuffix;
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.getExpectedHashForLineCount;
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.readFileBasedIOITPipelineOptions;
@@ -29,6 +29,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.Compression;
+import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.common.FileBasedIOITHelper;
@@ -127,7 +128,11 @@ public class TextIOIT {
 
     PCollection<String> consolidatedHashcode =
         testFilenames
-            .apply("Read all files", TextIO.readAll().withCompression(AUTO))
+            .apply("Match all files", FileIO.matchAll())
+            .apply(
+                "Read matches",
+                FileIO.readMatches().withDirectoryTreatment(DirectoryTreatment.PROHIBIT))
+            .apply("Read files", TextIO.readFiles())
             .apply(
                 "Collect read end time", ParDo.of(new TimeMonitor<>(FILEIOIT_NAMESPACE, "endTime")))
             .apply("Calculate hashcode", Combine.globally(new HashingFn()));


### PR DESCRIPTION
I also rewrote code to depend directly on ReadFiles instead of ReadAll for consistency (but kept ReadAll in the unit tests so we notice if somehow it breaks).

R: @chamikaramj 