### PR TITLE
Fix trigger paths filters to execute precommit tests only if needed

### DIFF
--- a/.test-infra/jenkins/job_PreCommit_Go.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Go.groovy
@@ -25,7 +25,6 @@ PrecommitJobBuilder builder = new PrecommitJobBuilder(
     triggerPathPatterns: [
       '^model/.*$',
       '^sdks/go/.*$',
-      '^runners/.*$',
       '^release/.*$',
     ]
 )

--- a/.test-infra/jenkins/job_PreCommit_Portable_Python.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Portable_Python.groovy
@@ -24,7 +24,12 @@ PrecommitJobBuilder builder = new PrecommitJobBuilder(
     gradleTask: ':portablePythonPreCommit',
     triggerPathPatterns: [
       '^model/.*$',
-      '^runners/.*$',
+      '^runners/core-construction-java/.*$',
+      '^runners/core-java/.*$',
+      '^runners/extensions-java/.*$'
+      '^runners/flink/.*$',
+      '^runners/java-fn-execution/.*$',
+      '^runners/reference/.*$'
       '^sdks/python/.*$',
       '^release/.*$',
     ]

--- a/.test-infra/jenkins/job_PreCommit_Python.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Python.groovy
@@ -24,7 +24,6 @@ PrecommitJobBuilder builder = new PrecommitJobBuilder(
     gradleTask: ':pythonPreCommit',
     triggerPathPatterns: [
       '^model/.*$',
-      '^runners/.*$',
       '^sdks/python/.*$',
       '^release/.*$',
     ]

--- a/.test-infra/jenkins/job_PreCommit_Python_ValidatesRunner_Flink.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Python_ValidatesRunner_Flink.groovy
@@ -1,4 +1,3 @@
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,16 +20,21 @@ import PrecommitJobBuilder
 
 // This job runs the suite of ValidatesRunner tests against the Flink runner.
 PrecommitJobBuilder builder = new PrecommitJobBuilder(
-        scope: this,
-        nameBase: 'Python_PVR_Flink',
-        gradleTask: ':sdks:python:flinkValidatesRunner',
-        triggerPathPatterns: [
-                '^model/.*$',
-                '^runners/.*$',
-                '^sdks/python/.*$',
-                '^release/.*$',
-        ]
+    scope: this,
+    nameBase: 'Python_PVR_Flink',
+    gradleTask: ':beam-sdks-python:flinkValidatesRunner',
+    triggerPathPatterns: [
+      '^model/.*$',
+      '^runners/core-construction-java/.*$',
+      '^runners/core-java/.*$',
+      '^runners/extensions-java/.*$'
+      '^runners/flink/.*$',
+      '^runners/java-fn-execution/.*$',
+      '^runners/reference/.*$',
+      '^sdks/python/.*$',
+      '^release/.*$',
+    ]
 )
 builder.build {
-  previousNames('beam_PostCommit_Python_VR_Flink')
+    previousNames('beam_PostCommit_Python_VR_Flink')
 }


### PR DESCRIPTION
I noticed that too many things were being executed as part of a PR in the Spark runner in particular Flink related validates runner and other tests, so I tried the matching patterns a bit.
Notice that for Python I removed it because it is already matched by the PortablePython precommit.

R: @angoenka @lukecwik 
CC: @mxm 