### PR TITLE
[BEAM-7547] Avoid WindmillStateCache cache hits for stale work.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContext.java
@@ -511,7 +511,8 @@ public class StreamingModeExecutionContext extends DataflowExecutionContext<Step
               stateFamily,
               stateReader,
               work.getIsNewKey(),
-              stateCache.forKey(getSerializedKey(), stateFamily, getWork().getCacheToken()),
+              stateCache.forKey(
+                  getSerializedKey(), stateFamily, getWork().getCacheToken(), getWorkToken()),
               scopedReadStateSupplier);
 
       this.systemTimerInternals =

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateCacheTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateCacheTest.java
@@ -131,26 +131,27 @@ public class WindmillStateCacheTest {
   @Before
   public void setUp() {
     cache = new WindmillStateCache();
-    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L);
     assertEquals(0, cache.getWeight());
   }
 
   @Test
   public void testBasic() throws Exception {
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 1L);
     assertNull(keyCache.get(StateNamespaces.global(), new TestStateTag("tag1")));
     assertNull(keyCache.get(windowNamespace(0), new TestStateTag("tag2")));
     assertNull(keyCache.get(triggerNamespace(0, 0), new TestStateTag("tag3")));
     assertNull(keyCache.get(triggerNamespace(0, 0), new TestStateTag("tag2")));
 
     keyCache.put(StateNamespaces.global(), new TestStateTag("tag1"), new TestState("g1"), 2);
-    assertEquals(121, cache.getWeight());
+    assertEquals(129, cache.getWeight());
     keyCache.put(windowNamespace(0), new TestStateTag("tag2"), new TestState("w2"), 2);
-    assertEquals(242, cache.getWeight());
+    assertEquals(258, cache.getWeight());
     keyCache.put(triggerNamespace(0, 0), new TestStateTag("tag3"), new TestState("t3"), 2);
-    assertEquals(260, cache.getWeight());
+    assertEquals(276, cache.getWeight());
     keyCache.put(triggerNamespace(0, 0), new TestStateTag("tag2"), new TestState("t2"), 2);
-    assertEquals(278, cache.getWeight());
+    assertEquals(294, cache.getWeight());
 
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 2L);
     assertEquals(
         new TestState("g1"), keyCache.get(StateNamespaces.global(), new TestStateTag("tag1")));
     assertEquals(new TestState("w2"), keyCache.get(windowNamespace(0), new TestStateTag("tag2")));
@@ -163,14 +164,17 @@ public class WindmillStateCacheTest {
   /** Verifies that values are cached in the appropriate namespaces. */
   @Test
   public void testInvalidation() throws Exception {
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 1L);
     assertNull(keyCache.get(StateNamespaces.global(), new TestStateTag("tag1")));
     keyCache.put(StateNamespaces.global(), new TestStateTag("tag1"), new TestState("g1"), 2);
-    assertEquals(121, cache.getWeight());
+
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 2L);
+    assertEquals(129, cache.getWeight());
     assertEquals(
         new TestState("g1"), keyCache.get(StateNamespaces.global(), new TestStateTag("tag1")));
 
-    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 1L);
-    assertEquals(121, cache.getWeight());
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 1L, 3L);
+    assertEquals(129, cache.getWeight());
     assertNull(keyCache.get(StateNamespaces.global(), new TestStateTag("tag1")));
     assertEquals(0, cache.getWeight());
   }
@@ -178,45 +182,102 @@ public class WindmillStateCacheTest {
   /** Verifies that the cache is invalidated when the cache token changes. */
   @Test
   public void testEviction() throws Exception {
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 1L);
     keyCache.put(windowNamespace(0), new TestStateTag("tag2"), new TestState("w2"), 2);
-    assertEquals(121, cache.getWeight());
+    assertEquals(129, cache.getWeight());
     keyCache.put(triggerNamespace(0, 0), new TestStateTag("tag3"), new TestState("t3"), 2000000000);
     assertEquals(0, cache.getWeight());
     // Eviction is atomic across the whole window.
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 2L);
     assertNull(keyCache.get(windowNamespace(0), new TestStateTag("tag2")));
     assertNull(keyCache.get(triggerNamespace(0, 0), new TestStateTag("tag3")));
+  }
+
+  /** Verifies that the cache does not vend for stale work tokens. */
+  @Test
+  public void testStaleWorkItem() throws Exception {
+    TestStateTag tag = new TestStateTag("tag2");
+
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 2L);
+    keyCache.put(windowNamespace(0), tag, new TestState("w2"), 2);
+    assertEquals(129, cache.getWeight());
+    // Same cache.
+    assertNull(keyCache.get(windowNamespace(0), tag));
+
+    // Previous work token.
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 1L);
+    assertNull(keyCache.get(windowNamespace(0), tag));
+
+    // Retry of work token that inserted.
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 2L);
+    assertNull(keyCache.get(windowNamespace(0), tag));
+
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 10L);
+    assertEquals(new TestState("w2"), keyCache.get(windowNamespace(0), tag));
+    keyCache.put(windowNamespace(0), tag, new TestState("w3"), 2);
+
+    // Ensure that second put updated work token.
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 5L);
+    assertNull(keyCache.get(windowNamespace(0), tag));
+
+    keyCache = cache.forComputation(COMPUTATION).forKey(KEY, STATE_FAMILY, 0L, 15L);
+    assertEquals(new TestState("w3"), keyCache.get(windowNamespace(0), tag));
   }
 
   /** Verifies that caches are kept independently per-key. */
   @Test
   public void testMultipleKeys() throws Exception {
-    WindmillStateCache.ForKey keyCache1 =
-        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L);
-    WindmillStateCache.ForKey keyCache2 =
-        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key2"), STATE_FAMILY, 0L);
-    WindmillStateCache.ForKey keyCache3 =
-        cache.forComputation("comp2").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L);
+    TestStateTag tag = new TestStateTag("tag1");
 
-    keyCache1.put(StateNamespaces.global(), new TestStateTag("tag1"), new TestState("g1"), 2);
-    assertEquals(
-        new TestState("g1"), keyCache1.get(StateNamespaces.global(), new TestStateTag("tag1")));
-    assertNull(keyCache2.get(StateNamespaces.global(), new TestStateTag("tag1")));
-    assertNull(keyCache3.get(StateNamespaces.global(), new TestStateTag("tag1")));
+    WindmillStateCache.ForKey keyCache1 =
+        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 0L);
+    WindmillStateCache.ForKey keyCache2 =
+        cache
+            .forComputation("comp1")
+            .forKey(ByteString.copyFromUtf8("key2"), STATE_FAMILY, 0L, 10L);
+    WindmillStateCache.ForKey keyCache3 =
+        cache.forComputation("comp2").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 0L);
+
+    TestState state1 = new TestState("g1");
+    keyCache1.put(StateNamespaces.global(), tag, state1, 2);
+    assertNull(keyCache1.get(StateNamespaces.global(), tag));
+    keyCache1 =
+        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 1L);
+    assertEquals(state1, keyCache1.get(StateNamespaces.global(), tag));
+    assertNull(keyCache2.get(StateNamespaces.global(), tag));
+    assertNull(keyCache3.get(StateNamespaces.global(), tag));
+
+    TestState state2 = new TestState("g2");
+    keyCache2.put(StateNamespaces.global(), tag, state2, 2);
+    assertNull(keyCache2.get(StateNamespaces.global(), tag));
+    keyCache2 =
+        cache
+            .forComputation("comp1")
+            .forKey(ByteString.copyFromUtf8("key2"), STATE_FAMILY, 0L, 20L);
+    assertEquals(state2, keyCache2.get(StateNamespaces.global(), tag));
+    assertEquals(state1, keyCache1.get(StateNamespaces.global(), tag));
+    assertNull(keyCache3.get(StateNamespaces.global(), tag));
   }
 
   /** Verifies explicit invalidation does indeed invalidate the correct entries. */
   @Test
   public void testExplicitInvalidation() throws Exception {
     WindmillStateCache.ForKey keyCache1 =
-        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L);
+        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 0L);
     WindmillStateCache.ForKey keyCache2 =
-        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key2"), STATE_FAMILY, 0L);
+        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key2"), STATE_FAMILY, 0L, 0L);
     WindmillStateCache.ForKey keyCache3 =
-        cache.forComputation("comp2").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L);
+        cache.forComputation("comp2").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 0L);
 
     keyCache1.put(StateNamespaces.global(), new TestStateTag("tag1"), new TestState("g1"), 1);
     keyCache2.put(StateNamespaces.global(), new TestStateTag("tag2"), new TestState("g2"), 2);
     keyCache3.put(StateNamespaces.global(), new TestStateTag("tag3"), new TestState("g3"), 3);
+    keyCache1 =
+        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 1L);
+    keyCache2 =
+        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key2"), STATE_FAMILY, 0L, 1L);
+    keyCache3 =
+        cache.forComputation("comp2").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 1L);
     assertEquals(
         new TestState("g1"), keyCache1.get(StateNamespaces.global(), new TestStateTag("tag1")));
     assertEquals(
@@ -256,10 +317,13 @@ public class WindmillStateCacheTest {
   @Test
   public void testBadCoderEquality() throws Exception {
     WindmillStateCache.ForKey keyCache1 =
-        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L);
+        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 0L);
 
     StateTag<TestState> tag = new TestStateTagWithBadEquality("tag1");
     keyCache1.put(StateNamespaces.global(), tag, new TestState("g1"), 1);
+
+    keyCache1 =
+        cache.forComputation("comp1").forKey(ByteString.copyFromUtf8("key1"), STATE_FAMILY, 0L, 1L);
     assertEquals(new TestState("g1"), keyCache1.get(StateNamespaces.global(), tag));
     assertEquals(
         new TestState("g1"),


### PR DESCRIPTION
Add the work id to the cache and use the sequencing of work ids to
prevent reading a cached value for stale work items.  This prevents
viewing cached state that is inconsistent with the work.  Reads of
persistent state to the Dataflow backend will fail with invalid work
token for stale work.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
