### PR TITLE
[BEAM-7463] parallelize BQ IT tests

### DIFF
--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -26,6 +26,7 @@ import logging
 import random
 import time
 import unittest
+import warnings
 
 from hamcrest.core.core.allof import all_of
 from nose.plugins.attrib import attr
@@ -70,6 +71,9 @@ DIALECT_OUTPUT_EXPECTED = [(u'apple',), (u'orange',)]
 
 
 class BigQueryQueryToTableIT(unittest.TestCase):
+  # Enable nose tests running in parallel
+  _multiprocess_can_split_ = True
+
   def setUp(self):
     self.test_pipeline = TestPipeline(is_integration_test=True)
     self.runner_name = type(self.test_pipeline.runner).__name__
@@ -78,10 +82,14 @@ class BigQueryQueryToTableIT(unittest.TestCase):
     self.bigquery_client = BigQueryWrapper()
     self.dataset_id = '%s%s%d' % (BIG_QUERY_DATASET_ID, str(int(time.time())),
                                   random.randint(0, 10000))
+    warnings.warn(
+        'Creating bigquery dataset %s.%s' % (self.project, self.dataset_id))
     self.bigquery_client.get_or_create_dataset(self.project, self.dataset_id)
     self.output_table = "%s.output_table" % (self.dataset_id)
 
   def tearDown(self):
+    warnings.warn(
+        'Deleting bigquery dataset %s.%s' % (self.project, self.dataset_id))
     request = bigquery.BigqueryDatasetsDeleteRequest(
         projectId=self.project, datasetId=self.dataset_id,
         deleteContents=True)

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -25,6 +25,7 @@ import os
 import random
 import time
 import unittest
+import warnings
 
 import mock
 from hamcrest.core import assert_that as hamcrest_assert
@@ -356,6 +357,8 @@ class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
 
 @unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')
 class BigQueryFileLoadsIT(unittest.TestCase):
+  # Enable nose tests running in parallel
+  _multiprocess_can_split_ = True
 
   BIG_QUERY_DATASET_ID = 'python_bq_file_loads_'
   BIG_QUERY_SCHEMA = (
@@ -377,6 +380,8 @@ class BigQueryFileLoadsIT(unittest.TestCase):
                                   str(int(time.time())),
                                   random.randint(0, 10000))
     self.bigquery_client = bigquery_tools.BigQueryWrapper()
+    warnings.warn(
+        'Create bigquery dataset %s.%s' % (self.project, self.dataset_id))
     self.bigquery_client.get_or_create_dataset(self.project, self.dataset_id)
     self.output_table = "%s.output_table" % (self.dataset_id)
     logging.info("Created dataset %s in project %s",
@@ -516,6 +521,8 @@ class BigQueryFileLoadsIT(unittest.TestCase):
     hamcrest_assert(p, all_of(*pipeline_verifiers))
 
   def tearDown(self):
+    warnings.warn(
+        'Deleting bigquery dataset %s.%s' % (self.project, self.dataset_id))
     request = bigquery_api.BigqueryDatasetsDeleteRequest(
         projectId=self.project, datasetId=self.dataset_id,
         deleteContents=True)

--- a/sdks/python/apache_beam/io/gcp/bigquery_read_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_read_it_test.py
@@ -23,6 +23,7 @@ import logging
 import random
 import time
 import unittest
+import warnings
 
 from nose.plugins.attrib import attr
 
@@ -43,6 +44,9 @@ except ImportError:
 
 
 class BigQueryReadIntegrationTests(unittest.TestCase):
+  # Enable nose tests running in parallel
+  _multiprocess_can_split_ = True
+
   BIG_QUERY_DATASET_ID = 'python_read_table_'
 
   def setUp(self):
@@ -54,11 +58,15 @@ class BigQueryReadIntegrationTests(unittest.TestCase):
     self.dataset_id = '%s%s%d' % (self.BIG_QUERY_DATASET_ID,
                                   str(int(time.time())),
                                   random.randint(0, 10000))
+    warnings.warn(
+        'Creating bigquery dataset %s.%s' % (self.project, self.dataset_id))
     self.bigquery_client.get_or_create_dataset(self.project, self.dataset_id)
     logging.info("Created dataset %s in project %s",
                  self.dataset_id, self.project)
 
   def tearDown(self):
+    warnings.warn(
+        'Deleting bigquery dataset %s.%s' % (self.project, self.dataset_id))
     request = bigquery.BigqueryDatasetsDeleteRequest(
         projectId=self.project, datasetId=self.dataset_id,
         deleteContents=True)

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -35,6 +35,7 @@ import re
 import sys
 import time
 import uuid
+import warnings
 from builtins import object
 
 from future.utils import iteritems
@@ -454,6 +455,8 @@ class BigQueryWrapper(object):
     try:
       dataset = self.client.datasets.Get(bigquery.BigqueryDatasetsGetRequest(
           projectId=project_id, datasetId=dataset_id))
+      warnings.warn(
+          'Get bigquery dataset %s.%s' % (project_id, dataset_id))
       return dataset
     except HttpError as exn:
       if exn.status_code == 404:
@@ -464,6 +467,8 @@ class BigQueryWrapper(object):
           dataset.location = location
         request = bigquery.BigqueryDatasetsInsertRequest(
             projectId=project_id, dataset=dataset)
+        warnings.warn(
+            'Created bigquery dataset %s.%s' % (project_id, dataset_id))
         response = self.client.datasets.Insert(request)
         # The response is a bigquery.Dataset instance.
         return response

--- a/sdks/python/apache_beam/io/gcp/bigquery_write_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_write_it_test.py
@@ -24,6 +24,7 @@ import logging
 import random
 import time
 import unittest
+import warnings
 
 import hamcrest as hc
 from nose.plugins.attrib import attr
@@ -44,6 +45,9 @@ except ImportError:
 
 
 class BigQueryWriteIntegrationTests(unittest.TestCase):
+  # Enable nose tests running in parallel
+  _multiprocess_can_split_ = True
+
   BIG_QUERY_DATASET_ID = 'python_write_to_table_'
 
   def setUp(self):
@@ -55,11 +59,15 @@ class BigQueryWriteIntegrationTests(unittest.TestCase):
     self.dataset_id = '%s%s%d' % (self.BIG_QUERY_DATASET_ID,
                                   str(int(time.time())),
                                   random.randint(0, 10000))
+    warnings.warn(
+        'Creating bigquery dataset %s.%s' % (self.project, self.dataset_id))
     self.bigquery_client.get_or_create_dataset(self.project, self.dataset_id)
     logging.info("Created dataset %s in project %s",
                  self.dataset_id, self.project)
 
   def tearDown(self):
+    warnings.warn(
+        'Deleting bigquery dataset %s.%s' % (self.project, self.dataset_id))
     request = bigquery.BigqueryDatasetsDeleteRequest(
         projectId=self.project, datasetId=self.dataset_id,
         deleteContents=True)

--- a/sdks/python/apache_beam/io/gcp/bigquery_write_perf_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_write_perf_test.py
@@ -1,0 +1,107 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+A pipeline that writes data from Synthetic Source to a BigQuery table.
+Besides of the standard options, there are options with special meaning:
+* output - BQ destination in the following format: 'dataset_id.table_id'.
+The table will be removed after test completion,
+* input_options - options for Synthetic Source:
+num_records - number of rows to be inserted,
+value_size - the length of a single row,
+key_size - required option, but its value has no meaning.
+
+Example test run on DataflowRunner:
+
+python setup.py nosetests \
+    --test-pipeline-options="
+    --runner=TestDataflowRunner
+    --project=...
+    --staging_location=gs://...
+    --temp_location=gs://...
+    --sdk_location=.../dist/apache-beam-x.x.x.dev0.tar.gz
+    --output_dataset=...
+    --output_table=...
+    --input_options='{
+    \"num_records\": 1024,
+    \"key_size\": 1,
+    \"value_size\": 1024,
+    }'" \
+    --tests apache_beam.io.gcp.bigquery_write_perf_test
+
+This setup will result in a table of 1MB size.
+"""
+
+from __future__ import absolute_import
+
+import base64
+import logging
+import os
+import unittest
+
+from apache_beam import Map
+from apache_beam.io import BigQueryDisposition
+from apache_beam.io import Read
+from apache_beam.io import WriteToBigQuery
+from apache_beam.io.gcp.bigquery_tools import parse_table_schema_from_json
+from apache_beam.io.gcp.tests import utils
+from apache_beam.testing.load_tests.load_test import LoadTest
+from apache_beam.testing.synthetic_pipeline import SyntheticSource
+
+load_test_enabled = False
+if os.environ.get('LOAD_TEST_ENABLED') == 'true':
+  load_test_enabled = True
+
+
+@unittest.skipIf(not load_test_enabled, 'Enabled only for phrase triggering.')
+class BigQueryWritePerfTest(LoadTest):
+  def setUp(self):
+    super(BigQueryWritePerfTest, self).setUp()
+    self.output_dataset = self.pipeline.get_option('output_dataset')
+    self.output_table = self.pipeline.get_option('output_table')
+
+  def tearDown(self):
+    super(BigQueryWritePerfTest, self).tearDown()
+    self._cleanup_data()
+
+  def _cleanup_data(self):
+    """Removes an output BQ table."""
+    utils.delete_bq_table(self.project_id, self.output_dataset,
+                          self.output_table)
+
+  def test(self):
+    SCHEMA = parse_table_schema_from_json(
+        '{"fields": [{"name": "data", "type": "BYTES"}]}')
+
+    def format_record(record):
+      # Since Synthetic Source returns data as a dictionary, we should skip one
+      # of the part
+      return {'data': base64.b64encode(record[1])}
+
+    # pylint: disable=expression-not-assigned
+    (self.pipeline
+     | 'ProduceRows' >> Read(SyntheticSource(self.parseTestPipelineOptions()))
+     | 'Format' >> Map(format_record)
+     | 'WriteToBigQuery' >> WriteToBigQuery(
+         self.output_dataset + '.' + self.output_table,
+         schema=SCHEMA,
+         create_disposition=BigQueryDisposition.CREATE_IF_NEEDED,
+         write_disposition=BigQueryDisposition.WRITE_EMPTY))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/testing/load_tests/load_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/load_test.py
@@ -49,6 +49,7 @@ class LoadTest(unittest.TestCase):
   def setUp(self):
     self.pipeline = TestPipeline()
     self.input_options = json.loads(self.pipeline.get_option('input_options'))
+    self.project_id = self.pipeline.get_option('project')
 
     self.publish_to_big_query = self.pipeline.get_option('publish_to_big_query')
     self.metrics_namespace = self.pipeline.get_option('metrics_table')


### PR DESCRIPTION

Updating `_multiprocess_can_split_ = True` makes sure that the test cases don't share any variables when run in parallel, this avoids flaky test results

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
