### PR TITLE
 Refactor default bundle size into a constant in TextIO

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/JavaReadViaImpulse.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/JavaReadViaImpulse.java
@@ -47,7 +47,7 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.annotations.VisibleF
  * transforms.
  */
 public class JavaReadViaImpulse {
-  private static final long DEFAULT_BUNDLE_SIZE = 64L << 20;
+  private static final long DEFAULT_BUNDLE_SIZE_BYTES = 64 * 1024 * 1024L;
 
   public static <T> PTransform<PBegin, PCollection<T>> bounded(BoundedSource<T> source) {
     return new BoundedReadViaImpulse<>(source);
@@ -77,7 +77,7 @@ public class JavaReadViaImpulse {
     public PCollection<T> expand(PBegin input) {
       return input
           .apply(Impulse.create())
-          .apply(ParDo.of(new SplitBoundedSourceFn<>(source, DEFAULT_BUNDLE_SIZE)))
+          .apply(ParDo.of(new SplitBoundedSourceFn<>(source, DEFAULT_BUNDLE_SIZE_BYTES)))
           .setCoder(new BoundedSourceCoder<>())
           .apply(Reshuffle.viaRandomKey())
           .apply(ParDo.of(new ReadFromBoundedSourceFn<>()))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -180,6 +180,8 @@ import org.joda.time.Duration;
  * DynamicDestinations} interface for advanced features via {@link Write#to(DynamicDestinations)}.
  */
 public class TextIO {
+  private static final long DEFAULT_BUNDLE_SIZE_BYTES = 64 * 1024 * 1024L;
+
   /**
    * A {@link PTransform} that reads from one or more text files and returns a bounded {@link
    * PCollection} containing one element for each line of the input files.
@@ -224,7 +226,7 @@ public class TextIO {
         // 64MB is a reasonable value that allows to amortize the cost of opening files,
         // but is not so large as to exhaust a typical runner's maximum amount of output per
         // ProcessElement call.
-        .setDesiredBundleSizeBytes(64 * 1024 * 1024L)
+        .setDesiredBundleSizeBytes(DEFAULT_BUNDLE_SIZE_BYTES)
         .build();
   }
 


### PR DESCRIPTION
Make more readable the default bundle how for JavaReadViaImpulse too.
These changes are mostly for consistency around the codebase.

R: @aromanenko-dev 