### PR TITLE
Add UsesSchema category to Schema transform tests

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastTest.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
@@ -33,8 +34,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Tests for {@link Cast}. */
+@RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class CastTest {
 
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastValidatorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastValidatorTest.java
@@ -31,11 +31,17 @@ import java.util.Map;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Tests for {@link Cast.Widening}, {@link Cast.Narrowing}. */
+@Category(UsesSchema.class)
+@RunWith(JUnit4.class)
 public class CastValidatorTest {
 
   public static final Map<TypeName, Number> NUMERICS =
@@ -73,7 +79,7 @@ public class CastValidatorTest {
         .forEach(input -> NUMERICS.keySet().forEach(output -> testCasting(input, output)));
   }
 
-  public void testCasting(TypeName inputType, TypeName outputType) {
+  private void testCasting(TypeName inputType, TypeName outputType) {
     Object output =
         Cast.castValue(NUMERICS.get(inputType), FieldType.of(inputType), FieldType.of(outputType));
 
@@ -88,7 +94,7 @@ public class CastValidatorTest {
     assertTrue(all);
   }
 
-  public void testWideningOrder(TypeName input, TypeName output) {
+  private void testWideningOrder(TypeName input, TypeName output) {
     Schema inputSchema = Schema.of(Schema.Field.of("f0", FieldType.of(input)));
     Schema outputSchema = Schema.of(Schema.Field.of("f0", FieldType.of(output)));
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
@@ -32,6 +32,7 @@ import org.apache.beam.sdk.schemas.transforms.CoGroup.By;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
@@ -46,8 +47,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Tests for {@link CoGroup}. */
+@RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class CoGroupTest {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule public transient ExpectedException thrown = ExpectedException.none();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/ConvertTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/ConvertTest.java
@@ -27,6 +27,7 @@ import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.values.PCollection;
@@ -36,8 +37,12 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Tests for the {@link Convert} class. */
+@RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class ConvertTest {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/FilterTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/FilterTest.java
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
@@ -30,8 +31,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Test for {@link Filter}. * */
+@RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class FilterTest {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule public transient ExpectedException thrown = ExpectedException.none();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/GroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/GroupTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
@@ -53,8 +54,12 @@ import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Test for {@link Group}. */
+@RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class GroupTest implements Serializable {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/JoinTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/JoinTest.java
@@ -26,6 +26,7 @@ import org.apache.beam.sdk.schemas.transforms.Join.FieldsEqual;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
@@ -33,8 +34,12 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Tests for {@link org.apache.beam.sdk.schemas.transforms.Join}. */
+@RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class JoinTest {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/SelectTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/SelectTest.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableList;
@@ -33,8 +34,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Test for {@link Select}. */
+@RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class SelectTest {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule public transient ExpectedException thrown = ExpectedException.none();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/UnnestTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/UnnestTest.java
@@ -27,6 +27,7 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
@@ -34,8 +35,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Tests for {@link org.apache.beam.sdk.schemas.transforms.Unnest}. */
+@RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class UnnestTest implements Serializable {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule public transient ExpectedException thrown = ExpectedException.none();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.junit.Rule;
@@ -32,6 +33,7 @@ import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link JsonToRow}. */
 @RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class JsonToRowTest implements Serializable {
 
   @Rule public transient TestPipeline pipeline = TestPipeline.create();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
@@ -49,6 +49,7 @@ import org.junit.runners.JUnit4;
 
 /** Test {@link Schema} support. */
 @RunWith(JUnit4.class)
+@Category(UsesSchema.class)
 public class ParDoSchemaTest implements Serializable {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule public transient ExpectedException thrown = ExpectedException.none();
@@ -64,7 +65,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testSimpleSchemaPipeline() {
     List<MyPojo> pojoList =
         Lists.newArrayList(new MyPojo("a", 1), new MyPojo("b", 2), new MyPojo("c", 3));
@@ -94,7 +95,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testReadAndWrite() {
     List<MyPojo> pojoList =
         Lists.newArrayList(new MyPojo("a", 1), new MyPojo("b", 2), new MyPojo("c", 3));
@@ -146,7 +147,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testReadAndWriteMultiOutput() {
     List<MyPojo> pojoList =
         Lists.newArrayList(new MyPojo("a", 1), new MyPojo("b", 2), new MyPojo("c", 3));
@@ -240,7 +241,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testReadAndWriteWithSchemaRegistry() {
     Schema schema =
         Schema.builder().addStringField("string_field").addInt32Field("integer_field").build();
@@ -285,7 +286,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testFieldAccessSchemaPipeline() {
     List<MyPojo> pojoList =
         Lists.newArrayList(new MyPojo("a", 1), new MyPojo("b", 2), new MyPojo("c", 3));
@@ -319,7 +320,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesSchema.class})
+  @Category(NeedsRunner.class)
   public void testNoSchema() {
     thrown.expect(IllegalArgumentException.class);
     pipeline
@@ -334,7 +335,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesSchema.class})
+  @Category(NeedsRunner.class)
   public void testUnmatchedSchema() {
     List<MyPojo> pojoList =
         Lists.newArrayList(new MyPojo("a", 1), new MyPojo("b", 2), new MyPojo("c", 3));
@@ -372,7 +373,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testInferredSchemaPipeline() {
     List<Inferred> pojoList =
         Lists.newArrayList(
@@ -396,7 +397,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testSchemasPassedThrough() {
     List<Inferred> pojoList =
         Lists.newArrayList(
@@ -420,7 +421,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testSchemaConversionPipeline() {
     List<Inferred> pojoList =
         Lists.newArrayList(
@@ -452,7 +453,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testNestedSchema() {
     List<Nested> pojoList =
         Lists.newArrayList(
@@ -493,7 +494,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testSchemaFieldSelectionUnboxing() {
     List<ForExtraction> pojoList =
         Lists.newArrayList(
@@ -533,7 +534,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testSchemaFieldDescriptorSelectionUnboxing() {
     List<ForExtraction> pojoList =
         Lists.newArrayList(
@@ -580,7 +581,7 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesSchema.class})
+  @Category(ValidatesRunner.class)
   public void testSchemaFieldSelectionNested() {
     List<ForExtraction> pojoList =
         Lists.newArrayList(


### PR DESCRIPTION
I decided to categorize them class wide in case someone forgets to add the annotation on new methods.
For some context this comes from testing support of both Spark and Flink runners.

R: @reuvenlax 