### PR TITLE
[BEAM-7512] Replace deprecated self.assertEquals with self.assertEqual

### DIFF
--- a/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
+++ b/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
@@ -85,43 +85,43 @@ class SyntheticPipelineTest(unittest.TestCase):
     provider = synthetic_pipeline.SyntheticSDFStepRestrictionProvider(
         5, 2, False, False, None)
 
-    self.assertEquals(
+    self.assertEqual(
         list(provider.split('ab', (2, 15))), [(2, 8), (8, 15)])
-    self.assertEquals(
+    self.assertEqual(
         list(provider.split('ab', (0, 8))), [(0, 4), (4, 8)])
-    self.assertEquals(
+    self.assertEqual(
         list(provider.split('ab', (0, 0))), [])
-    self.assertEquals(
+    self.assertEqual(
         list(provider.split('ab', (2, 3))), [(2, 3)])
 
     provider = synthetic_pipeline.SyntheticSDFStepRestrictionProvider(
         10, 1, False, False, None)
-    self.assertEquals(list(provider.split('ab', (1, 10))), [(1, 10)])
-    self.assertEquals(provider.restriction_size('ab', (1, 10)), 9 * 2)
+    self.assertEqual(list(provider.split('ab', (1, 10))), [(1, 10)])
+    self.assertEqual(provider.restriction_size('ab', (1, 10)), 9 * 2)
 
     provider = synthetic_pipeline.SyntheticSDFStepRestrictionProvider(
         10, 3, False, False, None)
-    self.assertEquals(list(provider.split('ab', (1, 10))),
-                      [(1, 4), (4, 7), (7, 10)])
-    self.assertEquals(provider.initial_restriction('a'), (0, 10))
+    self.assertEqual(list(provider.split('ab', (1, 10))),
+                     [(1, 4), (4, 7), (7, 10)])
+    self.assertEqual(provider.initial_restriction('a'), (0, 10))
 
     provider = synthetic_pipeline.SyntheticSDFStepRestrictionProvider(
         10, 3, False, False, 45)
-    self.assertEquals(provider.restriction_size('ab', (1, 3)), 45)
+    self.assertEqual(provider.restriction_size('ab', (1, 3)), 45)
 
     tracker = provider.create_tracker((1, 6))
     tracker.try_claim(1)  # Claim to allow splitting.
-    self.assertEquals(tracker.try_split(.5), ((1, 3), (3, 6)))
+    self.assertEqual(tracker.try_split(.5), ((1, 3), (3, 6)))
 
   def verify_random_splits(self, provider, start, stop, bundles):
     ranges = list(provider.split('ab', (start, stop)))
 
     prior_stop = start
     for r in ranges:
-      self.assertEquals(r[0], prior_stop)
+      self.assertEqual(r[0], prior_stop)
       prior_stop = r[1]
-    self.assertEquals(prior_stop, stop)
-    self.assertEquals(len(ranges), bundles)
+    self.assertEqual(prior_stop, stop)
+    self.assertEqual(len(ranges), bundles)
 
   def testSyntheticStepSplitProviderUnevenChunks(self):
     bundles = 4
@@ -138,14 +138,14 @@ class SyntheticPipelineTest(unittest.TestCase):
         5, 5, True, False, None)
     tracker = provider.create_tracker((1, 6))
     tracker.try_claim(2)
-    self.assertEquals(tracker.try_split(.5), ((1, 4), (4, 6)))
+    self.assertEqual(tracker.try_split(.5), ((1, 4), (4, 6)))
 
     # Verify No Liquid Sharding
     provider = synthetic_pipeline.SyntheticSDFStepRestrictionProvider(
         5, 5, True, True, None)
     tracker = provider.create_tracker((1, 6))
     tracker.try_claim(2)
-    self.assertEquals(tracker.try_split(3), None)
+    self.assertEqual(tracker.try_split(3), None)
 
   def testSyntheticSource(self):
     def assert_size(element, expected_size):

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -442,23 +442,23 @@ class LatestCombineFnTest(unittest.TestCase):
 
   def test_create_accumulator(self):
     accumulator = self.fn.create_accumulator()
-    self.assertEquals(accumulator, (None, window.MIN_TIMESTAMP))
+    self.assertEqual(accumulator, (None, window.MIN_TIMESTAMP))
 
   def test_add_input(self):
     accumulator = self.fn.create_accumulator()
     element = (1, 100)
     new_accumulator = self.fn.add_input(accumulator, element)
-    self.assertEquals(new_accumulator, (1, 100))
+    self.assertEqual(new_accumulator, (1, 100))
 
   def test_merge_accumulators(self):
     accumulators = [(2, 400), (5, 100), (9, 200)]
     merged_accumulator = self.fn.merge_accumulators(accumulators)
-    self.assertEquals(merged_accumulator, (2, 400))
+    self.assertEqual(merged_accumulator, (2, 400))
 
   def test_extract_output(self):
     accumulator = (1, 100)
     output = self.fn.extract_output(accumulator)
-    self.assertEquals(output, 1)
+    self.assertEqual(output, 1)
 
   def test_with_input_types_decorator_violation(self):
     l_int = [1, 2, 3]

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -1070,35 +1070,35 @@ class DecoratorHelpers(TypeHintTestCase):
 
   def test_getcallargs_forhints_builtins(self):
     if sys.version_info.major < 3:
-      self.assertEquals(
+      self.assertEqual(
           {'_': str,
            '__unknown__varargs': Tuple[Any, ...],
            '__unknown__keywords': typehints.Dict[Any, Any]},
           getcallargs_forhints(str.upper, str))
-      self.assertEquals(
+      self.assertEqual(
           {'_': str,
            '__unknown__varargs': Tuple[Any, ...],
            '__unknown__keywords': typehints.Dict[Any, Any]},
           getcallargs_forhints(str.strip, str, str))
-      self.assertEquals(
+      self.assertEqual(
           {'_': str,
            '__unknown__varargs': Tuple[Any, ...],
            '__unknown__keywords': typehints.Dict[Any, Any]},
           getcallargs_forhints(str.join, str, list))
     elif sys.version_info.minor < 7:
       # Signatures for builtins are not supported in 3.5 and 3.6.
-      self.assertEquals({}, getcallargs_forhints(str.upper, str))
-      self.assertEquals({}, getcallargs_forhints(str.strip, str, str))
-      self.assertEquals({}, getcallargs_forhints(str.join, str, list))
+      self.assertEqual({}, getcallargs_forhints(str.upper, str))
+      self.assertEqual({}, getcallargs_forhints(str.strip, str, str))
+      self.assertEqual({}, getcallargs_forhints(str.join, str, list))
     else:
-      self.assertEquals(
+      self.assertEqual(
           {'self': str},
           getcallargs_forhints(str.upper, str))
       # str.strip has an optional second argument.
-      self.assertEquals({'self': str, 'chars': Any},
-                        getcallargs_forhints(str.strip, str))
-      self.assertEquals({'self': str, 'iterable': list},
-                        getcallargs_forhints(str.join, str, list))
+      self.assertEqual({'self': str, 'chars': Any},
+                       getcallargs_forhints(str.strip, str))
+      self.assertEqual({'self': str, 'iterable': list},
+                       getcallargs_forhints(str.join, str, list))
 
 
 class TestCoerceToKvType(TypeHintTestCase):


### PR DESCRIPTION

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
