### PR TITLE
Fixed bug where fieldIdsAccessed order could be inconsistent with getFieldsAccessed

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldAccessDescriptor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldAccessDescriptor.java
@@ -316,11 +316,14 @@ public abstract class FieldAccessDescriptor implements Serializable {
     return toBuilder().setFieldInsertionOrder(true).build();
   }
 
-  /** Return the field ids accessed. Should not be called until after {@link #resolve} is called. */
-  public Set<Integer> fieldIdsAccessed() {
+  /**
+   * Return the field ids accessed. Should not be called until after {@link #resolve} is called.
+   * Iteration order is consistent with {@link #getFieldsAccessed}.
+   */
+  public List<Integer> fieldIdsAccessed() {
     return getFieldsAccessed().stream()
         .map(FieldDescriptor::getFieldId)
-        .collect(Collectors.toSet());
+        .collect(Collectors.toList());
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/FieldAccessDescriptorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/FieldAccessDescriptorTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor.FieldDescriptor;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableSet;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Sets;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -69,14 +69,14 @@ public class FieldAccessDescriptorTest {
   public void testFieldNames() {
     FieldAccessDescriptor fieldAccessDescriptor =
         FieldAccessDescriptor.withFieldNames("field0", "field2").resolve(SIMPLE_SCHEMA);
-    assertEquals(Sets.newHashSet(0, 2), fieldAccessDescriptor.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(0, 2), fieldAccessDescriptor.fieldIdsAccessed());
   }
 
   @Test
   public void testFieldIds() {
     FieldAccessDescriptor fieldAccessDescriptor =
         FieldAccessDescriptor.withFieldIds(1, 3).resolve(SIMPLE_SCHEMA);
-    assertEquals(Sets.newHashSet(1, 3), fieldAccessDescriptor.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(1, 3), fieldAccessDescriptor.fieldIdsAccessed());
   }
 
   @Test
@@ -118,7 +118,7 @@ public class FieldAccessDescriptorTest {
     assertTrue(resolved.fieldIdsAccessed().isEmpty());
     assertEquals(1, resolved.nestedFieldsById().size());
     resolved = resolved.nestedFieldsById().get(1);
-    assertEquals(Sets.newHashSet(2), resolved.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(2), resolved.fieldIdsAccessed());
   }
 
   @Test
@@ -131,7 +131,7 @@ public class FieldAccessDescriptorTest {
     assertTrue(resolved.fieldIdsAccessed().isEmpty());
     assertEquals(1, resolved.nestedFieldsById().size());
     resolved = resolved.nestedFieldsById().get(1);
-    assertEquals(Sets.newHashSet(2), resolved.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(2), resolved.fieldIdsAccessed());
   }
 
   @Test
@@ -144,7 +144,7 @@ public class FieldAccessDescriptorTest {
     assertTrue(resolved.fieldIdsAccessed().isEmpty());
     assertEquals(1, resolved.nestedFieldsById().size());
     resolved = resolved.nestedFieldsById().get(1);
-    assertEquals(Sets.newHashSet(2), resolved.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(2), resolved.fieldIdsAccessed());
   }
 
   @Test
@@ -218,7 +218,7 @@ public class FieldAccessDescriptorTest {
     assertTrue(fieldAccessDescriptor.fieldIdsAccessed().isEmpty());
     assertEquals(1, fieldAccessDescriptor.nestedFieldsById().size());
     fieldAccessDescriptor = fieldAccessDescriptor.nestedFieldsById().get(1);
-    assertEquals(Sets.newHashSet(2), fieldAccessDescriptor.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(2), fieldAccessDescriptor.fieldIdsAccessed());
   }
 
   @Test
@@ -229,7 +229,7 @@ public class FieldAccessDescriptorTest {
     assertTrue(fieldAccessDescriptor.fieldIdsAccessed().isEmpty());
     assertEquals(1, fieldAccessDescriptor.nestedFieldsById().size());
     fieldAccessDescriptor = fieldAccessDescriptor.nestedFieldsById().get(1);
-    assertEquals(Sets.newHashSet(2), fieldAccessDescriptor.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(2), fieldAccessDescriptor.fieldIdsAccessed());
   }
 
   @Test
@@ -240,7 +240,7 @@ public class FieldAccessDescriptorTest {
     assertTrue(fieldAccessDescriptor.fieldIdsAccessed().isEmpty());
     assertEquals(1, fieldAccessDescriptor.nestedFieldsById().size());
     fieldAccessDescriptor = fieldAccessDescriptor.nestedFieldsById().get(1);
-    assertEquals(Sets.newHashSet(2), fieldAccessDescriptor.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(2), fieldAccessDescriptor.fieldIdsAccessed());
   }
 
   private static final Schema DOUBLE_NESTED_ARRAY_SCHEMA =
@@ -257,7 +257,7 @@ public class FieldAccessDescriptorTest {
     assertTrue(fieldAccessDescriptor.fieldIdsAccessed().isEmpty());
     assertEquals(1, fieldAccessDescriptor.nestedFieldsById().size());
     fieldAccessDescriptor = fieldAccessDescriptor.nestedFieldsById().get(0);
-    assertEquals(Sets.newHashSet(2), fieldAccessDescriptor.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(2), fieldAccessDescriptor.fieldIdsAccessed());
   }
 
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -283,6 +283,25 @@ public class FieldAccessDescriptorTest {
     assertTrue(fieldAccessDescriptor.fieldIdsAccessed().isEmpty());
     assertEquals(1, fieldAccessDescriptor.nestedFieldsById().size());
     fieldAccessDescriptor = fieldAccessDescriptor.nestedFieldsById().get(0);
-    assertEquals(Sets.newHashSet(2), fieldAccessDescriptor.fieldIdsAccessed());
+    assertEquals(ImmutableList.of(2), fieldAccessDescriptor.fieldIdsAccessed());
+  }
+
+  @Test
+  public void testFieldAccessIdsDefaultOrdering() {
+    FieldAccessDescriptor fieldAccessDescriptor =
+        FieldAccessDescriptor.withFieldNames("field3", "field2", "field1", "field0")
+            .resolve(SIMPLE_SCHEMA);
+
+    assertEquals(ImmutableList.of(0, 1, 2, 3), fieldAccessDescriptor.fieldIdsAccessed());
+  }
+
+  @Test
+  public void testFieldInsertionOrdering() {
+    FieldAccessDescriptor fieldAccessDescriptor =
+        FieldAccessDescriptor.withFieldNames("field3", "field2", "field1", "field0")
+            .withOrderByFieldInsertionOrder()
+            .resolve(SIMPLE_SCHEMA);
+
+    assertEquals(ImmutableList.of(3, 2, 1, 0), fieldAccessDescriptor.fieldIdsAccessed());
   }
 }


### PR DESCRIPTION
In several places we make assumptions that `fieldIdsAccessed` returned a Set with the same iteration order as `getFieldsAccessed`, but this is not the case. Most notably this resulted in an error in `CoGroupTest` when joining by multiple keys. This bug could cause the pipeline to return results with (country, user) rather than (user, country).

This PR makes `fieldIdsAccessed` collect field ids into a List instead to maintain the original order.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
