### PR TITLE
[BEAM-5995] Add hot key to Python Synthetic Sources and use it in Load Tests

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_GBK_Python_reiterate.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Python_reiterate.groovy
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonJobProperties as commonJobProperties
+import CommonTestProperties
+import LoadTestsBuilder as loadTestsBuilder
+import PhraseTriggeringPostCommitBuilder
+import CronJobBuilder
+
+def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
+
+def loadTestConfigurations = [
+        [
+                title        : 'GroupByKey Python Load test: reiterate 4 times 10kB values',
+                itClass      :  'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                runner       : CommonTestProperties.Runner.DATAFLOW,
+                jobProperties: [
+                        project              : 'apache-beam-testing',
+                        job_name             : 'load-tests-python-dataflow-batch-gbk-6-' + now,
+                        temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
+                        publish_to_big_query : true,
+                        metrics_dataset      : 'load_test',
+                        metrics_table        : "python_dataflow_batch_gbk_6",
+                        input_options        : '\'{"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 200,' +
+                                '"hot_key_fraction": 1}\'',
+                        fanout               : 1,
+                        iterations           : 4,
+                        max_num_workers      : 5,
+                        num_workers          : 5,
+                        autoscaling_algorithm: "NONE"
+                ]
+        ],
+        [
+                title        : 'GroupByKey Python Load test: reiterate 4 times 2MB values',
+                itClass      :  'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                runner       : CommonTestProperties.Runner.DATAFLOW,
+                jobProperties: [
+                        project              : 'apache-beam-testing',
+                        job_name             : 'load-tests-python-dataflow-batch-gbk-7-' + now,
+                        temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
+                        publish_to_big_query : true,
+                        metrics_dataset      : 'load_test',
+                        metrics_table        : 'python_dataflow_batch_gbk_7',
+                        input_options        : '\'{"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 10,' +
+                                '"hot_key_fraction": 1}\'',
+                        fanout               : 1,
+                        iterations           : 4,
+                        max_num_workers      : 5,
+                        num_workers          : 5,
+                        autoscaling_algorithm: 'NONE'
+                ]
+        ]
+]
+
+def batchLoadTestJob = { scope, triggeringContext ->
+    scope.description('Runs Python GBK reiterate load tests on Dataflow runner in batch mode')
+    commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
+
+    for (testConfiguration in loadTestConfigurations) {
+        loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.PYTHON, testConfiguration.jobProperties, testConfiguration.itClass, triggeringContext)
+    }
+}
+
+CronJobBuilder.cronJob('beam_LoadTests_Python_GBK_Dataflow_Batch', 'H 14 * * *', this) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT)
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_LoadTests_Python_GBK_reiterate_Dataflow_Batch',
+        'Run Load Tests Python GBK reiterate Dataflow Batch',
+        'Load Tests Python GBK reiterate Dataflow Batch suite',
+        this
+) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.PR)
+}

--- a/sdks/python/apache_beam/testing/load_tests/load_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/load_test.py
@@ -33,6 +33,8 @@ class LoadTest(unittest.TestCase):
         'numRecords': options.get('num_records'),
         'keySizeBytes': options.get('key_size'),
         'valueSizeBytes': options.get('value_size'),
+        'hotKeyFraction': options.get('hot_key_fraction', 0),
+        'numHotKeys': options.get('num_hot_keys', 0),
         'bundleSizeDistribution': {
             'type': options.get(
                 'bundle_size_distribution_type', 'const'

--- a/sdks/python/apache_beam/testing/synthetic_pipeline.py
+++ b/sdks/python/apache_beam/testing/synthetic_pipeline.py
@@ -250,7 +250,7 @@ class SyntheticSource(iobase.BoundedSource):
       # Generate hot key.
       # An integer is randomly selected from the range [0, numHotKeys-1]
       # with equal probability.
-      r_hot = np.random.RandomState(self._num_hot_keys)
+      r_hot = np.random.RandomState(index % self._num_hot_keys)
       return r_hot.bytes(self._key_size), r.bytes(self._value_size)
     else:
       return r.bytes(self._key_size), r.bytes(self._value_size)

--- a/sdks/python/apache_beam/testing/synthetic_pipeline.py
+++ b/sdks/python/apache_beam/testing/synthetic_pipeline.py
@@ -135,6 +135,9 @@ class SyntheticSource(iobase.BoundedSource):
 
     self._num_records = input_spec['numRecords']
     self._key_size = maybe_parse_byte_size(input_spec.get('keySizeBytes', 1))
+    self._hot_key_fraction = input_spec.get('hotKeyFraction', 0)
+    self._num_hot_keys = input_spec.get('numHotKeys', 0)
+
     self._value_size = maybe_parse_byte_size(
         input_spec.get('valueSizeBytes', 1))
     self._total_size = self.element_size * self._num_records
@@ -238,13 +241,25 @@ class SyntheticSource(iobase.BoundedSource):
       tracker = range_trackers.UnsplittableRangeTracker(tracker)
     return tracker
 
+  def _gen_kv_pair(self, index):
+    r = np.random.RandomState(index)
+    rand = r.random_sample()
+
+    # Determines whether to generate hot key or not.
+    if rand < self._hot_key_fraction:
+      # Generate hot key.
+      # An integer is randomly selected from the range [0, numHotKeys-1]
+      # with equal probability.
+      r_hot = np.random.RandomState(self._num_hot_keys)
+      return r_hot.bytes(self._key_size), r.bytes(self._value_size)
+    else:
+      return r.bytes(self._key_size), r.bytes(self._value_size)
+
   def read(self, range_tracker):
     index = range_tracker.start_position()
     while range_tracker.try_claim(index):
-      r = np.random.RandomState(index)
-
       time.sleep(self._sleep_per_input_record_sec)
-      yield r.bytes(self._key_size), r.bytes(self._value_size)
+      yield self._gen_kv_pair(index)
       index += 1
 
   def default_output_coder(self):


### PR DESCRIPTION
Added two new parameters to Synthetic Sources in Python: hotkey number and hotkey fraction. They are used to produce hot keys in key-value production.

Added Python GBK load tests in Jenkins to use hot key in practice.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
