### PR TITLE
[BEAM-2888] Add the not-yet-fully-designed drain and checkpoint to runner comparison

### DIFF
--- a/website/src/_data/capability-matrix.yml
+++ b/website/src/_data/capability-matrix.yml
@@ -1481,3 +1481,106 @@ categories:
             l1: 'No'
             l2: pending model support
             l3: ''
+  - description: Additional common features not yet part of the Beam model
+    anchor: misc
+    color-b: 'aaa'
+    color-y: 'bbb'
+    color-p: 'ccc'
+    color-n: 'ddd'
+    rows:
+      - name: Drain
+        values:
+          - class: model
+            l1: 'Partially'
+            l2: 
+            l3: APIs and semantics for draining a pipeline are under discussion. This would cause incomplete aggregations to be emitted regardless of trigger and tagged with metadata indicating it is incomplated.
+          - class: dataflow
+            l1: 'Partially'
+            l2: 
+            l3: Dataflow has a native drain operation, but it does not work in the presence of event time timer loops. Final implemention pending model support.
+          - class: flink
+            l1: 'Partially'
+            l2: 
+            l3: Flink supports taking a "savepoint" of the pipeline and shutting the pipeline down after its completion.
+          - class: spark
+            l1: 
+            l2: 
+            l3: 
+          - class: apex
+            l1: 
+            l2: 
+            l3: 
+          - class: gearpump
+            l1: 
+            l2: 
+            l3: 
+          - class: mapreduce
+            l1: 
+            l2: 
+            l3: 
+          - class: jstorm
+            l1:
+            l2: 
+            l3: 
+          - class: ibmstreams
+            l1: 
+            l2: 
+            l3: 
+          - class: samza
+            l1: 
+            l2: 
+            l3: 
+          - class: nemo
+            l1: 
+            l2: 
+            l3:
+      - name: Checkpoint
+        values:
+          - class: model
+            l1: 'Partially'
+            l2: 
+            l3: APIs and semantics for saving a pipeline checkpoint are under discussion. This would be a runner-specific materialization of the pipeline state required to resume or duplicate the pipeline. 
+          - class: dataflow
+            l1: 'No'
+            l2: 
+            l3: 
+          - class: flink
+            l1: 'Partially'
+            l2: 
+            l3: Flink has a native savepoint capability.
+          - class: spark
+            l1: 'Partially'
+            l2: 
+            l3: Spark has a native savepoint capability.
+          - class: apex
+            l1: 
+            l2: 
+            l3: 
+          - class: gearpump
+            l1: 
+            l2: 
+            l3: 
+          - class: mapreduce
+            l1: 
+            l2: 
+            l3: 
+          - class: jstorm
+            l1: 
+            l2: 
+            l3: 
+          - class: ibmstreams
+            l1: 
+            l2: 
+            l3: 
+          - class: samza
+            l1: 'Partially'
+            l2: 
+            l3: Samza has a native checkpoint capability.
+          - class: nemo
+            l1: 
+            l2: 
+            l3: 
+          - class: jet
+            l1: 
+            l2: 
+            l3: 


### PR DESCRIPTION
These features have been discussed a bit on the mailing list and I get asked about them a bit. I think it is OK to list them here like we list retractions / metadata triggers, both of which are further from reality than checkpoint and drain.

I would have preferred to do the whole comparison rewrite of https://issues.apache.org/jira/browse/BEAM-2888 because the tabular form misleadingly implies these are yes/no features, when in reality they have many facets. But I haven't had time, and haven't convinced anyone else to take on that work.

So this is a low-effort compromise.

What do you think?

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
