### PR TITLE
[BEAM-7414] fix for message being not serializable due to LongString in headers

### DIFF
--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -19,12 +19,6 @@ package org.apache.beam.sdk.io.rabbitmq;
 
 import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
 
-import com.google.auto.value.AutoValue;
-import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.MessageProperties;
-import com.rabbitmq.client.QueueingConsumer;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
@@ -32,10 +26,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeoutException;
+
 import javax.annotation.Nullable;
+
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
@@ -49,593 +47,666 @@ import org.apache.beam.sdk.values.PCollection;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
+import com.google.auto.value.AutoValue;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.LongString;
+import com.rabbitmq.client.MessageProperties;
+import com.rabbitmq.client.QueueingConsumer;
+import com.rabbitmq.client.QueueingConsumer.Delivery;
+
 /**
  * A IO to publish or consume messages with a RabbitMQ broker.
  *
  * <h3>Consuming messages from RabbitMQ server</h3>
  *
- * <p>{@link RabbitMqIO} {@link Read} returns an unbounded {@link PCollection} containing RabbitMQ
- * messages body (as {@code byte[]}) wrapped as {@link RabbitMqMessage}.
+ * <p>
+ * {@link RabbitMqIO} {@link Read} returns an unbounded {@link PCollection}
+ * containing RabbitMQ messages body (as {@code byte[]}) wrapped as
+ * {@link RabbitMqMessage}.
  *
- * <p>To configure a RabbitMQ source, you have to provide a RabbitMQ {@code URI} to connect to a
- * RabbitMQ broker. The following example illustrates various options for configuring the source,
- * reading from the queue:
+ * <p>
+ * To configure a RabbitMQ source, you have to provide a RabbitMQ {@code URI} to
+ * connect to a RabbitMQ broker. The following example illustrates various
+ * options for configuring the source, reading from the queue:
  *
- * <pre>{@code
+ * <pre>
+ * {@code
  * PCollection<RabbitMqMessage> messages = pipeline.apply(
  *   RabbitMqIO.read().withUri("amqp://user:password@localhost:5672").withQueue("QUEUE"))
  *
- * }</pre>
+ * }
+ * </pre>
  *
- * <p>It's also possible to read from an exchange (providing the exchange type and routing key)
- * instead of directly from a queue:
+ * <p>
+ * It's also possible to read from an exchange (providing the exchange type and
+ * routing key) instead of directly from a queue:
  *
- * <pre>{@code
- * PCollection<RabbitMqMessage> messages = pipeline.apply(
- *   RabbitMqIO.read().withUri("amqp://user:password@localhost:5672").withExchange("EXCHANGE", "fanout", "QUEUE"));
- * }</pre>
+ * <pre>
+ * {
+ * 	&#64;code
+ * 	PCollection<RabbitMqMessage> messages = pipeline.apply(RabbitMqIO.read()
+ * 			.withUri("amqp://user:password@localhost:5672").withExchange("EXCHANGE", "fanout", "QUEUE"));
+ * }
+ * </pre>
  *
  * <h3>Publishing messages to RabbitMQ server</h3>
  *
- * <p>{@link RabbitMqIO} {@link Write} can send {@link RabbitMqMessage} to a RabbitMQ server queue
- * or exchange.
+ * <p>
+ * {@link RabbitMqIO} {@link Write} can send {@link RabbitMqMessage} to a
+ * RabbitMQ server queue or exchange.
  *
- * <p>As for the {@link Read}, the {@link Write} is configured with a RabbitMQ URI.
+ * <p>
+ * As for the {@link Read}, the {@link Write} is configured with a RabbitMQ URI.
  *
- * <p>For instance, you can write to an exchange (providing the exchange type):
+ * <p>
+ * For instance, you can write to an exchange (providing the exchange type):
  *
- * <pre>{@code
+ * <pre>
+ * {@code
  * pipeline
  *   .apply(...) // provide PCollection<RabbitMqMessage>
  *   .apply(RabbitMqIO.write().withUri("amqp://user:password@localhost:5672").withExchange("EXCHANGE", "fanout"));
- * }</pre>
+ * }
+ * </pre>
  *
- * <p>For instance, you can write to a queue:
+ * <p>
+ * For instance, you can write to a queue:
  *
- * <pre>{@code
+ * <pre>
+ * {@code
  * pipeline
  *   .apply(...) // provide PCollection<RabbitMqMessage>
  *   .apply(RabbitMqIO.write().withUri("amqp://user:password@localhost:5672").withQueue("QUEUE"));
  *
- * }</pre>
+ * }
+ * </pre>
  */
 @Experimental(Experimental.Kind.SOURCE_SINK)
 public class RabbitMqIO {
-  public static Read read() {
-    return new AutoValue_RabbitMqIO_Read.Builder()
-        .setQueueDeclare(false)
-        .setMaxReadTime(null)
-        .setMaxNumRecords(Long.MAX_VALUE)
-        .setUseCorrelationId(false)
-        .build();
-  }
-
-  public static Write write() {
-    return new AutoValue_RabbitMqIO_Write.Builder()
-        .setExchangeDeclare(false)
-        .setQueueDeclare(false)
-        .build();
-  }
+	public static Read read() {
+		return new AutoValue_RabbitMqIO_Read.Builder().setQueueDeclare(false).setMaxReadTime(null)
+				.setMaxNumRecords(Long.MAX_VALUE).setUseCorrelationId(false).build();
+	}
 
-  private RabbitMqIO() {}
-
-  private static class ConnectionHandler {
-
-    private final ConnectionFactory connectionFactory;
-    private Connection connection;
-    private Channel channel;
-
-    public ConnectionHandler(String uri)
-        throws URISyntaxException, NoSuchAlgorithmException, KeyManagementException {
-      connectionFactory = new ConnectionFactory();
-      connectionFactory.setUri(uri);
-      connectionFactory.setAutomaticRecoveryEnabled(true);
-      connectionFactory.setConnectionTimeout(60000);
-      connectionFactory.setNetworkRecoveryInterval(5000);
-      connectionFactory.setRequestedHeartbeat(60);
-      connectionFactory.setTopologyRecoveryEnabled(true);
-      connectionFactory.setRequestedChannelMax(0);
-      connectionFactory.setRequestedFrameMax(0);
-    }
-
-    public void start() throws TimeoutException, IOException {
-      connection = connectionFactory.newConnection();
-      channel = connection.createChannel();
-      if (channel == null) {
-        throw new IOException("No RabbitMQ channel available");
-      }
-    }
-
-    public Channel getChannel() {
-      return this.channel;
-    }
-
-    public void stop() throws IOException {
-      if (channel != null) {
-        try {
-          channel.close();
-        } catch (Exception e) {
-          // ignore
-        }
-      }
-      if (connection != null) {
-        connection.close();
-      }
-    }
-  }
-
-  /** A {@link PTransform} to consume messages from RabbitMQ server. */
-  @AutoValue
-  public abstract static class Read extends PTransform<PBegin, PCollection<RabbitMqMessage>> {
-    @Nullable
-    abstract String uri();
-
-    @Nullable
-    abstract String queue();
-
-    abstract boolean queueDeclare();
-
-    @Nullable
-    abstract String exchange();
-
-    @Nullable
-    abstract String exchangeType();
-
-    @Nullable
-    abstract String routingKey();
-
-    abstract boolean useCorrelationId();
-
-    abstract long maxNumRecords();
-
-    @Nullable
-    abstract Duration maxReadTime();
-
-    abstract Builder builder();
-
-    @AutoValue.Builder
-    abstract static class Builder {
-      abstract Builder setUri(String uri);
-
-      abstract Builder setQueue(String queue);
-
-      abstract Builder setQueueDeclare(boolean queueDeclare);
-
-      abstract Builder setExchange(String exchange);
-
-      abstract Builder setExchangeType(String exchangeType);
-
-      abstract Builder setRoutingKey(String routingKey);
-
-      abstract Builder setUseCorrelationId(boolean useCorrelationId);
-
-      abstract Builder setMaxNumRecords(long maxNumRecords);
-
-      abstract Builder setMaxReadTime(Duration maxReadTime);
-
-      abstract Read build();
-    }
-
-    public Read withUri(String uri) {
-      checkArgument(uri != null, "uri can not be null");
-      return builder().setUri(uri).build();
-    }
-
-    /**
-     * If you want to directly consume messages from a specific queue, you just have to specify the
-     * queue name. Optionally, you can declare the queue using {@link
-     * RabbitMqIO.Read#withQueueDeclare(boolean)}.
-     */
-    public Read withQueue(String queue) {
-      checkArgument(queue != null, "queue can not be null");
-      return builder().setQueue(queue).build();
-    }
-
-    /**
-     * You can "force" the declaration of a queue on the RabbitMQ broker. Exchanges and queues are
-     * the high-level building blocks of AMQP. These must be "declared" before they can be used.
-     * Declaring either type of object simply ensures that one of that name exists, creating it if
-     * necessary.
-     *
-     * @param queueDeclare If {@code true}, {@link RabbitMqIO} will declare the queue. If another
-     *     application declare the queue, it's not required.
-     */
-    public Read withQueueDeclare(boolean queueDeclare) {
-      return builder().setQueueDeclare(queueDeclare).build();
-    }
-
-    /**
-     * Instead of consuming messages on a specific queue, you can consume message from a given
-     * exchange. Then you specify the exchange name, type and optionally routing key where you want
-     * to consume messages.
-     */
-    public Read withExchange(String name, String type, String routingKey) {
-      checkArgument(name != null, "name can not be null");
-      checkArgument(type != null, "type can not be null");
-      return builder().setExchange(name).setExchangeType(type).setRoutingKey(routingKey).build();
-    }
-
-    /**
-     * Define the max number of records received by the {@link Read}. When this max number of
-     * records is lower than {@code Long.MAX_VALUE}, the {@link Read} will provide a bounded {@link
-     * PCollection}.
-     */
-    public Read withMaxNumRecords(long maxNumRecords) {
-      checkArgument(maxReadTime() == null, "maxNumRecord and maxReadTime are exclusive");
-      return builder().setMaxNumRecords(maxNumRecords).build();
-    }
-
-    /**
-     * Define the max read time (duration) while the {@link Read} will receive messages. When this
-     * max read time is not null, the {@link Read} will provide a bounded {@link PCollection}.
-     */
-    public Read withMaxReadTime(Duration maxReadTime) {
-      checkArgument(
-          maxNumRecords() == Long.MAX_VALUE, "maxNumRecord and maxReadTime are exclusive");
-      return builder().setMaxReadTime(maxReadTime).build();
-    }
-
-    @Override
-    public PCollection<RabbitMqMessage> expand(PBegin input) {
-      org.apache.beam.sdk.io.Read.Unbounded<RabbitMqMessage> unbounded =
-          org.apache.beam.sdk.io.Read.from(new RabbitMQSource(this));
-
-      PTransform<PBegin, PCollection<RabbitMqMessage>> transform = unbounded;
-
-      if (maxNumRecords() < Long.MAX_VALUE || maxReadTime() != null) {
-        transform = unbounded.withMaxReadTime(maxReadTime()).withMaxNumRecords(maxNumRecords());
-      }
-
-      return input.getPipeline().apply(transform);
-    }
-  }
-
-  static class RabbitMQSource extends UnboundedSource<RabbitMqMessage, RabbitMQCheckpointMark> {
-    final Read spec;
-
-    RabbitMQSource(Read spec) {
-      this.spec = spec;
-    }
-
-    @Override
-    public Coder<RabbitMqMessage> getOutputCoder() {
-      return SerializableCoder.of(RabbitMqMessage.class);
-    }
-
-    @Override
-    public List<RabbitMQSource> split(int desiredNumSplits, PipelineOptions options) {
-      // RabbitMQ uses queue, so, we can have several concurrent consumers as source
-      List<RabbitMQSource> sources = new ArrayList<>();
-      for (int i = 0; i < desiredNumSplits; i++) {
-        sources.add(this);
-      }
-      return sources;
-    }
-
-    @Override
-    public UnboundedReader<RabbitMqMessage> createReader(
-        PipelineOptions options, RabbitMQCheckpointMark checkpointMark) throws IOException {
-      return new UnboundedRabbitMqReader(this, checkpointMark);
-    }
-
-    @Override
-    public Coder<RabbitMQCheckpointMark> getCheckpointMarkCoder() {
-      return SerializableCoder.of(RabbitMQCheckpointMark.class);
-    }
-
-    @Override
-    public boolean requiresDeduping() {
-      return spec.useCorrelationId();
-    }
-  }
-
-  private static class RabbitMQCheckpointMark
-      implements UnboundedSource.CheckpointMark, Serializable {
-    transient Channel channel;
-    Instant oldestTimestamp = Instant.now();
-    final List<Long> sessionIds = new ArrayList<>();
-
-    @Override
-    public void finalizeCheckpoint() throws IOException {
-      for (Long sessionId : sessionIds) {
-        channel.basicAck(sessionId, false);
-      }
-      channel.txCommit();
-      oldestTimestamp = Instant.now();
-      sessionIds.clear();
-    }
-  }
-
-  private static class UnboundedRabbitMqReader
-      extends UnboundedSource.UnboundedReader<RabbitMqMessage> {
-    private final RabbitMQSource source;
-
-    private RabbitMqMessage current;
-    private byte[] currentRecordId;
-    private ConnectionHandler connectionHandler;
-    private QueueingConsumer consumer;
-    private Instant currentTimestamp;
-    private final RabbitMQCheckpointMark checkpointMark;
-
-    UnboundedRabbitMqReader(RabbitMQSource source, RabbitMQCheckpointMark checkpointMark)
-        throws IOException {
-      this.source = source;
-      this.current = null;
-      this.checkpointMark = checkpointMark != null ? checkpointMark : new RabbitMQCheckpointMark();
-      try {
-        connectionHandler = new ConnectionHandler(source.spec.uri());
-      } catch (Exception e) {
-        throw new IOException(e);
-      }
-    }
-
-    @Override
-    public Instant getWatermark() {
-      return checkpointMark.oldestTimestamp;
-    }
-
-    @Override
-    public UnboundedSource.CheckpointMark getCheckpointMark() {
-      return checkpointMark;
-    }
-
-    @Override
-    public RabbitMQSource getCurrentSource() {
-      return source;
-    }
-
-    @Override
-    public byte[] getCurrentRecordId() {
-      if (current == null) {
-        throw new NoSuchElementException();
-      }
-      if (currentRecordId != null) {
-        return currentRecordId;
-      } else {
-        return "".getBytes(StandardCharsets.UTF_8);
-      }
-    }
-
-    @Override
-    public Instant getCurrentTimestamp() {
-      if (currentTimestamp == null) {
-        throw new NoSuchElementException();
-      }
-      return currentTimestamp;
-    }
-
-    @Override
-    public RabbitMqMessage getCurrent() {
-      if (current == null) {
-        throw new NoSuchElementException();
-      }
-      return current;
-    }
-
-    @Override
-    public boolean start() throws IOException {
-      try {
-        ConnectionHandler connectionHandler = new ConnectionHandler(source.spec.uri());
-        connectionHandler.start();
-
-        Channel channel = connectionHandler.getChannel();
-
-        String queueName = source.spec.queue();
-        if (source.spec.queueDeclare()) {
-          // declare the queue (if not done by another application)
-          // channel.queueDeclare(queueName, durable, exclusive, autoDelete, arguments);
-          channel.queueDeclare(queueName, false, false, false, null);
-        }
-        if (source.spec.exchange() != null) {
-          channel.exchangeDeclare(source.spec.exchange(), source.spec.exchangeType());
-          if (queueName == null) {
-            queueName = channel.queueDeclare().getQueue();
-          }
-          channel.queueBind(queueName, source.spec.exchange(), source.spec.routingKey());
-        }
-        checkpointMark.channel = channel;
-        consumer = new QueueingConsumer(channel);
-        channel.txSelect();
-        // we consume message without autoAck (we want to do the ack ourselves)
-        channel.setDefaultConsumer(consumer);
-        channel.basicConsume(queueName, false, consumer);
-      } catch (Exception e) {
-        throw new IOException(e);
-      }
-      return advance();
-    }
-
-    @Override
-    public boolean advance() throws IOException {
-      try {
-        QueueingConsumer.Delivery delivery = consumer.nextDelivery(1000);
-        if (delivery == null) {
-          return false;
-        }
-        if (source.spec.useCorrelationId()) {
-          String correlationId = delivery.getProperties().getCorrelationId();
-          if (correlationId == null) {
-            throw new IOException(
-                "RabbitMqIO.Read uses message correlation ID, but received "
-                    + "message has a null correlation ID");
-          }
-          currentRecordId = correlationId.getBytes(StandardCharsets.UTF_8);
-        }
-        long deliveryTag = delivery.getEnvelope().getDeliveryTag();
-        checkpointMark.sessionIds.add(deliveryTag);
-
-        current = new RabbitMqMessage(source.spec.routingKey(), delivery);
-        currentTimestamp = new Instant(delivery.getProperties().getTimestamp());
-        if (currentTimestamp.isBefore(checkpointMark.oldestTimestamp)) {
-          checkpointMark.oldestTimestamp = currentTimestamp;
-        }
-      } catch (Exception e) {
-        throw new IOException(e);
-      }
-      return true;
-    }
-
-    @Override
-    public void close() throws IOException {
-      if (connectionHandler != null) {
-        connectionHandler.stop();
-      }
-    }
-  }
-
-  /** A {@link PTransform} to publish messages to a RabbitMQ server. */
-  @AutoValue
-  public abstract static class Write
-      extends PTransform<PCollection<RabbitMqMessage>, PCollection<?>> {
-
-    @Nullable
-    abstract String uri();
-
-    @Nullable
-    abstract String exchange();
-
-    @Nullable
-    abstract String exchangeType();
-
-    abstract boolean exchangeDeclare();
-
-    @Nullable
-    abstract String queue();
-
-    abstract boolean queueDeclare();
-
-    abstract Builder builder();
-
-    @AutoValue.Builder
-    abstract static class Builder {
-      abstract Builder setUri(String uri);
-
-      abstract Builder setExchange(String exchange);
-
-      abstract Builder setExchangeType(String exchangeType);
-
-      abstract Builder setExchangeDeclare(boolean exchangeDeclare);
-
-      abstract Builder setQueue(String queue);
-
-      abstract Builder setQueueDeclare(boolean queueDeclare);
-
-      abstract Write build();
-    }
-
-    public Write withUri(String uri) {
-      checkArgument(uri != null, "uri can not be null");
-      return builder().setUri(uri).build();
-    }
-
-    /**
-     * Defines the exchange where the messages will be sent. The exchange has to be declared. It can
-     * be done by another application or by {@link RabbitMqIO} if you define {@code true} for {@link
-     * RabbitMqIO.Write#withExchangeDeclare(boolean)}.
-     */
-    public Write withExchange(String exchange, String exchangeType) {
-      checkArgument(exchange != null, "exchange can not be null");
-      checkArgument(exchangeType != null, "exchangeType can not be null");
-      return builder().setExchange(exchange).setExchangeType(exchangeType).build();
-    }
-
-    /**
-     * If the exchange is not declared by another application, {@link RabbitMqIO} can declare the
-     * exchange itself.
-     *
-     * @param exchangeDeclare {@code true} to declare the exchange, {@code false} else.
-     */
-    public Write withExchangeDeclare(boolean exchangeDeclare) {
-      return builder().setExchangeDeclare(exchangeDeclare).build();
-    }
-
-    /**
-     * Defines the queue where the messages will be sent. The queue has to be declared. It can be
-     * done by another application or by {@link RabbitMqIO} if you set {@link
-     * Write#withQueueDeclare} to {@code true}.
-     */
-    public Write withQueue(String queue) {
-      checkArgument(queue != null, "queue can not be null");
-      return builder().setQueue(queue).build();
-    }
-
-    /**
-     * If the queue is not declared by another application, {@link RabbitMqIO} can declare the queue
-     * itself.
-     *
-     * @param queueDeclare {@code true} to declare the queue, {@code false} else.
-     */
-    public Write withQueueDeclare(boolean queueDeclare) {
-      return builder().setQueueDeclare(queueDeclare).build();
-    }
-
-    @Override
-    public PCollection<?> expand(PCollection<RabbitMqMessage> input) {
-      checkArgument(
-          exchange() != null || queue() != null, "Either exchange or queue has to be specified");
-      if (exchange() != null) {
-        checkArgument(queue() == null, "Queue can't be set in the same time as exchange");
-      }
-      if (queue() != null) {
-        checkArgument(exchange() == null, "Exchange can't be set in the same time as queue");
-      }
-      if (queueDeclare()) {
-        checkArgument(queue() != null, "Queue is required for the queue declare");
-      }
-      if (exchangeDeclare()) {
-        checkArgument(exchange() != null, "Exchange is required for the exchange declare");
-      }
-      return input.apply(ParDo.of(new WriteFn(this)));
-    }
-
-    private static class WriteFn extends DoFn<RabbitMqMessage, Void> {
-      private final Write spec;
-
-      private transient ConnectionHandler connectionHandler;
-
-      WriteFn(Write spec) {
-        this.spec = spec;
-      }
-
-      @Setup
-      public void setup() throws Exception {
-        connectionHandler = new ConnectionHandler(spec.uri());
-        connectionHandler.start();
-
-        Channel channel = connectionHandler.getChannel();
-
-        if (spec.exchange() != null && spec.exchangeDeclare()) {
-          channel.exchangeDeclare(spec.exchange(), spec.exchangeType());
-        }
-        if (spec.queue() != null && spec.queueDeclare()) {
-          channel.queueDeclare(spec.queue(), true, false, false, null);
-        }
-      }
-
-      @ProcessElement
-      public void processElement(ProcessContext c) throws IOException {
-        RabbitMqMessage message = c.element();
-        Channel channel = connectionHandler.getChannel();
-
-        if (spec.exchange() != null) {
-          channel.basicPublish(
-              spec.exchange(),
-              message.getRoutingKey(),
-              message.createProperties(),
-              message.getBody());
-        }
-        if (spec.queue() != null) {
-          channel.basicPublish(
-              "", spec.queue(), MessageProperties.PERSISTENT_TEXT_PLAIN, message.getBody());
-        }
-      }
-
-      @Teardown
-      public void teardown() throws Exception {
-        if (connectionHandler != null) {
-          connectionHandler.stop();
-        }
-      }
-    }
-  }
+	public static Write write() {
+		return new AutoValue_RabbitMqIO_Write.Builder().setExchangeDeclare(false).setQueueDeclare(false).build();
+	}
+
+	private RabbitMqIO() {
+	}
+
+	private static class ConnectionHandler {
+
+		private final ConnectionFactory connectionFactory;
+		private Connection connection;
+		private Channel channel;
+
+		public ConnectionHandler(String uri)
+				throws URISyntaxException, NoSuchAlgorithmException, KeyManagementException {
+			connectionFactory = new ConnectionFactory();
+			connectionFactory.setUri(uri);
+			connectionFactory.setAutomaticRecoveryEnabled(true);
+			connectionFactory.setConnectionTimeout(60000);
+			connectionFactory.setNetworkRecoveryInterval(5000);
+			connectionFactory.setRequestedHeartbeat(60);
+			connectionFactory.setTopologyRecoveryEnabled(true);
+			connectionFactory.setRequestedChannelMax(0);
+			connectionFactory.setRequestedFrameMax(0);
+		}
+
+		public void start() throws TimeoutException, IOException {
+			connection = connectionFactory.newConnection();
+			channel = connection.createChannel();
+			if (channel == null) {
+				throw new IOException("No RabbitMQ channel available");
+			}
+		}
+
+		public Channel getChannel() {
+			return this.channel;
+		}
+
+		public void stop() throws IOException {
+			if (channel != null) {
+				try {
+					channel.close();
+				} catch (Exception e) {
+					// ignore
+				}
+			}
+			if (connection != null) {
+				connection.close();
+			}
+		}
+	}
+
+	/** A {@link PTransform} to consume messages from RabbitMQ server. */
+	@AutoValue
+	public abstract static class Read extends PTransform<PBegin, PCollection<RabbitMqMessage>> {
+		@Nullable
+		abstract String uri();
+
+		@Nullable
+		abstract String queue();
+
+		abstract boolean queueDeclare();
+
+		@Nullable
+		abstract String exchange();
+
+		@Nullable
+		abstract String exchangeType();
+
+		@Nullable
+		abstract String routingKey();
+
+		abstract boolean useCorrelationId();
+
+		abstract long maxNumRecords();
+
+		@Nullable
+		abstract Duration maxReadTime();
+
+		abstract Builder builder();
+
+		@AutoValue.Builder
+		abstract static class Builder {
+			abstract Builder setUri(String uri);
+
+			abstract Builder setQueue(String queue);
+
+			abstract Builder setQueueDeclare(boolean queueDeclare);
+
+			abstract Builder setExchange(String exchange);
+
+			abstract Builder setExchangeType(String exchangeType);
+
+			abstract Builder setRoutingKey(String routingKey);
+
+			abstract Builder setUseCorrelationId(boolean useCorrelationId);
+
+			abstract Builder setMaxNumRecords(long maxNumRecords);
+
+			abstract Builder setMaxReadTime(Duration maxReadTime);
+
+			abstract Read build();
+		}
+
+		public Read withUri(String uri) {
+			checkArgument(uri != null, "uri can not be null");
+			return builder().setUri(uri).build();
+		}
+
+		/**
+		 * If you want to directly consume messages from a specific queue, you just have
+		 * to specify the queue name. Optionally, you can declare the queue using
+		 * {@link RabbitMqIO.Read#withQueueDeclare(boolean)}.
+		 */
+		public Read withQueue(String queue) {
+			checkArgument(queue != null, "queue can not be null");
+			return builder().setQueue(queue).build();
+		}
+
+		/**
+		 * You can "force" the declaration of a queue on the RabbitMQ broker. Exchanges
+		 * and queues are the high-level building blocks of AMQP. These must be
+		 * "declared" before they can be used. Declaring either type of object simply
+		 * ensures that one of that name exists, creating it if necessary.
+		 *
+		 * @param queueDeclare If {@code true}, {@link RabbitMqIO} will declare the
+		 *                     queue. If another application declare the queue, it's not
+		 *                     required.
+		 */
+		public Read withQueueDeclare(boolean queueDeclare) {
+			return builder().setQueueDeclare(queueDeclare).build();
+		}
+
+		/**
+		 * Instead of consuming messages on a specific queue, you can consume message
+		 * from a given exchange. Then you specify the exchange name, type and
+		 * optionally routing key where you want to consume messages.
+		 */
+		public Read withExchange(String name, String type, String routingKey) {
+			checkArgument(name != null, "name can not be null");
+			checkArgument(type != null, "type can not be null");
+			return builder().setExchange(name).setExchangeType(type).setRoutingKey(routingKey).build();
+		}
+
+		/**
+		 * Define the max number of records received by the {@link Read}. When this max
+		 * number of records is lower than {@code Long.MAX_VALUE}, the {@link Read} will
+		 * provide a bounded {@link PCollection}.
+		 */
+		public Read withMaxNumRecords(long maxNumRecords) {
+			checkArgument(maxReadTime() == null, "maxNumRecord and maxReadTime are exclusive");
+			return builder().setMaxNumRecords(maxNumRecords).build();
+		}
+
+		/**
+		 * Define the max read time (duration) while the {@link Read} will receive
+		 * messages. When this max read time is not null, the {@link Read} will provide
+		 * a bounded {@link PCollection}.
+		 */
+		public Read withMaxReadTime(Duration maxReadTime) {
+			checkArgument(maxNumRecords() == Long.MAX_VALUE, "maxNumRecord and maxReadTime are exclusive");
+			return builder().setMaxReadTime(maxReadTime).build();
+		}
+
+		@Override
+		public PCollection<RabbitMqMessage> expand(PBegin input) {
+			org.apache.beam.sdk.io.Read.Unbounded<RabbitMqMessage> unbounded = org.apache.beam.sdk.io.Read
+					.from(new RabbitMQSource(this));
+
+			PTransform<PBegin, PCollection<RabbitMqMessage>> transform = unbounded;
+
+			if (maxNumRecords() < Long.MAX_VALUE || maxReadTime() != null) {
+				transform = unbounded.withMaxReadTime(maxReadTime()).withMaxNumRecords(maxNumRecords());
+			}
+
+			return input.getPipeline().apply(transform);
+		}
+	}
+
+	static class RabbitMQSource extends UnboundedSource<RabbitMqMessage, RabbitMQCheckpointMark> {
+		final Read spec;
+
+		RabbitMQSource(Read spec) {
+			this.spec = spec;
+		}
+
+		@Override
+		public Coder<RabbitMqMessage> getOutputCoder() {
+			return SerializableCoder.of(RabbitMqMessage.class);
+		}
+
+		@Override
+		public List<RabbitMQSource> split(int desiredNumSplits, PipelineOptions options) {
+			// RabbitMQ uses queue, so, we can have several concurrent consumers as source
+			List<RabbitMQSource> sources = new ArrayList<>();
+			for (int i = 0; i < desiredNumSplits; i++) {
+				sources.add(this);
+			}
+			return sources;
+		}
+
+		@Override
+		public UnboundedReader<RabbitMqMessage> createReader(PipelineOptions options,
+				RabbitMQCheckpointMark checkpointMark) throws IOException {
+			return new UnboundedRabbitMqReader(this, checkpointMark);
+		}
+
+		@Override
+		public Coder<RabbitMQCheckpointMark> getCheckpointMarkCoder() {
+			return SerializableCoder.of(RabbitMQCheckpointMark.class);
+		}
+
+		@Override
+		public boolean requiresDeduping() {
+			return spec.useCorrelationId();
+		}
+	}
+
+	private static class RabbitMQCheckpointMark implements UnboundedSource.CheckpointMark, Serializable {
+		transient Channel channel;
+		Instant oldestTimestamp = Instant.now();
+		final List<Long> sessionIds = new ArrayList<>();
+
+		@Override
+		public void finalizeCheckpoint() throws IOException {
+			for (Long sessionId : sessionIds) {
+				try {
+					channel.basicAck(sessionId, false);
+				} catch (IOException e) {
+					channel.basicNack(sessionId, false, true);
+				}
+			}
+			channel.txCommit();
+			oldestTimestamp = Instant.now();
+			sessionIds.clear();
+		}
+	}
+
+	private static class UnboundedRabbitMqReader extends UnboundedSource.UnboundedReader<RabbitMqMessage> {
+		private final RabbitMQSource source;
+
+		private RabbitMqMessage current;
+		private byte[] currentRecordId;
+		private ConnectionHandler connectionHandler;
+		private QueueingConsumer consumer;
+		private Instant currentTimestamp;
+		private final RabbitMQCheckpointMark checkpointMark;
+
+		UnboundedRabbitMqReader(RabbitMQSource source, RabbitMQCheckpointMark checkpointMark) throws IOException {
+			this.source = source;
+			this.current = null;
+			this.checkpointMark = checkpointMark != null ? checkpointMark : new RabbitMQCheckpointMark();
+			try {
+				connectionHandler = new ConnectionHandler(source.spec.uri());
+			} catch (Exception e) {
+				throw new IOException(e);
+			}
+		}
+
+		@Override
+		public Instant getWatermark() {
+			return checkpointMark.oldestTimestamp;
+		}
+
+		@Override
+		public UnboundedSource.CheckpointMark getCheckpointMark() {
+			return checkpointMark;
+		}
+
+		@Override
+		public RabbitMQSource getCurrentSource() {
+			return source;
+		}
+
+		@Override
+		public byte[] getCurrentRecordId() {
+			if (current == null) {
+				throw new NoSuchElementException();
+			}
+			if (currentRecordId != null) {
+				return currentRecordId;
+			} else {
+				return "".getBytes(StandardCharsets.UTF_8);
+			}
+		}
+
+		@Override
+		public Instant getCurrentTimestamp() {
+			if (currentTimestamp == null) {
+				throw new NoSuchElementException();
+			}
+			return currentTimestamp;
+		}
+
+		@Override
+		public RabbitMqMessage getCurrent() {
+			if (current == null) {
+				throw new NoSuchElementException();
+			}
+			return current;
+		}
+
+		@Override
+		public boolean start() throws IOException {
+			try {
+				ConnectionHandler connectionHandler = new ConnectionHandler(source.spec.uri());
+				connectionHandler.start();
+
+				Channel channel = connectionHandler.getChannel();
+
+				String queueName = source.spec.queue();
+				if (source.spec.queueDeclare()) {
+					// declare the queue (if not done by another application)
+					// channel.queueDeclare(queueName, durable, exclusive, autoDelete, arguments);
+					channel.queueDeclare(queueName, false, false, false, null);
+				}
+				if (source.spec.exchange() != null) {
+					channel.exchangeDeclare(source.spec.exchange(), source.spec.exchangeType());
+					if (queueName == null) {
+						queueName = channel.queueDeclare().getQueue();
+					}
+					channel.queueBind(queueName, source.spec.exchange(), source.spec.routingKey());
+				}
+				checkpointMark.channel = channel;
+				consumer = new QueueingConsumer(channel);
+				channel.txSelect();
+				// we consume message without autoAck (we want to do the ack ourselves)
+				channel.setDefaultConsumer(consumer);
+				channel.basicConsume(queueName, false, consumer);
+			} catch (Exception e) {
+				throw new IOException(e);
+			}
+			return advance();
+		}
+
+		@Override
+		public boolean advance() throws IOException {
+			try {
+				QueueingConsumer.Delivery delivery = consumer.nextDelivery(1000);
+				if (delivery == null) {
+					return false;
+				}
+				delivery = serializableDeliveryOf(delivery);
+				if (source.spec.useCorrelationId()) {
+					String correlationId = delivery.getProperties().getCorrelationId();
+					if (correlationId == null) {
+						throw new IOException("RabbitMqIO.Read uses message correlation ID, but received "
+								+ "message has a null correlation ID");
+					}
+					currentRecordId = correlationId.getBytes(StandardCharsets.UTF_8);
+				}
+				long deliveryTag = delivery.getEnvelope().getDeliveryTag();
+				checkpointMark.sessionIds.add(deliveryTag);
+
+				current = new RabbitMqMessage(source.spec.routingKey(), delivery);
+				currentTimestamp = new Instant(delivery.getProperties().getTimestamp());
+				if (currentTimestamp.isBefore(checkpointMark.oldestTimestamp)) {
+					checkpointMark.oldestTimestamp = currentTimestamp;
+				}
+			} catch (Exception e) {
+				throw new IOException(e);
+			}
+			return true;
+		}
+
+		/**
+		 * ake delivery serializable by cloning all non-serializable values into
+		 * serializable ones. If it is not possible, initial delivery is returned and
+		 * error message is logged
+		 * 
+		 * @param processed
+		 * @return
+		 */
+		private Delivery serializableDeliveryOf(Delivery processed) {
+			// All content of envelope is serializable, so no problem there
+			Envelope envelope = processed.getEnvelope();
+			// in basicproperties, there may be LongString, which are *not* serializable
+			BasicProperties properties = processed.getProperties();
+			BasicProperties nextProperties = new BasicProperties.Builder().appId(properties.getAppId())
+					.clusterId(properties.getClusterId()).contentEncoding(properties.getContentEncoding())
+					.contentType(properties.getContentType()).correlationId(properties.getCorrelationId())
+					.deliveryMode(properties.getDeliveryMode()).expiration(properties.getExpiration())
+					.headers(serializableHeaders(properties.getHeaders()))
+					.messageId(properties.getMessageId())
+					.priority(properties.getPriority())
+					.replyTo(properties.getReplyTo())
+					.timestamp(properties.getTimestamp())
+					.type(properties.getType())
+					.userId(properties.getUserId())
+					.build();
+			return new Delivery(envelope, nextProperties, processed.getBody());
+		}
+
+		private Map<String, Object> serializableHeaders(Map<String, Object> headers) {
+			Map<String, Object> returned = new HashMap<>();
+			for (Map.Entry<String, Object> h : headers.entrySet()) {
+				Object value = h.getValue();
+				if (!(value instanceof Serializable)) {
+					try {
+						if (value instanceof LongString) {
+							LongString longString = (LongString) value;
+							byte[] bytes = longString.getBytes();
+							String s = new String(bytes, "UTF-8");
+							value = s;
+						} else {
+							throw new RuntimeException(String.format("no transformation defined for %s", value));
+						}
+					} catch (Throwable t) {
+						throw new UnsupportedOperationException(String.format(
+								"can't make unserializable value %s a serializable value (which is mandatory for Apache Beam dataflow implementation)",
+								value), t);
+					}
+				}
+				returned.put(h.getKey(), value);
+			}
+			return returned;
+		}
+
+		@Override
+		public void close() throws IOException {
+			if (connectionHandler != null) {
+				connectionHandler.stop();
+			}
+		}
+	}
+
+	/** A {@link PTransform} to publish messages to a RabbitMQ server. */
+	@AutoValue
+	public abstract static class Write extends PTransform<PCollection<RabbitMqMessage>, PCollection<?>> {
+
+		@Nullable
+		abstract String uri();
+
+		@Nullable
+		abstract String exchange();
+
+		@Nullable
+		abstract String exchangeType();
+
+		abstract boolean exchangeDeclare();
+
+		@Nullable
+		abstract String queue();
+
+		abstract boolean queueDeclare();
+
+		abstract Builder builder();
+
+		@AutoValue.Builder
+		abstract static class Builder {
+			abstract Builder setUri(String uri);
+
+			abstract Builder setExchange(String exchange);
+
+			abstract Builder setExchangeType(String exchangeType);
+
+			abstract Builder setExchangeDeclare(boolean exchangeDeclare);
+
+			abstract Builder setQueue(String queue);
+
+			abstract Builder setQueueDeclare(boolean queueDeclare);
+
+			abstract Write build();
+		}
+
+		public Write withUri(String uri) {
+			checkArgument(uri != null, "uri can not be null");
+			return builder().setUri(uri).build();
+		}
+
+		/**
+		 * Defines the exchange where the messages will be sent. The exchange has to be
+		 * declared. It can be done by another application or by {@link RabbitMqIO} if
+		 * you define {@code true} for
+		 * {@link RabbitMqIO.Write#withExchangeDeclare(boolean)}.
+		 */
+		public Write withExchange(String exchange, String exchangeType) {
+			checkArgument(exchange != null, "exchange can not be null");
+			checkArgument(exchangeType != null, "exchangeType can not be null");
+			return builder().setExchange(exchange).setExchangeType(exchangeType).build();
+		}
+
+		/**
+		 * If the exchange is not declared by another application, {@link RabbitMqIO}
+		 * can declare the exchange itself.
+		 *
+		 * @param exchangeDeclare {@code true} to declare the exchange, {@code false}
+		 *                        else.
+		 */
+		public Write withExchangeDeclare(boolean exchangeDeclare) {
+			return builder().setExchangeDeclare(exchangeDeclare).build();
+		}
+
+		/**
+		 * Defines the queue where the messages will be sent. The queue has to be
+		 * declared. It can be done by another application or by {@link RabbitMqIO} if
+		 * you set {@link Write#withQueueDeclare} to {@code true}.
+		 */
+		public Write withQueue(String queue) {
+			checkArgument(queue != null, "queue can not be null");
+			return builder().setQueue(queue).build();
+		}
+
+		/**
+		 * If the queue is not declared by another application, {@link RabbitMqIO} can
+		 * declare the queue itself.
+		 *
+		 * @param queueDeclare {@code true} to declare the queue, {@code false} else.
+		 */
+		public Write withQueueDeclare(boolean queueDeclare) {
+			return builder().setQueueDeclare(queueDeclare).build();
+		}
+
+		@Override
+		public PCollection<?> expand(PCollection<RabbitMqMessage> input) {
+			checkArgument(exchange() != null || queue() != null, "Either exchange or queue has to be specified");
+			if (exchange() != null) {
+				checkArgument(queue() == null, "Queue can't be set in the same time as exchange");
+			}
+			if (queue() != null) {
+				checkArgument(exchange() == null, "Exchange can't be set in the same time as queue");
+			}
+			if (queueDeclare()) {
+				checkArgument(queue() != null, "Queue is required for the queue declare");
+			}
+			if (exchangeDeclare()) {
+				checkArgument(exchange() != null, "Exchange is required for the exchange declare");
+			}
+			return input.apply(ParDo.of(new WriteFn(this)));
+		}
+
+		private static class WriteFn extends DoFn<RabbitMqMessage, Void> {
+			private final Write spec;
+
+			private transient ConnectionHandler connectionHandler;
+
+			WriteFn(Write spec) {
+				this.spec = spec;
+			}
+
+			@Setup
+			public void setup() throws Exception {
+				connectionHandler = new ConnectionHandler(spec.uri());
+				connectionHandler.start();
+
+				Channel channel = connectionHandler.getChannel();
+
+				if (spec.exchange() != null && spec.exchangeDeclare()) {
+					channel.exchangeDeclare(spec.exchange(), spec.exchangeType());
+				}
+				if (spec.queue() != null && spec.queueDeclare()) {
+					channel.queueDeclare(spec.queue(), true, false, false, null);
+				}
+			}
+
+			@ProcessElement
+			public void processElement(ProcessContext c) throws IOException {
+				RabbitMqMessage message = c.element();
+				Channel channel = connectionHandler.getChannel();
+
+				if (spec.exchange() != null) {
+					channel.basicPublish(spec.exchange(), message.getRoutingKey(), message.createProperties(),
+							message.getBody());
+				}
+				if (spec.queue() != null) {
+					channel.basicPublish("", spec.queue(), MessageProperties.PERSISTENT_TEXT_PLAIN, message.getBody());
+				}
+			}
+
+			@Teardown
+			public void teardown() throws Exception {
+				if (connectionHandler != null) {
+					connectionHandler.stop();
+				}
+			}
+		}
+	}
 }

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -76,9 +76,7 @@ import org.joda.time.Instant;
  * <p>It's also possible to read from an exchange (providing the exchange type and routing key)
  * instead of directly from a queue:
  *
- * <pre>
- * {
- * 	&#64;code
+ * <pre>{@code
  * 	PCollection<RabbitMqMessage> messages = pipeline.apply(RabbitMqIO.read()
  * 			.withUri("amqp://user:password@localhost:5672").withExchange("EXCHANGE", "fanout", "QUEUE"));
  * }

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -345,11 +345,7 @@ public class RabbitMqIO {
     @Override
     public void finalizeCheckpoint() throws IOException {
       for (Long sessionId : sessionIds) {
-        try {
-          channel.basicAck(sessionId, false);
-        } catch (IOException e) {
-          channel.basicNack(sessionId, false, true);
-        }
+        channel.basicAck(sessionId, false);
       }
       channel.txCommit();
       oldestTimestamp = Instant.now();

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -19,6 +19,16 @@ package org.apache.beam.sdk.io.rabbitmq;
 
 import static org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions.checkArgument;
 
+import com.google.auto.value.AutoValue;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.LongString;
+import com.rabbitmq.client.MessageProperties;
+import com.rabbitmq.client.QueueingConsumer;
+import com.rabbitmq.client.QueueingConsumer.Delivery;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
@@ -31,9 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeoutException;
-
 import javax.annotation.Nullable;
-
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
@@ -47,43 +55,26 @@ import org.apache.beam.sdk.values.PCollection;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
-import com.google.auto.value.AutoValue;
-import com.rabbitmq.client.AMQP.BasicProperties;
-import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.LongString;
-import com.rabbitmq.client.MessageProperties;
-import com.rabbitmq.client.QueueingConsumer;
-import com.rabbitmq.client.QueueingConsumer.Delivery;
-
 /**
  * A IO to publish or consume messages with a RabbitMQ broker.
  *
  * <h3>Consuming messages from RabbitMQ server</h3>
  *
- * <p>
- * {@link RabbitMqIO} {@link Read} returns an unbounded {@link PCollection}
- * containing RabbitMQ messages body (as {@code byte[]}) wrapped as
- * {@link RabbitMqMessage}.
+ * <p>{@link RabbitMqIO} {@link Read} returns an unbounded {@link PCollection} containing RabbitMQ
+ * messages body (as {@code byte[]}) wrapped as {@link RabbitMqMessage}.
  *
- * <p>
- * To configure a RabbitMQ source, you have to provide a RabbitMQ {@code URI} to
- * connect to a RabbitMQ broker. The following example illustrates various
- * options for configuring the source, reading from the queue:
+ * <p>To configure a RabbitMQ source, you have to provide a RabbitMQ {@code URI} to connect to a
+ * RabbitMQ broker. The following example illustrates various options for configuring the source,
+ * reading from the queue:
  *
- * <pre>
- * {@code
+ * <pre>{@code
  * PCollection<RabbitMqMessage> messages = pipeline.apply(
  *   RabbitMqIO.read().withUri("amqp://user:password@localhost:5672").withQueue("QUEUE"))
  *
- * }
- * </pre>
+ * }</pre>
  *
- * <p>
- * It's also possible to read from an exchange (providing the exchange type and
- * routing key) instead of directly from a queue:
+ * <p>It's also possible to read from an exchange (providing the exchange type and routing key)
+ * instead of directly from a queue:
  *
  * <pre>
  * {
@@ -95,618 +86,629 @@ import com.rabbitmq.client.QueueingConsumer.Delivery;
  *
  * <h3>Publishing messages to RabbitMQ server</h3>
  *
- * <p>
- * {@link RabbitMqIO} {@link Write} can send {@link RabbitMqMessage} to a
- * RabbitMQ server queue or exchange.
+ * <p>{@link RabbitMqIO} {@link Write} can send {@link RabbitMqMessage} to a RabbitMQ server queue
+ * or exchange.
  *
- * <p>
- * As for the {@link Read}, the {@link Write} is configured with a RabbitMQ URI.
+ * <p>As for the {@link Read}, the {@link Write} is configured with a RabbitMQ URI.
  *
- * <p>
- * For instance, you can write to an exchange (providing the exchange type):
+ * <p>For instance, you can write to an exchange (providing the exchange type):
  *
- * <pre>
- * {@code
+ * <pre>{@code
  * pipeline
  *   .apply(...) // provide PCollection<RabbitMqMessage>
  *   .apply(RabbitMqIO.write().withUri("amqp://user:password@localhost:5672").withExchange("EXCHANGE", "fanout"));
- * }
- * </pre>
+ * }</pre>
  *
- * <p>
- * For instance, you can write to a queue:
+ * <p>For instance, you can write to a queue:
  *
- * <pre>
- * {@code
+ * <pre>{@code
  * pipeline
  *   .apply(...) // provide PCollection<RabbitMqMessage>
  *   .apply(RabbitMqIO.write().withUri("amqp://user:password@localhost:5672").withQueue("QUEUE"));
  *
- * }
- * </pre>
+ * }</pre>
  */
 @Experimental(Experimental.Kind.SOURCE_SINK)
 public class RabbitMqIO {
-	public static Read read() {
-		return new AutoValue_RabbitMqIO_Read.Builder().setQueueDeclare(false).setMaxReadTime(null)
-				.setMaxNumRecords(Long.MAX_VALUE).setUseCorrelationId(false).build();
-	}
+  public static Read read() {
+    return new AutoValue_RabbitMqIO_Read.Builder()
+        .setQueueDeclare(false)
+        .setMaxReadTime(null)
+        .setMaxNumRecords(Long.MAX_VALUE)
+        .setUseCorrelationId(false)
+        .build();
+  }
+
+  public static Write write() {
+    return new AutoValue_RabbitMqIO_Write.Builder()
+        .setExchangeDeclare(false)
+        .setQueueDeclare(false)
+        .build();
+  }
 
-	public static Write write() {
-		return new AutoValue_RabbitMqIO_Write.Builder().setExchangeDeclare(false).setQueueDeclare(false).build();
-	}
-
-	private RabbitMqIO() {
-	}
-
-	private static class ConnectionHandler {
-
-		private final ConnectionFactory connectionFactory;
-		private Connection connection;
-		private Channel channel;
-
-		public ConnectionHandler(String uri)
-				throws URISyntaxException, NoSuchAlgorithmException, KeyManagementException {
-			connectionFactory = new ConnectionFactory();
-			connectionFactory.setUri(uri);
-			connectionFactory.setAutomaticRecoveryEnabled(true);
-			connectionFactory.setConnectionTimeout(60000);
-			connectionFactory.setNetworkRecoveryInterval(5000);
-			connectionFactory.setRequestedHeartbeat(60);
-			connectionFactory.setTopologyRecoveryEnabled(true);
-			connectionFactory.setRequestedChannelMax(0);
-			connectionFactory.setRequestedFrameMax(0);
-		}
-
-		public void start() throws TimeoutException, IOException {
-			connection = connectionFactory.newConnection();
-			channel = connection.createChannel();
-			if (channel == null) {
-				throw new IOException("No RabbitMQ channel available");
-			}
-		}
-
-		public Channel getChannel() {
-			return this.channel;
-		}
-
-		public void stop() throws IOException {
-			if (channel != null) {
-				try {
-					channel.close();
-				} catch (Exception e) {
-					// ignore
-				}
-			}
-			if (connection != null) {
-				connection.close();
-			}
-		}
-	}
-
-	/** A {@link PTransform} to consume messages from RabbitMQ server. */
-	@AutoValue
-	public abstract static class Read extends PTransform<PBegin, PCollection<RabbitMqMessage>> {
-		@Nullable
-		abstract String uri();
-
-		@Nullable
-		abstract String queue();
-
-		abstract boolean queueDeclare();
-
-		@Nullable
-		abstract String exchange();
-
-		@Nullable
-		abstract String exchangeType();
-
-		@Nullable
-		abstract String routingKey();
-
-		abstract boolean useCorrelationId();
-
-		abstract long maxNumRecords();
-
-		@Nullable
-		abstract Duration maxReadTime();
-
-		abstract Builder builder();
-
-		@AutoValue.Builder
-		abstract static class Builder {
-			abstract Builder setUri(String uri);
-
-			abstract Builder setQueue(String queue);
-
-			abstract Builder setQueueDeclare(boolean queueDeclare);
-
-			abstract Builder setExchange(String exchange);
-
-			abstract Builder setExchangeType(String exchangeType);
-
-			abstract Builder setRoutingKey(String routingKey);
-
-			abstract Builder setUseCorrelationId(boolean useCorrelationId);
-
-			abstract Builder setMaxNumRecords(long maxNumRecords);
-
-			abstract Builder setMaxReadTime(Duration maxReadTime);
-
-			abstract Read build();
-		}
-
-		public Read withUri(String uri) {
-			checkArgument(uri != null, "uri can not be null");
-			return builder().setUri(uri).build();
-		}
-
-		/**
-		 * If you want to directly consume messages from a specific queue, you just have
-		 * to specify the queue name. Optionally, you can declare the queue using
-		 * {@link RabbitMqIO.Read#withQueueDeclare(boolean)}.
-		 */
-		public Read withQueue(String queue) {
-			checkArgument(queue != null, "queue can not be null");
-			return builder().setQueue(queue).build();
-		}
-
-		/**
-		 * You can "force" the declaration of a queue on the RabbitMQ broker. Exchanges
-		 * and queues are the high-level building blocks of AMQP. These must be
-		 * "declared" before they can be used. Declaring either type of object simply
-		 * ensures that one of that name exists, creating it if necessary.
-		 *
-		 * @param queueDeclare If {@code true}, {@link RabbitMqIO} will declare the
-		 *                     queue. If another application declare the queue, it's not
-		 *                     required.
-		 */
-		public Read withQueueDeclare(boolean queueDeclare) {
-			return builder().setQueueDeclare(queueDeclare).build();
-		}
-
-		/**
-		 * Instead of consuming messages on a specific queue, you can consume message
-		 * from a given exchange. Then you specify the exchange name, type and
-		 * optionally routing key where you want to consume messages.
-		 */
-		public Read withExchange(String name, String type, String routingKey) {
-			checkArgument(name != null, "name can not be null");
-			checkArgument(type != null, "type can not be null");
-			return builder().setExchange(name).setExchangeType(type).setRoutingKey(routingKey).build();
-		}
-
-		/**
-		 * Define the max number of records received by the {@link Read}. When this max
-		 * number of records is lower than {@code Long.MAX_VALUE}, the {@link Read} will
-		 * provide a bounded {@link PCollection}.
-		 */
-		public Read withMaxNumRecords(long maxNumRecords) {
-			checkArgument(maxReadTime() == null, "maxNumRecord and maxReadTime are exclusive");
-			return builder().setMaxNumRecords(maxNumRecords).build();
-		}
-
-		/**
-		 * Define the max read time (duration) while the {@link Read} will receive
-		 * messages. When this max read time is not null, the {@link Read} will provide
-		 * a bounded {@link PCollection}.
-		 */
-		public Read withMaxReadTime(Duration maxReadTime) {
-			checkArgument(maxNumRecords() == Long.MAX_VALUE, "maxNumRecord and maxReadTime are exclusive");
-			return builder().setMaxReadTime(maxReadTime).build();
-		}
-
-		@Override
-		public PCollection<RabbitMqMessage> expand(PBegin input) {
-			org.apache.beam.sdk.io.Read.Unbounded<RabbitMqMessage> unbounded = org.apache.beam.sdk.io.Read
-					.from(new RabbitMQSource(this));
-
-			PTransform<PBegin, PCollection<RabbitMqMessage>> transform = unbounded;
-
-			if (maxNumRecords() < Long.MAX_VALUE || maxReadTime() != null) {
-				transform = unbounded.withMaxReadTime(maxReadTime()).withMaxNumRecords(maxNumRecords());
-			}
-
-			return input.getPipeline().apply(transform);
-		}
-	}
-
-	static class RabbitMQSource extends UnboundedSource<RabbitMqMessage, RabbitMQCheckpointMark> {
-		final Read spec;
-
-		RabbitMQSource(Read spec) {
-			this.spec = spec;
-		}
-
-		@Override
-		public Coder<RabbitMqMessage> getOutputCoder() {
-			return SerializableCoder.of(RabbitMqMessage.class);
-		}
-
-		@Override
-		public List<RabbitMQSource> split(int desiredNumSplits, PipelineOptions options) {
-			// RabbitMQ uses queue, so, we can have several concurrent consumers as source
-			List<RabbitMQSource> sources = new ArrayList<>();
-			for (int i = 0; i < desiredNumSplits; i++) {
-				sources.add(this);
-			}
-			return sources;
-		}
-
-		@Override
-		public UnboundedReader<RabbitMqMessage> createReader(PipelineOptions options,
-				RabbitMQCheckpointMark checkpointMark) throws IOException {
-			return new UnboundedRabbitMqReader(this, checkpointMark);
-		}
-
-		@Override
-		public Coder<RabbitMQCheckpointMark> getCheckpointMarkCoder() {
-			return SerializableCoder.of(RabbitMQCheckpointMark.class);
-		}
-
-		@Override
-		public boolean requiresDeduping() {
-			return spec.useCorrelationId();
-		}
-	}
-
-	private static class RabbitMQCheckpointMark implements UnboundedSource.CheckpointMark, Serializable {
-		transient Channel channel;
-		Instant oldestTimestamp = Instant.now();
-		final List<Long> sessionIds = new ArrayList<>();
-
-		@Override
-		public void finalizeCheckpoint() throws IOException {
-			for (Long sessionId : sessionIds) {
-				try {
-					channel.basicAck(sessionId, false);
-				} catch (IOException e) {
-					channel.basicNack(sessionId, false, true);
-				}
-			}
-			channel.txCommit();
-			oldestTimestamp = Instant.now();
-			sessionIds.clear();
-		}
-	}
-
-	private static class UnboundedRabbitMqReader extends UnboundedSource.UnboundedReader<RabbitMqMessage> {
-		private final RabbitMQSource source;
-
-		private RabbitMqMessage current;
-		private byte[] currentRecordId;
-		private ConnectionHandler connectionHandler;
-		private QueueingConsumer consumer;
-		private Instant currentTimestamp;
-		private final RabbitMQCheckpointMark checkpointMark;
-
-		UnboundedRabbitMqReader(RabbitMQSource source, RabbitMQCheckpointMark checkpointMark) throws IOException {
-			this.source = source;
-			this.current = null;
-			this.checkpointMark = checkpointMark != null ? checkpointMark : new RabbitMQCheckpointMark();
-			try {
-				connectionHandler = new ConnectionHandler(source.spec.uri());
-			} catch (Exception e) {
-				throw new IOException(e);
-			}
-		}
-
-		@Override
-		public Instant getWatermark() {
-			return checkpointMark.oldestTimestamp;
-		}
-
-		@Override
-		public UnboundedSource.CheckpointMark getCheckpointMark() {
-			return checkpointMark;
-		}
-
-		@Override
-		public RabbitMQSource getCurrentSource() {
-			return source;
-		}
-
-		@Override
-		public byte[] getCurrentRecordId() {
-			if (current == null) {
-				throw new NoSuchElementException();
-			}
-			if (currentRecordId != null) {
-				return currentRecordId;
-			} else {
-				return "".getBytes(StandardCharsets.UTF_8);
-			}
-		}
-
-		@Override
-		public Instant getCurrentTimestamp() {
-			if (currentTimestamp == null) {
-				throw new NoSuchElementException();
-			}
-			return currentTimestamp;
-		}
-
-		@Override
-		public RabbitMqMessage getCurrent() {
-			if (current == null) {
-				throw new NoSuchElementException();
-			}
-			return current;
-		}
-
-		@Override
-		public boolean start() throws IOException {
-			try {
-				ConnectionHandler connectionHandler = new ConnectionHandler(source.spec.uri());
-				connectionHandler.start();
-
-				Channel channel = connectionHandler.getChannel();
-
-				String queueName = source.spec.queue();
-				if (source.spec.queueDeclare()) {
-					// declare the queue (if not done by another application)
-					// channel.queueDeclare(queueName, durable, exclusive, autoDelete, arguments);
-					channel.queueDeclare(queueName, false, false, false, null);
-				}
-				if (source.spec.exchange() != null) {
-					channel.exchangeDeclare(source.spec.exchange(), source.spec.exchangeType());
-					if (queueName == null) {
-						queueName = channel.queueDeclare().getQueue();
-					}
-					channel.queueBind(queueName, source.spec.exchange(), source.spec.routingKey());
-				}
-				checkpointMark.channel = channel;
-				consumer = new QueueingConsumer(channel);
-				channel.txSelect();
-				// we consume message without autoAck (we want to do the ack ourselves)
-				channel.setDefaultConsumer(consumer);
-				channel.basicConsume(queueName, false, consumer);
-			} catch (Exception e) {
-				throw new IOException(e);
-			}
-			return advance();
-		}
-
-		@Override
-		public boolean advance() throws IOException {
-			try {
-				QueueingConsumer.Delivery delivery = consumer.nextDelivery(1000);
-				if (delivery == null) {
-					return false;
-				}
-				delivery = serializableDeliveryOf(delivery);
-				if (source.spec.useCorrelationId()) {
-					String correlationId = delivery.getProperties().getCorrelationId();
-					if (correlationId == null) {
-						throw new IOException("RabbitMqIO.Read uses message correlation ID, but received "
-								+ "message has a null correlation ID");
-					}
-					currentRecordId = correlationId.getBytes(StandardCharsets.UTF_8);
-				}
-				long deliveryTag = delivery.getEnvelope().getDeliveryTag();
-				checkpointMark.sessionIds.add(deliveryTag);
-
-				current = new RabbitMqMessage(source.spec.routingKey(), delivery);
-				currentTimestamp = new Instant(delivery.getProperties().getTimestamp());
-				if (currentTimestamp.isBefore(checkpointMark.oldestTimestamp)) {
-					checkpointMark.oldestTimestamp = currentTimestamp;
-				}
-			} catch (Exception e) {
-				throw new IOException(e);
-			}
-			return true;
-		}
-
-		/**
-		 * ake delivery serializable by cloning all non-serializable values into
-		 * serializable ones. If it is not possible, initial delivery is returned and
-		 * error message is logged
-		 * 
-		 * @param processed
-		 * @return
-		 */
-		private Delivery serializableDeliveryOf(Delivery processed) {
-			// All content of envelope is serializable, so no problem there
-			Envelope envelope = processed.getEnvelope();
-			// in basicproperties, there may be LongString, which are *not* serializable
-			BasicProperties properties = processed.getProperties();
-			BasicProperties nextProperties = new BasicProperties.Builder().appId(properties.getAppId())
-					.clusterId(properties.getClusterId()).contentEncoding(properties.getContentEncoding())
-					.contentType(properties.getContentType()).correlationId(properties.getCorrelationId())
-					.deliveryMode(properties.getDeliveryMode()).expiration(properties.getExpiration())
-					.headers(serializableHeaders(properties.getHeaders()))
-					.messageId(properties.getMessageId())
-					.priority(properties.getPriority())
-					.replyTo(properties.getReplyTo())
-					.timestamp(properties.getTimestamp())
-					.type(properties.getType())
-					.userId(properties.getUserId())
-					.build();
-			return new Delivery(envelope, nextProperties, processed.getBody());
-		}
-
-		private Map<String, Object> serializableHeaders(Map<String, Object> headers) {
-			Map<String, Object> returned = new HashMap<>();
-			for (Map.Entry<String, Object> h : headers.entrySet()) {
-				Object value = h.getValue();
-				if (!(value instanceof Serializable)) {
-					try {
-						if (value instanceof LongString) {
-							LongString longString = (LongString) value;
-							byte[] bytes = longString.getBytes();
-							String s = new String(bytes, "UTF-8");
-							value = s;
-						} else {
-							throw new RuntimeException(String.format("no transformation defined for %s", value));
-						}
-					} catch (Throwable t) {
-						throw new UnsupportedOperationException(String.format(
-								"can't make unserializable value %s a serializable value (which is mandatory for Apache Beam dataflow implementation)",
-								value), t);
-					}
-				}
-				returned.put(h.getKey(), value);
-			}
-			return returned;
-		}
-
-		@Override
-		public void close() throws IOException {
-			if (connectionHandler != null) {
-				connectionHandler.stop();
-			}
-		}
-	}
-
-	/** A {@link PTransform} to publish messages to a RabbitMQ server. */
-	@AutoValue
-	public abstract static class Write extends PTransform<PCollection<RabbitMqMessage>, PCollection<?>> {
-
-		@Nullable
-		abstract String uri();
-
-		@Nullable
-		abstract String exchange();
-
-		@Nullable
-		abstract String exchangeType();
-
-		abstract boolean exchangeDeclare();
-
-		@Nullable
-		abstract String queue();
-
-		abstract boolean queueDeclare();
-
-		abstract Builder builder();
-
-		@AutoValue.Builder
-		abstract static class Builder {
-			abstract Builder setUri(String uri);
-
-			abstract Builder setExchange(String exchange);
-
-			abstract Builder setExchangeType(String exchangeType);
-
-			abstract Builder setExchangeDeclare(boolean exchangeDeclare);
-
-			abstract Builder setQueue(String queue);
-
-			abstract Builder setQueueDeclare(boolean queueDeclare);
-
-			abstract Write build();
-		}
-
-		public Write withUri(String uri) {
-			checkArgument(uri != null, "uri can not be null");
-			return builder().setUri(uri).build();
-		}
-
-		/**
-		 * Defines the exchange where the messages will be sent. The exchange has to be
-		 * declared. It can be done by another application or by {@link RabbitMqIO} if
-		 * you define {@code true} for
-		 * {@link RabbitMqIO.Write#withExchangeDeclare(boolean)}.
-		 */
-		public Write withExchange(String exchange, String exchangeType) {
-			checkArgument(exchange != null, "exchange can not be null");
-			checkArgument(exchangeType != null, "exchangeType can not be null");
-			return builder().setExchange(exchange).setExchangeType(exchangeType).build();
-		}
-
-		/**
-		 * If the exchange is not declared by another application, {@link RabbitMqIO}
-		 * can declare the exchange itself.
-		 *
-		 * @param exchangeDeclare {@code true} to declare the exchange, {@code false}
-		 *                        else.
-		 */
-		public Write withExchangeDeclare(boolean exchangeDeclare) {
-			return builder().setExchangeDeclare(exchangeDeclare).build();
-		}
-
-		/**
-		 * Defines the queue where the messages will be sent. The queue has to be
-		 * declared. It can be done by another application or by {@link RabbitMqIO} if
-		 * you set {@link Write#withQueueDeclare} to {@code true}.
-		 */
-		public Write withQueue(String queue) {
-			checkArgument(queue != null, "queue can not be null");
-			return builder().setQueue(queue).build();
-		}
-
-		/**
-		 * If the queue is not declared by another application, {@link RabbitMqIO} can
-		 * declare the queue itself.
-		 *
-		 * @param queueDeclare {@code true} to declare the queue, {@code false} else.
-		 */
-		public Write withQueueDeclare(boolean queueDeclare) {
-			return builder().setQueueDeclare(queueDeclare).build();
-		}
-
-		@Override
-		public PCollection<?> expand(PCollection<RabbitMqMessage> input) {
-			checkArgument(exchange() != null || queue() != null, "Either exchange or queue has to be specified");
-			if (exchange() != null) {
-				checkArgument(queue() == null, "Queue can't be set in the same time as exchange");
-			}
-			if (queue() != null) {
-				checkArgument(exchange() == null, "Exchange can't be set in the same time as queue");
-			}
-			if (queueDeclare()) {
-				checkArgument(queue() != null, "Queue is required for the queue declare");
-			}
-			if (exchangeDeclare()) {
-				checkArgument(exchange() != null, "Exchange is required for the exchange declare");
-			}
-			return input.apply(ParDo.of(new WriteFn(this)));
-		}
-
-		private static class WriteFn extends DoFn<RabbitMqMessage, Void> {
-			private final Write spec;
-
-			private transient ConnectionHandler connectionHandler;
-
-			WriteFn(Write spec) {
-				this.spec = spec;
-			}
-
-			@Setup
-			public void setup() throws Exception {
-				connectionHandler = new ConnectionHandler(spec.uri());
-				connectionHandler.start();
-
-				Channel channel = connectionHandler.getChannel();
-
-				if (spec.exchange() != null && spec.exchangeDeclare()) {
-					channel.exchangeDeclare(spec.exchange(), spec.exchangeType());
-				}
-				if (spec.queue() != null && spec.queueDeclare()) {
-					channel.queueDeclare(spec.queue(), true, false, false, null);
-				}
-			}
-
-			@ProcessElement
-			public void processElement(ProcessContext c) throws IOException {
-				RabbitMqMessage message = c.element();
-				Channel channel = connectionHandler.getChannel();
-
-				if (spec.exchange() != null) {
-					channel.basicPublish(spec.exchange(), message.getRoutingKey(), message.createProperties(),
-							message.getBody());
-				}
-				if (spec.queue() != null) {
-					channel.basicPublish("", spec.queue(), MessageProperties.PERSISTENT_TEXT_PLAIN, message.getBody());
-				}
-			}
-
-			@Teardown
-			public void teardown() throws Exception {
-				if (connectionHandler != null) {
-					connectionHandler.stop();
-				}
-			}
-		}
-	}
+  private RabbitMqIO() {}
+
+  private static class ConnectionHandler {
+
+    private final ConnectionFactory connectionFactory;
+    private Connection connection;
+    private Channel channel;
+
+    public ConnectionHandler(String uri)
+        throws URISyntaxException, NoSuchAlgorithmException, KeyManagementException {
+      connectionFactory = new ConnectionFactory();
+      connectionFactory.setUri(uri);
+      connectionFactory.setAutomaticRecoveryEnabled(true);
+      connectionFactory.setConnectionTimeout(60000);
+      connectionFactory.setNetworkRecoveryInterval(5000);
+      connectionFactory.setRequestedHeartbeat(60);
+      connectionFactory.setTopologyRecoveryEnabled(true);
+      connectionFactory.setRequestedChannelMax(0);
+      connectionFactory.setRequestedFrameMax(0);
+    }
+
+    public void start() throws TimeoutException, IOException {
+      connection = connectionFactory.newConnection();
+      channel = connection.createChannel();
+      if (channel == null) {
+        throw new IOException("No RabbitMQ channel available");
+      }
+    }
+
+    public Channel getChannel() {
+      return this.channel;
+    }
+
+    public void stop() throws IOException {
+      if (channel != null) {
+        try {
+          channel.close();
+        } catch (Exception e) {
+          // ignore
+        }
+      }
+      if (connection != null) {
+        connection.close();
+      }
+    }
+  }
+
+  /** A {@link PTransform} to consume messages from RabbitMQ server. */
+  @AutoValue
+  public abstract static class Read extends PTransform<PBegin, PCollection<RabbitMqMessage>> {
+    @Nullable
+    abstract String uri();
+
+    @Nullable
+    abstract String queue();
+
+    abstract boolean queueDeclare();
+
+    @Nullable
+    abstract String exchange();
+
+    @Nullable
+    abstract String exchangeType();
+
+    @Nullable
+    abstract String routingKey();
+
+    abstract boolean useCorrelationId();
+
+    abstract long maxNumRecords();
+
+    @Nullable
+    abstract Duration maxReadTime();
+
+    abstract Builder builder();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setUri(String uri);
+
+      abstract Builder setQueue(String queue);
+
+      abstract Builder setQueueDeclare(boolean queueDeclare);
+
+      abstract Builder setExchange(String exchange);
+
+      abstract Builder setExchangeType(String exchangeType);
+
+      abstract Builder setRoutingKey(String routingKey);
+
+      abstract Builder setUseCorrelationId(boolean useCorrelationId);
+
+      abstract Builder setMaxNumRecords(long maxNumRecords);
+
+      abstract Builder setMaxReadTime(Duration maxReadTime);
+
+      abstract Read build();
+    }
+
+    public Read withUri(String uri) {
+      checkArgument(uri != null, "uri can not be null");
+      return builder().setUri(uri).build();
+    }
+
+    /**
+     * If you want to directly consume messages from a specific queue, you just have to specify the
+     * queue name. Optionally, you can declare the queue using {@link
+     * RabbitMqIO.Read#withQueueDeclare(boolean)}.
+     */
+    public Read withQueue(String queue) {
+      checkArgument(queue != null, "queue can not be null");
+      return builder().setQueue(queue).build();
+    }
+
+    /**
+     * You can "force" the declaration of a queue on the RabbitMQ broker. Exchanges and queues are
+     * the high-level building blocks of AMQP. These must be "declared" before they can be used.
+     * Declaring either type of object simply ensures that one of that name exists, creating it if
+     * necessary.
+     *
+     * @param queueDeclare If {@code true}, {@link RabbitMqIO} will declare the queue. If another
+     *     application declare the queue, it's not required.
+     */
+    public Read withQueueDeclare(boolean queueDeclare) {
+      return builder().setQueueDeclare(queueDeclare).build();
+    }
+
+    /**
+     * Instead of consuming messages on a specific queue, you can consume message from a given
+     * exchange. Then you specify the exchange name, type and optionally routing key where you want
+     * to consume messages.
+     */
+    public Read withExchange(String name, String type, String routingKey) {
+      checkArgument(name != null, "name can not be null");
+      checkArgument(type != null, "type can not be null");
+      return builder().setExchange(name).setExchangeType(type).setRoutingKey(routingKey).build();
+    }
+
+    /**
+     * Define the max number of records received by the {@link Read}. When this max number of
+     * records is lower than {@code Long.MAX_VALUE}, the {@link Read} will provide a bounded {@link
+     * PCollection}.
+     */
+    public Read withMaxNumRecords(long maxNumRecords) {
+      checkArgument(maxReadTime() == null, "maxNumRecord and maxReadTime are exclusive");
+      return builder().setMaxNumRecords(maxNumRecords).build();
+    }
+
+    /**
+     * Define the max read time (duration) while the {@link Read} will receive messages. When this
+     * max read time is not null, the {@link Read} will provide a bounded {@link PCollection}.
+     */
+    public Read withMaxReadTime(Duration maxReadTime) {
+      checkArgument(
+          maxNumRecords() == Long.MAX_VALUE, "maxNumRecord and maxReadTime are exclusive");
+      return builder().setMaxReadTime(maxReadTime).build();
+    }
+
+    @Override
+    public PCollection<RabbitMqMessage> expand(PBegin input) {
+      org.apache.beam.sdk.io.Read.Unbounded<RabbitMqMessage> unbounded =
+          org.apache.beam.sdk.io.Read.from(new RabbitMQSource(this));
+
+      PTransform<PBegin, PCollection<RabbitMqMessage>> transform = unbounded;
+
+      if (maxNumRecords() < Long.MAX_VALUE || maxReadTime() != null) {
+        transform = unbounded.withMaxReadTime(maxReadTime()).withMaxNumRecords(maxNumRecords());
+      }
+
+      return input.getPipeline().apply(transform);
+    }
+  }
+
+  static class RabbitMQSource extends UnboundedSource<RabbitMqMessage, RabbitMQCheckpointMark> {
+    final Read spec;
+
+    RabbitMQSource(Read spec) {
+      this.spec = spec;
+    }
+
+    @Override
+    public Coder<RabbitMqMessage> getOutputCoder() {
+      return SerializableCoder.of(RabbitMqMessage.class);
+    }
+
+    @Override
+    public List<RabbitMQSource> split(int desiredNumSplits, PipelineOptions options) {
+      // RabbitMQ uses queue, so, we can have several concurrent consumers as source
+      List<RabbitMQSource> sources = new ArrayList<>();
+      for (int i = 0; i < desiredNumSplits; i++) {
+        sources.add(this);
+      }
+      return sources;
+    }
+
+    @Override
+    public UnboundedReader<RabbitMqMessage> createReader(
+        PipelineOptions options, RabbitMQCheckpointMark checkpointMark) throws IOException {
+      return new UnboundedRabbitMqReader(this, checkpointMark);
+    }
+
+    @Override
+    public Coder<RabbitMQCheckpointMark> getCheckpointMarkCoder() {
+      return SerializableCoder.of(RabbitMQCheckpointMark.class);
+    }
+
+    @Override
+    public boolean requiresDeduping() {
+      return spec.useCorrelationId();
+    }
+  }
+
+  private static class RabbitMQCheckpointMark
+      implements UnboundedSource.CheckpointMark, Serializable {
+    transient Channel channel;
+    Instant oldestTimestamp = Instant.now();
+    final List<Long> sessionIds = new ArrayList<>();
+
+    @Override
+    public void finalizeCheckpoint() throws IOException {
+      for (Long sessionId : sessionIds) {
+        try {
+          channel.basicAck(sessionId, false);
+        } catch (IOException e) {
+          channel.basicNack(sessionId, false, true);
+        }
+      }
+      channel.txCommit();
+      oldestTimestamp = Instant.now();
+      sessionIds.clear();
+    }
+  }
+
+  private static class UnboundedRabbitMqReader
+      extends UnboundedSource.UnboundedReader<RabbitMqMessage> {
+    private final RabbitMQSource source;
+
+    private RabbitMqMessage current;
+    private byte[] currentRecordId;
+    private ConnectionHandler connectionHandler;
+    private QueueingConsumer consumer;
+    private Instant currentTimestamp;
+    private final RabbitMQCheckpointMark checkpointMark;
+
+    UnboundedRabbitMqReader(RabbitMQSource source, RabbitMQCheckpointMark checkpointMark)
+        throws IOException {
+      this.source = source;
+      this.current = null;
+      this.checkpointMark = checkpointMark != null ? checkpointMark : new RabbitMQCheckpointMark();
+      try {
+        connectionHandler = new ConnectionHandler(source.spec.uri());
+      } catch (Exception e) {
+        throw new IOException(e);
+      }
+    }
+
+    @Override
+    public Instant getWatermark() {
+      return checkpointMark.oldestTimestamp;
+    }
+
+    @Override
+    public UnboundedSource.CheckpointMark getCheckpointMark() {
+      return checkpointMark;
+    }
+
+    @Override
+    public RabbitMQSource getCurrentSource() {
+      return source;
+    }
+
+    @Override
+    public byte[] getCurrentRecordId() {
+      if (current == null) {
+        throw new NoSuchElementException();
+      }
+      if (currentRecordId != null) {
+        return currentRecordId;
+      } else {
+        return "".getBytes(StandardCharsets.UTF_8);
+      }
+    }
+
+    @Override
+    public Instant getCurrentTimestamp() {
+      if (currentTimestamp == null) {
+        throw new NoSuchElementException();
+      }
+      return currentTimestamp;
+    }
+
+    @Override
+    public RabbitMqMessage getCurrent() {
+      if (current == null) {
+        throw new NoSuchElementException();
+      }
+      return current;
+    }
+
+    @Override
+    public boolean start() throws IOException {
+      try {
+        ConnectionHandler connectionHandler = new ConnectionHandler(source.spec.uri());
+        connectionHandler.start();
+
+        Channel channel = connectionHandler.getChannel();
+
+        String queueName = source.spec.queue();
+        if (source.spec.queueDeclare()) {
+          // declare the queue (if not done by another application)
+          // channel.queueDeclare(queueName, durable, exclusive, autoDelete, arguments);
+          channel.queueDeclare(queueName, false, false, false, null);
+        }
+        if (source.spec.exchange() != null) {
+          channel.exchangeDeclare(source.spec.exchange(), source.spec.exchangeType());
+          if (queueName == null) {
+            queueName = channel.queueDeclare().getQueue();
+          }
+          channel.queueBind(queueName, source.spec.exchange(), source.spec.routingKey());
+        }
+        checkpointMark.channel = channel;
+        consumer = new QueueingConsumer(channel);
+        channel.txSelect();
+        // we consume message without autoAck (we want to do the ack ourselves)
+        channel.setDefaultConsumer(consumer);
+        channel.basicConsume(queueName, false, consumer);
+      } catch (Exception e) {
+        throw new IOException(e);
+      }
+      return advance();
+    }
+
+    @Override
+    public boolean advance() throws IOException {
+      try {
+        QueueingConsumer.Delivery delivery = consumer.nextDelivery(1000);
+        if (delivery == null) {
+          return false;
+        }
+        delivery = serializableDeliveryOf(delivery);
+        if (source.spec.useCorrelationId()) {
+          String correlationId = delivery.getProperties().getCorrelationId();
+          if (correlationId == null) {
+            throw new IOException(
+                "RabbitMqIO.Read uses message correlation ID, but received "
+                    + "message has a null correlation ID");
+          }
+          currentRecordId = correlationId.getBytes(StandardCharsets.UTF_8);
+        }
+        long deliveryTag = delivery.getEnvelope().getDeliveryTag();
+        checkpointMark.sessionIds.add(deliveryTag);
+
+        current = new RabbitMqMessage(source.spec.routingKey(), delivery);
+        currentTimestamp = new Instant(delivery.getProperties().getTimestamp());
+        if (currentTimestamp.isBefore(checkpointMark.oldestTimestamp)) {
+          checkpointMark.oldestTimestamp = currentTimestamp;
+        }
+      } catch (Exception e) {
+        throw new IOException(e);
+      }
+      return true;
+    }
+
+    /**
+     * ake delivery serializable by cloning all non-serializable values into serializable ones. If
+     * it is not possible, initial delivery is returned and error message is logged
+     *
+     * @param processed
+     * @return
+     */
+    private Delivery serializableDeliveryOf(Delivery processed) {
+      // All content of envelope is serializable, so no problem there
+      Envelope envelope = processed.getEnvelope();
+      // in basicproperties, there may be LongString, which are *not* serializable
+      BasicProperties properties = processed.getProperties();
+      BasicProperties nextProperties =
+          new BasicProperties.Builder()
+              .appId(properties.getAppId())
+              .clusterId(properties.getClusterId())
+              .contentEncoding(properties.getContentEncoding())
+              .contentType(properties.getContentType())
+              .correlationId(properties.getCorrelationId())
+              .deliveryMode(properties.getDeliveryMode())
+              .expiration(properties.getExpiration())
+              .headers(serializableHeaders(properties.getHeaders()))
+              .messageId(properties.getMessageId())
+              .priority(properties.getPriority())
+              .replyTo(properties.getReplyTo())
+              .timestamp(properties.getTimestamp())
+              .type(properties.getType())
+              .userId(properties.getUserId())
+              .build();
+      return new Delivery(envelope, nextProperties, processed.getBody());
+    }
+
+    private Map<String, Object> serializableHeaders(Map<String, Object> headers) {
+      Map<String, Object> returned = new HashMap<>();
+      for (Map.Entry<String, Object> h : headers.entrySet()) {
+        Object value = h.getValue();
+        if (!(value instanceof Serializable)) {
+          try {
+            if (value instanceof LongString) {
+              LongString longString = (LongString) value;
+              byte[] bytes = longString.getBytes();
+              String s = new String(bytes, "UTF-8");
+              value = s;
+            } else {
+              throw new RuntimeException(String.format("no transformation defined for %s", value));
+            }
+          } catch (Throwable t) {
+            throw new UnsupportedOperationException(
+                String.format(
+                    "can't make unserializable value %s a serializable value (which is mandatory for Apache Beam dataflow implementation)",
+                    value),
+                t);
+          }
+        }
+        returned.put(h.getKey(), value);
+      }
+      return returned;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (connectionHandler != null) {
+        connectionHandler.stop();
+      }
+    }
+  }
+
+  /** A {@link PTransform} to publish messages to a RabbitMQ server. */
+  @AutoValue
+  public abstract static class Write
+      extends PTransform<PCollection<RabbitMqMessage>, PCollection<?>> {
+
+    @Nullable
+    abstract String uri();
+
+    @Nullable
+    abstract String exchange();
+
+    @Nullable
+    abstract String exchangeType();
+
+    abstract boolean exchangeDeclare();
+
+    @Nullable
+    abstract String queue();
+
+    abstract boolean queueDeclare();
+
+    abstract Builder builder();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setUri(String uri);
+
+      abstract Builder setExchange(String exchange);
+
+      abstract Builder setExchangeType(String exchangeType);
+
+      abstract Builder setExchangeDeclare(boolean exchangeDeclare);
+
+      abstract Builder setQueue(String queue);
+
+      abstract Builder setQueueDeclare(boolean queueDeclare);
+
+      abstract Write build();
+    }
+
+    public Write withUri(String uri) {
+      checkArgument(uri != null, "uri can not be null");
+      return builder().setUri(uri).build();
+    }
+
+    /**
+     * Defines the exchange where the messages will be sent. The exchange has to be declared. It can
+     * be done by another application or by {@link RabbitMqIO} if you define {@code true} for {@link
+     * RabbitMqIO.Write#withExchangeDeclare(boolean)}.
+     */
+    public Write withExchange(String exchange, String exchangeType) {
+      checkArgument(exchange != null, "exchange can not be null");
+      checkArgument(exchangeType != null, "exchangeType can not be null");
+      return builder().setExchange(exchange).setExchangeType(exchangeType).build();
+    }
+
+    /**
+     * If the exchange is not declared by another application, {@link RabbitMqIO} can declare the
+     * exchange itself.
+     *
+     * @param exchangeDeclare {@code true} to declare the exchange, {@code false} else.
+     */
+    public Write withExchangeDeclare(boolean exchangeDeclare) {
+      return builder().setExchangeDeclare(exchangeDeclare).build();
+    }
+
+    /**
+     * Defines the queue where the messages will be sent. The queue has to be declared. It can be
+     * done by another application or by {@link RabbitMqIO} if you set {@link
+     * Write#withQueueDeclare} to {@code true}.
+     */
+    public Write withQueue(String queue) {
+      checkArgument(queue != null, "queue can not be null");
+      return builder().setQueue(queue).build();
+    }
+
+    /**
+     * If the queue is not declared by another application, {@link RabbitMqIO} can declare the queue
+     * itself.
+     *
+     * @param queueDeclare {@code true} to declare the queue, {@code false} else.
+     */
+    public Write withQueueDeclare(boolean queueDeclare) {
+      return builder().setQueueDeclare(queueDeclare).build();
+    }
+
+    @Override
+    public PCollection<?> expand(PCollection<RabbitMqMessage> input) {
+      checkArgument(
+          exchange() != null || queue() != null, "Either exchange or queue has to be specified");
+      if (exchange() != null) {
+        checkArgument(queue() == null, "Queue can't be set in the same time as exchange");
+      }
+      if (queue() != null) {
+        checkArgument(exchange() == null, "Exchange can't be set in the same time as queue");
+      }
+      if (queueDeclare()) {
+        checkArgument(queue() != null, "Queue is required for the queue declare");
+      }
+      if (exchangeDeclare()) {
+        checkArgument(exchange() != null, "Exchange is required for the exchange declare");
+      }
+      return input.apply(ParDo.of(new WriteFn(this)));
+    }
+
+    private static class WriteFn extends DoFn<RabbitMqMessage, Void> {
+      private final Write spec;
+
+      private transient ConnectionHandler connectionHandler;
+
+      WriteFn(Write spec) {
+        this.spec = spec;
+      }
+
+      @Setup
+      public void setup() throws Exception {
+        connectionHandler = new ConnectionHandler(spec.uri());
+        connectionHandler.start();
+
+        Channel channel = connectionHandler.getChannel();
+
+        if (spec.exchange() != null && spec.exchangeDeclare()) {
+          channel.exchangeDeclare(spec.exchange(), spec.exchangeType());
+        }
+        if (spec.queue() != null && spec.queueDeclare()) {
+          channel.queueDeclare(spec.queue(), true, false, false, null);
+        }
+      }
+
+      @ProcessElement
+      public void processElement(ProcessContext c) throws IOException {
+        RabbitMqMessage message = c.element();
+        Channel channel = connectionHandler.getChannel();
+
+        if (spec.exchange() != null) {
+          channel.basicPublish(
+              spec.exchange(),
+              message.getRoutingKey(),
+              message.createProperties(),
+              message.getBody());
+        }
+        if (spec.queue() != null) {
+          channel.basicPublish(
+              "", spec.queue(), MessageProperties.PERSISTENT_TEXT_PLAIN, message.getBody());
+        }
+      }
+
+      @Teardown
+      public void teardown() throws Exception {
+        if (connectionHandler != null) {
+          connectionHandler.stop();
+        }
+      }
+    }
+  }
 }

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -523,27 +523,30 @@ public class RabbitMqIO {
 
     private Map<String, Object> serializableHeaders(Map<String, Object> headers) {
       Map<String, Object> returned = new HashMap<>();
-      for (Map.Entry<String, Object> h : headers.entrySet()) {
-        Object value = h.getValue();
-        if (!(value instanceof Serializable)) {
-          try {
-            if (value instanceof LongString) {
-              LongString longString = (LongString) value;
-              byte[] bytes = longString.getBytes();
-              String s = new String(bytes, "UTF-8");
-              value = s;
-            } else {
-              throw new RuntimeException(String.format("no transformation defined for %s", value));
+      if (headers != null) {
+        for (Map.Entry<String, Object> h : headers.entrySet()) {
+          Object value = h.getValue();
+          if (!(value instanceof Serializable)) {
+            try {
+              if (value instanceof LongString) {
+                LongString longString = (LongString) value;
+                byte[] bytes = longString.getBytes();
+                String s = new String(bytes, "UTF-8");
+                value = s;
+              } else {
+                throw new RuntimeException(
+                    String.format("no transformation defined for %s", value));
+              }
+            } catch (Throwable t) {
+              throw new UnsupportedOperationException(
+                  String.format(
+                      "can't make unserializable value %s a serializable value (which is mandatory for Apache Beam dataflow implementation)",
+                      value),
+                  t);
             }
-          } catch (Throwable t) {
-            throw new UnsupportedOperationException(
-                String.format(
-                    "can't make unserializable value %s a serializable value (which is mandatory for Apache Beam dataflow implementation)",
-                    value),
-                t);
           }
+          returned.put(h.getKey(), value);
         }
-        returned.put(h.getKey(), value);
       }
       return returned;
     }

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -25,7 +25,6 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.MessageProperties;
 import com.rabbitmq.client.QueueingConsumer;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
@@ -74,8 +73,7 @@ import org.joda.time.Instant;
  * <pre>{@code
  * 	PCollection<RabbitMqMessage> messages = pipeline.apply(RabbitMqIO.read()
  * 			.withUri("amqp://user:password@localhost:5672").withExchange("EXCHANGE", "fanout", "QUEUE"));
- * }
- * </pre>
+ * }</pre>
  *
  * <h3>Publishing messages to RabbitMQ server</h3>
  *

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqMessage.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqMessage.java
@@ -18,7 +18,11 @@
 package org.apache.beam.sdk.io.rabbitmq;
 
 import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.LongString;
 import com.rabbitmq.client.QueueingConsumer;
+import com.rabbitmq.client.QueueingConsumer.Delivery;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Date;
@@ -32,6 +36,67 @@ import javax.annotation.Nullable;
  * reason of this class is that AMQP.BasicProperties doesn't provide a serializable public API.
  */
 public class RabbitMqMessage implements Serializable {
+
+  /**
+   * Make delivery serializable by cloning all non-serializable values into serializable ones. If it
+   * is not possible, initial delivery is returned and error message is logged
+   *
+   * @param processed
+   * @return
+   */
+  private static Delivery serializableDeliveryOf(Delivery processed) {
+    // All content of envelope is serializable, so no problem there
+    Envelope envelope = processed.getEnvelope();
+    // in basicproperties, there may be LongString, which are *not* serializable
+    BasicProperties properties = processed.getProperties();
+    BasicProperties nextProperties =
+        new BasicProperties.Builder()
+            .appId(properties.getAppId())
+            .clusterId(properties.getClusterId())
+            .contentEncoding(properties.getContentEncoding())
+            .contentType(properties.getContentType())
+            .correlationId(properties.getCorrelationId())
+            .deliveryMode(properties.getDeliveryMode())
+            .expiration(properties.getExpiration())
+            .headers(serializableHeaders(properties.getHeaders()))
+            .messageId(properties.getMessageId())
+            .priority(properties.getPriority())
+            .replyTo(properties.getReplyTo())
+            .timestamp(properties.getTimestamp())
+            .type(properties.getType())
+            .userId(properties.getUserId())
+            .build();
+    return new Delivery(envelope, nextProperties, processed.getBody());
+  }
+
+  private static Map<String, Object> serializableHeaders(Map<String, Object> headers) {
+    Map<String, Object> returned = new HashMap<>();
+    if (headers != null) {
+      for (Map.Entry<String, Object> h : headers.entrySet()) {
+        Object value = h.getValue();
+        if (!(value instanceof Serializable)) {
+          try {
+            if (value instanceof LongString) {
+              LongString longString = (LongString) value;
+              byte[] bytes = longString.getBytes();
+              String s = new String(bytes, "UTF-8");
+              value = s;
+            } else {
+              throw new RuntimeException(String.format("no transformation defined for %s", value));
+            }
+          } catch (Throwable t) {
+            throw new UnsupportedOperationException(
+                String.format(
+                    "can't make unserializable value %s a serializable value (which is mandatory for Apache Beam dataflow implementation)",
+                    value),
+                t);
+          }
+        }
+        returned.put(h.getKey(), value);
+      }
+    }
+    return returned;
+  }
 
   @Nullable private final String routingKey;
   private final byte[] body;
@@ -71,6 +136,7 @@ public class RabbitMqMessage implements Serializable {
 
   public RabbitMqMessage(String routingKey, QueueingConsumer.Delivery delivery) {
     this.routingKey = routingKey;
+    delivery = serializableDeliveryOf(delivery);
     body = delivery.getBody();
     contentType = delivery.getProperties().getContentType();
     contentEncoding = delivery.getProperties().getContentEncoding();


### PR DESCRIPTION
This is a fix for https://issues.apache.org/jira/browse/BEAM-7414
Basically, when receiving a RabbitMqMessage, I copy all its delivery fields into a new delivery object, which allows me to replace LongString by String.
The try/catch loop is there for cases where LongString objects are too long to be transformed into String

Code can be reviewed by @jbonofre or @aromanenko-dev which are both aware of the issue (but i guesse @jbonofre would be a better reviewer)

Notice that i'm trying to communicate with RabbitMq team in parallel to have issue fixed in a more elegant way on their side

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
