### PR TITLE
[BEAM-5791] splitting support over FnAPI for Go SDK

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -19,7 +19,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync/atomic"
+	"math"
+	"sync"
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
@@ -34,9 +35,12 @@ type DataSource struct {
 	Coder *coder.Coder
 	Out   Node
 
-	source DataManager
-	count  int64
-	start  time.Time
+	source   DataManager
+	count    int64
+	splitPos int64
+	start    time.Time
+
+	mu sync.Mutex
 }
 
 func (n *DataSource) ID() UnitID {
@@ -48,9 +52,12 @@ func (n *DataSource) Up(ctx context.Context) error {
 }
 
 func (n *DataSource) StartBundle(ctx context.Context, id string, data DataContext) error {
+	n.mu.Lock()
 	n.source = data.Data
 	n.start = time.Now()
-	atomic.StoreInt64(&n.count, 0)
+	n.count = 0
+	n.splitPos = math.MaxInt64
+	n.mu.Unlock()
 	return n.Out.StartBundle(ctx, id, data)
 }
 
@@ -70,6 +77,9 @@ func (n *DataSource) Process(ctx context.Context) error {
 		cv := MakeElementDecoder(c.Components[1])
 
 		for {
+			if n.IncrementCountAndCheckSplit(ctx) {
+				return nil
+			}
 			ws, t, err := DecodeWindowedValueHeader(wc, r)
 			if err != nil {
 				if err == io.EOF {
@@ -102,8 +112,6 @@ func (n *DataSource) Process(ctx context.Context) error {
 				// Single chunk stream.
 
 				// log.Printf("Fixed size=%v", size)
-				atomic.AddInt64(&n.count, int64(size))
-
 				for i := int32(0); i < size; i++ {
 					value, err := cv.Decode(r)
 					if err != nil {
@@ -126,7 +134,6 @@ func (n *DataSource) Process(ctx context.Context) error {
 						break
 					}
 
-					atomic.AddInt64(&n.count, int64(chunk))
 					for i := uint64(0); i < chunk; i++ {
 						value, err := cv.Decode(r)
 						if err != nil {
@@ -147,7 +154,10 @@ func (n *DataSource) Process(ctx context.Context) error {
 		ec := MakeElementDecoder(c)
 
 		for {
-			atomic.AddInt64(&n.count, 1)
+			if n.IncrementCountAndCheckSplit(ctx) {
+				return nil
+			}
+
 			ws, t, err := DecodeWindowedValueHeader(wc, r)
 			if err != nil {
 				if err == io.EOF {
@@ -173,10 +183,13 @@ func (n *DataSource) Process(ctx context.Context) error {
 }
 
 func (n *DataSource) FinishBundle(ctx context.Context) error {
-	log.Infof(ctx, "DataSource: %d elements in %d ns", atomic.LoadInt64(&n.count), time.Now().Sub(n.start))
+	n.mu.Lock()
+	log.Infof(ctx, "DataSource: %d elements in %d ns", n.count, time.Now().Sub(n.start))
 	n.source = nil
 	err := n.Out.FinishBundle(ctx)
-	atomic.StoreInt64(&n.count, 0)
+	n.count = 0
+	n.splitPos = math.MaxInt64
+	n.mu.Unlock()
 	return err
 }
 
@@ -187,6 +200,23 @@ func (n *DataSource) Down(ctx context.Context) error {
 
 func (n *DataSource) String() string {
 	return fmt.Sprintf("DataSource[%v] Coder:%v Out:%v", n.SID, n.Coder, n.Out.ID())
+}
+
+// IncrementCountAndCheckSplit increments DataSource.count by one and checks to
+// make sure the new value is smaller than the promised split point. If the new
+// value is greater than or equal to the split point, calls the FinishBundle and
+// returns true to indicate that the caller should stop processing elements and
+// exit. If the new value is before the split point (or if the split point
+// hasn't been set), returns false.
+func (n *DataSource) IncrementCountAndCheckSplit(ctx context.Context) bool {
+	b := false
+	n.mu.Lock()
+	n.count++
+	if n.count >= n.splitPos {
+		b = true
+	}
+	n.mu.Unlock()
+	return b
 }
 
 // ProgressReportSnapshot captures the progress reading an input source.
@@ -200,5 +230,41 @@ func (n *DataSource) Progress() ProgressReportSnapshot {
 	if n == nil {
 		return ProgressReportSnapshot{}
 	}
-	return ProgressReportSnapshot{n.SID.Target.ID, n.SID.Target.Name, atomic.LoadInt64(&n.count)}
+	n.mu.Lock()
+	c := n.count
+	n.mu.Unlock()
+	return ProgressReportSnapshot{n.SID.Target.ID, n.SID.Target.Name, c}
+}
+
+// Split takes a sorted set of potential split points, selects and actuates
+// split on an appropriate split point, and returns the selected split point
+// if successful. Returns an error when unable to split.
+func (n *DataSource) Split(splits []int64, frac float32) (int64, error) {
+	if splits == nil {
+		return 0, fmt.Errorf("failed to split: requested splits were empty")
+	}
+	if n == nil {
+		return 0, fmt.Errorf("failed to split at requested splits: {%v}, DataSource not initialized", splits)
+	}
+	n.mu.Lock()
+	c := n.count
+	// Find the smallest split index that we haven't yet processed.
+	p := math.MaxInt64
+
+	for i := int(0); i < len(splits); i++ {
+		if splits[i] >= c {
+			p = i
+			break
+		}
+	}
+	if p < len(splits) {
+		n.splitPos = splits[p]
+		fs := n.splitPos
+		n.mu.Unlock()
+		return fs, nil
+	}
+	n.mu.Unlock()
+	// If we can't find a suitable split point from the requested choices,
+	// return an error.
+	return 0, fmt.Errorf("failed to split at requested splits: {%v}, DataSource at index: %v", splits, c)
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -184,12 +184,12 @@ func (n *DataSource) Process(ctx context.Context) error {
 
 func (n *DataSource) FinishBundle(ctx context.Context) error {
 	n.mu.Lock()
+	defer n.mu.Unlock()
 	log.Infof(ctx, "DataSource: %d elements in %d ns", n.count, time.Now().Sub(n.start))
 	n.source = nil
 	err := n.Out.FinishBundle(ctx)
 	n.count = 0
 	n.splitPos = math.MaxInt64
-	defer n.mu.Unlock()
 	return err
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/plan.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan.go
@@ -191,3 +191,19 @@ func (p *Plan) Metrics() *fnpb.Metrics {
 		Ptransforms: transforms,
 	}
 }
+
+// SplitPoints captures the split requested by the Runner.
+type SplitPoints struct {
+	Splits []int64
+	Frac   float32
+}
+
+// Split takes a set of potential split points, selects and actuates split on an
+// appropriate split point, and returns the selected split point if successful.
+// Returns an error when unable to split.
+func (p *Plan) Split(s SplitPoints) (int64, error) {
+	if p.source != nil {
+		return p.source.Split(s.Splits, s.Frac)
+	}
+	return 0, fmt.Errorf("failed to split at requested splits: {%v}, Source not initialized", s)
+}

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -247,11 +247,35 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 		msg := req.GetProcessBundleSplit()
 
 		log.Debugf(ctx, "PB Split: %v", msg)
+		ref := msg.GetInstructionReference()
+		c.mu.Lock()
+		plan, ok := c.active[ref]
+		c.mu.Unlock()
+		if !ok {
+			return fail(id, "execution plan for %v not found", ref)
+		}
+
+		ds := msg.GetDesiredSplits()["0"]
+		if ds == nil {
+			return fail(id, "failed to split: desired splits for root was empty.")
+		}
+		split, err := plan.Split(exec.SplitPoints{ds.GetAllowedSplitPoints(), ds.GetFractionOfRemainder()})
+
+		if err != nil {
+			return fail(id, "unable to split: %v", err)
+		}
 
 		return &fnpb.InstructionResponse{
 			InstructionId: id,
 			Response: &fnpb.InstructionResponse_ProcessBundleSplit{
-				ProcessBundleSplit: &fnpb.ProcessBundleSplitResponse{},
+				ProcessBundleSplit: &fnpb.ProcessBundleSplitResponse{
+					ChannelSplits: []*fnpb.ProcessBundleSplitResponse_ChannelSplit{
+						&fnpb.ProcessBundleSplitResponse_ChannelSplit{
+							LastPrimaryElement:   int32(split - 1),
+							FirstResidualElement: int32(split),
+						},
+					},
+				},
 			},
 		}
 

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -255,6 +255,7 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 			return fail(id, "execution plan for %v not found", ref)
 		}
 
+		// Get the desired splits for the root FnAPI read operation.
 		ds := msg.GetDesiredSplits()["0"]
 		if ds == nil {
 			return fail(id, "failed to split: desired splits for root was empty.")


### PR DESCRIPTION
Adding support for splitting over FnApi for Go SDK.

------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
