### PR TITLE
Add retry strategy when TableRow or TableCell is null from BQ response.

### DIFF
--- a/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficMaxLaneFlowIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficMaxLaneFlowIT.java
@@ -19,22 +19,31 @@ package org.apache.beam.examples.complete;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.api.client.util.BackOff;
+import com.google.api.client.util.BackOffUtils;
+import com.google.api.client.util.Sleeper;
 import com.google.api.services.bigquery.model.QueryResponse;
 import org.apache.beam.examples.complete.TrafficMaxLaneFlow.FormatMaxesFn;
 import org.apache.beam.examples.complete.TrafficMaxLaneFlow.TrafficMaxLaneFlowOptions;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.extensions.gcp.util.BackOffAdapter;
 import org.apache.beam.sdk.io.gcp.testing.BigqueryClient;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.util.FluentBackoff;
+import org.joda.time.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** End-to-end tests of TrafficMaxLaneFlowIT. */
 @RunWith(JUnit4.class)
 public class TrafficMaxLaneFlowIT {
+  private static final Logger LOG = LoggerFactory.getLogger(TrafficMaxLaneFlowIT.class);
   private TrafficMaxLaneFlowOptions options;
   private final String timestamp = Long.toString(System.currentTimeMillis());
   private final String outputDatasetId = "traffic_max_lane_flow_" + timestamp;
@@ -63,14 +72,31 @@ public class TrafficMaxLaneFlowIT {
     this.options.setBigQueryDataset(this.outputDatasetId);
     this.options.setBigQueryTable(this.outputTable);
     TrafficMaxLaneFlow.runTrafficMaxLaneFlow(this.options);
-
-    QueryResponse response =
-        this.bqClient.queryWithRetries(
-            String.format(
-                "SELECT count(*) as total FROM [%s:%s.%s]",
-                this.projectId, this.outputDatasetId, this.outputTable),
-            this.projectId);
-    String res = response.getRows().get(0).getF().get(0).getV().toString();
+    FluentBackoff backoffFactory =
+        FluentBackoff.DEFAULT.withMaxRetries(4).withInitialBackoff(Duration.standardSeconds(1L));
+    Sleeper sleeper = Sleeper.DEFAULT;
+    BackOff backoff = BackOffAdapter.toGcpBackOff(backoffFactory.backoff());
+    String res = "empty_result";
+    // Having 4 retries to get ride of the failure caused by the latency that between data wrote
+    // to BigQuery and be able to query from BigQuery.
+    // Partial results are still returned making traversal of nested result object NPE prone.
+    do {
+      QueryResponse response =
+          this.bqClient.queryWithRetries(
+              String.format(
+                  "SELECT count(*) as total FROM [%s:%s.%s]",
+                  this.projectId, this.outputDatasetId, this.outputTable),
+              this.projectId);
+      // Having 4 retries to get ride of the failure caused by the latency that between data wrote
+      // to BigQuery and be able to query from BigQuery.
+      // Partial results are still returned making traversal of nested result object NPE prone.
+      try {
+        res = response.getRows().get(0).getF().get(0).getV().toString();
+        break;
+      } catch (NullPointerException e) {
+        // Ignore NullPointerException during retry.
+      }
+    } while (BackOffUtils.next(sleeper, backoff));
     assertEquals("9763", res);
   }
 }

--- a/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficRoutesIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficRoutesIT.java
@@ -77,7 +77,6 @@ public class TrafficRoutesIT {
     Sleeper sleeper = Sleeper.DEFAULT;
     BackOff backoff = BackOffAdapter.toGcpBackOff(backoffFactory.backoff());
     String res = "empty_result";
-    int attemptNum = 1;
     do {
       QueryResponse response =
           this.bqClient.queryWithRetries(

--- a/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficRoutesIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/TrafficRoutesIT.java
@@ -19,22 +19,31 @@ package org.apache.beam.examples.complete;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.api.client.util.BackOff;
+import com.google.api.client.util.BackOffUtils;
+import com.google.api.client.util.Sleeper;
 import com.google.api.services.bigquery.model.QueryResponse;
 import org.apache.beam.examples.complete.TrafficRoutes.FormatStatsFn;
 import org.apache.beam.examples.complete.TrafficRoutes.TrafficRoutesOptions;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.extensions.gcp.util.BackOffAdapter;
 import org.apache.beam.sdk.io.gcp.testing.BigqueryClient;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.util.FluentBackoff;
+import org.joda.time.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** End-to-end tests of TrafficRoutes. */
 @RunWith(JUnit4.class)
 public class TrafficRoutesIT {
+  private static final Logger LOG = LoggerFactory.getLogger(TrafficRoutesIT.class);
   private TrafficRoutesOptions options;
   private final String timestamp = Long.toString(System.currentTimeMillis());
   private final String outputDatasetId = "traffic_routes_" + timestamp;
@@ -63,14 +72,30 @@ public class TrafficRoutesIT {
     this.options.setBigQueryDataset(this.outputDatasetId);
     this.options.setBigQueryTable(this.outputTable);
     TrafficRoutes.runTrafficRoutes(options);
+    FluentBackoff backoffFactory =
+        FluentBackoff.DEFAULT.withMaxRetries(4).withInitialBackoff(Duration.standardSeconds(1L));
+    Sleeper sleeper = Sleeper.DEFAULT;
+    BackOff backoff = BackOffAdapter.toGcpBackOff(backoffFactory.backoff());
+    String res = "empty_result";
+    int attemptNum = 1;
+    do {
+      QueryResponse response =
+          this.bqClient.queryWithRetries(
+              String.format(
+                  "SELECT count(*) as total FROM [%s:%s.%s]",
+                  this.projectId, this.outputDatasetId, this.outputTable),
+              this.projectId);
+      // Having 4 retries to get ride of the failure caused by the latency that between data wrote
+      // to BigQuery and be able to query from BigQuery.
+      // Partial results are still returned making traversal of nested result object NPE prone.
+      try {
+        res = response.getRows().get(0).getF().get(0).getV().toString();
+        break;
+      } catch (NullPointerException e) {
+        // Ignore NullPointerException during retry.
+      }
+    } while (BackOffUtils.next(sleeper, backoff));
 
-    QueryResponse response =
-        this.bqClient.queryWithRetries(
-            String.format(
-                "SELECT count(*) as total FROM [%s:%s.%s]",
-                this.projectId, this.outputDatasetId, this.outputTable),
-            this.projectId);
-    String res = response.getRows().get(0).getF().get(0).getV().toString();
     assertEquals("27", res);
   }
 }


### PR DESCRIPTION
Patched TrafficRoutesIT and TrafficMaxLaneFlowIT.
R: @angoenka 