### PR TITLE
[BEAM-7443] Create a BoundedSource -> SDF wrapper in Python SDK

### DIFF
--- a/sdks/python/apache_beam/io/concat_source_test.py
+++ b/sdks/python/apache_beam/io/concat_source_test.py
@@ -32,6 +32,8 @@ from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 
+__all__ = ['RangeSource']
+
 
 class RangeSource(iobase.BoundedSource):
 
@@ -61,7 +63,7 @@ class RangeSource(iobase.BoundedSource):
       yield iobase.SourceBundle(
           sub_end - sub_start,
           RangeSource(sub_start, sub_end, self._split_freq),
-          None, None)
+          sub_start, sub_end)
 
   def get_range_tracker(self, start_position, end_position):
     start, end = self._normalize(start_position, end_position)

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -845,6 +845,16 @@ class Read(ptransform.PTransform):
     super(Read, self).__init__()
     self.source = source
 
+  @staticmethod
+  def get_desired_chunk_size(total_size):
+    total_size
+    if total_size:
+      # 1MB = 1 shard, 1GB = 32 shards, 1TB = 1000 shards, 1PB = 32k shards
+      chunk_size = max(1 << 20, 1000 * int(math.sqrt(total_size)))
+    else:
+      chunk_size = 64 << 20  # 64mb
+    return chunk_size
+
   def expand(self, pbegin):
     from apache_beam.options.pipeline_options import DebugOptions
     from apache_beam.transforms import util
@@ -857,13 +867,8 @@ class Read(ptransform.PTransform):
       source = self.source
 
       def split_source(unused_impulse):
-        total_size = source.estimate_size()
-        if total_size:
-          # 1MB = 1 shard, 1GB = 32 shards, 1TB = 1000 shards, 1PB = 32k shards
-          chunk_size = max(1 << 20, 1000 * int(math.sqrt(total_size)))
-        else:
-          chunk_size = 64 << 20  # 64mb
-        return source.split(chunk_size)
+        return source.split(
+            self.get_desired_chunk_size(self.source.estimate_size()))
 
       return (
           pbegin
@@ -1122,6 +1127,8 @@ class RestrictionTracker(object):
     Methods of the class ``RestrictionTracker`` including this method may get
     invoked by different threads, hence must be made thread-safe, e.g. by using
     a single lock object.
+
+    TODO(BEAM-7473): Remove thread safety requirements from API implementation.
     """
     raise NotImplementedError
 
@@ -1148,6 +1155,8 @@ class RestrictionTracker(object):
     Methods of the class ``RestrictionTracker`` including this method may get
     invoked by different threads, hence must be made thread-safe, e.g. by using
     a single lock object.
+
+    TODO(BEAM-7473): Remove thread safety requirements from API implementation.
     """
 
     raise NotImplementedError
@@ -1168,9 +1177,100 @@ class RestrictionTracker(object):
     invoked by different threads, hence must be made thread-safe, e.g. by using
     a single lock object.
 
+    TODO(BEAM-7473): Remove thread safety requirements from API implementation.
+
     Returns: ``True`` if current restriction has been fully processed.
     Raises:
       ~exceptions.ValueError: if there is still any unclaimed work remaining.
+    """
+    raise NotImplementedError
+
+  def try_split(self, fraction_of_remainder):
+    """Splits current restriction based on fraction_of_remainder.
+
+    If splitting the current restriction is possible, the current restriction is
+    split into a primary and residual restriction pair. This invocation updates
+    the ``current_restriction()`` to be the primary restriction effectively
+    having the current ``DoFn.process()`` execution responsible for performing
+    the work that the primary restriction represents. The residual restriction
+    will be executed in a separate ``DoFn.process()`` invocation (likely in a
+    different process). The work performed by executing the primary and residual
+    restrictions as separate ``DoFn.process()`` invocations MUST be equivalent
+    to the work performed as if this split never occurred.
+
+    The ``fraction_of_remainder`` should be used in a best effort manner to
+    choose a primary and residual restriction based upon the fraction of the
+    remaining work that the current ``DoFn.process()`` invocation is responsible
+    for. For example, if a ``DoFn.process()`` was reading a file with a
+    restriction representing the offset range [100, 200) and has processed up to
+    offset 130 with a fraction_of_remainder of 0.7, the primary and residual
+    restrictions returned would be [100, 179), [179, 200) (note: current_offset
+    + fraction_of_remainder * remaining_work = 130 + 0.7 * 70 = 179).
+
+    It is very important for pipeline scaling and end to end pipeline execution
+    that try_split is implemented well.
+
+    Args:
+      fraction_of_remainder: A hint as to the fraction of work the primary
+        restriction should represent based upon the current known remaining
+        amount of work.
+
+    Returns:
+      (primary_restriction, residual_restriction) if a split was possible,
+      otherwise returns ``None``.
+
+    ** Thread safety **
+
+    Methods of the class ``RestrictionTracker`` including this method may get
+    invoked by different threads, hence must be made thread-safe, e.g. by using
+    a single lock object.
+
+    TODO(BEAM-7473): Remove thread safety requirements from API implementation.
+    """
+    raise NotImplementedError
+
+  def try_claim(self, position):
+    """ Attempts to claim the block of work in the current restriction
+    identified by the given position.
+
+    If this succeeds, the DoFn MUST execute the entire block of work. If it
+    fails, the ``DoFn.process()`` MUST return ``None`` without performing any
+    additional work or emitting output (note that emitting output or performing
+    work from ``DoFn.process()`` is also not allowed before the first call of
+    this method).
+
+    Args:
+      position: current position that wants to be claimed.
+
+    Returns: ``True`` if the position can be claimed as current_position.
+    Otherwise, returns ``False``.
+
+    ** Thread safety **
+
+    Methods of the class ``RestrictionTracker`` including this method may get
+    invoked by different threads, hence must be made thread-safe, e.g. by using
+    a single lock object.
+
+    TODO(BEAM-7473): Remove thread safety requirements from API implementation.
+    """
+    raise NotImplementedError
+
+  def defer_remainder(self, watermark=None):
+    """ Invokes checkpoint() in an SDF.process().
+
+    TODO(BEAM-7472): Remove defer_remainder() once SDF.process() uses
+    ``ProcessContinuation``.
+
+    Args:
+      watermark
+    """
+    raise NotImplementedError
+
+  def deferred_status(self):
+    """ Returns deferred_residual with deferred_watermark.
+
+    TODO(BEAM-7472): Remove defer_status() once SDF.process() uses
+    ``ProcessContinuation``.
     """
     raise NotImplementedError
 
@@ -1226,3 +1326,122 @@ class RestrictionProgress(object):
   def with_completed(self, completed):
     return RestrictionProgress(
         fraction=self._fraction, remaining=self._remaining, completed=completed)
+
+
+class _SDFBoundedSourceWrapper(ptransform.PTransform):
+  """A ``PTransform`` that uses SDF to read from a ``BoundedSource``.
+
+  NOTE: This transform can only be used with beam_fn_api enabled.
+  """
+  class _SDFBoundedSourceRestrictionTracker(RestrictionTracker):
+    """An `iobase.RestrictionTracker` implementations for wrapping BoundedSource
+    with SDF.
+
+    Delegated RangeTracker guarantees synchronization safety.
+    """
+    def __init__(self, range_tracker):
+      if not isinstance(range_tracker, RangeTracker):
+        raise ValueError('Initializing SDFBoundedSourceRestrictionTracker'
+                         'requires a RangeTracker')
+      self._delegate_range_tracker = range_tracker
+
+    def current_restriction(self):
+      return (self._delegate_range_tracker.start_position(),
+              self._delegate_range_tracker.stop_position())
+
+    def start_pos(self):
+      return self._delegate_range_tracker.start_position()
+
+    def stop_pos(self):
+      return self._delegate_range_tracker.stop_position()
+
+    def try_claim(self, position):
+      return self._delegate_range_tracker.try_claim(position)
+
+    def try_split(self, fraction_of_remainder):
+      consumed_fraction = self._delegate_range_tracker.fraction_consumed()
+      fraction = (consumed_fraction +
+                  (1 - consumed_fraction) * fraction_of_remainder)
+      position = self._delegate_range_tracker.position_at_fraction(fraction)
+      # Need to stash current stop_pos before splitting since
+      # range_tracker.split will update its stop_pos if splits
+      # successfully.
+      stop_pos = self.stop_pos()
+      split_pos, _ = self._delegate_range_tracker.try_split(position)
+      if split_pos:
+        return ((self._delegate_range_tracker.start_position(), split_pos),
+                (split_pos, stop_pos))
+
+    def deferred_status(self):
+      return None
+
+  class _SDFBoundedSourceRestrictionProvider(core.RestrictionProvider):
+    """A `RestrictionProvider` that is used by SDF for `BoundedSource`."""
+
+    def __init__(self, source, desired_chunk_size=None):
+      self._source = source
+      self._desired_chunk_size = desired_chunk_size
+
+    def initial_restriction(self, element):
+      # Get initial range_tracker from source
+      range_tracker = self._source.get_range_tracker(None, None)
+      return SourceBundle(None,
+                          self._source,
+                          range_tracker.start_position(),
+                          range_tracker.stop_position())
+
+    def create_tracker(self, restriction):
+      return _SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionTracker(
+          restriction.source.get_range_tracker(restriction.start_position,
+                                               restriction.stop_position))
+
+    def split(self, element, restriction):
+      # Invoke source.split to get initial splitting results.
+      source_bundles = self._source.split(self._desired_chunk_size)
+      for source_bundle in source_bundles:
+        yield source_bundle
+
+    def restriction_size(self, element, restriction):
+      return restriction.weight
+
+  def __init__(self, source):
+    if not isinstance(source, BoundedSource):
+      raise RuntimeError('SDFBoundedSourceWrapper can only wrap BoundedSource')
+    super(_SDFBoundedSourceWrapper, self).__init__()
+    self.source = source
+
+  def _create_sdf_bounded_source_dofn(self):
+    source = self.source
+    chunk_size = Read.get_desired_chunk_size(source.estimate_size())
+
+    class SDFBoundedSourceDoFn(core.DoFn):
+      def __init__(self, read_source):
+        self.source = read_source
+
+      def process(
+          self,
+          element,
+          restriction_tracker=core.DoFn.RestrictionParam(
+              _SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionProvider(
+                  source, chunk_size))):
+        start_pos, end_pos = restriction_tracker.current_restriction()
+        range_tracker = self.source.get_range_tracker(start_pos, end_pos)
+        return self.source.read(range_tracker)
+
+    return SDFBoundedSourceDoFn(self.source)
+
+  def expand(self, pbegin):
+    return (pbegin
+            | core.Impulse()
+            | core.ParDo(self._create_sdf_bounded_source_dofn()))
+
+  def get_windowing(self, unused_inputs):
+    return core.Windowing(window.GlobalWindows())
+
+  def _infer_output_coder(self, input_type=None, input_coder=None):
+    return self.source.default_output_coder()
+
+  def display_data(self):
+    return {'source': DisplayDataItem(self.source.__class__,
+                                      label='Read Source'),
+            'source_dd': self.source}

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -1,0 +1,150 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the SDFRestrictionProvider module."""
+
+from __future__ import absolute_import
+
+import unittest
+
+from apache_beam.io.concat_source import ConcatSource
+from apache_beam.io.concat_source_test import RangeSource
+from apache_beam.io import iobase
+from apache_beam.io.iobase import SourceBundle
+from apache_beam.io.range_trackers import OffsetRangeTracker
+
+
+class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
+  def setUp(self):
+    self.initial_range_start = 0
+    self.initial_range_stop = 4
+    self.initial_range_source = RangeSource(self.initial_range_start,
+                                            self.initial_range_stop)
+    self.sdf_restriction_provider = (
+        iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionProvider(
+            self.initial_range_source,
+            desired_chunk_size=2))
+
+  def test_initial_restriction(self):
+    unused_element = None
+    restriction = (
+        self.sdf_restriction_provider.initial_restriction(unused_element))
+    self.assertTrue(isinstance(restriction, SourceBundle))
+    self.assertEqual(self.initial_range_start, restriction.start_position)
+    self.assertEqual(self.initial_range_stop, restriction.stop_position)
+    self.assertTrue(isinstance(restriction.source, RangeSource))
+
+  def test_create_tracker(self):
+    expected_start = 1
+    expected_stop = 3
+    restriction = SourceBundle(expected_stop - expected_start,
+                               RangeSource(1, 3),
+                               expected_start,
+                               expected_stop)
+    restriction_tracker = (
+        self.sdf_restriction_provider.create_tracker(restriction))
+    self.assertTrue(isinstance(restriction_tracker,
+                               iobase.
+                               _SDFBoundedSourceWrapper.
+                               _SDFBoundedSourceRestrictionTracker))
+    self.assertEqual(expected_start, restriction_tracker.start_pos())
+    self.assertEqual(expected_stop, restriction_tracker.stop_pos())
+
+  def test_simple_source_split(self):
+    unused_element = None
+    restriction = (
+        self.sdf_restriction_provider.initial_restriction(unused_element))
+    expect_splits = [(0, 2), (2, 4)]
+    split_bundles = list(self.sdf_restriction_provider.split(unused_element,
+                                                             restriction))
+    self.assertTrue(
+        all([isinstance(bundle, SourceBundle) for bundle in split_bundles]))
+
+    splits = ([(bundle.start_position,
+                bundle.stop_position) for bundle in split_bundles])
+    self.assertEqual(expect_splits, list(splits))
+
+  def test_concat_source_split(self):
+    unused_element = None
+    initial_concat_source = ConcatSource([self.initial_range_source])
+    sdf_concat_restriction_provider = (
+        iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionProvider(
+            initial_concat_source,
+            desired_chunk_size=2))
+    restriction = (
+        self.sdf_restriction_provider.initial_restriction(unused_element))
+    expect_splits = [(0, 2), (2, 4)]
+    split_bundles = list(sdf_concat_restriction_provider.split(unused_element,
+                                                               restriction))
+    self.assertTrue(
+        all([isinstance(bundle, SourceBundle) for bundle in split_bundles]))
+    splits = ([(bundle.start_position,
+                bundle.stop_position) for bundle in split_bundles])
+    self.assertEqual(expect_splits, list(splits))
+
+  def test_restriction_size(self):
+    unused_element = None
+    restriction = (
+        self.sdf_restriction_provider.initial_restriction(unused_element))
+    split_1, split_2 = self.sdf_restriction_provider.split(unused_element,
+                                                           restriction)
+    split_1_size = self.sdf_restriction_provider.restriction_size(
+        unused_element, split_1)
+    split_2_size = self.sdf_restriction_provider.restriction_size(
+        unused_element, split_2)
+    self.assertEqual(2, split_1_size)
+    self.assertEqual(2, split_2_size)
+
+
+class SDFBoundedSourceRestrictionTrackerTest(unittest.TestCase):
+
+  def setUp(self):
+    self.initial_start_pos = 0
+    self.initial_stop_pos = 4
+    self.range_tracker = OffsetRangeTracker(self.initial_start_pos,
+                                            self.initial_stop_pos)
+    self.sdf_restriction_tracker = (
+        iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionTracker(
+            self.range_tracker))
+
+  def test_current_restriction_before_split(self):
+    actual_start, actual_stop = (
+        self.sdf_restriction_tracker.current_restriction())
+    self.assertEqual(self.initial_start_pos, actual_start)
+    self.assertEqual(self.initial_stop_pos, actual_stop)
+
+  def test_current_restriction_after_split(self):
+    fraction_of_remainder = 0.5
+    self.sdf_restriction_tracker.try_claim(1)
+    expected_restriction, _ = (
+        self.sdf_restriction_tracker.try_split(fraction_of_remainder))
+    self.assertEqual(expected_restriction,
+                     self.sdf_restriction_tracker.current_restriction())
+
+  def test_try_split_at_remainder(self):
+    fraction_of_remainder = 0.5
+    expected_primary = (0, 3)
+    expected_residual = (3, 4)
+    self.sdf_restriction_tracker.try_claim(1)
+    actual_primary, actual_residual = (
+        self.sdf_restriction_tracker.try_split(fraction_of_remainder))
+    self.assertEqual(expected_primary, actual_primary)
+    self.assertEqual(expected_residual, actual_residual)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/io/restriction_trackers.py
+++ b/sdks/python/apache_beam/io/restriction_trackers.py
@@ -148,14 +148,15 @@ class OffsetRestrictionTracker(RestrictionTracker):
 
       return False
 
-  def try_split(self, fraction):
+  def try_split(self, fraction_of_remainder):
     with self._lock:
       if not self._checkpointed:
         if self._current_position is None:
           cur = self._range.start - 1
         else:
           cur = self._current_position
-        split_point = cur + int(max(1, (self._range.stop - cur) * fraction))
+        split_point = (
+            cur + int(max(1, (self._range.stop - cur) * fraction_of_remainder)))
         if split_point < self._range.stop:
           prev_stop, self._range.stop = self._range.stop, split_point
           return (self._range.start, split_point), (split_point, prev_stop)

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -94,9 +94,14 @@ class DataflowRunner(PipelineRunner):
   # Imported here to avoid circular dependencies.
   # TODO: Remove the apache_beam.pipeline dependency in CreatePTransformOverride
   from apache_beam.runners.dataflow.ptransform_overrides import CreatePTransformOverride
+  from apache_beam.runners.dataflow.ptransform_overrides import ReadPTransformOverride
 
   _PTRANSFORM_OVERRIDES = [
       CreatePTransformOverride(),
+  ]
+
+  _SDF_PTRANSFORM_OVERRIDES = [
+      ReadPTransformOverride(),
   ]
 
   def __init__(self, cache=None):
@@ -371,6 +376,8 @@ class DataflowRunner(PipelineRunner):
     # done before Runner API serialization, since the new proto needs to contain
     # any added PTransforms.
     pipeline.replace_all(DataflowRunner._PTRANSFORM_OVERRIDES)
+    if apiclient._use_sdf_bounded_source(options):
+      pipeline.replace_all(DataflowRunner._SDF_PTRANSFORM_OVERRIDES)
 
     # Snapshot the pipeline in a portable proto.
     self.proto_pipeline, self.proto_context = pipeline.to_runner_api(

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -877,6 +877,13 @@ def _use_unified_worker(pipeline_options):
       'use_unified_worker' in debug_options.experiments)
 
 
+def _use_sdf_bounded_source(pipeline_options):
+  debug_options = pipeline_options.view_as(DebugOptions)
+  return _use_fnapi(pipeline_options) and (
+      debug_options.experiments and
+      'use_sdf_bounded_source' in debug_options.experiments)
+
+
 def get_default_container_image_for_current_sdk(job_type):
   """For internal use only; no backwards-compatibility guarantees.
 

--- a/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
+++ b/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
@@ -48,3 +48,20 @@ class CreatePTransformOverride(PTransformOverride):
       StreamingCreate
     coder = typecoders.registry.get_coder(ptransform.get_output_type())
     return StreamingCreate(ptransform.values, coder)
+
+
+class ReadPTransformOverride(PTransformOverride):
+  """A ``PTransformOverride`` for ``Read(BoundedSource)``"""
+
+  def matches(self, applied_ptransform):
+    from apache_beam.io import Read
+    from apache_beam.io.iobase import BoundedSource
+    # Only overrides Read(BoundedSource) transform
+    if isinstance(applied_ptransform.transform, Read):
+      if isinstance(applied_ptransform.transform.source, BoundedSource):
+        return True
+    return False
+
+  def get_replacement_transform(self, ptransform):
+    from apache_beam.io.iobase import _SDFBoundedSourceWrapper
+    return _SDFBoundedSourceWrapper(ptransform.source)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -31,7 +31,8 @@ import unittest
 import uuid
 from builtins import range
 
-import hamcrest
+import hamcrest  # pylint: disable=ungrouped-imports
+import mock
 from hamcrest.core.matcher import Matcher
 from hamcrest.core.string_description import StringDescription
 from tenacity import retry
@@ -39,6 +40,7 @@ from tenacity import stop_after_attempt
 
 import apache_beam as beam
 from apache_beam.io import restriction_trackers
+from apache_beam.io.concat_source_test import RangeSource
 from apache_beam.metrics import monitoring_infos
 from apache_beam.metrics.execution import MetricKey
 from apache_beam.metrics.execution import MetricsEnvironment
@@ -477,6 +479,34 @@ class FnApiRunnerTest(unittest.TestCase):
       counters = res.metrics().query(beam.metrics.MetricsFilter())['counters']
       self.assertEqual(1, len(counters))
       self.assertEqual(counters[0].committed, len(''.join(data)))
+
+  def _run_sdf_wrapper_pipeline(self, source, expected_value):
+    with self.create_pipeline() as p:
+      from apache_beam.options.pipeline_options import DebugOptions
+      experiments = (p._options.view_as(DebugOptions).experiments or [])
+
+      # Setup experiment option to enable using SDFBoundedSourceWrapper
+      if not 'use_sdf_bounded_source' in experiments:
+        experiments.append('use_sdf_bounded_source')
+
+      p._options.view_as(DebugOptions).experiments = experiments
+
+      actual = (
+          p | beam.io.Read(source)
+      )
+    assert_that(actual, equal_to(expected_value))
+
+  @mock.patch('apache_beam.io.iobase._SDFBoundedSourceWrapper.expand')
+  def test_sdf_wrapper_overrides_read(self, sdf_wrapper_mock_expand):
+    def _fake_wrapper_expand(pbegin):
+      return (pbegin
+              | beam.Create(['1']))
+
+    sdf_wrapper_mock_expand.side_effect = _fake_wrapper_expand
+    self._run_sdf_wrapper_pipeline(RangeSource(0, 4), ['1'])
+
+  def test_sdf_wrap_range_source(self):
+    self._run_sdf_wrapper_pipeline(RangeSource(0, 4), [0, 1, 2, 3])
 
   def test_group_by_key(self):
     with self.create_pipeline() as p:


### PR DESCRIPTION
Create a wrapper tp wrapping python BoundedSource into SDF in python SDK. 
Major components of wrapper included:
* SDFBoundedSourceWrapper
* SDFBoundedSourceRestrictionTracker
* SDFBoundedSourceDoFn

In dataflow_runner and fn_api_runner, if pipeline running with "use_sdf_bounded_source" option, the runner will override Read(BoundedSource) with SDFBoundedSourceWrapper(BoundedSource). No support for other runners for now.

R: @lukecwik @robertwb 
CC: @laraschmidt
