### PR TITLE
[BEAM-7086] Refactoring repetitive error code.

### DIFF
--- a/sdks/go/pkg/beam/core/graph/edge.go
+++ b/sdks/go/pkg/beam/core/graph/edge.go
@@ -186,14 +186,15 @@ func (e *MultiEdge) String() string {
 
 // NewCoGBK inserts a new CoGBK edge into the graph.
 func NewCoGBK(g *Graph, s *Scope, ns []*Node) (*MultiEdge, error) {
+	addContext := func(err error, s *Scope) error {
+		return errors.WithContextf(err, "creating new CoGBK in scope %v", s)
+	}
+
 	if len(ns) == 0 {
-		// TODO(BEAM-7086) Reduce the repetition in the context of all the errors in this file.
-		err := errors.New("needs at least 1 input")
-		return nil, errors.WithContextf(err, "creating new CoGBK in scope %v", s)
+		return nil, addContext(errors.New("needs at least 1 input"), s)
 	}
 	if !typex.IsKV(ns[0].Type()) {
-		err := errors.Errorf("input type must be KV: %v", ns[0])
-		return nil, errors.WithContextf(err, "creating new CoGBK in scope %v", s)
+		return nil, addContext(errors.Errorf("input type must be KV: %v", ns[0]), s)
 	}
 
 	// (1) Create CoGBK result type: KV<T,U>, .., KV<T,Z> -> CoGBK<T,U,..,Z>.
@@ -206,20 +207,16 @@ func NewCoGBK(g *Graph, s *Scope, ns []*Node) (*MultiEdge, error) {
 	for i := 1; i < len(ns); i++ {
 		n := ns[i]
 		if !typex.IsKV(n.Type()) {
-			err := errors.Errorf("input type must be KV: %v", n)
-			return nil, errors.WithContextf(err, "creating new CoGBK in scope %v", s)
+			return nil, addContext(errors.Errorf("input type must be KV: %v", n), s)
 		}
 		if !n.Coder.Components[0].Equals(c) {
-			err := errors.Errorf("key coder for %v is %v, want %v", n, n.Coder.Components[0], c)
-			return nil, errors.WithContextf(err, "creating new CoGBK in scope %v", s)
+			return nil, addContext(errors.Errorf("key coder for %v is %v, want %v", n, n.Coder.Components[0], c), s)
 		}
 		if !w.Equals(n.WindowingStrategy()) {
-			err := errors.Errorf("mismatched CoGBK windowing strategies: %v, want %v", n.WindowingStrategy(), w)
-			return nil, errors.WithContextf(err, "creating new CoGBK in scope %v", s)
+			return nil, addContext(errors.Errorf("mismatched CoGBK windowing strategies: %v, want %v", n.WindowingStrategy(), w), s)
 		}
 		if bounded != n.Bounded() {
-			err := errors.Errorf("unmatched CoGBK boundedness: %v, want %v", n.Bounded(), bounded)
-			return nil, errors.WithContextf(err, "creating new CoGBK in scope %v", s)
+			return nil, addContext(errors.Errorf("unmatched CoGBK boundedness: %v, want %v", n.Bounded(), bounded), s)
 		}
 
 		comp = append(comp, n.Type().Components()[1])
@@ -242,9 +239,12 @@ func NewCoGBK(g *Graph, s *Scope, ns []*Node) (*MultiEdge, error) {
 // NewFlatten inserts a new Flatten edge in the graph. Flatten output type is
 // the shared input type.
 func NewFlatten(g *Graph, s *Scope, in []*Node) (*MultiEdge, error) {
+	addContext := func(err error, s *Scope) error {
+		return errors.WithContextf(err, "creating new Flatten in scope %v", s)
+	}
+
 	if len(in) < 2 {
-		err := errors.Errorf("Flatten needs at least 2 input, got %v", len(in))
-		return nil, errors.WithContextf(err, "creating new Flatten in scope %v", s)
+		return nil, addContext(errors.Errorf("Flatten needs at least 2 input, got %v", len(in)), s)
 	}
 	t := in[0].Type()
 	w := inputWindow(in)
@@ -260,17 +260,14 @@ func NewFlatten(g *Graph, s *Scope, in []*Node) (*MultiEdge, error) {
 	}
 	for _, n := range in {
 		if !typex.IsEqual(t, n.Type()) {
-			err := errors.Errorf("mismatched Flatten input types: %v, want %v", n.Type(), t)
-			return nil, errors.WithContextf(err, "creating new Flatten in scope %v", s)
+			return nil, addContext(errors.Errorf("mismatched Flatten input types: %v, want %v", n.Type(), t), s)
 		}
 		if !w.Equals(n.WindowingStrategy()) {
-			err := errors.Errorf("mismatched Flatten window types: %v, want %v", n.WindowingStrategy(), w)
-			return nil, errors.WithContextf(err, "creating new Flatten in scope %v", s)
+			return nil, addContext(errors.Errorf("mismatched Flatten window types: %v, want %v", n.WindowingStrategy(), w), s)
 		}
 	}
 	if typex.IsCoGBK(t) {
-		err := errors.Errorf("Flatten input type cannot be CoGBK: %v", t)
-		return nil, errors.WithContextf(err, "creating new Flatten in scope %v", s)
+		return nil, addContext(errors.Errorf("Flatten input type cannot be CoGBK: %v", t), s)
 	}
 
 	edge := g.NewEdge(s)
@@ -338,14 +335,16 @@ const CombinePerKeyScope = "CombinePerKey"
 // NewCombine inserts a new Combine edge into the graph. Combines cannot have side
 // input.
 func NewCombine(g *Graph, s *Scope, u *CombineFn, in *Node, ac *coder.Coder) (*MultiEdge, error) {
+	addContext := func(err error, s *Scope) error {
+		return errors.WithContextf(err, "creating new Combine in scope %v", s)
+	}
+
 	inT := in.Type()
 	if !typex.IsCoGBK(inT) {
-		err := errors.Errorf("Combine requires CoGBK type: %v", inT)
-		return nil, errors.WithContextf(err, "creating new Combine in scope %v", s)
+		return nil, addContext(errors.Errorf("Combine requires CoGBK type: %v", inT), s)
 	}
 	if len(inT.Components()) > 2 {
-		err := errors.Errorf("Combine cannot follow multi-input CoGBK: %v", inT)
-		return nil, errors.WithContextf(err, "creating new Combine in scope %v", s)
+		return nil, addContext(errors.Errorf("Combine cannot follow multi-input CoGBK: %v", inT), s)
 	}
 
 	// Create a synthetic function for binding purposes. It takes main input
@@ -394,7 +393,7 @@ func NewCombine(g *Graph, s *Scope, u *CombineFn, in *Node, ac *coder.Coder) (*M
 
 	inbound, kinds, outbound, out, err := Bind(synth, nil, inT)
 	if err != nil {
-		return nil, errors.WithContextf(err, "creating new Combine in scope %v", s)
+		return nil, addContext(err, s)
 	}
 
 	edge := g.NewEdge(s)


### PR DESCRIPTION
Straightforward change, make some function literals for the really
repetitive error code.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
