### PR TITLE
Adding a Sequence Generator for SQL, and posting about SQL data sources

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTable.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.seqgen;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
+import org.apache.beam.sdk.extensions.sql.meta.Table;
+import org.apache.beam.sdk.io.GenerateSequence;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.WithTimestamps;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollection.IsBounded;
+import org.apache.beam.sdk.values.POutput;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+class GenerateSequenceTable extends BaseBeamTable implements Serializable {
+  static public final Schema tableSchema = Schema.of(
+      Field.of("sequence", FieldType.INT64),
+      Field.of("timestamp", FieldType.DATETIME));
+
+  Integer elementsPerSecond = 5;
+
+
+  GenerateSequenceTable(Table table) {
+    super(tableSchema);
+    if (table.getProperties().containsKey("elementsPerSecond")) {
+      elementsPerSecond = table.getProperties().getInteger("elementsPerSecond");
+    }
+  }
+
+  @Override
+  public PCollection.IsBounded isBounded() {
+    return IsBounded.UNBOUNDED;
+  }
+
+  @Override
+  public PCollection<Row> buildIOReader(PBegin begin) {
+    return begin
+        .apply(GenerateSequence.from(0).withRate(elementsPerSecond, Duration.standardSeconds(1)))
+        .apply(MapElements
+            .into(TypeDescriptor.of(Row.class))
+            .via(elm -> Row.withSchema(tableSchema).addValues(elm, Instant.now()).build()))
+        .setRowSchema(getSchema());
+  }
+
+  @Override
+  public POutput buildIOWriter(PCollection<Row> input) {
+    throw new UnsupportedOperationException("buildIOWriter unsupported!");
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTableProvider.java
@@ -30,8 +30,8 @@ import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
  *
  * <pre>{@code
  * CREATE EXTERNAL TABLE MY_SEQUENCE(
- *   SEQUENCE INT COMMENT 'this is the primary key',
- *   EVENT_TIME TIMESTAMP COMMENT 'this is the element timestamp'
+ *   sequence INT COMMENT 'this is the primary key',
+ *   event_time TIMESTAMP COMMENT 'this is the element timestamp'
  * )
  * TYPE 'sequence';
  * }</pre>

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTableProvider.java
@@ -30,7 +30,7 @@ import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
  *
  * <pre>{@code
  * CREATE EXTERNAL TABLE MY_SEQUENCE(
- *   sequence INT COMMENT 'this is the primary key',
+ *   sequence BIGINT COMMENT 'this is the primary key',
  *   event_time TIMESTAMP COMMENT 'this is the element timestamp'
  * )
  * TYPE 'sequence';

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTableProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.seqgen;
+
+import com.google.auto.service.AutoService;
+import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
+import org.apache.beam.sdk.extensions.sql.meta.Table;
+import org.apache.beam.sdk.extensions.sql.meta.provider.InMemoryMetaTableProvider;
+import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
+
+@AutoService(TableProvider.class)
+public class GenerateSequenceTableProvider extends InMemoryMetaTableProvider {
+
+  @Override
+  public String getTableType() {
+    return "sequence";
+  }
+
+  @Override
+  public BeamSqlTable buildBeamSqlTable(Table table) {
+    return new GenerateSequenceTable(table);
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/GenerateSequenceTableProvider.java
@@ -23,6 +23,19 @@ import org.apache.beam.sdk.extensions.sql.meta.Table;
 import org.apache.beam.sdk.extensions.sql.meta.provider.InMemoryMetaTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 
+/**
+ * Sequence generator table provider.
+ *
+ * <p>A sample of text table is:
+ *
+ * <pre>{@code
+ * CREATE EXTERNAL TABLE MY_SEQUENCE(
+ *   SEQUENCE INT COMMENT 'this is the primary key',
+ *   EVENT_TIME TIMESTAMP COMMENT 'this is the element timestamp'
+ * )
+ * TYPE 'sequence';
+ * }</pre>
+ */
 @AutoService(TableProvider.class)
 public class GenerateSequenceTableProvider extends InMemoryMetaTableProvider {
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/seqgen/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Table schema for streaming sequence generator. */
+package org.apache.beam.sdk.extensions.sql.meta.provider.seqgen;

--- a/website/src/_posts/2019-05-01-adding-data-sources-to-sql.md
+++ b/website/src/_posts/2019-05-01-adding-data-sources-to-sql.md
@@ -31,11 +31,11 @@ Beam also has a fancy new SQL command line that you can use to query your
 data interactively, be it Batch or Streaming. If you haven't tried it, check out
 [http://bit.ly/ExploreBeamSQL](http://bit.ly/ExploreBeamSQL).
 
-A nice feature of the SQL CLI is that you can use `CREATE TABLE` commands to
-*add* data sources to be accessed in the CLI. Currently, the CLI supports
-creating tables from BigQuery, PubSub, Kafka, and text files. In this post, we
-explore how to add new data sources, so that you will be able to consume data
-from other Beam sources.
+A nice feature of the SQL CLI is that you can use `CREATE EXTERNAL TABLE`
+commands to *add* data sources to be accessed in the CLI. Currently, the CLI
+supports creating tables from BigQuery, PubSub, Kafka, and text files. In this
+post, we explore how to add new data sources, so that you will be able to
+consume data from other Beam sources.
 
 <!--more-->
 
@@ -49,7 +49,7 @@ in SQL like this:
 CREATE EXTERNAL TABLE                      -- all tables in Beam are external, they are not persisted
   sequenceTable                              -- table alias that will be used in queries
   (
-         sequence INT,                     -- sequence number
+         sequence BIGINT,                  -- sequence number
          event_timestamp TIMESTAMP         -- timestamp of the generated event
   )
 TYPE sequence                              -- type identifies the table provider
@@ -154,7 +154,7 @@ can now perform selections on the table:
 
 ```
 0: BeamSQL> CREATE EXTERNAL TABLE input_seq (
-. . . . . >   sequence INT COMMENT 'this is the primary key',
+. . . . . >   sequence BIGINT COMMENT 'this is the primary key',
 . . . . . >   event_time TIMESTAMP COMMENT 'this is the element timestamp'
 . . . . . > )
 . . . . . > TYPE 'sequence';

--- a/website/src/_posts/2019-05-01-adding-data-sources-to-sql.md
+++ b/website/src/_posts/2019-05-01-adding-data-sources-to-sql.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Adding new Data Sources to Beam SQL CLI"
-date:   2019-05-01 00:00:01 -0800
+date:   2019-06-04 00:00:01 -0800
 excerpt_separator: <!--more-->
 categories: blog
 authors:

--- a/website/src/_posts/2019-05-01-adding-data-sources-to-sql.md
+++ b/website/src/_posts/2019-05-01-adding-data-sources-to-sql.md
@@ -1,0 +1,111 @@
+---
+layout: post
+title:  "Adding new Data Sources to Beam SQL CLI"
+date:   2019-05-01 00:00:01 -0800
+excerpt_separator: <!--more-->
+categories: blog
+authors:
+        - pabloem
+
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+A new, exciting feature that came to Apache Beam is the ability to use
+SQL in your pipelines. This is done using Beam's
+[`SqlTransform`](https://beam.apache.org/releases/javadoc/latest/org/apache/beam/sdk/extensions/sql/SqlTransform.html)
+in Java pipelines.
+
+Beam also has a fancy new SQL command line that you can use to query your
+data interactively, be it Batch or Streaming. If you haven't tried it, check out
+[http://bit.ly/ExploreBeamSQL](http://bit.ly/ExploreBeamSQL).
+
+A nice feature of the SQL CLI is that you can use `CREATE TABLE` commands to
+*add* data sources to be accessed in the CLI. Currently, the CLI supports
+creating tables from BigQuery, PubSub, Kafka, and text files. In this post, we
+explore how to add new data sources, so that you will be able to consume data
+from other Beam sources.
+
+<!--more-->
+
+Beam's `SqlTransform` works by relying on `TableProvider`s, which it uses when
+one uses a `CREATE TABLE` statement. If you are looking to add a new data source
+to the Beam SQL CLI, then you will want to add a `TableProvider` to do it. In
+this post, I will show what steps are necessary to create a new table provider
+for the [`GenerateSequence` transform](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/GenerateSequence.html) available in the Java SDK.
+
+The `TableProvider` classes are under
+[`sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/`](https://github.com/apache/beam/tree/master/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider). If you look in there, you can find providers, and their implementations, for all available data sources. So, you just need to add the one you want, along with an implementation of `BaseBeamTable`.
+
+### The GenerateSequenceTableProvider
+
+Our table provider looks like this:
+
+```java
+@AutoService(TableProvider.class)
+public class GenerateSequenceTableProvider extends InMemoryMetaTableProvider {
+
+  @Override
+  public String getTableType() {
+    return "sequence";
+  }
+
+  @Override
+  public BeamSqlTable buildBeamSqlTable(Table table) {
+    return new GenerateSequenceTable(table);
+  }
+}
+```
+
+### The GenerateSequenceTable
+
+We want a table implementation that supports streaming properly, so we will
+allow users to define the number of elements to be emitted per second.
+
+```java
+class GenerateSequenceTable extends BaseBeamTable implements Serializable {
+  static public final Schema tableSchema = Schema.of(Field.of("sequence", FieldType.INT64));
+
+  Integer elementsPerSecond = 5;
+
+
+  GenerateSequenceTable(Table table) {
+    super(tableSchema);
+    if (table.getProperties().containsKey("elementsPerSecond")) {
+      elementsPerSecond = table.getProperties().getInteger("elementsPerSecond");
+    }
+  }
+
+  @Override
+  public PCollection.IsBounded isBounded() {
+    return IsBounded.UNBOUNDED;
+  }
+
+  @Override
+  public PCollection<Row> buildIOReader(PBegin begin) {
+    return begin
+        .apply(GenerateSequence.from(0).withRate(elementsPerSecond, Duration.standardSeconds(1)))
+        .apply(WithTimestamps.of(elm -> Instant.now().plus(elm)))
+        .apply(MapElements
+            .into(TypeDescriptor.of(Row.class))
+            .via(elm -> Row.withSchema(tableSchema).addValue(elm).build()))
+        .setRowSchema(getSchema());
+  }
+
+  @Override
+  public POutput buildIOWriter(PCollection<Row> input) {
+    throw new UnsupportedOperationException("buildIOWriter unsupported!");
+  }
+}
+```


### PR DESCRIPTION
r: @apilloud 
I've successfully ran the pipelines that I'm detailing in the blog post. I think a sequence generator is a reasonable thing to have available for anyone.
For the demo for our talk, I'll develop a custom thing to generate random data with `player, team, score` rows, and we can perform aggregations. Maybe another one with `trade, currency, amount` - and converting everything to USD or IDK.