### PR TITLE
[BEAM-7427] Fix JmsCheckpointMark Avro Encoding

### DIFF
--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
@@ -17,16 +17,11 @@
  */
 package org.apache.beam.sdk.io.jms;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
 import javax.jms.Message;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.io.UnboundedSource;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +35,7 @@ public class JmsCheckpointMark implements UnboundedSource.CheckpointMark {
 
   private static final Logger LOG = LoggerFactory.getLogger(JmsCheckpointMark.class);
 
-  private final State state = new State();
+  private final JmsCheckpointMarkState state = new JmsCheckpointMarkState();
 
   public JmsCheckpointMark() {}
 
@@ -68,8 +63,8 @@ public class JmsCheckpointMark implements UnboundedSource.CheckpointMark {
    */
   @Override
   public void finalizeCheckpoint() {
-    State snapshot = state.snapshot();
-    for (Message message : snapshot.messages) {
+    JmsCheckpointMarkState snapshot = state.snapshot();
+    for (Message message : snapshot.getMessages()) {
       try {
         message.acknowledge();
         Instant currentMessageTimestamp = new Instant(message.getJMSTimestamp());
@@ -80,105 +75,9 @@ public class JmsCheckpointMark implements UnboundedSource.CheckpointMark {
     }
     state.atomicWrite(
         () -> {
-          state.removeMessages(snapshot.messages);
-          state.updateOldestPendingTimestampIf(snapshot.oldestPendingTimestamp, Instant::isAfter);
+          state.removeMessages(snapshot.getMessages());
+          state.updateOldestPendingTimestampIf(
+              snapshot.getOldestPendingTimestamp(), Instant::isAfter);
         });
-  }
-
-  /**
-   * Encapsulates the state of a checkpoint mark; the list of messages pending finalisation and the
-   * oldest pending timestamp. Read/write-exclusive access is provided throughout, and constructs
-   * allowing multiple operations to be performed atomically -- i.e. performed within the context of
-   * a single lock operation -- are made available.
-   */
-  private class State {
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-
-    private final List<Message> messages;
-    private Instant oldestPendingTimestamp;
-
-    public State() {
-      this(new ArrayList<>(), BoundedWindow.TIMESTAMP_MIN_VALUE);
-    }
-
-    private State(List<Message> messages, Instant oldestPendingTimestamp) {
-      this.messages = messages;
-      this.oldestPendingTimestamp = oldestPendingTimestamp;
-    }
-
-    /**
-     * Create and return a copy of the current state.
-     *
-     * @return A new {@code State} instance which is a deep copy of the target instance at the time
-     *     of execution.
-     */
-    public State snapshot() {
-      return atomicRead(() -> new State(new ArrayList<>(messages), oldestPendingTimestamp));
-    }
-
-    public Instant getOldestPendingTimestamp() {
-      return atomicRead(() -> oldestPendingTimestamp);
-    }
-
-    public List<Message> getMessages() {
-      return atomicRead(() -> messages);
-    }
-
-    public void addMessage(Message message) {
-      atomicWrite(() -> messages.add(message));
-    }
-
-    public void removeMessages(List<Message> messages) {
-      atomicWrite(() -> this.messages.removeAll(messages));
-    }
-
-    /**
-     * Conditionally sets {@code oldestPendingTimestamp} to the value of the supplied {@code
-     * candidate}, iff the provided {@code check} yields true for the {@code candidate} when called
-     * with the existing {@code oldestPendingTimestamp} value.
-     *
-     * @param candidate The potential new value.
-     * @param check The comparison method to call on {@code candidate} passing the existing {@code
-     *     oldestPendingTimestamp} value as a parameter.
-     */
-    private void updateOldestPendingTimestampIf(
-        Instant candidate, BiFunction<Instant, Instant, Boolean> check) {
-      atomicWrite(
-          () -> {
-            if (check.apply(candidate, oldestPendingTimestamp)) {
-              oldestPendingTimestamp = candidate;
-            }
-          });
-    }
-
-    /**
-     * Call the provided {@link Supplier} under this State's read lock and return its result.
-     *
-     * @param operation The code to execute in the context of this State's read lock.
-     * @param <T> The return type of the provided {@link Supplier}.
-     * @return The value produced by the provided {@link Supplier}.
-     */
-    public <T> T atomicRead(Supplier<T> operation) {
-      lock.readLock().lock();
-      try {
-        return operation.get();
-      } finally {
-        lock.readLock().unlock();
-      }
-    }
-
-    /**
-     * Call the provided {@link Runnable} under this State's write lock.
-     *
-     * @param operation The code to execute in the context of this State's write lock.
-     */
-    public void atomicWrite(Runnable operation) {
-      lock.writeLock().lock();
-      try {
-        operation.run();
-      } finally {
-        lock.writeLock().unlock();
-      }
-    }
   }
 }

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMarkState.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMarkState.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.jms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import javax.jms.Message;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.joda.time.Instant;
+
+/**
+ * Encapsulates the state of a checkpoint mark; the list of messages pending finalisation and the
+ * oldest pending timestamp. Read/write-exclusive access is provided throughout, and constructs
+ * allowing multiple operations to be performed atomically -- i.e. performed within the context of a
+ * single lock operation -- are made available.
+ */
+class JmsCheckpointMarkState {
+  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+  private final List<Message> messages;
+  private Instant oldestPendingTimestamp;
+
+  public JmsCheckpointMarkState() {
+    this(new ArrayList<>(), BoundedWindow.TIMESTAMP_MIN_VALUE);
+  }
+
+  private JmsCheckpointMarkState(List<Message> messages, Instant oldestPendingTimestamp) {
+    this.messages = messages;
+    this.oldestPendingTimestamp = oldestPendingTimestamp;
+  }
+
+  /**
+   * Create and return a copy of the current state.
+   *
+   * @return A new {@code State} instance which is a deep copy of the target instance at the time of
+   *     execution.
+   */
+  public JmsCheckpointMarkState snapshot() {
+    return atomicRead(
+        () -> new JmsCheckpointMarkState(new ArrayList<>(messages), oldestPendingTimestamp));
+  }
+
+  public Instant getOldestPendingTimestamp() {
+    return atomicRead(() -> oldestPendingTimestamp);
+  }
+
+  public List<Message> getMessages() {
+    return atomicRead(() -> messages);
+  }
+
+  public void addMessage(Message message) {
+    atomicWrite(() -> messages.add(message));
+  }
+
+  public void removeMessages(List<Message> messages) {
+    atomicWrite(() -> this.messages.removeAll(messages));
+  }
+
+  /**
+   * Conditionally sets {@code oldestPendingTimestamp} to the value of the supplied {@code
+   * candidate}, iff the provided {@code check} yields true for the {@code candidate} when called
+   * with the existing {@code oldestPendingTimestamp} value.
+   *
+   * @param candidate The potential new value.
+   * @param check The comparison method to call on {@code candidate} passing the existing {@code
+   *     oldestPendingTimestamp} value as a parameter.
+   */
+  void updateOldestPendingTimestampIf(
+      Instant candidate, BiFunction<Instant, Instant, Boolean> check) {
+    atomicWrite(
+        () -> {
+          if (check.apply(candidate, oldestPendingTimestamp)) {
+            oldestPendingTimestamp = candidate;
+          }
+        });
+  }
+
+  /**
+   * Call the provided {@link Supplier} under this State's read lock and return its result.
+   *
+   * @param operation The code to execute in the context of this State's read lock.
+   * @param <T> The return type of the provided {@link Supplier}.
+   * @return The value produced by the provided {@link Supplier}.
+   */
+  public <T> T atomicRead(Supplier<T> operation) {
+    lock.readLock().lock();
+    try {
+      return operation.get();
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Call the provided {@link Runnable} under this State's write lock.
+   *
+   * @param operation The code to execute in the context of this State's write lock.
+   */
+  public void atomicWrite(Runnable operation) {
+    lock.writeLock().lock();
+    try {
+      operation.run();
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+}

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -18,11 +18,7 @@
 package org.apache.beam.sdk.io.jms;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.lang.reflect.Proxy;
@@ -48,6 +44,7 @@ import org.apache.activemq.security.AuthenticationUser;
 import org.apache.activemq.security.SimpleAuthenticationPlugin;
 import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.activemq.util.Callback;
+import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -331,6 +328,13 @@ public class JmsIOTest {
     reader.getCheckpointMark().finalizeCheckpoint();
 
     assertEquals(0, count(QUEUE));
+  }
+
+  @Test
+  public void testJmsCheckpointMarkAvroEncoding() {
+    AvroCoder<JmsCheckpointMark> avroCoder = AvroCoder.of(JmsCheckpointMark.class);
+
+    assertNotNull(avroCoder);
   }
 
   @Test

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -18,7 +18,12 @@
 package org.apache.beam.sdk.io.jms;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Proxy;


### PR DESCRIPTION
`JmsCheckpointMark` can't be serialized with AvroCoder beause of the inner class `State`
Avro schema generation of `JmsCheckpointMark` fails
the externalisation of the inner class fixes the issue.

R: @iemejia 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
