### PR TITLE
[BEAM-7263] Deprecate set/getClientConfiguration in JdbcIO

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -429,6 +429,8 @@ public class JdbcIO {
   /** Implementation of {@link #read}. */
   @AutoValue
   public abstract static class Read<T> extends PTransform<PBegin, PCollection<T>> {
+    /** @deprecated It is not needed anymore. It will be removed in a future version of Beam. */
+    @Deprecated
     @Nullable
     abstract DataSourceConfiguration getDataSourceConfiguration();
 
@@ -455,6 +457,8 @@ public class JdbcIO {
 
     @AutoValue.Builder
     abstract static class Builder<T> {
+      /** @deprecated It is not needed anymore. It will be removed in a future version of Beam. */
+      @Deprecated
       abstract Builder<T> setDataSourceConfiguration(DataSourceConfiguration config);
 
       abstract Builder<T> setDataSourceProviderFn(
@@ -572,6 +576,8 @@ public class JdbcIO {
   @AutoValue
   public abstract static class ReadAll<ParameterT, OutputT>
       extends PTransform<PCollection<ParameterT>, PCollection<OutputT>> {
+    /** @deprecated It is not needed anymore. It will be removed in a future version of Beam. */
+    @Deprecated
     @Nullable
     abstract DataSourceConfiguration getDataSourceConfiguration();
 
@@ -598,6 +604,8 @@ public class JdbcIO {
 
     @AutoValue.Builder
     abstract static class Builder<ParameterT, OutputT> {
+      /** @deprecated It is not needed anymore. It will be removed in a future version of Beam. */
+      @Deprecated
       abstract Builder<ParameterT, OutputT> setDataSourceConfiguration(
           DataSourceConfiguration config);
 
@@ -870,6 +878,8 @@ public class JdbcIO {
   /** A {@link PTransform} to write to a JDBC datasource. */
   @AutoValue
   public abstract static class WriteVoid<T> extends PTransform<PCollection<T>, PCollection<Void>> {
+    /** @deprecated It is not needed anymore. It will be removed in a future version of Beam. */
+    @Deprecated
     @Nullable
     abstract DataSourceConfiguration getDataSourceConfiguration();
 
@@ -891,6 +901,8 @@ public class JdbcIO {
 
     @AutoValue.Builder
     abstract static class Builder<T> {
+      /** @deprecated It is not needed anymore. It will be removed in a future version of Beam. */
+      @Deprecated
       abstract Builder<T> setDataSourceConfiguration(DataSourceConfiguration config);
 
       abstract Builder<T> setDataSourceProviderFn(


### PR DESCRIPTION
This is a minor clean up to deprecate the two methods because they are not used internally anymore, the `ClientConfiguration` object is now wrapped and passed as a function to `withDataSourceProviderFn`. This has almost zero impact on end users because the set functionality is already covered by the `with` method and the `get` method is not mandatory because the user already has the reference.

R: @jbonofre 
