### PR TITLE
[BEAM-7239] Do not close DataSource on Teardown on JdbcIO

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -769,9 +769,6 @@ public class JdbcIO {
     @Teardown
     public void teardown() throws Exception {
       connection.close();
-      if (dataSource instanceof AutoCloseable) {
-        ((AutoCloseable) dataSource).close();
-      }
     }
   }
 
@@ -1074,13 +1071,6 @@ public class JdbcIO {
           }
         }
         records.clear();
-      }
-
-      @Teardown
-      public void teardown() throws Exception {
-        if (dataSource instanceof AutoCloseable) {
-          ((AutoCloseable) dataSource).close();
-        }
       }
     }
   }


### PR DESCRIPTION
DataSource implementations do not necessarily implement close() and even
if so, it may make sense not to close them systematically on @Teardown
because they could be provided for a longer lifecycle than the DoFn
thread, e.g. PoolableDataSource should not be instantiated per DoFn
in particular for Streaming Jobs but by VM.
(See [BEAM-7230](https://issues.apache.org/jira/browse/BEAM-7230) for details.

R: @aromanenko-dev 
CC: @jbonofre 