### PR TITLE
Make temp_location an attribute of the StandardOptions class

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -238,7 +238,7 @@ def pipeline_options_remote(argv):
   google_cloud_options.project = 'my-project-id'
   google_cloud_options.job_name = 'myjob'
   google_cloud_options.staging_location = 'gs://my-bucket/binaries'
-  google_cloud_options.temp_location = 'gs://my-bucket/temp'
+  google_cloud_options.gcp_temp_location = 'gs://my-bucket/temp'
   options.view_as(StandardOptions).runner = 'DataflowRunner'
 
   # Create the Pipeline with the specified options.
@@ -423,7 +423,7 @@ def examples_wordcount_minimal(renames):
   google_cloud_options.project = 'my-project-id'
   google_cloud_options.job_name = 'myjob'
   google_cloud_options.staging_location = 'gs://your-bucket-name-here/staging'
-  google_cloud_options.temp_location = 'gs://your-bucket-name-here/temp'
+  google_cloud_options.gcp_temp_location = 'gs://your-bucket-name-here/temp'
   options.view_as(StandardOptions).runner = 'DataflowRunner'
   # [END examples_wordcount_minimal_options]
 

--- a/sdks/python/apache_beam/io/fileio.py
+++ b/sdks/python/apache_beam/io/fileio.py
@@ -110,7 +110,7 @@ import apache_beam as beam
 from apache_beam.io import filesystem
 from apache_beam.io import filesystems
 from apache_beam.io.filesystem import BeamIOError
-from apache_beam.options.pipeline_options import GoogleCloudOptions
+from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.value_provider import StaticValueProvider
 from apache_beam.options.value_provider import ValueProvider
 from apache_beam.transforms.window import GlobalWindow
@@ -490,7 +490,7 @@ class WriteToFiles(beam.PTransform):
 
     if not self._temp_directory:
       temp_location = (
-          p.options.view_as(GoogleCloudOptions).temp_location
+          p.options.view_as(StandardOptions).temp_location
           or self.path.get())
       dir_uid = str(uuid.uuid4())
       self._temp_directory = StaticValueProvider(

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -768,7 +768,7 @@ class BigQueryBatchFileLoads(beam.PTransform):
   def expand(self, pcoll):
     p = pcoll.pipeline
 
-    temp_location = p.options.view_as(GoogleCloudOptions).temp_location
+    temp_location = p.options.view_as(GoogleCloudOptions).gcp_temp_location
 
     empty_pc = p | "ImpulseEmptyPC" >> beam.Create([])
     singleton_pc = p | "ImpulseSingleElementPC" >> beam.Create([None])

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -590,7 +590,7 @@ class GoogleCloudOptions(PipelineOptions):
       super(GoogleCloudOptions, self).__setattr__(name, value)
 
   @deprecated(
-      since='2.16.0',
+      since='2.17.0',
       custom_message=(
           'GoogleCloudOptions.temp_location is deprecated since %since%. '
           'Please use StandardOptions.temp_location or '
@@ -602,7 +602,7 @@ class GoogleCloudOptions(PipelineOptions):
       return self.view_as(StandardOptions).temp_location
 
   @deprecated(
-      since='2.16.0',
+      since='2.17.0',
       custom_message=(
           'GoogleCloudOptions.temp_location is deprecated since %since%. '
           'Please use StandardOptions.temp_location or '

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -593,7 +593,8 @@ class GoogleCloudOptions(PipelineOptions):
       since='2.16.0',
       custom_message=(
           'GoogleCloudOptions.temp_location is deprecated since %since%. '
-          'Use GoogleCloudOptions.gcp_temp_location instead.'))
+          'Please use StandardOptions.temp_location or '
+          'GoogleCloudOptions.gcp_temp_location, as appropriate.'))
   def _get_temp_location(self):
     if self.gcp_temp_location is not None:
       return self.gcp_temp_location
@@ -604,7 +605,8 @@ class GoogleCloudOptions(PipelineOptions):
       since='2.16.0',
       custom_message=(
           'GoogleCloudOptions.temp_location is deprecated since %since%. '
-          'Use GoogleCloudOptions.gcp_temp_location instead.'))
+          'Please use StandardOptions.temp_location or '
+          'GoogleCloudOptions.gcp_temp_location, as appropriate.'))
   def _set_temp_location(self, temp_location):
     self.gcp_temp_location = temp_location
 

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -41,6 +41,7 @@ from apache_beam.options.value_provider import StaticValueProvider
 from apache_beam.options.value_provider import ValueProvider
 from apache_beam.transforms.display import HasDisplayData
 from apache_beam.utils import processes
+from apache_beam.utils.annotations import deprecated
 
 __all__ = [
     'PipelineOptions',
@@ -387,11 +388,16 @@ class StandardOptions(PipelineOptions):
         '--runner',
         help=('Pipeline runner used to execute the workflow. Valid values are '
               'DirectRunner, DataflowRunner.'))
-    # Whether to enable streaming mode.
     parser.add_argument('--streaming',
                         default=False,
                         action='store_true',
                         help='Whether to enable streaming mode.')
+    parser.add_argument('--temp_location',
+                        default=None,
+                        help='Location where to store temporary files. Can be '
+                        'a local folder or the URL of an object store bucket. '
+                        'This location must be accessable by all worker '
+                        'processes.')
 
 
 class TypeOptions(PipelineOptions):
@@ -474,13 +480,13 @@ class GoogleCloudOptions(PipelineOptions):
                         default=None,
                         help='Name of the Cloud Dataflow job.')
     # Remote execution must check that this option is not None.
+    # If staging_location is not set, it defaults to gcp_temp_location.
     parser.add_argument('--staging_location',
                         default=None,
                         help='GCS path for staging code packages needed by '
                         'workers.')
-    # Remote execution must check that this option is not None.
-    # If staging_location is not set, it defaults to temp_location.
-    parser.add_argument('--temp_location',
+    # If gcp_temp_location is not set, it defaults to temp_location.
+    parser.add_argument('--gcp_temp_location',
                         default=None,
                         help='GCS path for saving temporary workflow jobs.')
     # The Google Compute Engine region for creating Dataflow jobs. See
@@ -571,13 +577,52 @@ class GoogleCloudOptions(PipelineOptions):
         'https://cloud.google.com/compute/docs/regions-zones')
     return 'us-central1'
 
+  def __getattr__(self, name):
+    if name in ["temp_location"]:
+      return self._get_temp_location()
+    else:
+      return super(GoogleCloudOptions, self).__getattr__(name)
+
+  def __setattr__(self, name, value):
+    if name in ["temp_location"]:
+      self._set_temp_location(value)
+    else:
+      super(GoogleCloudOptions, self).__setattr__(name, value)
+
+  @deprecated(
+      since='2.16.0',
+      custom_message=(
+          'GoogleCloudOptions.temp_location is deprecated since %since%. '
+          'Use GoogleCloudOptions.gcp_temp_location instead.'))
+  def _get_temp_location(self):
+    if self.gcp_temp_location is not None:
+      return self.gcp_temp_location
+    else:
+      return self.view_as(StandardOptions).temp_location
+
+  @deprecated(
+      since='2.16.0',
+      custom_message=(
+          'GoogleCloudOptions.temp_location is deprecated since %since%. '
+          'Use GoogleCloudOptions.gcp_temp_location instead.'))
+  def _set_temp_location(self, temp_location):
+    self.gcp_temp_location = temp_location
+
   def validate(self, validator):
     errors = []
     if validator.is_service_runner():
       errors.extend(validator.validate_cloud_options(self))
-      errors.extend(validator.validate_gcs_path(self, 'temp_location'))
-      if getattr(self, 'staging_location',
-                 None) or getattr(self, 'temp_location', None) is None:
+      if getattr(self.view_as(GoogleCloudOptions), "gcp_temp_location", None):
+        errors.extend(
+            validator.validate_gcs_path(
+                self.view_as(GoogleCloudOptions), "gcp_temp_location"))
+      else:
+        errors.extend(
+            validator.validate_gcs_path(
+                self.view_as(StandardOptions), "temp_location"))
+      if (getattr(self, 'staging_location', None) or
+          (not getattr(self, 'gcp_temp_location', None) and
+           not getattr(self.view_as(StandardOptions), 'temp_location', None))):
         errors.extend(validator.validate_gcs_path(self, 'staging_location'))
 
     if self.view_as(DebugOptions).dataflow_job_file:


### PR DESCRIPTION
Currently, the `--temp_location` argument is parsed by the `GoogleCloudOptions` class. However, `--temp_location` or a similar argument may be useful for other runners as well.

For example, in the case of `DirectRunner`, `temp_location` may be the place where the runner stores its temporary files, if it ever supports out of process shuffles, combines, etc. In the case of `InteractiveRunner`, `temp_location` may be a good default location for the runner to store its cache files. In the case of the `WriteToFiles` transform, setting `temp_location` to `p.options.view_as(GoogleCloudOptions).temp_location` makes it appear as if `temp_location` has to be on GCS, which from my understanding, is not the case unless we are using the `DataflowRunner`?

CC: @ivant @ananvay 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
