### PR TITLE
[BEAM-6027] Fix slow downloads when reading from GCS

### DIFF
--- a/sdks/python/apache_beam/io/filesystemio.py
+++ b/sdks/python/apache_beam/io/filesystemio.py
@@ -80,8 +80,10 @@ class Uploader(with_metaclass(abc.ABCMeta, object)):
 class DownloaderStream(io.RawIOBase):
   """Provides a stream interface for Downloader objects."""
 
-  def __init__(self, downloader, read_buffer_size=io.DEFAULT_BUFFER_SIZE,
-   mode='rb'):
+  def __init__(self, 
+               downloader,
+               read_buffer_size=io.DEFAULT_BUFFER_SIZE,
+               mode='rb'):
     """Initializes the stream.
 
     Args:

--- a/sdks/python/apache_beam/io/filesystemio.py
+++ b/sdks/python/apache_beam/io/filesystemio.py
@@ -157,6 +157,19 @@ class DownloaderStream(io.RawIOBase):
   def readable(self):
     return True
 
+  def readall(self):
+      """Read until EOF, using multiple read() call."""
+      res = bytearray()
+      while True:
+          data = self.read(gcsio.DEFAULT_READ_BUFFER_SIZE)
+          if not data:
+              break
+          res += data
+      if res:
+          return bytes(res)
+      else:
+          return data
+
 
 class UploaderStream(io.RawIOBase):
   """Provides a stream interface for Uploader objects."""

--- a/sdks/python/apache_beam/io/filesystemio.py
+++ b/sdks/python/apache_beam/io/filesystemio.py
@@ -80,11 +80,12 @@ class Uploader(with_metaclass(abc.ABCMeta, object)):
 class DownloaderStream(io.RawIOBase):
   """Provides a stream interface for Downloader objects."""
 
-  def __init__(self, downloader, mode='rb'):
+  def __init__(self, downloader, read_buffer_size=io.DEFAULT_BUFFER_SIZE, mode='rb'):
     """Initializes the stream.
 
     Args:
       downloader: (Downloader) Filesystem dependent implementation.
+      read_buffer_size: (int) Buffer size to use during read operations.
       mode: (string) Python mode attribute for this stream.
     """
     self._downloader = downloader
@@ -161,7 +162,7 @@ class DownloaderStream(io.RawIOBase):
       """Read until EOF, using multiple read() call."""
       res = bytearray()
       while True:
-          data = self.read(gcsio.DEFAULT_READ_BUFFER_SIZE)
+          data = self.read(read_buffer_size)
           if not data:
               break
           res += data

--- a/sdks/python/apache_beam/io/filesystemio.py
+++ b/sdks/python/apache_beam/io/filesystemio.py
@@ -80,7 +80,8 @@ class Uploader(with_metaclass(abc.ABCMeta, object)):
 class DownloaderStream(io.RawIOBase):
   """Provides a stream interface for Downloader objects."""
 
-  def __init__(self, downloader, read_buffer_size=io.DEFAULT_BUFFER_SIZE, mode='rb'):
+  def __init__(self, downloader, read_buffer_size=io.DEFAULT_BUFFER_SIZE,
+   mode='rb'):
     """Initializes the stream.
 
     Args:
@@ -160,18 +161,14 @@ class DownloaderStream(io.RawIOBase):
     return True
 
   def readall(self):
-      """Read until EOF, using multiple read() call."""
-      res = bytearray()
-      while True:
-          data = self.read(self._reader_buffer_size)
-          if not data:
-              break
-          res += data
-      if res:
-          return bytes(res)
-      else:
-          return data
-
+    """Read until EOF, using multiple read() call."""
+    res = []
+    while True:
+      data = self.read(self._reader_buffer_size)
+      if not data:
+        break
+      res.append(data)
+    return b''.join(res)
 
 class UploaderStream(io.RawIOBase):
   """Provides a stream interface for Uploader objects."""

--- a/sdks/python/apache_beam/io/filesystemio.py
+++ b/sdks/python/apache_beam/io/filesystemio.py
@@ -172,6 +172,7 @@ class DownloaderStream(io.RawIOBase):
       res.append(data)
     return b''.join(res)
 
+
 class UploaderStream(io.RawIOBase):
   """Provides a stream interface for Uploader objects."""
 

--- a/sdks/python/apache_beam/io/filesystemio.py
+++ b/sdks/python/apache_beam/io/filesystemio.py
@@ -80,7 +80,7 @@ class Uploader(with_metaclass(abc.ABCMeta, object)):
 class DownloaderStream(io.RawIOBase):
   """Provides a stream interface for Downloader objects."""
 
-  def __init__(self, 
+  def __init__(self,
                downloader,
                read_buffer_size=io.DEFAULT_BUFFER_SIZE,
                mode='rb'):

--- a/sdks/python/apache_beam/io/filesystemio.py
+++ b/sdks/python/apache_beam/io/filesystemio.py
@@ -91,6 +91,7 @@ class DownloaderStream(io.RawIOBase):
     self._downloader = downloader
     self.mode = mode
     self._position = 0
+    self._reader_buffer_size = read_buffer_size
 
   def readinto(self, b):
     """Read up to len(b) bytes into b.
@@ -162,7 +163,7 @@ class DownloaderStream(io.RawIOBase):
       """Read until EOF, using multiple read() call."""
       res = bytearray()
       while True:
-          data = self.read(read_buffer_size)
+          data = self.read(self._reader_buffer_size)
           if not data:
               break
           res += data

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -174,7 +174,7 @@ class GcsIO(object):
     if mode == 'r' or mode == 'rb':
       downloader = GcsDownloader(self.client, filename,
                                  buffer_size=read_buffer_size)
-      return io.BufferedReader(DownloaderStream(downloader, mode=mode),
+      return io.BufferedReader(DownloaderStream(downloader, read_buffer_size=read_buffer_size, mode=mode),
                                buffer_size=read_buffer_size)
     elif mode == 'w' or mode == 'wb':
       uploader = GcsUploader(self.client, filename, mime_type)


### PR DESCRIPTION
Overrides `io.RawIOBase.readall` in `filesystemio.DownloaderStream` as proposed in [BEAM-6027](https://issues.apache.org/jira/browse/BEAM-6027).
It improves download time in ~40x.

