### PR TITLE
[BEAM-7216] reinstate checks for Kafka client methods

### DIFF
--- a/sdks/java/io/kafka/build.gradle
+++ b/sdks/java/io/kafka/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   testCompile library.java.hamcrest_core
   testCompile library.java.hamcrest_library
   testCompile library.java.junit
+  testCompile library.java.powermock
   testCompile library.java.slf4j_jdk14
   testRuntimeOnly project(path: ":beam-runners-direct-java")
 }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConsumerSpEL.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConsumerSpEL.java
@@ -53,12 +53,12 @@ class ConsumerSpEL {
 
   private boolean hasRecordTimestamp = false;
   private boolean hasOffsetsForTimes = false;
-  static boolean hasHeaders = false;
 
-  static {
+  static boolean hasHeaders() {
+    boolean clientHasHeaders = false;
     try {
       // It is supported by Kafka Client 0.11.0.0 onwards.
-      hasHeaders =
+      clientHasHeaders =
           "org.apache.kafka.common.header.Headers"
               .equals(
                   ConsumerRecord.class
@@ -68,6 +68,7 @@ class ConsumerSpEL {
     } catch (NoSuchMethodException | SecurityException e) {
       LOG.debug("Headers is not available");
     }
+    return clientHasHeaders;
   }
 
   public ConsumerSpEL() {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaRecord.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaRecord.java
@@ -82,7 +82,7 @@ public class KafkaRecord<K, V> {
   }
 
   public Headers getHeaders() {
-    if (!ConsumerSpEL.hasHeaders) {
+    if (!ConsumerSpEL.hasHeaders()) {
       throw new RuntimeException(
           "The version kafka-clients does not support record headers, "
               + "please use version 0.11.0.0 or newer");

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaRecordCoder.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaRecordCoder.java
@@ -79,7 +79,7 @@ public class KafkaRecordCoder<K, V> extends StructuredCoder<KafkaRecord<K, V>> {
   }
 
   private Object toHeaders(Iterable<KV<String, byte[]>> records) {
-    if (!ConsumerSpEL.hasHeaders) {
+    if (!ConsumerSpEL.hasHeaders()) {
       return null;
     }
 
@@ -90,7 +90,7 @@ public class KafkaRecordCoder<K, V> extends StructuredCoder<KafkaRecord<K, V>> {
   }
 
   private Iterable<KV<String, byte[]>> toIterable(KafkaRecord record) {
-    if (!ConsumerSpEL.hasHeaders) {
+    if (!ConsumerSpEL.hasHeaders()) {
       return Collections.emptyList();
     }
 
@@ -129,7 +129,7 @@ public class KafkaRecordCoder<K, V> extends StructuredCoder<KafkaRecord<K, V>> {
           value.getOffset(),
           value.getTimestamp(),
           value.getTimestampType(),
-          !ConsumerSpEL.hasHeaders ? null : value.getHeaders(),
+          !ConsumerSpEL.hasHeaders() ? null : value.getHeaders(),
           (KV<Object, Object>) kvCoder.structuralValue(value.getKV()));
     }
   }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -208,7 +208,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
                 rawRecord.offset(),
                 consumerSpEL.getRecordTimestamp(rawRecord),
                 consumerSpEL.getRecordTimestampType(rawRecord),
-                ConsumerSpEL.hasHeaders ? rawRecord.headers() : null,
+                ConsumerSpEL.hasHeaders() ? rawRecord.headers() : null,
                 keyDeserializerInstance.deserialize(rawRecord.topic(), rawRecord.key()),
                 valueDeserializerInstance.deserialize(rawRecord.topic(), rawRecord.value()));
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ProducerRecordCoder.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ProducerRecordCoder.java
@@ -79,14 +79,14 @@ public class ProducerRecordCoder<K, V> extends StructuredCoder<ProducerRecord<K,
 
     Headers headers = (Headers) toHeaders(headerCoder.decode(inStream));
     KV<K, V> kv = kvCoder.decode(inStream);
-    if (ConsumerSpEL.hasHeaders) {
+    if (ConsumerSpEL.hasHeaders()) {
       return new ProducerRecord<>(topic, partition, timestamp, kv.getKey(), kv.getValue(), headers);
     }
     return new ProducerRecord<>(topic, partition, timestamp, kv.getKey(), kv.getValue());
   }
 
   private Object toHeaders(Iterable<KV<String, byte[]>> records) {
-    if (!ConsumerSpEL.hasHeaders) {
+    if (!ConsumerSpEL.hasHeaders()) {
       return null;
     }
 
@@ -97,7 +97,7 @@ public class ProducerRecordCoder<K, V> extends StructuredCoder<ProducerRecord<K,
   }
 
   private Iterable<KV<String, byte[]>> toIterable(ProducerRecord record) {
-    if (!ConsumerSpEL.hasHeaders) {
+    if (!ConsumerSpEL.hasHeaders()) {
       return Collections.emptyList();
     }
     List<KV<String, byte[]>> vals = new ArrayList<>();
@@ -128,13 +128,18 @@ public class ProducerRecordCoder<K, V> extends StructuredCoder<ProducerRecord<K,
     if (consistentWithEquals()) {
       return value;
     } else {
-      return new ProducerRecord<>(
-          value.topic(),
-          value.partition(),
-          value.timestamp(),
-          value.key(),
-          value.value(),
-          value.headers());
+      if (!ConsumerSpEL.hasHeaders()) {
+        return new ProducerRecord<>(
+            value.topic(), value.partition(), value.timestamp(), value.key(), value.value());
+      } else {
+        return new ProducerRecord<>(
+            value.topic(),
+            value.partition(),
+            value.timestamp(),
+            value.key(),
+            value.value(),
+            value.headers());
+      }
     }
   }
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ProducerRecordCoderTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ProducerRecordCoderTest.java
@@ -17,13 +17,16 @@
  */
 package org.apache.beam.sdk.io.kafka;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -33,10 +36,12 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /** Tests for {@link ProducerRecordCoder}. */
-@RunWith(JUnit4.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ConsumerSpEL.class)
 public class ProducerRecordCoderTest {
   @Test
   public void testCoderIsSerializableWithWellKnownCoderType() {
@@ -47,7 +52,7 @@ public class ProducerRecordCoderTest {
   @Test
   public void testProducerRecordSerializableWithHeaders() throws IOException {
     RecordHeaders headers = new RecordHeaders();
-    headers.add("headerKey", "headerVal".getBytes(StandardCharsets.UTF_8));
+    headers.add("headerKey", "headerVal".getBytes(UTF_8));
     verifySerialization(headers, 0, System.currentTimeMillis());
   }
 
@@ -82,6 +87,37 @@ public class ProducerRecordCoderTest {
   public void testProducerRecordSerializableWithoutTimestamp() throws IOException {
     ProducerRecord<String, String> decodedRecord = verifySerialization(1, null);
     assertNull(decodedRecord.timestamp());
+  }
+
+  @Test
+  public void testProducerRecordStructuralValueWithHeadersApi() throws IOException {
+    RecordHeaders headers = new RecordHeaders();
+    headers.add("headerKey", "headerVal".getBytes(UTF_8));
+    ProducerRecordCoder producerRecordCoder =
+        ProducerRecordCoder.of(ByteArrayCoder.of(), ByteArrayCoder.of());
+    ProducerRecord<byte[], byte[]> producerRecord =
+        new ProducerRecord<>(
+            "topic", 1, null, "key".getBytes(UTF_8), "value".getBytes(UTF_8), headers);
+
+    ProducerRecord testProducerRecord =
+        (ProducerRecord) producerRecordCoder.structuralValue(producerRecord);
+    assertEquals(testProducerRecord.headers(), headers);
+  }
+
+  @Test
+  public void testProducerRecordStructuralValueWithoutHeadersApi() throws IOException {
+    RecordHeaders headers = new RecordHeaders();
+    headers.add("headerKey", "headerVal".getBytes(UTF_8));
+    ProducerRecordCoder producerRecordCoder =
+        ProducerRecordCoder.of(ByteArrayCoder.of(), ByteArrayCoder.of());
+    ProducerRecord<byte[], byte[]> producerRecord =
+        new ProducerRecord<>(
+            "topic", 1, null, "key".getBytes(UTF_8), "value".getBytes(UTF_8), headers);
+    mockStatic(ConsumerSpEL.class);
+    when(ConsumerSpEL.hasHeaders()).thenReturn(false);
+    ProducerRecord testProducerRecord =
+        (ProducerRecord) producerRecordCoder.structuralValue(producerRecord);
+    assertEquals(testProducerRecord.headers(), new RecordHeaders());
   }
 
   private ProducerRecord<String, String> verifySerialization(Integer partition, Long timestamp)


### PR DESCRIPTION
[BEAM-7216] reinstate checks for Kafka client methods
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
