### PR TITLE
[BEAM-7126] Fix StateRequestHandler type variables to allow for proper key parameterization

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/state/InMemoryBagUserStateFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/state/InMemoryBagUserStateFactory.java
@@ -34,8 +34,8 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
  * Holds user state in memory. Only one key is active at a time due to the GroupReduceFunction being
  * called once per key. Needs to be reset via {@code resetForNewKey()} before processing a new key.
  */
-public class InMemoryBagUserStateFactory
-    implements StateRequestHandlers.BagUserStateHandlerFactory {
+public class InMemoryBagUserStateFactory<K, V, W extends BoundedWindow>
+    implements StateRequestHandlers.BagUserStateHandlerFactory<K, V, W> {
 
   private List<InMemorySingleKeyBagState> handlers;
 
@@ -44,13 +44,12 @@ public class InMemoryBagUserStateFactory
   }
 
   @Override
-  public <K, V, W extends BoundedWindow>
-      StateRequestHandlers.BagUserStateHandler<K, V, W> forUserState(
-          String pTransformId,
-          String userStateId,
-          Coder<K> keyCoder,
-          Coder<V> valueCoder,
-          Coder<W> windowCoder) {
+  public StateRequestHandlers.BagUserStateHandler<K, V, W> forUserState(
+      String pTransformId,
+      String userStateId,
+      Coder<K> keyCoder,
+      Coder<V> valueCoder,
+      Coder<W> windowCoder) {
 
     InMemorySingleKeyBagState<K, V, W> bagUserStateHandler =
         new InMemorySingleKeyBagState<>(userStateId, valueCoder, windowCoder);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/state/StateRequestHandlers.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/state/StateRequestHandlers.java
@@ -145,8 +145,8 @@ public class StateRequestHandlers {
    * <p>Note that this factory should be thread safe.
    */
   @ThreadSafe
-  public interface BagUserStateHandlerFactory {
-    <K, V, W extends BoundedWindow> BagUserStateHandler<K, V, W> forUserState(
+  public interface BagUserStateHandlerFactory<K, V, W extends BoundedWindow> {
+    BagUserStateHandler<K, V, W> forUserState(
         String pTransformId,
         String userStateId,
         Coder<K> keyCoder,
@@ -154,10 +154,10 @@ public class StateRequestHandlers {
         Coder<W> windowCoder);
 
     /** Throws a {@link UnsupportedOperationException} on the first access. */
-    static BagUserStateHandlerFactory unsupported() {
-      return new BagUserStateHandlerFactory() {
+    static <K, V, W extends BoundedWindow> BagUserStateHandlerFactory<K, V, W> unsupported() {
+      return new BagUserStateHandlerFactory<K, V, W>() {
         @Override
-        public <K, V, W extends BoundedWindow> BagUserStateHandler<K, V, W> forUserState(
+        public BagUserStateHandler<K, V, W> forUserState(
             String pTransformId,
             String userStateId,
             Coder<K> keyCoder,

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -884,27 +884,28 @@ public class RemoteExecutionTest implements Serializable {
     StateRequestHandler stateRequestHandler =
         StateRequestHandlers.forBagUserStateHandlerFactory(
             descriptor,
-            new BagUserStateHandlerFactory() {
+            new BagUserStateHandlerFactory<ByteString, Object, BoundedWindow>() {
               @Override
-              public <K, V, W extends BoundedWindow> BagUserStateHandler<K, V, W> forUserState(
+              public BagUserStateHandler<ByteString, Object, BoundedWindow> forUserState(
                   String pTransformId,
                   String userStateId,
-                  Coder<K> keyCoder,
-                  Coder<V> valueCoder,
-                  Coder<W> windowCoder) {
-                return new BagUserStateHandler<K, V, W>() {
+                  Coder<ByteString> keyCoder,
+                  Coder<Object> valueCoder,
+                  Coder<BoundedWindow> windowCoder) {
+                return new BagUserStateHandler<ByteString, Object, BoundedWindow>() {
                   @Override
-                  public Iterable<V> get(K key, W window) {
+                  public Iterable<Object> get(ByteString key, BoundedWindow window) {
                     return (Iterable) userStateData.get(userStateId);
                   }
 
                   @Override
-                  public void append(K key, W window, Iterator<V> values) {
+                  public void append(
+                      ByteString key, BoundedWindow window, Iterator<Object> values) {
                     Iterators.addAll(userStateData.get(userStateId), (Iterator) values);
                   }
 
                   @Override
-                  public void clear(K key, W window) {
+                  public void clear(ByteString key, BoundedWindow window) {
                     userStateData.get(userStateId).clear();
                   }
                 };


### PR DESCRIPTION
This is the change I intended to make with an earlier PR that was block by the length prefix / double encoding of keys.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
