### PR TITLE
[BEAM-7365] Reduces the volume of test data in fastavro branch of test_dynamic_work_rebalancing_exhaustive to match the volume of avro branch.

### DIFF
--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -359,7 +359,7 @@ class AvroBase(object):
       source_test_utils.assert_split_at_fraction_exhaustive(splits[0].source)
 
     if self.use_fastavro:
-      file_name = self._write_data(count=200, sync_interval=2)
+      file_name = self._write_data(count=5, sync_interval=2)
       compare_split_points(file_name)
     else:
       old_sync_interval = avro.datafile.SYNC_INTERVAL

--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -277,13 +277,9 @@ class AvroBase(object):
 
   def test_split_points(self):
     num_records = 12000
-    if self.use_fastavro:
-      sync_interval = 16000
-      file_name = self._write_data(count=num_records,
-                                   sync_interval=sync_interval)
-    else:
-      sync_interval = avro.datafile.SYNC_INTERVAL
-      file_name = self._write_data(count=num_records)
+    sync_interval = 16000
+    file_name = self._write_data(count=num_records,
+                                 sync_interval=sync_interval)
 
     source = _create_avro_source(file_name, use_fastavro=self.use_fastavro)
 
@@ -348,8 +344,6 @@ class AvroBase(object):
     self._run_avro_test(pattern, 100, True, expected_result)
 
   def test_dynamic_work_rebalancing_exhaustive(self):
-    # Adjusting block size so that we can perform a exhaustive dynamic
-    # work rebalancing test that completes within an acceptable amount of time.
     def compare_split_points(file_name):
       source = _create_avro_source(file_name,
                                    use_fastavro=self.use_fastavro)
@@ -358,17 +352,11 @@ class AvroBase(object):
       assert len(splits) == 1
       source_test_utils.assert_split_at_fraction_exhaustive(splits[0].source)
 
-    if self.use_fastavro:
-      file_name = self._write_data(count=5, sync_interval=2)
-      compare_split_points(file_name)
-    else:
-      old_sync_interval = avro.datafile.SYNC_INTERVAL
-      try:
-        avro.datafile.SYNC_INTERVAL = 2
-        file_name = self._write_data(count=5)
-        compare_split_points(file_name)
-      finally:
-        avro.datafile.SYNC_INTERVAL = old_sync_interval
+    # Adjusting block size so that we can perform a exhaustive dynamic
+    # work rebalancing test that completes within an acceptable amount of time.
+    file_name = self._write_data(count=5, sync_interval=2)
+
+    compare_split_points(file_name)
 
   def test_corrupted_file(self):
     file_name = self._write_data()
@@ -490,17 +478,23 @@ class TestAvro(AvroBase, unittest.TestCase):
                   directory=None,
                   prefix=tempfile.template,
                   codec='null',
-                  count=len(RECORDS)):
-    with tempfile.NamedTemporaryFile(delete=False,
-                                     dir=directory,
-                                     prefix=prefix) as f:
-      writer = DataFileWriter(f, DatumWriter(), self.SCHEMA, codec=codec)
-      len_records = len(self.RECORDS)
-      for i in range(count):
-        writer.append(self.RECORDS[i % len_records])
-      writer.close()
-      self._temp_files.append(f.name)
-      return f.name
+                  count=len(RECORDS),
+                  sync_interval=avro.datafile.SYNC_INTERVAL):
+    old_sync_interval = avro.datafile.SYNC_INTERVAL
+    try:
+      avro.datafile.SYNC_INTERVAL = sync_interval
+      with tempfile.NamedTemporaryFile(delete=False,
+                                       dir=directory,
+                                       prefix=prefix) as f:
+        writer = DataFileWriter(f, DatumWriter(), self.SCHEMA, codec=codec)
+        len_records = len(self.RECORDS)
+        for i in range(count):
+          writer.append(self.RECORDS[i % len_records])
+        writer.close()
+        self._temp_files.append(f.name)
+        return f.name
+    finally:
+      avro.datafile.SYNC_INTERVAL = old_sync_interval
 
 
 class TestFastAvro(AvroBase, unittest.TestCase):


### PR DESCRIPTION
Context: FastAvro flavor of test_dynamic_work_rebalancing_exhaustive test currently uses 40x bigger input than Avro flavor of the same test, causing slowness during test execution.   

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
