### PR TITLE
[BEAM-6908] Enable WordCountIT benchmark on Py36 and Py37

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Python.groovy
@@ -89,7 +89,37 @@ def testConfigurations = [
             num_workers: '10',
             autoscaling_algorithm: 'NONE',  // Disable autoscale the worker pool.
         ],
-    )
+    ),
+    new PerformanceTestConfigurations(
+        jobName           : 'beam_PerformanceTests_WordCountIT_Py36',
+        jobDescription    : 'Python SDK Performance Test - Run WordCountIT in Py36 with 1Gb files',
+        jobTriggerPhrase  : 'Run Python36 WordCountIT Performance Test',
+        resultTable       : 'beam_performance.wordcount_py36_pkb_results',
+        itClass           : 'apache_beam.examples.wordcount_it_test:WordCountIT.test_wordcount_it',
+        itModule          : 'sdks/python/test-suites/dataflow/py36',
+        extraPipelineArgs : dataflowPipelineArgs + [
+            input: 'gs://apache-beam-samples/input_small_files/ascii_sort_1MB_input.0000*', // 1Gb
+            output: 'gs://temp-storage-for-end-to-end-tests/py-it-cloud/output',
+            expect_checksum: 'ea0ca2e5ee4ea5f218790f28d0b9fe7d09d8d710',
+            num_workers: '10',
+            autoscaling_algorithm: 'NONE',  // Disable autoscale the worker pool.
+        ],
+    ),
+    new PerformanceTestConfigurations(
+        jobName           : 'beam_PerformanceTests_WordCountIT_Py37',
+        jobDescription    : 'Python SDK Performance Test - Run WordCountIT in Py37 with 1Gb files',
+        jobTriggerPhrase  : 'Run Python37 WordCountIT Performance Test',
+        resultTable       : 'beam_performance.wordcount_py37_pkb_results',
+        itClass           : 'apache_beam.examples.wordcount_it_test:WordCountIT.test_wordcount_it',
+        itModule          : 'sdks/python/test-suites/dataflow/py37',
+        extraPipelineArgs : dataflowPipelineArgs + [
+            input: 'gs://apache-beam-samples/input_small_files/ascii_sort_1MB_input.0000*', // 1Gb
+            output: 'gs://temp-storage-for-end-to-end-tests/py-it-cloud/output',
+            expect_checksum: 'ea0ca2e5ee4ea5f218790f28d0b9fe7d09d8d710',
+            num_workers: '10',
+            autoscaling_algorithm: 'NONE',  // Disable autoscale the worker pool.
+        ],
+    ),
 ]
 
 

--- a/sdks/python/test-suites/dataflow/py36/build.gradle
+++ b/sdks/python/test-suites/dataflow/py36/build.gradle
@@ -18,6 +18,7 @@
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
 applyPythonNature()
+enablePythonPerformanceTest()
 
 // Required to setup a Python 3 virtualenv.
 pythonVersion = '3.6'

--- a/sdks/python/test-suites/dataflow/py37/build.gradle
+++ b/sdks/python/test-suites/dataflow/py37/build.gradle
@@ -18,6 +18,7 @@
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
 applyPythonNature()
+enablePythonPerformanceTest()
 
 // Required to setup a Python 3 virtualenv.
 pythonVersion = '3.7'


### PR DESCRIPTION
Enable WordCountIT benchmark running on Python36 and Python37 separatedly. Two new Jenkins jobs are created to run these builds and the performance metrics will be exported to Bigquery table `beam_performance.wordcount_py36_pkb_results` and `beam_performance.wordcount_py37_pkb_results`.

TODO: Add this benchmark results to [performance dashboard](https://apache-beam-testing.appspot.com/explore?dashboard=5691127080419328).

+R: @tvalentyn 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
