### PR TITLE
[BEAM-2943] Check existence of to-be-staged files in PipelineResources

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineResources.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineResources.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.util.ZipFiles;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.hash.Funnels;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.hash.Hasher;
@@ -82,12 +83,14 @@ public class PipelineResources {
       List<String> resourcesToStage, String tmpJarLocation) {
     return resourcesToStage.stream()
         .map(File::new)
-        .filter(File::exists)
         .map(
-            file ->
-                file.isDirectory()
-                    ? packageDirectoriesToStage(file, tmpJarLocation)
-                    : file.getAbsolutePath())
+            file -> {
+              Preconditions.checkState(
+                  file.exists(), "To-be-staged file does not exist: '%s'", file);
+              return file.isDirectory()
+                  ? packageDirectoriesToStage(file, tmpJarLocation)
+                  : file.getAbsolutePath();
+            })
         .collect(Collectors.toList());
   }
 

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineResourcesTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineResourcesTest.java
@@ -18,9 +18,8 @@
 package org.apache.beam.runners.core.construction;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -77,17 +76,17 @@ public class PipelineResourcesTest {
   }
 
   @Test
-  public void testRemovingNonexistentFilesFromFilesToStage() throws IOException {
+  public void testFailOnNonExistingPaths() throws IOException {
     String nonexistentFilePath = tmpFolder.getRoot().getPath() + "/nonexistent/file";
     String existingFilePath = tmpFolder.newFile("existingFile").getAbsolutePath();
     String temporaryLocation = tmpFolder.newFolder().getAbsolutePath();
 
     List<String> filesToStage = Arrays.asList(nonexistentFilePath, existingFilePath);
-    List<String> expectedFilesToStage = Arrays.asList(existingFilePath);
 
-    List<String> result = PipelineResources.prepareFilesForStaging(filesToStage, temporaryLocation);
-
-    assertThat(result, is(expectedFilesToStage));
+    assertThrows(
+        "To-be-staged file does not exist: ",
+        IllegalStateException.class,
+        () -> PipelineResources.prepareFilesForStaging(filesToStage, temporaryLocation));
   }
 
   @Test

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironmentTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironmentTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.runners.flink;
 
-import static java.util.Arrays.asList;
 import static org.apache.beam.sdk.testing.RegexMatcher.matches;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -27,6 +26,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Every.everyItem;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -36,6 +36,7 @@ import java.io.PrintStream;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.beam.runners.core.construction.PTransformMatchers;
@@ -106,17 +107,25 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   @Test
   public void shouldPrepareFilesToStageWhenFlinkMasterIsSetExplicitly() throws IOException {
-    FlinkPipelineOptions options = testPreparingResourcesToStage("localhost:8081");
+    FlinkPipelineOptions options = testPreparingResourcesToStage("localhost:8081", false);
 
-    assertThat(options.getFilesToStage().size(), is(1));
+    assertThat(options.getFilesToStage().size(), is(2));
     assertThat(options.getFilesToStage().get(0), matches(".*\\.jar"));
+  }
+
+  @Test
+  public void shouldFailWhenFileDoesNotExistAndFlinkMasterIsSetExplicitly() {
+    assertThrows(
+        "To-be-staged file does not exist: ",
+        IllegalStateException.class,
+        () -> testPreparingResourcesToStage("localhost:8081", true));
   }
 
   @Test
   public void shouldNotPrepareFilesToStageWhenFlinkMasterIsSetToAuto() throws IOException {
     FlinkPipelineOptions options = testPreparingResourcesToStage("[auto]");
 
-    assertThat(options.getFilesToStage().size(), is(2));
+    assertThat(options.getFilesToStage().size(), is(3));
     assertThat(options.getFilesToStage(), everyItem(not(matches(".*\\.jar"))));
   }
 
@@ -124,7 +133,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
   public void shouldNotPrepareFilesToStagewhenFlinkMasterIsSetToCollection() throws IOException {
     FlinkPipelineOptions options = testPreparingResourcesToStage("[collection]");
 
-    assertThat(options.getFilesToStage().size(), is(2));
+    assertThat(options.getFilesToStage().size(), is(3));
     assertThat(options.getFilesToStage(), everyItem(not(matches(".*\\.jar"))));
   }
 
@@ -132,7 +141,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
   public void shouldNotPrepareFilesToStageWhenFlinkMasterIsSetToLocal() throws IOException {
     FlinkPipelineOptions options = testPreparingResourcesToStage("[local]");
 
-    assertThat(options.getFilesToStage().size(), is(2));
+    assertThat(options.getFilesToStage().size(), is(3));
     assertThat(options.getFilesToStage(), everyItem(not(matches(".*\\.jar"))));
   }
 
@@ -360,16 +369,28 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   private FlinkPipelineOptions testPreparingResourcesToStage(String flinkMaster)
       throws IOException {
+    return testPreparingResourcesToStage(flinkMaster, true);
+  }
+
+  private FlinkPipelineOptions testPreparingResourcesToStage(
+      String flinkMaster, boolean includeNonExisting) throws IOException {
     Pipeline pipeline = Pipeline.create();
     String tempLocation = tmpFolder.newFolder().getAbsolutePath();
 
-    File notEmptyDir = tmpFolder.newFolder();
-    notEmptyDir.createNewFile();
-    String notEmptyDirPath = notEmptyDir.getAbsolutePath();
-    String notExistingPath = "/path/to/not/existing/dir";
+    List<String> filesToStage = new ArrayList<>();
 
-    FlinkPipelineOptions options =
-        setPipelineOptions(flinkMaster, tempLocation, asList(notEmptyDirPath, notExistingPath));
+    File stagingDir = tmpFolder.newFolder();
+    stagingDir.createNewFile();
+    filesToStage.add(stagingDir.getAbsolutePath());
+
+    File individualStagingFile = tmpFolder.newFile();
+    filesToStage.add(individualStagingFile.getAbsolutePath());
+
+    if (includeNonExisting) {
+      filesToStage.add("/path/to/not/existing/dir");
+    }
+
+    FlinkPipelineOptions options = setPipelineOptions(flinkMaster, tempLocation, filesToStage);
     FlinkPipelineExecutionEnvironment flinkEnv = new FlinkPipelineExecutionEnvironment(options);
     flinkEnv.translate(pipeline);
     return options;


### PR DESCRIPTION
The current behavior to silently ignore non-existing files or directories has
been a source of confusion for many users. This enforces a strict check to avoid
leaving out essential dependencies which usually lead to unexpected failures
during runtime, e.g. ClassNotFoundException.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
