### PR TITLE
[BEAM-5354] Add side input nodes to their consumer's parent-scope.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
@@ -41,22 +41,36 @@ func pickFn(a int, small, big func(int)) {
 	}
 }
 
-func pick(t *testing.T, g *graph.Graph) *graph.MultiEdge {
-	dofn, err := graph.NewDoFn(pickFn)
+func pickSideFn(a, side int, small, big func(int)) {
+	if a < side {
+		small(a)
+	} else {
+		big(a)
+	}
+}
+
+func addDoFn(t *testing.T, g *graph.Graph, fn interface{}, scope *graph.Scope, inputs []*graph.Node, outputCoders []*coder.Coder) {
+	t.Helper()
+	dofn, err := graph.NewDoFn(fn)
 	if err != nil {
 		t.Fatal(err)
 	}
+	e, err := graph.NewParDo(g, scope, dofn, inputs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outputCoders) != len(e.Output) {
+		t.Fatalf("%v has %d outputs, but only got %d coders", dofn.Name(), len(e.Output), len(outputCoders))
+	}
+	for i, c := range outputCoders {
+		e.Output[i].To.Coder = c
+	}
+}
 
+func newIntInput(g *graph.Graph) *graph.Node {
 	in := g.NewNode(intT(), window.DefaultWindowingStrategy(), true)
 	in.Coder = intCoder()
-
-	e, err := graph.NewParDo(g, g.Root(), dofn, []*graph.Node{in}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	e.Output[0].To.Coder = intCoder()
-	e.Output[1].To.Coder = intCoder()
-	return e
+	return in
 }
 
 func intT() typex.FullType {
@@ -67,30 +81,82 @@ func intCoder() *coder.Coder {
 	return custom("int", reflectx.Int)
 }
 
-// TestParDo verifies that ParDo can be serialized.
-func TestParDo(t *testing.T) {
-	g := graph.New()
-	pick(t, g)
+// TestMarshal verifies that ParDo can be serialized.
+func TestMarshal(t *testing.T) {
+	tests := []struct {
+		name                     string
+		makeGraph                func(t *testing.T, g *graph.Graph)
+		edges, transforms, roots int
+	}{
+		{
+			name: "ParDo",
+			makeGraph: func(t *testing.T, g *graph.Graph) {
+				addDoFn(t, g, pickFn, g.Root(), []*graph.Node{newIntInput(g)}, []*coder.Coder{intCoder(), intCoder()})
+			},
+			edges:      1,
+			transforms: 1,
+			roots:      1,
+		}, {
+			name: "ScopedParDo",
+			makeGraph: func(t *testing.T, g *graph.Graph) {
+				addDoFn(t, g, pickFn, g.NewScope(g.Root(), "sub"), []*graph.Node{newIntInput(g)}, []*coder.Coder{intCoder(), intCoder()})
+			},
+			edges:      1,
+			transforms: 2,
+			roots:      1,
+		}, {
+			name: "SideInput",
+			makeGraph: func(t *testing.T, g *graph.Graph) {
+				in := newIntInput(g)
+				side := newIntInput(g)
+				addDoFn(t, g, pickSideFn, g.Root(), []*graph.Node{in, side}, []*coder.Coder{intCoder(), intCoder()})
+			},
+			edges:      1,
+			transforms: 2,
+			roots:      2,
+		}, {
+			name: "ScopedSideInput",
+			makeGraph: func(t *testing.T, g *graph.Graph) {
+				in := newIntInput(g)
+				side := newIntInput(g)
+				addDoFn(t, g, pickSideFn, g.NewScope(g.Root(), "sub"), []*graph.Node{in, side}, []*coder.Coder{intCoder(), intCoder()})
+			},
+			edges:      1,
+			transforms: 3,
+			roots:      1,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
 
-	edges, _, err := g.Build()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(edges) != 1 {
-		t.Fatal("expected a single edge")
-	}
+			g := graph.New()
+			test.makeGraph(t, g)
 
-	payload, err := proto.Marshal(&pb.DockerPayload{ContainerImage: "foo"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	p, err := graphx.Marshal(edges,
-		&graphx.Options{Environment: pb.Environment{Urn: "beam:env:docker:v1", Payload: payload}})
-	if err != nil {
-		t.Fatal(err)
-	}
+			edges, _, err := g.Build()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(edges) != test.edges {
+				t.Fatal("expected a single edge")
+			}
 
-	if len(p.GetComponents().GetTransforms()) != 1 {
-		t.Errorf("bad ParDo translation: %v", proto.MarshalTextString(p))
+			payload, err := proto.Marshal(&pb.DockerPayload{ContainerImage: "foo"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			p, err := graphx.Marshal(edges,
+				&graphx.Options{Environment: pb.Environment{Urn: "beam:env:docker:v1", Payload: payload}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := len(p.GetComponents().GetTransforms()), test.transforms; got != want {
+				t.Errorf("got %d transforms, want %d : %v", got, want, proto.MarshalTextString(p))
+			}
+			if got, want := len(p.GetRootTransformIds()), test.roots; got != want {
+				t.Errorf("got %d roots, want %d : %v", got, want, proto.MarshalTextString(p))
+			}
+		})
 	}
 }

--- a/sdks/go/test/integration/primitives/pardo.go
+++ b/sdks/go/test/integration/primitives/pardo.go
@@ -53,7 +53,8 @@ func ParDoSideInput() *beam.Pipeline {
 	p, s := beam.NewPipelineWithRoot()
 
 	in := beam.Create(s, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-	out := beam.ParDo(s, sumValuesFn, beam.Impulse(s), beam.SideInput{Input: in})
+	sub := s.Scope("subscope") // Ensure scoping works with side inputs. See: BEAM-5354
+	out := beam.ParDo(sub, sumValuesFn, beam.Impulse(s), beam.SideInput{Input: in})
 	passert.Sum(s, out, "out", 1, 45)
 
 	return p


### PR DESCRIPTION
Some transforms require additional nodes in the Portable Pipeline Proto representation, and in particular, side inputs. The node representing the source of the Side input was previously being added as a root transform, which is OK as far as the model is concerned, but for ordering dependent runners (like Dataflow is currently), this can cause issues, since it requires nodes be specified before they're depended on (topological ordering). 

This change ensures that new side input nodes are added as siblings to their consumer's scope, rather than as unique root transforms, which fits things into the pipeline hypergraph naturally.

Added additional tests to the translation from the Go SDK's internal representation, to the PPP, and modified one of the integration tests to trigger this behavior.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
