### PR TITLE
[BEAM-7536] Fix BigQuery dataset name in collecting Load Tests metrics

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_Combine_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Java.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 
-def commonLoadTestConfig = { jobType, isStreaming ->
+def commonLoadTestConfig = { jobType, isStreaming, datasetName ->
     [
             [
             title        : 'Load test: 2GB of 10B records',
@@ -33,7 +33,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                     appName             : "load_tests_Java_Dataflow_${jobType}_Combine_1",
                     tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                     publishToBigQuery   : true,
-                    bigQueryDataset     : 'load_test',
+                    bigQueryDataset     : datasetName,
                     bigQueryTable       : "java_dataflow_${jobType}_Combine_1",
                     sourceOptions       : """
                                             {
@@ -61,7 +61,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                             appName             : "load_tests_Java_Dataflow_${jobType}_Combine_2",
                             tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery   : true,
-                            bigQueryDataset     : 'load_test',
+                            bigQueryDataset     : datasetName,
                             bigQueryTable       : "java_dataflow_${jobType}_Combine_2",
                             sourceOptions       : """
                                                     {
@@ -90,7 +90,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                             appName             : "load_tests_Java_Dataflow_${jobType}_Combine_3",
                             tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery   : true,
-                            bigQueryDataset     : 'load_test',
+                            bigQueryDataset     : datasetName,
                             bigQueryTable       : "java_dataflow_${jobType}_Combine_3",
                             sourceOptions       : """
                                                     {
@@ -119,7 +119,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                             appName             : "load_tests_Java_Dataflow_${jobType}_Combine_4",
                             tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery   : true,
-                            bigQueryDataset     : 'load_test',
+                            bigQueryDataset     : datasetName,
                             bigQueryTable       : "java_dataflow_${jobType}_Combine_4",
                             sourceOptions       : """
                                                     {
@@ -147,7 +147,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                             appName             : "load_tests_Java_Dataflow_${jobType}_Combine_5",
                             tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery   : true,
-                            bigQueryDataset     : 'load_test',
+                            bigQueryDataset     : datasetName,
                             bigQueryTable       : "java_dataflow_${jobType}_Combine_5",
                             sourceOptions       : """
                                                     {
@@ -171,16 +171,18 @@ def commonLoadTestConfig = { jobType, isStreaming ->
 
 
 def batchLoadTestJob = { scope, triggeringContext ->
-    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, commonLoadTestConfig('batch', false), triggeringContext, "Combine", "batch")
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, commonLoadTestConfig('batch', false, datasetName), "Combine", "batch")
 }
 
 def streamingLoadTestJob = {scope, triggeringContext ->
     scope.description('Runs Java Combine load tests on Dataflow runner in streaming mode')
     commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
 
-    for (testConfiguration in commonLoadTestConfig('streaming', true)) {
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    for (testConfiguration in commonLoadTestConfig('streaming', true, datasetName)) {
         testConfiguration.jobProperties << [inputWindowDurationSec: 1200]
-        loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.JAVA, testConfiguration.jobProperties, testConfiguration.itClass, triggeringContext)
+        loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.JAVA, testConfiguration.jobProperties, testConfiguration.itClass)
     }
 }
 

--- a/.test-infra/jenkins/job_LoadTests_GBK_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Java.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 
-def loadTestConfigurations = { mode, isStreaming ->
+def loadTestConfigurations = { mode, isStreaming, datasetName ->
     [
             [
                     title        : 'Load test: 2GB of 10B records',
@@ -33,7 +33,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             appName               : "load_tests_Java_Dataflow_${mode}_GBK_1",
                             tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery     : true,
-                            bigQueryDataset       : 'load_test',
+                            bigQueryDataset       : datasetName,
                             bigQueryTable         : "java_dataflow_${mode}_GBK_1",
                             sourceOptions         : """
                                             {
@@ -59,7 +59,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             appName               : "load_tests_Java_Dataflow_${mode}_GBK_2",
                             tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery     : true,
-                            bigQueryDataset       : 'load_test',
+                            bigQueryDataset       : datasetName,
                             bigQueryTable         : "java_dataflow_${mode}_GBK_2",
                             sourceOptions         : """
                                             {
@@ -86,7 +86,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             appName               : "load_tests_Java_Dataflow_${mode}_GBK_3",
                             tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery     : true,
-                            bigQueryDataset       : 'load_test',
+                            bigQueryDataset       : datasetName,
                             bigQueryTable         : "java_dataflow_${mode}_GBK_3",
                             sourceOptions         : """
                                             {
@@ -113,7 +113,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             appName               : 'load_tests_Java_Dataflow_${mode}_GBK_4',
                             tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery     : true,
-                            bigQueryDataset       : 'load_test',
+                            bigQueryDataset       : datasetName,
                             bigQueryTable         : "java_dataflow_${mode}_GBK_4",
                             sourceOptions         : """
                                             {
@@ -139,7 +139,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             appName               : "load_tests_Java_Dataflow_${mode}_GBK_5",
                             tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery     : true,
-                            bigQueryDataset       : 'load_test',
+                            bigQueryDataset       : datasetName,
                             bigQueryTable         : "java_dataflow_${mode}_GBK_5",
                             sourceOptions         : """
                                             {
@@ -165,7 +165,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             appName               : "load_tests_Java_Dataflow_${mode}_GBK_6",
                             tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery     : true,
-                            bigQueryDataset       : 'load_test',
+                            bigQueryDataset       : datasetName,
                             bigQueryTable         : "java_dataflow_${mode}_GBK_6",
                             sourceOptions         : """
                                             {
@@ -193,7 +193,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             appName               : "load_tests_Java_Dataflow_${mode}_GBK_7",
                             tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery     : true,
-                            bigQueryDataset       : 'load_test',
+                            bigQueryDataset       : datasetName,
                             bigQueryTable         : "java_dataflow_${mode}_GBK_7",
                             sourceOptions         : """
                                             {
@@ -219,9 +219,10 @@ def streamingLoadTestJob = { scope, triggeringContext ->
   scope.description('Runs Java GBK load tests on Dataflow runner in streaming mode')
   commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
 
-  for (testConfiguration in loadTestConfigurations('streaming', true)) {
+  def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+  for (testConfiguration in loadTestConfigurations('streaming', true, datasetName)) {
     testConfiguration.jobProperties << [inputWindowDurationSec: 1200]
-    loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.JAVA, testConfiguration.jobProperties, testConfiguration.itClass, triggeringContext)
+    loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.JAVA, testConfiguration.jobProperties, testConfiguration.itClass)
   }
 }
 
@@ -240,7 +241,8 @@ PhraseTriggeringPostCommitBuilder.postCommitJob(
 
 
 def batchLoadTestJob = { scope, triggeringContext ->
-    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, loadTestConfigurations('batch', false), triggeringContext, "GBK", "batch")
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, loadTestConfigurations('batch', false, datasetName), "GBK", "batch")
 }
 
 CronJobBuilder.cronJob('beam_LoadTests_Java_GBK_Dataflow_Batch', 'H 14 * * *', this) {

--- a/.test-infra/jenkins/job_LoadTests_GBK_Python_reiterate.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Python_reiterate.groovy
@@ -24,7 +24,7 @@ import CronJobBuilder
 
 def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
-def loadTestConfigurations = [
+def loadTestConfigurations = { datasetName -> [
         [
                 title        : 'GroupByKey Python Load test: reiterate 4 times 10kB values',
                 itClass      :  'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
@@ -34,7 +34,7 @@ def loadTestConfigurations = [
                         job_name             : 'load-tests-python-dataflow-batch-gbk-6-' + now,
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
                         publish_to_big_query : true,
-                        metrics_dataset      : 'load_test',
+                        metrics_dataset      : datasetName,
                         metrics_table        : "python_dataflow_batch_gbk_6",
                         input_options        : '\'{"num_records": 20000000,' +
                                 '"key_size": 10,' +
@@ -57,7 +57,7 @@ def loadTestConfigurations = [
                         job_name             : 'load-tests-python-dataflow-batch-gbk-7-' + now,
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
                         publish_to_big_query : true,
-                        metrics_dataset      : 'load_test',
+                        metrics_dataset      : datasetName,
                         metrics_table        : 'python_dataflow_batch_gbk_7',
                         input_options        : '\'{"num_records": 20000000,' +
                                 '"key_size": 10,' +
@@ -71,14 +71,15 @@ def loadTestConfigurations = [
                         autoscaling_algorithm: 'NONE'
                 ]
         ]
-]
+]}
 
 def batchLoadTestJob = { scope, triggeringContext ->
     scope.description('Runs Python GBK reiterate load tests on Dataflow runner in batch mode')
     commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
 
-    for (testConfiguration in loadTestConfigurations) {
-        loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.PYTHON, testConfiguration.jobProperties, testConfiguration.itClass, triggeringContext)
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    for (testConfiguration in loadTestConfigurations(datasetName)) {
+        loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.PYTHON, testConfiguration.jobProperties, testConfiguration.itClass)
     }
 }
 

--- a/.test-infra/jenkins/job_LoadTests_Java_Smoke.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Java_Smoke.groovy
@@ -20,14 +20,14 @@ import CommonTestProperties
 import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 
-def smokeTestConfigurations = [
+def smokeTestConfigurations = { datasetName -> [
         [
                 title        : 'GroupByKey load test Direct',
                 itClass      : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
                 runner       : CommonTestProperties.Runner.DIRECT,
                 jobProperties: [
                         publishToBigQuery: true,
-                        bigQueryDataset  : 'load_test_SMOKE',
+                        bigQueryDataset  : datasetName,
                         bigQueryTable    : 'direct_gbk',
                         sourceOptions    : '{"numRecords":100000,"splitPointFrequencyRecords":1}',
                         stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true}',
@@ -43,7 +43,7 @@ def smokeTestConfigurations = [
                         project          : 'apache-beam-testing',
                         tempLocation     : 'gs://temp-storage-for-perf-tests/smoketests',
                         publishToBigQuery: true,
-                        bigQueryDataset  : 'load_test_SMOKE',
+                        bigQueryDataset  : datasetName,
                         bigQueryTable    : 'dataflow_gbk',
                         sourceOptions    : '{"numRecords":100000,"splitPointFrequencyRecords":1}',
                         stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true}',
@@ -57,7 +57,7 @@ def smokeTestConfigurations = [
                 runner       : CommonTestProperties.Runner.FLINK,
                 jobProperties: [
                         publishToBigQuery: true,
-                        bigQueryDataset  : 'load_test_SMOKE',
+                        bigQueryDataset  : datasetName,
                         bigQueryTable    : 'flink_gbk',
                         sourceOptions    : '{"numRecords":100000,"splitPointFrequencyRecords":1}',
                         stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true}',
@@ -72,7 +72,7 @@ def smokeTestConfigurations = [
                 jobProperties: [
                         sparkMaster      : 'local[4]',
                         publishToBigQuery: true,
-                        bigQueryDataset  : 'load_test_SMOKE',
+                        bigQueryDataset  : datasetName,
                         bigQueryTable    : 'spark_gbk',
                         sourceOptions    : '{"numRecords":100000,"splitPointFrequencyRecords":1}',
                         stepOptions      : '{"outputRecordsPerInputRecord":1,"preservesInputKeyDistribution":true}',
@@ -80,7 +80,7 @@ def smokeTestConfigurations = [
                         iterations       : 1,
                 ]
         ]
-]
+]}
 
 
 // Runs a tiny version load test suite to ensure nothing is broken.
@@ -90,5 +90,6 @@ PhraseTriggeringPostCommitBuilder.postCommitJob(
         'Java Load Tests Smoke',
         this
 ) {
-  loadTestsBuilder.loadTests(delegate, CommonTestProperties.SDK.JAVA, smokeTestConfigurations, CommonTestProperties.TriggeringContext.PR, "GBK", "smoke")
+  def datasetName = loadTestsBuilder.getBigQueryDataset('load_test_SMOKE', CommonTestProperties.TriggeringContext.PR)
+  loadTestsBuilder.loadTests(delegate, CommonTestProperties.SDK.JAVA, smokeTestConfigurations(datasetName), "GBK", "smoke")
 }

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Java.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 
-def commonLoadTestConfig = { jobType, isStreaming ->
+def commonLoadTestConfig = { jobType, isStreaming, datasetName ->
     [
             [
             title        : 'Load test: ParDo 2GB 100 byte records 10 times',
@@ -33,7 +33,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                     appName             : "load_tests_Java_Dataflow_${jobType}_ParDo_1",
                     tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                     publishToBigQuery   : true,
-                    bigQueryDataset     : 'load_test',
+                    bigQueryDataset     : datasetName,
                     bigQueryTable       : "java_dataflow_${jobType}_ParDo_1",
                     sourceOptions       : """
                                             {
@@ -60,7 +60,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                             appName             : "load_tests_Java_Dataflow_${jobType}_ParDo_2",
                             tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery   : true,
-                            bigQueryDataset     : 'load_test',
+                            bigQueryDataset     : datasetName,
                             bigQueryTable       : "java_dataflow_${jobType}_ParDo_2",
                             sourceOptions       : """
                                                     {
@@ -88,7 +88,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                             appName             : "load_tests_Java_Dataflow_${jobType}_ParDo_3",
                             tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery   : true,
-                            bigQueryDataset     : 'load_test',
+                            bigQueryDataset     : datasetName,
                             bigQueryTable       : "java_dataflow_${jobType}_ParDo_3",
                             sourceOptions       : """
                                                     {
@@ -116,7 +116,7 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                             appName             : "load_tests_Java_Dataflow_${jobType}_ParDo_4",
                             tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
                             publishToBigQuery   : true,
-                            bigQueryDataset     : 'load_test',
+                            bigQueryDataset     : datasetName,
                             bigQueryTable       : "java_dataflow_${jobType}_ParDo_4",
                             sourceOptions       : """
                                                     {
@@ -139,16 +139,18 @@ def commonLoadTestConfig = { jobType, isStreaming ->
 
 
 def batchLoadTestJob = { scope, triggeringContext ->
-    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, commonLoadTestConfig('batch', false), triggeringContext, "ParDo", "batch")
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, commonLoadTestConfig('batch', false, datasetName), "ParDo", "batch")
 }
 
 def streamingLoadTestJob = {scope, triggeringContext ->
     scope.description('Runs Java ParDo load tests on Dataflow runner in streaming mode')
     commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
 
-    for (testConfiguration in commonLoadTestConfig('streaming', true)) {
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    for (testConfiguration in commonLoadTestConfig('streaming', true, datasetName)) {
         testConfiguration.jobProperties << [inputWindowDurationSec: 1200]
-        loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.JAVA, testConfiguration.jobProperties, testConfiguration.itClass, triggeringContext)
+        loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.JAVA, testConfiguration.jobProperties, testConfiguration.itClass)
     }
 }
 

--- a/.test-infra/jenkins/job_LoadTests_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Python.groovy
@@ -21,7 +21,7 @@ import PhraseTriggeringPostCommitBuilder
 
 def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
-def loadTestConfigurations = [
+def loadTestConfigurations = { datasetName -> [
         [
                 title        : 'GroupByKey Python Load test: 2GB of 10B records',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
@@ -32,7 +32,7 @@ def loadTestConfigurations = [
                         project              : 'apache-beam-testing',
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
                         publish_to_big_query : true,
-                        metrics_dataset      : 'load_test',
+                        metrics_dataset      : datasetName,
                         metrics_table        : 'python_dataflow_batch_gbk_1',
                         input_options        : '\'{"num_records": 200000000,' +
                                 '"key_size": 1,' +
@@ -54,7 +54,7 @@ def loadTestConfigurations = [
                         project              : 'apache-beam-testing',
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
                         publish_to_big_query : true,
-                        metrics_dataset      : 'load_test',
+                        metrics_dataset      : datasetName,
                         metrics_table        : 'python_dataflow_batch_gbk_2',
                         input_options        : '\'{"num_records": 20000000,' +
                                 '"key_size": 10,' +
@@ -76,7 +76,7 @@ def loadTestConfigurations = [
                         project              : 'apache-beam-testing',
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
                         publish_to_big_query : true,
-                        metrics_dataset      : 'load_test',
+                        metrics_dataset      : datasetName,
                         metrics_table        : 'python_dataflow_batch_gbk_3',
                         input_options        : '\'{"num_records": 2000,' +
                                 '"key_size": 100000,' +
@@ -98,7 +98,7 @@ def loadTestConfigurations = [
                         project              : 'apache-beam-testing',
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
                         publish_to_big_query : true,
-                        metrics_dataset      : 'load_test',
+                        metrics_dataset      : datasetName,
                         metrics_table        : 'python_dataflow_batch_gbk_4',
                         input_options        : '\'{"num_records": 5000000,' +
                                 '"key_size": 10,' +
@@ -120,7 +120,7 @@ def loadTestConfigurations = [
                         project              : 'apache-beam-testing',
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
                         publish_to_big_query : true,
-                        metrics_dataset      : 'load_test',
+                        metrics_dataset      : datasetName,
                         metrics_table        : 'python_dataflow_batch_gbk_5',
                         input_options        : '\'{"num_records": 2500000,' +
                                 '"key_size": 10,' +
@@ -132,7 +132,7 @@ def loadTestConfigurations = [
                         autoscaling_algorithm: "NONE"
                 ]
         ],
-]
+]}
 
 PhraseTriggeringPostCommitBuilder.postCommitJob(
         'beam_LoadTests_Python_GBK_Dataflow_Batch',
@@ -140,10 +140,12 @@ PhraseTriggeringPostCommitBuilder.postCommitJob(
         'Load Tests Python GBK Dataflow Batch suite',
         this
 ) {
-        loadTestsBuilder.loadTests(delegate, CommonTestProperties.SDK.PYTHON, loadTestConfigurations, CommonTestProperties.TriggeringContext.PR, "GBK", "batch")
+        def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', CommonTestProperties.TriggeringContext.PR)
+        loadTestsBuilder.loadTests(delegate, CommonTestProperties.SDK.PYTHON, loadTestConfigurations(datasetName), "GBK", "batch")
 }
 
 CronJobBuilder.cronJob('beam_LoadTests_Python_GBK_Dataflow_Batch', 'H 12 * * *', this) {
-        loadTestsBuilder.loadTests(delegate, CommonTestProperties.SDK.PYTHON, loadTestConfigurations, CommonTestProperties.TriggeringContext.POST_COMMIT, "GBK", "batch")
+        def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', CommonTestProperties.TriggeringContext.POST_COMMIT)
+        loadTestsBuilder.loadTests(delegate, CommonTestProperties.SDK.PYTHON, loadTestConfigurations(datasetName), "GBK", "batch")
 }
 

--- a/.test-infra/jenkins/job_LoadTests_Python_Smoke.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Python_Smoke.groovy
@@ -21,7 +21,7 @@ import PhraseTriggeringPostCommitBuilder
 
 def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
-def smokeTestConfigurations = [
+def smokeTestConfigurations = { datasetName -> [
         [
                 title        : 'GroupByKey Python load test Direct',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
@@ -30,7 +30,7 @@ def smokeTestConfigurations = [
                 jobProperties: [
                         publish_to_big_query: true,
                         project             : 'apache-beam-testing',
-                        metrics_dataset     : 'load_test_SMOKE',
+                        metrics_dataset     : datasetName,
                         metrics_table       : 'python_direct_gbk',
                         input_options       : '\'{"num_records": 100000,' +
                                 '"key_size": 1,' +
@@ -48,7 +48,7 @@ def smokeTestConfigurations = [
                         project             : 'apache-beam-testing',
                         temp_location       : 'gs://temp-storage-for-perf-tests/smoketests',
                         publish_to_big_query: true,
-                        metrics_dataset     : 'load_test_SMOKE',
+                        metrics_dataset     : datasetName,
                         metrics_table       : 'python_dataflow_gbk',
                         input_options       : '\'{"num_records": 100000,' +
                                 '"key_size": 1,' +
@@ -56,7 +56,7 @@ def smokeTestConfigurations = [
                         max_num_workers       : 1,
                 ]
         ],
-]
+]}
 
 // Runs a tiny version load test suite to ensure nothing is broken.
 PhraseTriggeringPostCommitBuilder.postCommitJob(
@@ -65,5 +65,6 @@ PhraseTriggeringPostCommitBuilder.postCommitJob(
         'Python Load Tests Smoke',
         this
 ) {
-    loadTestsBuilder.loadTests(delegate, CommonTestProperties.SDK.PYTHON, smokeTestConfigurations, CommonTestProperties.TriggeringContext.PR, "GBK", "smoke")
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test_SMOKE', CommonTestProperties.TriggeringContext.PR)
+    loadTestsBuilder.loadTests(delegate, CommonTestProperties.SDK.PYTHON, smokeTestConfigurations(datasetName), "GBK", "smoke")
 }


### PR DESCRIPTION
Dataset should have _PR suffix __ in case of phrase triggered load tests and no suffix in Cron tasks. It requires fix in case of Python SDK.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
