### PR TITLE
[BEAM-7348] Support environment expiration

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
@@ -18,11 +18,12 @@
 package org.apache.beam.runners.fnexecution.control;
 
 import com.google.auto.value.AutoValue;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.Target;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
@@ -57,6 +58,8 @@ import org.apache.beam.sdk.fn.IdGenerators;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
 import org.apache.beam.sdk.function.ThrowingFunction;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions;
@@ -85,6 +88,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
   private final ExecutorService executor;
   private final MapControlClientPool clientPool;
   private final IdGenerator stageIdGenerator;
+  private final int environmentExpirationMillis;
 
   public static DefaultJobBundleFactory create(JobInfo jobInfo) {
     Map<String, EnvironmentFactory.Provider> environmentFactoryProviderMap =
@@ -114,89 +118,72 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
     this.executor = Executors.newCachedThreadPool();
     this.clientPool = MapControlClientPool.create();
     this.stageIdGenerator = stageIdGenerator;
+    this.environmentExpirationMillis = getEnvironmentExpirationMillis(jobInfo);
     this.environmentCache =
         createEnvironmentCache(serverFactory -> createServerInfo(jobInfo, serverFactory));
   }
 
   @VisibleForTesting
   DefaultJobBundleFactory(
+      JobInfo jobInfo,
       Map<String, EnvironmentFactory.Provider> environmentFactoryMap,
       IdGenerator stageIdGenerator,
-      GrpcFnServer<FnApiControlClientPoolService> controlServer,
-      GrpcFnServer<GrpcLoggingService> loggingServer,
-      GrpcFnServer<ArtifactRetrievalService> retrievalServer,
-      GrpcFnServer<StaticGrpcProvisionService> provisioningServer,
-      GrpcFnServer<GrpcDataService> dataServer,
-      GrpcFnServer<GrpcStateService> stateServer) {
+      ServerInfo serverInfo) {
     this.environmentFactoryProviderMap = environmentFactoryMap;
     this.executor = Executors.newCachedThreadPool();
     this.clientPool = MapControlClientPool.create();
     this.stageIdGenerator = stageIdGenerator;
-    ServerInfo serverInfo =
-        new AutoValue_DefaultJobBundleFactory_ServerInfo.Builder()
-            .setControlServer(controlServer)
-            .setLoggingServer(loggingServer)
-            .setRetrievalServer(retrievalServer)
-            .setProvisioningServer(provisioningServer)
-            .setDataServer(dataServer)
-            .setStateServer(stateServer)
-            .build();
+    this.environmentExpirationMillis = getEnvironmentExpirationMillis(jobInfo);
     this.environmentCache = createEnvironmentCache(serverFactory -> serverInfo);
+  }
+
+  private static int getEnvironmentExpirationMillis(JobInfo jobInfo) {
+    PipelineOptions pipelineOptions =
+        PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions());
+    return pipelineOptions.as(PortablePipelineOptions.class).getEnvironmentExpirationMillis();
   }
 
   private LoadingCache<Environment, WrappedSdkHarnessClient> createEnvironmentCache(
       ThrowingFunction<ServerFactory, ServerInfo> serverInfoCreator) {
-    return CacheBuilder.newBuilder()
-        .removalListener(
-            (RemovalNotification<Environment, WrappedSdkHarnessClient> notification) -> {
-              LOG.debug("Cleaning up for environment {}", notification.getKey().getUrn());
-              try {
-                notification.getValue().close();
-              } catch (Exception e) {
-                LOG.warn(
-                    String.format("Error cleaning up environment %s", notification.getKey()), e);
-              }
-            })
-        .build(
-            new CacheLoader<Environment, WrappedSdkHarnessClient>() {
-              @Override
-              public WrappedSdkHarnessClient load(Environment environment) throws Exception {
-                EnvironmentFactory.Provider environmentFactoryProvider =
-                    environmentFactoryProviderMap.get(environment.getUrn());
-                ServerFactory serverFactory = environmentFactoryProvider.getServerFactory();
-                ServerInfo serverInfo = serverInfoCreator.apply(serverFactory);
+    CacheBuilder builder =
+        CacheBuilder.newBuilder()
+            .removalListener(
+                (RemovalNotification<Environment, WrappedSdkHarnessClient> notification) -> {
+                  int refCount = notification.getValue().unref();
+                  LOG.debug(
+                      "Removed environment {} with {} remaining bundle references.",
+                      notification.getKey(),
+                      refCount);
+                });
 
-                EnvironmentFactory environmentFactory =
-                    environmentFactoryProvider.createEnvironmentFactory(
-                        serverInfo.getControlServer(),
-                        serverInfo.getLoggingServer(),
-                        serverInfo.getRetrievalServer(),
-                        serverInfo.getProvisioningServer(),
-                        clientPool,
-                        stageIdGenerator);
-                return WrappedSdkHarnessClient.wrapping(
-                    environmentFactory.createEnvironment(environment), serverInfo);
-              }
-            });
+    if (environmentExpirationMillis > 0) {
+      builder = builder.expireAfterWrite(environmentExpirationMillis, TimeUnit.MILLISECONDS);
+    }
+    return builder.build(
+        new CacheLoader<Environment, WrappedSdkHarnessClient>() {
+          @Override
+          public WrappedSdkHarnessClient load(Environment environment) throws Exception {
+            EnvironmentFactory.Provider environmentFactoryProvider =
+                environmentFactoryProviderMap.get(environment.getUrn());
+            ServerFactory serverFactory = environmentFactoryProvider.getServerFactory();
+            ServerInfo serverInfo = serverInfoCreator.apply(serverFactory);
+            EnvironmentFactory environmentFactory =
+                environmentFactoryProvider.createEnvironmentFactory(
+                    serverInfo.getControlServer(),
+                    serverInfo.getLoggingServer(),
+                    serverInfo.getRetrievalServer(),
+                    serverInfo.getProvisioningServer(),
+                    clientPool,
+                    stageIdGenerator);
+            return WrappedSdkHarnessClient.wrapping(
+                environmentFactory.createEnvironment(environment), serverInfo);
+          }
+        });
   }
 
   @Override
   public StageBundleFactory forStage(ExecutableStage executableStage) {
-    WrappedSdkHarnessClient wrappedClient =
-        environmentCache.getUnchecked(executableStage.getEnvironment());
-    ExecutableProcessBundleDescriptor processBundleDescriptor;
-    try {
-      processBundleDescriptor =
-          ProcessBundleDescriptors.fromExecutableStage(
-              stageIdGenerator.getId(),
-              executableStage,
-              wrappedClient.getServerInfo().getDataServer().getApiServiceDescriptor(),
-              wrappedClient.getServerInfo().getStateServer().getApiServiceDescriptor());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    return SimpleStageBundleFactory.create(
-        wrappedClient, processBundleDescriptor, wrappedClient.getServerInfo().getStateServer());
+    return new SimpleStageBundleFactory(executableStage);
   }
 
   @Override
@@ -209,37 +196,42 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
     executor.shutdown();
   }
 
-  /** A simple stage bundle factory for remotely processing bundles. */
-  protected static class SimpleStageBundleFactory implements StageBundleFactory {
+  /**
+   * A {@link StageBundleFactory} for remotely processing bundles that supports environment
+   * expiration.
+   */
+  private class SimpleStageBundleFactory implements StageBundleFactory {
 
-    private final BundleProcessor processor;
-    private final ExecutableProcessBundleDescriptor processBundleDescriptor;
+    private final ExecutableStage executableStage;
+    private BundleProcessor processor;
+    private ExecutableProcessBundleDescriptor processBundleDescriptor;
+    private WrappedSdkHarnessClient wrappedClient;
 
-    // Store the wrapped client in order to keep a live reference into the cache.
-    @SuppressFBWarnings private WrappedSdkHarnessClient wrappedClient;
+    private SimpleStageBundleFactory(ExecutableStage executableStage) {
+      this.executableStage = executableStage;
+      prepare(environmentCache.getUnchecked(executableStage.getEnvironment()));
+    }
 
-    static SimpleStageBundleFactory create(
-        WrappedSdkHarnessClient wrappedClient,
-        ExecutableProcessBundleDescriptor processBundleDescriptor,
-        GrpcFnServer<GrpcStateService> stateServer) {
-      @SuppressWarnings("unchecked")
-      BundleProcessor processor =
+    private void prepare(WrappedSdkHarnessClient wrappedClient) {
+      try {
+        this.wrappedClient = wrappedClient;
+        this.processBundleDescriptor =
+            ProcessBundleDescriptors.fromExecutableStage(
+                stageIdGenerator.getId(),
+                executableStage,
+                wrappedClient.getServerInfo().getDataServer().getApiServiceDescriptor(),
+                wrappedClient.getServerInfo().getStateServer().getApiServiceDescriptor());
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to create ProcessBundleDescriptor.", e);
+      }
+
+      this.processor =
           wrappedClient
               .getClient()
               .getProcessor(
                   processBundleDescriptor.getProcessBundleDescriptor(),
                   processBundleDescriptor.getRemoteInputDestinations(),
-                  stateServer.getService());
-      return new SimpleStageBundleFactory(processBundleDescriptor, processor, wrappedClient);
-    }
-
-    SimpleStageBundleFactory(
-        ExecutableProcessBundleDescriptor processBundleDescriptor,
-        BundleProcessor processor,
-        WrappedSdkHarnessClient wrappedClient) {
-      this.processBundleDescriptor = processBundleDescriptor;
-      this.processor = processor;
-      this.wrappedClient = wrappedClient;
+                  wrappedClient.getServerInfo().getStateServer().getService());
     }
 
     @Override
@@ -267,7 +259,39 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
             outputReceiverFactory.create(bundleOutputPCollection);
         outputReceivers.put(target, RemoteOutputReceiver.of(coder, outputReceiver));
       }
-      return processor.newBundle(outputReceivers.build(), stateRequestHandler, progressHandler);
+
+      if (environmentExpirationMillis == 0) {
+        return processor.newBundle(outputReceivers.build(), stateRequestHandler, progressHandler);
+      }
+
+      final WrappedSdkHarnessClient client =
+          environmentCache.getUnchecked(executableStage.getEnvironment());
+      client.ref();
+
+      if (client != wrappedClient) {
+        // reset after environment expired
+        prepare(client);
+      }
+
+      final RemoteBundle bundle =
+          processor.newBundle(outputReceivers.build(), stateRequestHandler, progressHandler);
+      return new RemoteBundle() {
+        @Override
+        public String getId() {
+          return bundle.getId();
+        }
+
+        @Override
+        public Map<String, FnDataReceiver<WindowedValue<?>>> getInputReceivers() {
+          return bundle.getInputReceivers();
+        }
+
+        @Override
+        public void close() throws Exception {
+          bundle.close();
+          client.unref();
+        }
+      };
     }
 
     @Override
@@ -292,6 +316,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
     private final RemoteEnvironment environment;
     private final SdkHarnessClient client;
     private final ServerInfo serverInfo;
+    private final AtomicInteger bundleRefCount = new AtomicInteger();
 
     static WrappedSdkHarnessClient wrapping(RemoteEnvironment environment, ServerInfo serverInfo) {
       SdkHarnessClient client =
@@ -305,6 +330,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
       this.environment = environment;
       this.client = client;
       this.serverInfo = serverInfo;
+      ref();
     }
 
     SdkHarnessClient getClient() {
@@ -327,6 +353,24 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
           AutoCloseable retrievalServer = serverInfo.getRetrievalServer();
           AutoCloseable provisioningServer = serverInfo.getProvisioningServer()) {}
       // TODO: Wait for executor shutdown?
+    }
+
+    private int ref() {
+      return bundleRefCount.incrementAndGet();
+    }
+
+    private int unref() {
+      int count = bundleRefCount.decrementAndGet();
+      if (count == 0) {
+        // Close environment after it was removed from cache and all bundles finished.
+        LOG.info("Closing environment {}", environment.getEnvironment());
+        try {
+          close();
+        } catch (Exception e) {
+          LOG.warn("Error cleaning up environment {}", environment.getEnvironment(), e);
+        }
+      }
+      return count;
     }
   }
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
@@ -386,12 +386,12 @@ public class SdkHarnessClient implements AutoCloseable {
    */
   public BundleProcessor getProcessor(
       BeamFnApi.ProcessBundleDescriptor descriptor,
-      Map<String, RemoteInputDestination<WindowedValue<?>>> remoteInputDesinations,
+      Map<String, RemoteInputDestination<WindowedValue<?>>> remoteInputDestinations,
       StateDelegator stateDelegator) {
     @SuppressWarnings("unchecked")
     BundleProcessor bundleProcessor =
         clientProcessors.computeIfAbsent(
-            descriptor.getId(), s -> create(descriptor, remoteInputDesinations, stateDelegator));
+            descriptor.getId(), s -> create(descriptor, remoteInputDestinations, stateDelegator));
     checkArgument(
         bundleProcessor.processBundleDescriptor.equals(descriptor),
         "The provided %s with id %s collides with an existing %s with the same id but "

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.SdkFunctionSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.WindowingStrategy;
 import org.apache.beam.runners.core.construction.ModelCoders;
+import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.fnexecution.GrpcFnServer;
 import org.apache.beam.runners.fnexecution.ServerFactory;
@@ -48,8 +49,13 @@ import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
 import org.apache.beam.runners.fnexecution.state.GrpcStateService;
+import org.apache.beam.runners.fnexecution.state.StateDelegator;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.beam.sdk.fn.IdGenerator;
 import org.apache.beam.sdk.fn.IdGenerators;
+import org.apache.beam.sdk.fn.data.CloseableFnDataReceiver;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.vendor.grpc.v1p13p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p13p1.com.google.protobuf.Struct;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
@@ -90,6 +96,7 @@ public class DefaultJobBundleFactoryTest {
           IdGenerator idGenerator) -> envFactory;
   private final Map<String, EnvironmentFactory.Provider> envFactoryProviderMap =
       ImmutableMap.of(environment.getUrn(), envFactoryProvider);
+  private DefaultJobBundleFactory.ServerInfo serverInfo;
 
   @Before
   public void setUpMocks() throws Exception {
@@ -100,22 +107,30 @@ public class DefaultJobBundleFactoryTest {
         .thenReturn(CompletableFuture.completedFuture(instructionResponse));
     when(dataServer.getApiServiceDescriptor())
         .thenReturn(ApiServiceDescriptor.getDefaultInstance());
+    GrpcDataService dataService = mock(GrpcDataService.class);
+    when(dataService.send(any(), any())).thenReturn(mock(CloseableFnDataReceiver.class));
+    when(dataServer.getService()).thenReturn(dataService);
     when(stateServer.getApiServiceDescriptor())
         .thenReturn(ApiServiceDescriptor.getDefaultInstance());
+    GrpcStateService stateService = mock(GrpcStateService.class);
+    when(stateService.registerForProcessBundleInstructionId(any(), any()))
+        .thenReturn(mock(StateDelegator.Registration.class));
+    when(stateServer.getService()).thenReturn(stateService);
+    serverInfo =
+        new AutoValue_DefaultJobBundleFactory_ServerInfo.Builder()
+            .setControlServer(controlServer)
+            .setLoggingServer(loggingServer)
+            .setRetrievalServer(retrievalServer)
+            .setProvisioningServer(provisioningServer)
+            .setDataServer(dataServer)
+            .setStateServer(stateServer)
+            .build();
   }
 
   @Test
   public void createsCorrectEnvironment() throws Exception {
     try (DefaultJobBundleFactory bundleFactory =
-        new DefaultJobBundleFactory(
-            envFactoryProviderMap,
-            stageIdGenerator,
-            controlServer,
-            loggingServer,
-            retrievalServer,
-            provisioningServer,
-            dataServer,
-            stateServer)) {
+        createDefaultJobBundleFactory(envFactoryProviderMap)) {
       bundleFactory.forStage(getExecutableStage(environment));
       verify(envFactory).createEnvironment(environment);
     }
@@ -160,9 +175,7 @@ public class DefaultJobBundleFactoryTest {
             environmentA.getUrn(), environmentProviderFactoryA,
             environmentB.getUrn(), environmentProviderFactoryB);
     try (DefaultJobBundleFactory bundleFactory =
-        DefaultJobBundleFactory.create(
-            JobInfo.create("testJob", "testJob", "token", Struct.getDefaultInstance()),
-            environmentFactoryProviderMap)) {
+        createDefaultJobBundleFactory(environmentFactoryProviderMap)) {
       bundleFactory.forStage(getExecutableStage(environmentA));
       verify(environmentProviderFactoryA, Mockito.times(1))
           .createEnvironmentFactory(any(), any(), any(), any(), any(), any());
@@ -221,18 +234,49 @@ public class DefaultJobBundleFactoryTest {
   }
 
   @Test
-  public void closesEnvironmentOnCleanup() throws Exception {
-    DefaultJobBundleFactory bundleFactory =
+  public void expiresEnvironment() throws Exception {
+    ServerFactory serverFactory = ServerFactory.createDefault();
+
+    Environment environmentA = Environment.newBuilder().setUrn("env:urn:a").build();
+    EnvironmentFactory envFactoryA = mock(EnvironmentFactory.class);
+    when(envFactoryA.createEnvironment(environmentA)).thenReturn(remoteEnvironment);
+    EnvironmentFactory.Provider environmentProviderFactoryA =
+        mock(EnvironmentFactory.Provider.class);
+    when(environmentProviderFactoryA.createEnvironmentFactory(
+            any(), any(), any(), any(), any(), any()))
+        .thenReturn(envFactoryA);
+    when(environmentProviderFactoryA.getServerFactory()).thenReturn(serverFactory);
+
+    Map<String, Provider> environmentFactoryProviderMap =
+        ImmutableMap.of(environmentA.getUrn(), environmentProviderFactoryA);
+
+    PortablePipelineOptions portableOptions =
+        PipelineOptionsFactory.as(PortablePipelineOptions.class);
+    portableOptions.setEnvironmentExpirationMillis(1);
+    Struct pipelineOptions = PipelineOptionsTranslation.toProto(portableOptions);
+
+    try (DefaultJobBundleFactory bundleFactory =
         new DefaultJobBundleFactory(
-            envFactoryProviderMap,
+            JobInfo.create("testJob", "testJob", "token", pipelineOptions),
+            environmentFactoryProviderMap,
             stageIdGenerator,
-            controlServer,
-            loggingServer,
-            retrievalServer,
-            provisioningServer,
-            dataServer,
-            stateServer);
-    try (AutoCloseable unused = bundleFactory) {
+            serverInfo)) {
+      OutputReceiverFactory orf = mock(OutputReceiverFactory.class);
+      StateRequestHandler srh = mock(StateRequestHandler.class);
+      StageBundleFactory sbf = bundleFactory.forStage(getExecutableStage(environmentA));
+      Thread.sleep(10); // allow environment to expire
+      sbf.getBundle(orf, srh, BundleProgressHandler.ignored()).close();
+      Thread.sleep(10); // allow environment to expire
+      sbf.getBundle(orf, srh, BundleProgressHandler.ignored()).close();
+    }
+    verify(envFactoryA, Mockito.times(3)).createEnvironment(environmentA);
+    verify(remoteEnvironment, Mockito.times(3)).close();
+  }
+
+  @Test
+  public void closesEnvironmentOnCleanup() throws Exception {
+    try (DefaultJobBundleFactory bundleFactory =
+        createDefaultJobBundleFactory(envFactoryProviderMap)) {
       bundleFactory.forStage(getExecutableStage(environment));
     }
     verify(remoteEnvironment).close();
@@ -241,15 +285,7 @@ public class DefaultJobBundleFactoryTest {
   @Test
   public void cachesEnvironment() throws Exception {
     try (DefaultJobBundleFactory bundleFactory =
-        new DefaultJobBundleFactory(
-            envFactoryProviderMap,
-            stageIdGenerator,
-            controlServer,
-            loggingServer,
-            retrievalServer,
-            provisioningServer,
-            dataServer,
-            stateServer)) {
+        createDefaultJobBundleFactory(envFactoryProviderMap)) {
       StageBundleFactory bf1 = bundleFactory.forStage(getExecutableStage(environment));
       StageBundleFactory bf2 = bundleFactory.forStage(getExecutableStage(environment));
       // NOTE: We hang on to stage bundle references to ensure their underlying environments are not
@@ -277,21 +313,22 @@ public class DefaultJobBundleFactoryTest {
         .thenReturn(CompletableFuture.completedFuture(instructionResponse));
 
     try (DefaultJobBundleFactory bundleFactory =
-        new DefaultJobBundleFactory(
-            envFactoryProviderMapFoo,
-            stageIdGenerator,
-            controlServer,
-            loggingServer,
-            retrievalServer,
-            provisioningServer,
-            dataServer,
-            stateServer)) {
+        createDefaultJobBundleFactory(envFactoryProviderMapFoo)) {
       bundleFactory.forStage(getExecutableStage(environment));
       bundleFactory.forStage(getExecutableStage(envFoo));
       verify(envFactory).createEnvironment(environment);
       verify(envFactory).createEnvironment(envFoo);
       verifyNoMoreInteractions(envFactory);
     }
+  }
+
+  private DefaultJobBundleFactory createDefaultJobBundleFactory(
+      Map<String, EnvironmentFactory.Provider> envFactoryProviderMap) {
+    return new DefaultJobBundleFactory(
+        JobInfo.create("testJob", "testJob", "token", Struct.getDefaultInstance()),
+        envFactoryProviderMap,
+        stageIdGenerator,
+        serverInfo);
   }
 
   private static ExecutableStage getExecutableStage(Environment environment) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
@@ -80,4 +80,10 @@ public interface PortablePipelineOptions extends PipelineOptions {
   int getEnvironmentCacheMillis();
 
   void setEnvironmentCacheMillis(int environmentCacheMillis);
+
+  @Description("Duration in milliseconds for environment expiration. 0 means no expiration.")
+  @Default.Integer(0)
+  int getEnvironmentExpirationMillis();
+
+  void setEnvironmentExpirationMillis(int environmentExpirationMillis);
 }


### PR DESCRIPTION
It turns out that this capability fits easily into the existing structure. We can probably handle expiration in `SimpleStageBundleFactory` and remove the wrapper.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
