### PR TITLE
Refines categories to use `UsesTestStreamWithProcessingTime` in `TestStreamTests`

### DIFF
--- a/runners/spark/build.gradle
+++ b/runners/spark/build.gradle
@@ -120,21 +120,27 @@ task validatesRunnerBatch(type: Test) {
   systemProperty "spark.ui.enabled", "false"
   systemProperty "spark.ui.showConsoleProgress", "false"
 
-
   classpath = configurations.validatesRunner
-  testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs) + files(project(":beam-sdks-java-io-hadoop-format").sourceSets.test.output.classesDirs) + files(project.sourceSets.test.output.classesDirs)
+  testClassesDirs += files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
+  testClassesDirs += files(project.sourceSets.test.output.classesDirs)
+
   // Only one SparkContext may be running in a JVM (SPARK-2243)
   forkEvery 1
   maxParallelForks 4
   useJUnit {
     includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
     includeCategories 'org.apache.beam.runners.spark.UsesCheckpointRecovery'
-    excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
-    excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
     excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
-    excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse'
+    // Unbounded
     excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedPCollections'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
+    // Metrics
+    excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+    // SDF
     excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+    // Portability
+    excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesCrossLanguageTransforms'
   }
 }
 
@@ -148,7 +154,8 @@ task validatesRunnerStreaming(type: Test) {
   systemProperty "beamTestPipelineOptions", pipelineOptions
 
   classpath = configurations.validatesRunner
-  testClassesDirs = files(project.sourceSets.test.output.classesDirs)
+  testClassesDirs += files(project.sourceSets.test.output.classesDirs)
+
   // Only one SparkContext may be running in a JVM (SPARK-2243)
   forkEvery 1
   maxParallelForks 4

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/LargeKeys.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/LargeKeys.java
@@ -20,17 +20,17 @@ package org.apache.beam.sdk.testing;
 /** Category tags for tests which validate that a Beam runner can handle keys up to a given size. */
 public interface LargeKeys {
   /** Tests if a runner supports 10KB keys. */
-  public interface Above10KB {}
+  interface Above10KB {}
 
   /** Tests if a runner supports 100KB keys. */
-  public interface Above100KB extends Above10KB {}
+  interface Above100KB extends Above10KB {}
 
   /** Tests if a runner supports 1MB keys. */
-  public interface Above1MB extends Above100KB {}
+  interface Above1MB extends Above100KB {}
 
   /** Tests if a runner supports 10MB keys. */
-  public interface Above10MB extends Above1MB {}
+  interface Above10MB extends Above1MB {}
 
   /** Tests if a runner supports 100MB keys. */
-  public interface Above100MB extends Above10MB {}
+  interface Above100MB extends Above10MB {}
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordIOTest.java
@@ -173,7 +173,6 @@ public class TFRecordIOTest {
   public void testReadInvalidRecord() throws Exception {
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage("Not a valid TFRecord. Fewer than 12 bytes.");
-    System.out.println("abr".getBytes(Charsets.UTF_8).length);
     runTestRead("bar".getBytes(Charsets.UTF_8), new String[0]);
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
@@ -137,7 +137,7 @@ public class TestStreamTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesTestStream.class})
+  @Category({NeedsRunner.class, UsesTestStreamWithProcessingTime.class})
   public void testProcessingTimeTrigger() {
     TestStream<Long> source =
         TestStream.create(VarLongCoder.of())
@@ -335,7 +335,7 @@ public class TestStreamTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesTestStream.class})
+  @Category({NeedsRunner.class, UsesTestStreamWithProcessingTime.class})
   public void testEarlyPanesOfWindow() {
     TestStream<Long> source =
         TestStream.create(VarLongCoder.of())
@@ -387,6 +387,7 @@ public class TestStreamTest implements Serializable {
   }
 
   @Test
+  @Category(UsesTestStreamWithProcessingTime.class)
   public void testCoder() throws Exception {
     TestStream<String> testStream =
         TestStream.create(StringUtf8Coder.of())


### PR DESCRIPTION
and other minor fixes.
R: @mxm 