### PR TITLE
[BEAM-7388] Reify PTransform for Python SDK

### DIFF
--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -465,6 +465,74 @@ class ToStringTest(unittest.TestCase):
       assert_that(result, equal_to(["one\t1", "two\t2"]))
 
 
+class ReifyTest(unittest.TestCase):
+
+  def test_timestamp(self):
+    l = [TimestampedValue('a', 100),
+         TimestampedValue('b', 200),
+         TimestampedValue('c', 300)]
+    expected = [TestWindowedValue('a', 100, [GlobalWindow()]),
+                TestWindowedValue('b', 200, [GlobalWindow()]),
+                TestWindowedValue('c', 300, [GlobalWindow()])]
+    with TestPipeline() as p:
+      # Map(lambda x: x) PTransform is added after Create here, because when
+      # a PCollection of TimestampedValues is created with Create PTransform,
+      # the timestamps are not assigned to it. Adding a Map forces the
+      # PCollection to go through a DoFn so that the PCollection consists of
+      # the elements with timestamps assigned to them instead of a PCollection
+      # of TimestampedValue(element, timestamp).
+      pc = p | beam.Create(l) | beam.Map(lambda x: x)
+      reified_pc = pc | util.Reify.Timestamp()
+      assert_that(reified_pc, equal_to(expected), reify_windows=True)
+
+  def test_window(self):
+    l = [GlobalWindows.windowed_value('a', 100),
+         GlobalWindows.windowed_value('b', 200),
+         GlobalWindows.windowed_value('c', 300)]
+    expected = [TestWindowedValue(('a', 100, GlobalWindow()), 100,
+                                  [GlobalWindow()]),
+                TestWindowedValue(('b', 200, GlobalWindow()), 200,
+                                  [GlobalWindow()]),
+                TestWindowedValue(('c', 300, GlobalWindow()), 300,
+                                  [GlobalWindow()])]
+    with TestPipeline() as p:
+      pc = p | beam.Create(l)
+      reified_pc = pc | util.Reify.Window()
+      assert_that(reified_pc, equal_to(expected), reify_windows=True)
+
+  def test_timestamp_in_value(self):
+    l = [TimestampedValue(('a', 1), 100),
+         TimestampedValue(('b', 2), 200),
+         TimestampedValue(('c', 3), 300)]
+    expected = [TestWindowedValue(('a', TimestampedValue(1, 100)), 100,
+                                  [GlobalWindow()]),
+                TestWindowedValue(('b', TimestampedValue(2, 200)), 200,
+                                  [GlobalWindow()]),
+                TestWindowedValue(('c', TimestampedValue(3, 300)), 300,
+                                  [GlobalWindow()])]
+    with TestPipeline() as p:
+      pc = p | beam.Create(l) | beam.Map(lambda x: x)
+      reified_pc = pc | util.Reify.TimestampInValue()
+      assert_that(reified_pc, equal_to(expected), reify_windows=True)
+
+  def test_window_in_value(self):
+    l = [GlobalWindows.windowed_value(('a', 1), 100),
+         GlobalWindows.windowed_value(('b', 2), 200),
+         GlobalWindows.windowed_value(('c', 3), 300)]
+    expected = [TestWindowedValue(('a', (1, 100, GlobalWindow())), 100,
+                                  [GlobalWindow()]),
+                TestWindowedValue(('b', (2, 200, GlobalWindow())), 200,
+                                  [GlobalWindow()]),
+                TestWindowedValue(('c', (3, 300, GlobalWindow())), 300,
+                                  [GlobalWindow()])]
+    with TestPipeline() as p:
+      # Map(lambda x: x) hack is used for the same reason here.
+      # Also, this makes the typehint on Reify.WindowInValue work.
+      pc = p | beam.Create(l) | beam.Map(lambda x: x)
+      reified_pc = pc | util.Reify.WindowInValue()
+      assert_that(reified_pc, equal_to(expected), reify_windows=True)
+
+
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()


### PR DESCRIPTION
This PR adds useful Reify PTransforms similar to the Java SDK.
It will make code much cleaner. Eg: https://github.com/apache/beam/pull/8589
Related JIRA: https://issues.apache.org/jira/browse/BEAM-7388

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
