### PR TITLE
Importing hamcrest dependency at matcher runtime

### DIFF
--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -25,9 +25,6 @@ import io
 import tempfile
 from builtins import object
 
-from hamcrest.core import assert_that as hamcrest_assert
-from hamcrest.library.collection import contains_inanyorder
-
 from apache_beam import pvalue
 from apache_beam.transforms import window
 from apache_beam.transforms.core import Create
@@ -154,6 +151,8 @@ def matches_all(expected):
       the elements of a single PCollection.
   """
   def _matches(actual):
+    from hamcrest.core import assert_that as hamcrest_assert
+    from hamcrest.library.collection import contains_inanyorder
     expected_list = list(expected)
 
     hamcrest_assert(actual, contains_inanyorder(*expected_list))


### PR DESCRIPTION
This prevents us from importing hamcrest dependency every time we run Beam.