### PR TITLE
[release-2.13.0][BEAM-7239] Do not close DataSource on Teardown on JdbcIO

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -761,9 +761,6 @@ public class JdbcIO {
     @Teardown
     public void teardown() throws Exception {
       connection.close();
-      if (dataSource instanceof AutoCloseable) {
-        ((AutoCloseable) dataSource).close();
-      }
     }
   }
 
@@ -1062,13 +1059,6 @@ public class JdbcIO {
           }
         }
         records.clear();
-      }
-
-      @Teardown
-      public void teardown() throws Exception {
-        if (dataSource instanceof AutoCloseable) {
-          ((AutoCloseable) dataSource).close();
-        }
       }
     }
   }


### PR DESCRIPTION
This is a cherry-pick of #8565 for the release branch

R: @jbonofre @aromanenko-dev 
CC: @angoenka 