### PR TITLE
[BEAM-7101] Remove usages of deprecated self.assertEquals in Python codebase

### DIFF
--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -31,16 +31,16 @@ class PickleCoderTest(unittest.TestCase):
   def test_basics(self):
     v = ('a' * 10, 'b' * 90)
     pickler = coders.PickleCoder()
-    self.assertEquals(v, pickler.decode(pickler.encode(v)))
+    self.assertEqual(v, pickler.decode(pickler.encode(v)))
     pickler = coders.Base64PickleCoder()
-    self.assertEquals(v, pickler.decode(pickler.encode(v)))
-    self.assertEquals(
+    self.assertEqual(v, pickler.decode(pickler.encode(v)))
+    self.assertEqual(
         coders.Base64PickleCoder().encode(v),
         base64.b64encode(coders.PickleCoder().encode(v)))
 
   def test_equality(self):
-    self.assertEquals(coders.PickleCoder(), coders.PickleCoder())
-    self.assertEquals(coders.Base64PickleCoder(), coders.Base64PickleCoder())
+    self.assertEqual(coders.PickleCoder(), coders.PickleCoder())
+    self.assertEqual(coders.Base64PickleCoder(), coders.Base64PickleCoder())
     self.assertNotEquals(coders.Base64PickleCoder(), coders.PickleCoder())
     self.assertNotEquals(coders.Base64PickleCoder(), object())
 

--- a/sdks/python/apache_beam/coders/observable_test.py
+++ b/sdks/python/apache_beam/coders/observable_test.py
@@ -47,9 +47,9 @@ class ObservableMixinTest(unittest.TestCase):
     for _ in watched:
       pass
 
-    self.assertEquals(3, self.observed_count)
-    self.assertEquals(8, self.observed_sum)
-    self.assertEquals(['a1', 'a3', 'a4'], sorted(self.observed_keys))
+    self.assertEqual(3, self.observed_count)
+    self.assertEqual(8, self.observed_sum)
+    self.assertEqual(['a1', 'a3', 'a4'], sorted(self.observed_keys))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/coders/stream_test.py
+++ b/sdks/python/apache_beam/coders/stream_test.py
@@ -41,15 +41,15 @@ class StreamTest(unittest.TestCase):
     out_s.write(b'xyz', True)
     out_s.write(b'', True)
     in_s = self.InputStream(out_s.get())
-    self.assertEquals(b'abc\0\t\n', in_s.read(6))
-    self.assertEquals(b'xyz', in_s.read_all(True))
-    self.assertEquals(b'', in_s.read_all(True))
+    self.assertEqual(b'abc\0\t\n', in_s.read(6))
+    self.assertEqual(b'xyz', in_s.read_all(True))
+    self.assertEqual(b'', in_s.read_all(True))
 
   def test_read_all(self):
     out_s = self.OutputStream()
     out_s.write(b'abc')
     in_s = self.InputStream(out_s.get())
-    self.assertEquals(b'abc', in_s.read_all(False))
+    self.assertEqual(b'abc', in_s.read_all(False))
 
   def test_read_write_byte(self):
     out_s = self.OutputStream()
@@ -57,9 +57,9 @@ class StreamTest(unittest.TestCase):
     out_s.write_byte(0)
     out_s.write_byte(0xFF)
     in_s = self.InputStream(out_s.get())
-    self.assertEquals(1, in_s.read_byte())
-    self.assertEquals(0, in_s.read_byte())
-    self.assertEquals(0xFF, in_s.read_byte())
+    self.assertEqual(1, in_s.read_byte())
+    self.assertEqual(0, in_s.read_byte())
+    self.assertEqual(0xFF, in_s.read_byte())
 
   def test_read_write_large(self):
     values = range(4 * 1024)
@@ -68,7 +68,7 @@ class StreamTest(unittest.TestCase):
       out_s.write_bigendian_int64(v)
     in_s = self.InputStream(out_s.get())
     for v in values:
-      self.assertEquals(v, in_s.read_bigendian_int64())
+      self.assertEqual(v, in_s.read_bigendian_int64())
 
   def run_read_write_var_int64(self, values):
     out_s = self.OutputStream()
@@ -76,7 +76,7 @@ class StreamTest(unittest.TestCase):
       out_s.write_var_int64(v)
     in_s = self.InputStream(out_s.get())
     for v in values:
-      self.assertEquals(v, in_s.read_var_int64())
+      self.assertEqual(v, in_s.read_var_int64())
 
   def test_small_var_int64(self):
     self.run_read_write_var_int64(range(-10, 30))
@@ -97,7 +97,7 @@ class StreamTest(unittest.TestCase):
       out_s.write_bigendian_double(v)
     in_s = self.InputStream(out_s.get())
     for v in values:
-      self.assertEquals(v, in_s.read_bigendian_double())
+      self.assertEqual(v, in_s.read_bigendian_double())
 
   def test_read_write_bigendian_int64(self):
     values = 0, 1, -1, 2**63-1, -2**63, int(2**61 * math.pi)
@@ -106,7 +106,7 @@ class StreamTest(unittest.TestCase):
       out_s.write_bigendian_int64(v)
     in_s = self.InputStream(out_s.get())
     for v in values:
-      self.assertEquals(v, in_s.read_bigendian_int64())
+      self.assertEqual(v, in_s.read_bigendian_int64())
 
   def test_read_write_bigendian_uint64(self):
     values = 0, 1, 2**64-1, int(2**61 * math.pi)
@@ -115,7 +115,7 @@ class StreamTest(unittest.TestCase):
       out_s.write_bigendian_uint64(v)
     in_s = self.InputStream(out_s.get())
     for v in values:
-      self.assertEquals(v, in_s.read_bigendian_uint64())
+      self.assertEqual(v, in_s.read_bigendian_uint64())
 
   def test_read_write_bigendian_int32(self):
     values = 0, 1, -1, 2**31-1, -2**31, int(2**29 * math.pi)
@@ -124,31 +124,31 @@ class StreamTest(unittest.TestCase):
       out_s.write_bigendian_int32(v)
     in_s = self.InputStream(out_s.get())
     for v in values:
-      self.assertEquals(v, in_s.read_bigendian_int32())
+      self.assertEqual(v, in_s.read_bigendian_int32())
 
   def test_byte_counting(self):
     bc_s = self.ByteCountingOutputStream()
-    self.assertEquals(0, bc_s.get_count())
+    self.assertEqual(0, bc_s.get_count())
     bc_s.write(b'def')
-    self.assertEquals(3, bc_s.get_count())
+    self.assertEqual(3, bc_s.get_count())
     bc_s.write(b'')
-    self.assertEquals(3, bc_s.get_count())
+    self.assertEqual(3, bc_s.get_count())
     bc_s.write_byte(10)
-    self.assertEquals(4, bc_s.get_count())
+    self.assertEqual(4, bc_s.get_count())
     # "nested" also writes the length of the string, which should
     # cause 1 extra byte to be counted.
     bc_s.write(b'2345', nested=True)
-    self.assertEquals(9, bc_s.get_count())
+    self.assertEqual(9, bc_s.get_count())
     bc_s.write_var_int64(63)
-    self.assertEquals(10, bc_s.get_count())
+    self.assertEqual(10, bc_s.get_count())
     bc_s.write_bigendian_int64(42)
-    self.assertEquals(18, bc_s.get_count())
+    self.assertEqual(18, bc_s.get_count())
     bc_s.write_bigendian_int32(36)
-    self.assertEquals(22, bc_s.get_count())
+    self.assertEqual(22, bc_s.get_count())
     bc_s.write_bigendian_double(6.25)
-    self.assertEquals(30, bc_s.get_count())
+    self.assertEqual(30, bc_s.get_count())
     bc_s.write_bigendian_uint64(47)
-    self.assertEquals(38, bc_s.get_count())
+    self.assertEqual(38, bc_s.get_count())
 
 
 try:

--- a/sdks/python/apache_beam/internal/gcp/json_value_test.py
+++ b/sdks/python/apache_beam/internal/gcp/json_value_test.py
@@ -39,65 +39,65 @@ except ImportError:
 class JsonValueTest(unittest.TestCase):
 
   def test_string_to(self):
-    self.assertEquals(JsonValue(string_value='abc'), to_json_value('abc'))
+    self.assertEqual(JsonValue(string_value='abc'), to_json_value('abc'))
 
   def test_bytes_to(self):
-    self.assertEquals(JsonValue(string_value='abc'), to_json_value(b'abc'))
+    self.assertEqual(JsonValue(string_value='abc'), to_json_value(b'abc'))
 
   def test_true_to(self):
-    self.assertEquals(JsonValue(boolean_value=True), to_json_value(True))
+    self.assertEqual(JsonValue(boolean_value=True), to_json_value(True))
 
   def test_false_to(self):
-    self.assertEquals(JsonValue(boolean_value=False), to_json_value(False))
+    self.assertEqual(JsonValue(boolean_value=False), to_json_value(False))
 
   def test_int_to(self):
-    self.assertEquals(JsonValue(integer_value=14), to_json_value(14))
+    self.assertEqual(JsonValue(integer_value=14), to_json_value(14))
 
   def test_float_to(self):
-    self.assertEquals(JsonValue(double_value=2.75), to_json_value(2.75))
+    self.assertEqual(JsonValue(double_value=2.75), to_json_value(2.75))
 
   def test_static_value_provider_to(self):
     svp = StaticValueProvider(str, 'abc')
-    self.assertEquals(JsonValue(string_value=svp.value), to_json_value(svp))
+    self.assertEqual(JsonValue(string_value=svp.value), to_json_value(svp))
 
   def test_runtime_value_provider_to(self):
     RuntimeValueProvider.runtime_options = None
     rvp = RuntimeValueProvider('arg', 123, int)
-    self.assertEquals(JsonValue(is_null=True), to_json_value(rvp))
+    self.assertEqual(JsonValue(is_null=True), to_json_value(rvp))
 
   def test_none_to(self):
-    self.assertEquals(JsonValue(is_null=True), to_json_value(None))
+    self.assertEqual(JsonValue(is_null=True), to_json_value(None))
 
   def test_string_from(self):
-    self.assertEquals('WXYZ', from_json_value(to_json_value('WXYZ')))
+    self.assertEqual('WXYZ', from_json_value(to_json_value('WXYZ')))
 
   def test_true_from(self):
-    self.assertEquals(True, from_json_value(to_json_value(True)))
+    self.assertEqual(True, from_json_value(to_json_value(True)))
 
   def test_false_from(self):
-    self.assertEquals(False, from_json_value(to_json_value(False)))
+    self.assertEqual(False, from_json_value(to_json_value(False)))
 
   def test_int_from(self):
-    self.assertEquals(-27, from_json_value(to_json_value(-27)))
+    self.assertEqual(-27, from_json_value(to_json_value(-27)))
 
   def test_float_from(self):
-    self.assertEquals(4.5, from_json_value(to_json_value(4.5)))
+    self.assertEqual(4.5, from_json_value(to_json_value(4.5)))
 
   def test_with_type(self):
     rt = from_json_value(to_json_value('abcd', with_type=True))
-    self.assertEquals('http://schema.org/Text', rt['@type'])
-    self.assertEquals('abcd', rt['value'])
+    self.assertEqual('http://schema.org/Text', rt['@type'])
+    self.assertEqual('abcd', rt['value'])
 
   def test_none_from(self):
     self.assertIsNone(from_json_value(to_json_value(None)))
 
   def test_large_integer(self):
     num = 1 << 35
-    self.assertEquals(num, from_json_value(to_json_value(num)))
+    self.assertEqual(num, from_json_value(to_json_value(num)))
 
   def test_long_value(self):
     num = 1 << 63 - 1
-    self.assertEquals(num, from_json_value(to_json_value(num)))
+    self.assertEqual(num, from_json_value(to_json_value(num)))
 
   def test_too_long_value(self):
     with self.assertRaises(TypeError):

--- a/sdks/python/apache_beam/internal/http_client_test.py
+++ b/sdks/python/apache_beam/internal/http_client_test.py
@@ -35,54 +35,54 @@ class HttpClientTest(unittest.TestCase):
     with mock.patch.dict(os.environ, http_proxy='http://localhost:9000'):
       proxy_info = proxy_info_from_environment_var('http_proxy')
       expected = ProxyInfo(3, 'localhost', 9000)
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_https_with_port(self):
     with mock.patch.dict(os.environ, https_proxy='https://localhost:9000'):
       proxy_info = proxy_info_from_environment_var('https_proxy')
       expected = ProxyInfo(3, 'localhost', 9000)
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_http_without_port(self):
     with mock.patch.dict(os.environ, http_proxy='http://localhost'):
       proxy_info = proxy_info_from_environment_var('http_proxy')
       expected = ProxyInfo(3, 'localhost', 80)
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_https_without_port(self):
     with mock.patch.dict(os.environ, https_proxy='https://localhost'):
       proxy_info = proxy_info_from_environment_var('https_proxy')
       expected = ProxyInfo(3, 'localhost', 443)
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_http_without_method(self):
     with mock.patch.dict(os.environ, http_proxy='localhost:8000'):
       proxy_info = proxy_info_from_environment_var('http_proxy')
       expected = ProxyInfo(3, 'localhost', 8000)
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_https_without_method(self):
     with mock.patch.dict(os.environ, https_proxy='localhost:8000'):
       proxy_info = proxy_info_from_environment_var('https_proxy')
       expected = ProxyInfo(3, 'localhost', 8000)
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_http_without_port_without_method(self):
     with mock.patch.dict(os.environ, http_proxy='localhost'):
       proxy_info = proxy_info_from_environment_var('http_proxy')
       expected = ProxyInfo(3, 'localhost', 80)
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_https_without_port_without_method(self):
     with mock.patch.dict(os.environ, https_proxy='localhost'):
       proxy_info = proxy_info_from_environment_var('https_proxy')
       expected = ProxyInfo(3, 'localhost', 443)
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_invalid_var(self):
     proxy_info = proxy_info_from_environment_var('http_proxy_host')
     expected = None
-    self.assertEquals(str(expected), str(proxy_info))
+    self.assertEqual(str(expected), str(proxy_info))
 
   def test_proxy_from_env_wrong_method_in_var_name(self):
     with mock.patch.dict(os.environ, smtp_proxy='localhost'):
@@ -93,17 +93,17 @@ class HttpClientTest(unittest.TestCase):
     with mock.patch.dict(os.environ, http_proxy='smtp://localhost:8000'):
       proxy_info = proxy_info_from_environment_var('http_proxy')
       expected = ProxyInfo(3, 'smtp', 80) # wrong proxy info generated
-      self.assertEquals(str(expected), str(proxy_info))
+      self.assertEqual(str(expected), str(proxy_info))
 
   def test_get_new_http_proxy_info(self):
     with mock.patch.dict(os.environ, http_proxy='localhost'):
       http = get_new_http()
       expected = ProxyInfo(3, 'localhost', 80)
-      self.assertEquals(str(http.proxy_info), str(expected))
+      self.assertEqual(str(http.proxy_info), str(expected))
 
   def test_get_new_http_timeout(self):
     http = get_new_http()
-    self.assertEquals(http.timeout, DEFAULT_HTTP_TIMEOUT_SECONDS)
+    self.assertEqual(http.timeout, DEFAULT_HTTP_TIMEOUT_SECONDS)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/internal/pickler_test.py
+++ b/sdks/python/apache_beam/internal/pickler_test.py
@@ -29,52 +29,52 @@ from apache_beam.internal.pickler import loads
 class PicklerTest(unittest.TestCase):
 
   def test_basics(self):
-    self.assertEquals([1, 'a', (u'z',)], loads(dumps([1, 'a', (u'z',)])))
+    self.assertEqual([1, 'a', (u'z',)], loads(dumps([1, 'a', (u'z',)])))
     fun = lambda x: 'xyz-%s' % x
-    self.assertEquals('xyz-abc', loads(dumps(fun))('abc'))
+    self.assertEqual('xyz-abc', loads(dumps(fun))('abc'))
 
   def test_lambda_with_globals(self):
     """Tests that the globals of a function are preserved."""
 
     # The point of the test is that the lambda being called after unpickling
     # relies on having the re module being loaded.
-    self.assertEquals(
+    self.assertEqual(
         ['abc', 'def'],
         loads(dumps(module_test.get_lambda_with_globals()))('abc def'))
 
   def test_lambda_with_main_globals(self):
-    self.assertEquals(unittest, loads(dumps(lambda: unittest))())
+    self.assertEqual(unittest, loads(dumps(lambda: unittest))())
 
   def test_lambda_with_closure(self):
     """Tests that the closure of a function is preserved."""
-    self.assertEquals(
+    self.assertEqual(
         'closure: abc',
         loads(dumps(module_test.get_lambda_with_closure('abc')))())
 
   def test_class(self):
     """Tests that a class object is pickled correctly."""
-    self.assertEquals(
+    self.assertEqual(
         ['abc', 'def'],
         loads(dumps(module_test.Xyz))().foo('abc def'))
 
   def test_object(self):
     """Tests that a class instance is pickled correctly."""
-    self.assertEquals(
+    self.assertEqual(
         ['abc', 'def'],
         loads(dumps(module_test.XYZ_OBJECT)).foo('abc def'))
 
   def test_nested_class(self):
     """Tests that a nested class object is pickled correctly."""
-    self.assertEquals(
+    self.assertEqual(
         'X:abc',
         loads(dumps(module_test.TopClass.NestedClass('abc'))).datum)
-    self.assertEquals(
+    self.assertEqual(
         'Y:abc',
         loads(dumps(module_test.TopClass.MiddleClass.NestedClass('abc'))).datum)
 
   def test_dynamic_class(self):
     """Tests that a nested class object is pickled correctly."""
-    self.assertEquals(
+    self.assertEqual(
         'Z:abc',
         loads(dumps(module_test.create_class('abc'))).get())
 
@@ -83,8 +83,8 @@ class PicklerTest(unittest.TestCase):
       dumps((_ for _ in range(10)))
 
   def test_recursive_class(self):
-    self.assertEquals('RecursiveClass:abc',
-                      loads(dumps(module_test.RecursiveClass('abc').datum)))
+    self.assertEqual('RecursiveClass:abc',
+                     loads(dumps(module_test.RecursiveClass('abc').datum)))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/internal/util_test.py
+++ b/sdks/python/apache_beam/internal/util_test.py
@@ -30,32 +30,32 @@ class UtilTest(unittest.TestCase):
   def test_remove_objects_from_args(self):
     args, kwargs, objs = remove_objects_from_args(
         [1, 'a'], {'x': 1, 'y': 3.14}, (str, float))
-    self.assertEquals([1, ArgumentPlaceholder()], args)
-    self.assertEquals({'x': 1, 'y': ArgumentPlaceholder()}, kwargs)
-    self.assertEquals(['a', 3.14], objs)
+    self.assertEqual([1, ArgumentPlaceholder()], args)
+    self.assertEqual({'x': 1, 'y': ArgumentPlaceholder()}, kwargs)
+    self.assertEqual(['a', 3.14], objs)
 
   def test_remove_objects_from_args_nothing_to_remove(self):
     args, kwargs, objs = remove_objects_from_args(
         [1, 2], {'x': 1, 'y': 2}, (str, float))
-    self.assertEquals([1, 2], args)
-    self.assertEquals({'x': 1, 'y': 2}, kwargs)
-    self.assertEquals([], objs)
+    self.assertEqual([1, 2], args)
+    self.assertEqual({'x': 1, 'y': 2}, kwargs)
+    self.assertEqual([], objs)
 
   def test_insert_values_in_args(self):
     values = ['a', 'b']
     args = [1, ArgumentPlaceholder()]
     kwargs = {'x': 1, 'y': ArgumentPlaceholder()}
     args, kwargs = insert_values_in_args(args, kwargs, values)
-    self.assertEquals([1, 'a'], args)
-    self.assertEquals({'x': 1, 'y': 'b'}, kwargs)
+    self.assertEqual([1, 'a'], args)
+    self.assertEqual({'x': 1, 'y': 'b'}, kwargs)
 
   def test_insert_values_in_args_nothing_to_insert(self):
     values = []
     args = [1, 'a']
     kwargs = {'x': 1, 'y': 'b'}
     args, kwargs = insert_values_in_args(args, kwargs, values)
-    self.assertEquals([1, 'a'], args)
-    self.assertEquals({'x': 1, 'y': 'b'}, kwargs)
+    self.assertEqual([1, 'a'], args)
+    self.assertEqual({'x': 1, 'y': 'b'}, kwargs)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/io/concat_source_test.py
+++ b/sdks/python/apache_beam/io/concat_source_test.py
@@ -145,64 +145,64 @@ class ConcatSourceTest(unittest.TestCase):
                            for range in ranges])
 
     range_tracker = source.get_range_tracker()
-    self.assertEquals(range_tracker.position_at_fraction(0), (0, 0))
-    self.assertEquals(range_tracker.position_at_fraction(.01), (0, 1))
-    self.assertEquals(range_tracker.position_at_fraction(.1), (0, 4))
-    self.assertEquals(range_tracker.position_at_fraction(.125), (1, 4))
-    self.assertEquals(range_tracker.position_at_fraction(.2), (1, 7))
-    self.assertEquals(range_tracker.position_at_fraction(.7), (2, 23))
-    self.assertEquals(range_tracker.position_at_fraction(.75), (3, 24))
-    self.assertEquals(range_tracker.position_at_fraction(.8), (3, 26))
-    self.assertEquals(range_tracker.position_at_fraction(1), (4, None))
+    self.assertEqual(range_tracker.position_at_fraction(0), (0, 0))
+    self.assertEqual(range_tracker.position_at_fraction(.01), (0, 1))
+    self.assertEqual(range_tracker.position_at_fraction(.1), (0, 4))
+    self.assertEqual(range_tracker.position_at_fraction(.125), (1, 4))
+    self.assertEqual(range_tracker.position_at_fraction(.2), (1, 7))
+    self.assertEqual(range_tracker.position_at_fraction(.7), (2, 23))
+    self.assertEqual(range_tracker.position_at_fraction(.75), (3, 24))
+    self.assertEqual(range_tracker.position_at_fraction(.8), (3, 26))
+    self.assertEqual(range_tracker.position_at_fraction(1), (4, None))
 
     range_tracker = source.get_range_tracker((1, None), (3, None))
-    self.assertEquals(range_tracker.position_at_fraction(0), (1, 4))
-    self.assertEquals(range_tracker.position_at_fraction(.01), (1, 5))
-    self.assertEquals(range_tracker.position_at_fraction(.5), (1, 14))
-    self.assertEquals(range_tracker.position_at_fraction(.599), (1, 16))
-    self.assertEquals(range_tracker.position_at_fraction(.601), (2, 17))
-    self.assertEquals(range_tracker.position_at_fraction(1), (3, None))
+    self.assertEqual(range_tracker.position_at_fraction(0), (1, 4))
+    self.assertEqual(range_tracker.position_at_fraction(.01), (1, 5))
+    self.assertEqual(range_tracker.position_at_fraction(.5), (1, 14))
+    self.assertEqual(range_tracker.position_at_fraction(.599), (1, 16))
+    self.assertEqual(range_tracker.position_at_fraction(.601), (2, 17))
+    self.assertEqual(range_tracker.position_at_fraction(1), (3, None))
 
   def test_empty_source(self):
     read_all = source_test_utils.read_from_source
 
     empty = RangeSource(0, 0)
-    self.assertEquals(read_all(ConcatSource([])), [])
-    self.assertEquals(read_all(ConcatSource([empty])), [])
-    self.assertEquals(read_all(ConcatSource([empty, empty])), [])
+    self.assertEqual(read_all(ConcatSource([])), [])
+    self.assertEqual(read_all(ConcatSource([empty])), [])
+    self.assertEqual(read_all(ConcatSource([empty, empty])), [])
 
     range10 = RangeSource(0, 10)
-    self.assertEquals(read_all(ConcatSource([range10]), (0, None), (0, 0)),
-                      [])
-    self.assertEquals(read_all(ConcatSource([range10]), (0, 10), (1, None)),
-                      [])
-    self.assertEquals(read_all(ConcatSource([range10, range10]),
-                               (0, 10), (1, 0)),
-                      [])
+    self.assertEqual(read_all(ConcatSource([range10]), (0, None), (0, 0)),
+                     [])
+    self.assertEqual(read_all(ConcatSource([range10]), (0, 10), (1, None)),
+                     [])
+    self.assertEqual(read_all(ConcatSource([range10, range10]),
+                              (0, 10), (1, 0)),
+                     [])
 
   def test_single_source(self):
     read_all = source_test_utils.read_from_source
 
     range10 = RangeSource(0, 10)
-    self.assertEquals(read_all(ConcatSource([range10])), list(range(10)))
-    self.assertEquals(read_all(ConcatSource([range10]), (0, 5)),
-                      list(range(5, 10)))
-    self.assertEquals(read_all(ConcatSource([range10]), None, (0, 5)),
-                      list(range(5)))
+    self.assertEqual(read_all(ConcatSource([range10])), list(range(10)))
+    self.assertEqual(read_all(ConcatSource([range10]), (0, 5)),
+                     list(range(5, 10)))
+    self.assertEqual(read_all(ConcatSource([range10]), None, (0, 5)),
+                     list(range(5)))
 
   def test_source_with_empty_ranges(self):
     read_all = source_test_utils.read_from_source
 
     empty = RangeSource(0, 0)
-    self.assertEquals(read_all(empty), [])
+    self.assertEqual(read_all(empty), [])
 
     range10 = RangeSource(0, 10)
-    self.assertEquals(read_all(ConcatSource([empty, empty, range10])),
-                      list(range(10)))
-    self.assertEquals(read_all(ConcatSource([empty, range10, empty])),
-                      list(range(10)))
-    self.assertEquals(read_all(ConcatSource([range10, empty, range10, empty])),
-                      list(range(10)) + list(range(10)))
+    self.assertEqual(read_all(ConcatSource([empty, empty, range10])),
+                     list(range(10)))
+    self.assertEqual(read_all(ConcatSource([empty, range10, empty])),
+                     list(range(10)))
+    self.assertEqual(read_all(ConcatSource([range10, empty, range10, empty])),
+                     list(range(10)) + list(range(10)))
 
   def test_source_with_empty_ranges_exhastive(self):
     empty = RangeSource(0, 0)

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -233,7 +233,7 @@ class TestConcatSource(unittest.TestCase):
                for start in [0, 10, 20]]
     concat = ConcatSource(sources)
     splits = [split for split in concat.split()]
-    self.assertEquals(6, len(splits))
+    self.assertEqual(6, len(splits))
 
     # Reading all splits
     read_data = []
@@ -249,7 +249,7 @@ class TestConcatSource(unittest.TestCase):
     sources = [TestConcatSource.DummySource(range(start, start + 10)) for start
                in [0, 10, 20]]
     concat = ConcatSource(sources)
-    self.assertEquals(30, concat.estimate_size())
+    self.assertEqual(30, concat.estimate_size())
 
 
 class TestFileBasedSource(unittest.TestCase):
@@ -344,18 +344,18 @@ class TestFileBasedSource(unittest.TestCase):
     file_name, expected_data = write_data(10)
     assert len(expected_data) == 10
     fbs = LineSource(file_name)
-    self.assertEquals(10 * 6, fbs.estimate_size())
+    self.assertEqual(10 * 6, fbs.estimate_size())
 
   def test_estimate_size_of_pattern(self):
     pattern, expected_data = write_pattern([5, 3, 10, 8, 8, 4])
     assert len(expected_data) == 38
     fbs = LineSource(pattern)
-    self.assertEquals(38 * 6, fbs.estimate_size())
+    self.assertEqual(38 * 6, fbs.estimate_size())
 
     pattern, expected_data = write_pattern([5, 3, 9])
     assert len(expected_data) == 17
     fbs = LineSource(pattern)
-    self.assertEquals(17 * 6, fbs.estimate_size())
+    self.assertEqual(17 * 6, fbs.estimate_size())
 
   def test_estimate_size_with_sampling_same_size(self):
     num_files = 2 * FileBasedSource.MIN_NUMBER_OF_FILES_TO_STAT
@@ -451,7 +451,7 @@ class TestFileBasedSource(unittest.TestCase):
     assert len(expected_data) == 20
     fbs = LineSource(pattern, splittable=False)
     splits = [split for split in fbs.split(desired_bundle_size=15)]
-    self.assertEquals(3, len(splits))
+    self.assertEqual(3, len(splits))
 
   def test_source_file_unsplittable(self):
     file_name, expected_data = write_data(100)
@@ -681,11 +681,11 @@ class TestSingleFileSource(unittest.TestCase):
     # Should simply return stop_offset - start_offset
     source = SingleFileSource(
         fbs, file_name='dummy_file', start_offset=0, stop_offset=100)
-    self.assertEquals(100, source.estimate_size())
+    self.assertEqual(100, source.estimate_size())
 
     source = SingleFileSource(fbs, file_name='dummy_file', start_offset=10,
                               stop_offset=100)
-    self.assertEquals(90, source.estimate_size())
+    self.assertEqual(90, source.estimate_size())
 
   def test_read_range_at_beginning(self):
     fbs = LineSource('dummy_pattern', validate=False)
@@ -727,10 +727,10 @@ class TestSingleFileSource(unittest.TestCase):
     assert len(expected_data) == 10
     source = SingleFileSource(fbs, file_name, 0, 10 * 6)
     splits = [split for split in source.split(desired_bundle_size=100)]
-    self.assertEquals(1, len(splits))
-    self.assertEquals(60, splits[0].weight)
-    self.assertEquals(0, splits[0].start_position)
-    self.assertEquals(60, splits[0].stop_position)
+    self.assertEqual(1, len(splits))
+    self.assertEqual(60, splits[0].weight)
+    self.assertEqual(0, splits[0].start_position)
+    self.assertEqual(60, splits[0].stop_position)
 
     range_tracker = splits[0].source.get_range_tracker(None, None)
     read_data = [value for value in splits[0].source.read(range_tracker)]
@@ -743,7 +743,7 @@ class TestSingleFileSource(unittest.TestCase):
     assert len(expected_data) == 10
     source = SingleFileSource(fbs, file_name, 0, 10 * 6)
     splits = [split for split in source.split(desired_bundle_size=25)]
-    self.assertEquals(3, len(splits))
+    self.assertEqual(3, len(splits))
 
     read_data = []
     for split in splits:
@@ -763,7 +763,7 @@ class TestSingleFileSource(unittest.TestCase):
     splits = [split for split in
               source.split(desired_bundle_size=15, start_offset=10,
                            stop_offset=50)]
-    self.assertEquals(3, len(splits))
+    self.assertEqual(3, len(splits))
 
     read_data = []
     for split in splits:

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools_test.py
@@ -406,8 +406,8 @@ class TestBigQueryReader(unittest.TestCase):
     options = PipelineOptions(flags=['--project', 'myproject'])
     source.pipeline_options = options
     reader = source.reader()
-    self.assertEquals('SELECT * FROM [myproject:mydataset.mytable];',
-                      reader.query)
+    self.assertEqual('SELECT * FROM [myproject:mydataset.mytable];',
+                     reader.query)
 
 
 @unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')
@@ -573,7 +573,7 @@ class TestBigQueryWriter(unittest.TestCase):
     options = PipelineOptions(flags=['--project', 'myproject'])
     sink.pipeline_options = options
     writer = sink.writer()
-    self.assertEquals('myproject', writer.project_id)
+    self.assertEqual('myproject', writer.project_id)
 
 
 @unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')

--- a/sdks/python/apache_beam/io/gcp/gcsio_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_test.py
@@ -305,7 +305,7 @@ class TestGCSIO(unittest.TestCase):
     self._insert_random_file(self.client, file_name, file_size)
     with self.assertRaises(HttpError) as cm:
       self.gcs.exists(file_name)
-    self.assertEquals(400, cm.exception.status_code)
+    self.assertEqual(400, cm.exception.status_code)
 
   def test_checksum(self):
     file_name = 'gs://gcsio-test/dummy_file'

--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -276,12 +276,12 @@ class HadoopFileSystemTest(unittest.TestCase):
                       for filename in ['old_file1', 'old_file2']]
     result = self.fs.match([self.tmpdir + '/'], [1])[0]
     files = [f.path for f in result.metadata_list]
-    self.assertEquals(len(files), 1)
+    self.assertEqual(len(files), 1)
     self.assertIn(files[0], expected_files)
 
   def test_match_file_with_zero_limit(self):
     result = self.fs.match([self.tmpdir + '/'], [0])[0]
-    self.assertEquals(len(result.metadata_list), 0)
+    self.assertEqual(len(result.metadata_list), 0)
 
   def test_match_file_empty(self):
     url = self.fs.join(self.tmpdir, 'nonexistent_file')

--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -299,8 +299,8 @@ class LocalFileSystemTest(unittest.TestCase):
       f.write('Hello')
     with open(path2, 'a') as f:
       f.write('foo')
-    self.assertEquals(self.fs.checksum(path1), str(5))
-    self.assertEquals(self.fs.checksum(path2), str(3))
+    self.assertEqual(self.fs.checksum(path1), str(5))
+    self.assertEqual(self.fs.checksum(path2), str(3))
 
   def make_tree(self, path, value, expected_leaf_count=None):
     """Create a file+directory structure from a simple dict-based DSL

--- a/sdks/python/apache_beam/io/parquetio_test.py
+++ b/sdks/python/apache_beam/io/parquetio_test.py
@@ -353,7 +353,7 @@ class TestParquet(unittest.TestCase):
     splits = [
         split for split in source.split(desired_bundle_size=1)
     ]
-    self.assertEquals(len(splits), 1)
+    self.assertEqual(len(splits), 1)
 
     source = _create_parquet_source(file_name, min_bundle_size=0)
     splits = [
@@ -396,13 +396,13 @@ class TestParquet(unittest.TestCase):
 
     # When reading records of the first group, range_tracker.split_points()
     # should return (0, iobase.RangeTracker.SPLIT_POINTS_UNKNOWN)
-    self.assertEquals(
+    self.assertEqual(
         split_points_report[:10],
         [(0, RangeTracker.SPLIT_POINTS_UNKNOWN)] * 10)
 
     # When reading records of last group, range_tracker.split_points() should
     # return (3, 1)
-    self.assertEquals(split_points_report[-10:], [(3, 1)] * 10)
+    self.assertEqual(split_points_report[-10:], [(3, 1)] * 10)
 
   def test_selective_columns(self):
     file_name = self._write_data()

--- a/sdks/python/apache_beam/io/source_test_utils_test.py
+++ b/sdks/python/apache_beam/io/source_test_utils_test.py
@@ -82,8 +82,8 @@ class SourceTestUtilsTest(unittest.TestCase):
     result2 = source_test_utils.assert_split_at_fraction_behavior(
         source, 20, 0.5,
         source_test_utils.ExpectedSplitOutcome.MUST_SUCCEED_AND_BE_CONSISTENT)
-    self.assertEquals(result1, result2)
-    self.assertEquals(100, result1[0] + result1[1])
+    self.assertEqual(result1, result2)
+    self.assertEqual(100, result1[0] + result1[1])
 
     result3 = source_test_utils.assert_split_at_fraction_behavior(
         source, 30, 0.8,
@@ -91,8 +91,8 @@ class SourceTestUtilsTest(unittest.TestCase):
     result4 = source_test_utils.assert_split_at_fraction_behavior(
         source, 50, 0.8,
         source_test_utils.ExpectedSplitOutcome.MUST_SUCCEED_AND_BE_CONSISTENT)
-    self.assertEquals(result3, result4)
-    self.assertEquals(100, result3[0] + result4[1])
+    self.assertEqual(result3, result4)
+    self.assertEqual(100, result3[0] + result4[1])
 
     self.assertTrue(result1[0] < result3[0])
     self.assertTrue(result1[1] > result3[1])
@@ -103,8 +103,8 @@ class SourceTestUtilsTest(unittest.TestCase):
 
     result = source_test_utils.assert_split_at_fraction_behavior(
         source, 90, 0.1, source_test_utils.ExpectedSplitOutcome.MUST_FAIL)
-    self.assertEquals(result[0], 100)
-    self.assertEquals(result[1], -1)
+    self.assertEqual(result[0], 100)
+    self.assertEqual(result[1], -1)
 
     with self.assertRaises(ValueError):
       source_test_utils.assert_split_at_fraction_behavior(

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -376,7 +376,7 @@ class PipelineTest(unittest.TestCase):
                | 'NoOp' >> beam.Map(lambda x: x))
 
       p.replace_all([override])
-      self.assertEquals(pcoll.producer.inputs[0].element_type, expected_type)
+      self.assertEqual(pcoll.producer.inputs[0].element_type, expected_type)
 
 
 class DoFnTest(unittest.TestCase):
@@ -482,29 +482,29 @@ class PipelineOptionsTest(unittest.TestCase):
 
   def test_flag_parsing(self):
     options = Breakfast(['--slices=3', '--style=sunny side up', '--ignored'])
-    self.assertEquals(3, options.slices)
-    self.assertEquals('sunny side up', options.style)
+    self.assertEqual(3, options.slices)
+    self.assertEqual('sunny side up', options.style)
 
   def test_keyword_parsing(self):
     options = Breakfast(
         ['--slices=3', '--style=sunny side up', '--ignored'],
         slices=10)
-    self.assertEquals(10, options.slices)
-    self.assertEquals('sunny side up', options.style)
+    self.assertEqual(10, options.slices)
+    self.assertEqual('sunny side up', options.style)
 
   def test_attribute_setting(self):
     options = Breakfast(slices=10)
-    self.assertEquals(10, options.slices)
+    self.assertEqual(10, options.slices)
     options.slices = 20
-    self.assertEquals(20, options.slices)
+    self.assertEqual(20, options.slices)
 
   def test_view_as(self):
     generic_options = PipelineOptions(['--slices=3'])
-    self.assertEquals(3, generic_options.view_as(Bacon).slices)
-    self.assertEquals(3, generic_options.view_as(Breakfast).slices)
+    self.assertEqual(3, generic_options.view_as(Bacon).slices)
+    self.assertEqual(3, generic_options.view_as(Breakfast).slices)
 
     generic_options.view_as(Breakfast).slices = 10
-    self.assertEquals(10, generic_options.view_as(Bacon).slices)
+    self.assertEqual(10, generic_options.view_as(Bacon).slices)
 
     with self.assertRaises(AttributeError):
       generic_options.slices  # pylint: disable=pointless-statement
@@ -514,17 +514,17 @@ class PipelineOptionsTest(unittest.TestCase):
 
   def test_defaults(self):
     options = Breakfast(['--slices=3'])
-    self.assertEquals(3, options.slices)
-    self.assertEquals('scrambled', options.style)
+    self.assertEqual(3, options.slices)
+    self.assertEqual('scrambled', options.style)
 
   def test_dir(self):
     options = Breakfast()
-    self.assertEquals(
+    self.assertEqual(
         set(['from_dictionary', 'get_all_options', 'slices', 'style',
              'view_as', 'display_data']),
         set([attr for attr in dir(options) if not attr.startswith('_') and
              attr != 'next']))
-    self.assertEquals(
+    self.assertEqual(
         set(['from_dictionary', 'get_all_options', 'style', 'view_as',
              'display_data']),
         set([attr for attr in dir(options.view_as(Eggs))
@@ -545,8 +545,8 @@ class RunnerApiTest(unittest.TestCase):
     p = Pipeline.from_runner_api(
         Pipeline.to_runner_api(p, use_fake_coders=True), None, None)
     self.assertIsNotNone(p.transforms_stack[0].parts[0].parent)
-    self.assertEquals(p.transforms_stack[0].parts[0].parent,
-                      p.transforms_stack[0])
+    self.assertEqual(p.transforms_stack[0].parts[0].parent,
+                     p.transforms_stack[0])
 
 
 class DirectRunnerRetryTests(unittest.TestCase):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
@@ -122,7 +122,7 @@ class SdkWorkerMainTest(unittest.TestCase):
           Exception, sdk_worker_main._get_worker_count,
           PipelineOptions.from_dictionary(json.loads(pipeline_options)))
     else:
-      self.assertEquals(
+      self.assertEqual(
           sdk_worker_main._get_worker_count(
               PipelineOptions.from_dictionary(json.loads(pipeline_options))),
           expected)

--- a/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
+++ b/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
@@ -89,7 +89,7 @@ class SyntheticPipelineTest(unittest.TestCase):
     splits = source.split(100)
     sources_info = [(split.source, split.start_position, split.stop_position)
                     for split in splits]
-    self.assertEquals(20, len(sources_info))
+    self.assertEqual(20, len(sources_info))
     source_test_utils.assert_sources_equal_reference_source(
         (source, None, None), sources_info)
 
@@ -99,7 +99,7 @@ class SyntheticPipelineTest(unittest.TestCase):
     splits = source.split(100)
     sources_info = [(split.source, split.start_position, split.stop_position)
                     for split in splits]
-    self.assertEquals(10, len(sources_info))
+    self.assertEqual(10, len(sources_info))
     source_test_utils.assert_sources_equal_reference_source(
         (source, None, None), sources_info)
 

--- a/sdks/python/apache_beam/transforms/dataflow_distribution_counter_test.py
+++ b/sdks/python/apache_beam/transforms/dataflow_distribution_counter_test.py
@@ -29,7 +29,7 @@ class DataflowDistributionAccumulatorTest(unittest.TestCase):
   def test_calculate_bucket_index_with_input_0(self):
     counter = DataflowDistributionCounter()
     index = counter.calculate_bucket_index(0)
-    self.assertEquals(index, 0)
+    self.assertEqual(index, 0)
 
   def test_calculate_bucket_index_within_max_long(self):
     counter = DataflowDistributionCounter()
@@ -39,7 +39,7 @@ class DataflowDistributionAccumulatorTest(unittest.TestCase):
       for multiplier in [1, 2, 5]:
         value = multiplier * power_of_ten
         actual_bucket = counter.calculate_bucket_index(value - 1)
-        self.assertEquals(actual_bucket, bucket - 1)
+        self.assertEqual(actual_bucket, bucket - 1)
         bucket += 1
       power_of_ten *= 10
 
@@ -55,28 +55,28 @@ class DataflowDistributionAccumulatorTest(unittest.TestCase):
       counter.add_input(element)
     histogram = Mock(firstBucketOffset=None, bucketCounts=None)
     counter.translate_to_histogram(histogram)
-    self.assertEquals(counter.sum, expected_sum)
-    self.assertEquals(counter.count, expected_count)
-    self.assertEquals(counter.min, expected_min)
-    self.assertEquals(counter.max, expected_max)
-    self.assertEquals(histogram.firstBucketOffset, expected_first_bucket_index)
-    self.assertEquals(histogram.bucketCounts, expected_buckets)
+    self.assertEqual(counter.sum, expected_sum)
+    self.assertEqual(counter.count, expected_count)
+    self.assertEqual(counter.min, expected_min)
+    self.assertEqual(counter.max, expected_max)
+    self.assertEqual(histogram.firstBucketOffset, expected_first_bucket_index)
+    self.assertEqual(histogram.bucketCounts, expected_buckets)
 
   def test_translate_to_histogram_with_input_0(self):
     counter = DataflowDistributionCounter()
     counter.add_input(0)
     histogram = Mock(firstBucketOffset=None, bucketCounts=None)
     counter.translate_to_histogram(histogram)
-    self.assertEquals(histogram.firstBucketOffset, 0)
-    self.assertEquals(histogram.bucketCounts, [1])
+    self.assertEqual(histogram.firstBucketOffset, 0)
+    self.assertEqual(histogram.bucketCounts, [1])
 
   def test_translate_to_histogram_with_max_input(self):
     counter = DataflowDistributionCounter()
     counter.add_input(INT64_MAX)
     histogram = Mock(firstBucketOffset=None, bucketCounts=None)
     counter.translate_to_histogram(histogram)
-    self.assertEquals(histogram.firstBucketOffset, 57)
-    self.assertEquals(histogram.bucketCounts, [1])
+    self.assertEqual(histogram.firstBucketOffset, 57)
+    self.assertEqual(histogram.bucketCounts, [1])
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/transforms/trigger_test.py
+++ b/sdks/python/apache_beam/transforms/trigger_test.py
@@ -617,7 +617,7 @@ class TranscriptTest(unittest.TestCase):
 
       if action != 'expect':
         # Fail if we have output that was not expected in the transcript.
-        self.assertEquals(
+        self.assertEqual(
             [], output, msg='Unexpected output: %s before %s' % (output, line))
 
       if action == 'input':
@@ -654,7 +654,7 @@ class TranscriptTest(unittest.TestCase):
         self.fail('Unknown action: ' + action)
 
     # Fail if we have output that was not expected in the transcript.
-    self.assertEquals([], output, msg='Unexpected output: %s' % output)
+    self.assertEqual([], output, msg='Unexpected output: %s' % output)
 
 
 TRANSCRIPT_TEST_FILE = os.path.join(

--- a/sdks/python/apache_beam/typehints/trivial_inference_test.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference_test.py
@@ -36,7 +36,7 @@ global_int = 1
 class TrivialInferenceTest(unittest.TestCase):
 
   def assertReturnType(self, expected, f, inputs=()):
-    self.assertEquals(expected, trivial_inference.infer_return_type(f, inputs))
+    self.assertEqual(expected, trivial_inference.infer_return_type(f, inputs))
 
   def testIdentity(self):
     self.assertReturnType(int, lambda x: x, [int])

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -112,7 +112,7 @@ class MainInputTest(unittest.TestCase):
     def filter_fn(data):
       return data % 2
 
-    self.assertEquals([1, 3], [1, 2, 3] | beam.Filter(filter_fn))
+    self.assertEqual([1, 3], [1, 2, 3] | beam.Filter(filter_fn))
 
 
 @unittest.skipIf(sys.version_info >= (3, 7, 0) and

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -1048,22 +1048,22 @@ class DecoratorHelpers(TypeHintTestCase):
     self.assertFalse(is_consistent_with(Union[str, int], str))
 
   def test_positional_arg_hints(self):
-    self.assertEquals(typehints.Any, _positional_arg_hints('x', {}))
-    self.assertEquals(int, _positional_arg_hints('x', {'x': int}))
-    self.assertEquals(typehints.Tuple[int, typehints.Any],
-                      _positional_arg_hints(['x', 'y'], {'x': int}))
+    self.assertEqual(typehints.Any, _positional_arg_hints('x', {}))
+    self.assertEqual(int, _positional_arg_hints('x', {'x': int}))
+    self.assertEqual(typehints.Tuple[int, typehints.Any],
+                     _positional_arg_hints(['x', 'y'], {'x': int}))
 
   def test_getcallargs_forhints(self):
     def func(a, b_c, *d):
       b, c = b_c # pylint: disable=unused-variable
       return None
-    self.assertEquals(
+    self.assertEqual(
         {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...]},
         getcallargs_forhints(func, *[Any, Any]))
-    self.assertEquals(
+    self.assertEqual(
         {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...]},
         getcallargs_forhints(func, *[Any, Any, Any, int]))
-    self.assertEquals(
+    self.assertEqual(
         {'a': int, 'b_c': Tuple[str, Any], 'd': Tuple[Any, ...]},
         getcallargs_forhints(func, *[int, Tuple[str, Any]]))
 


### PR DESCRIPTION
This PR replaces the deprecated `self.assertEquals` with the new naming `self.assertEqual` @tvalentyn 

------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
