### PR TITLE
[BEAM-6877] Fix trivial_inference for Python 3.x

### DIFF
--- a/sdks/python/apache_beam/examples/streaming_wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount_it_test.py
@@ -40,7 +40,7 @@ INPUT_SUB = 'wc_subscription_input'
 OUTPUT_SUB = 'wc_subscription_output'
 
 DEFAULT_INPUT_NUMBERS = 500
-WAIT_UNTIL_FINISH_DURATION = 3 * 60 * 1000   # in milliseconds
+WAIT_UNTIL_FINISH_DURATION = 6 * 60 * 1000   # in milliseconds
 
 
 class StreamingWordCountIT(unittest.TestCase):

--- a/sdks/python/apache_beam/typehints/trivial_inference.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference.py
@@ -27,6 +27,7 @@ import dis
 import inspect
 import pprint
 import sys
+import traceback
 import types
 from builtins import object
 from builtins import zip
@@ -141,11 +142,20 @@ class FrameState(object):
   def const_type(self, i):
     return Const(self.co.co_consts[i])
 
+  def get_closure(self, i):
+    num_cellvars = len(self.co.co_cellvars)
+    if i < num_cellvars:
+      return self.vars[i]
+    else:
+      return self.f.__closure__[i - num_cellvars].cell_contents
+
   def closure_type(self, i):
-    ncellvars = len(self.co.co_cellvars)
-    if i < ncellvars:
-      return Any
-    return Const(self.f.__closure__[i - ncellvars].cell_contents)
+    """Returns a TypeConstraint or Const."""
+    val = self.get_closure(i)
+    if isinstance(val, typehints.TypeConstraint):
+      return val
+    else:
+      return Const(val)
 
   def get_global(self, i):
     name = self.get_name(i)
@@ -190,6 +200,20 @@ def union(a, b):
   elif type(a) == type(b) and element_type(b) == typehints.Union[()]:
     return a
   return typehints.Union[a, b]
+
+
+def finalize_hints(type_hint):
+  """Sets type hint for empty data structures to Any."""
+  def visitor(tc, unused_arg):
+    if isinstance(tc, typehints.DictConstraint):
+      empty_union = typehints.Union[()]
+      if tc.key_type == empty_union:
+        tc.key_type = Any
+      if tc.value_type == empty_union:
+        tc.value_type = Any
+
+  if isinstance(type_hint, typehints.TypeConstraint):
+    type_hint.visit(visitor, None)
 
 
 def element_type(hint):
@@ -244,6 +268,7 @@ def infer_return_type(c, input_types, debug=False, depth=5):
   """Analyses a callable to deduce its return type.
 
   Args:
+
     c: A Python callable to infer the return type of.
     input_types: A sequence of inputs corresponding to the input types.
     debug: Whether to print verbose debugging information.
@@ -277,6 +302,8 @@ def infer_return_type(c, input_types, debug=False, depth=5):
     else:
       return Any
   except TypeInferenceError:
+    if debug:
+      traceback.print_exc()
     return Any
   except Exception:
     if debug:
@@ -305,6 +332,7 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
   if debug:
     print()
     print(f, id(f), input_types)
+    dis.dis(f)
   from . import opcodes
   simple_ops = dict((k.upper(), v) for k, v in opcodes.__dict__.items())
 
@@ -312,7 +340,7 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
   code = co.co_code
   end = len(code)
   pc = 0
-  extended_arg = 0
+  extended_arg = 0  # Python 2 only.
   free = None
 
   yields = set()
@@ -324,28 +352,44 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
   states = collections.defaultdict(lambda: None)
   jumps = collections.defaultdict(int)
 
+  # In Python 3, use dis library functions to disassemble bytecode and handle
+  # EXTENDED_ARGs.
+  is_py3 = sys.version_info[0] == 3
+  if is_py3:
+    ofs_table = {}  # offset -> instruction
+    for instruction in dis.get_instructions(f):
+      ofs_table[instruction.offset] = instruction
+
+  # Python 2 - 3.5: 1 byte opcode + optional 2 byte arg (1 or 3 bytes).
+  # Python 3.6+: 1 byte opcode + 1 byte arg (2 bytes, arg may be ignored).
+  if sys.version_info[0] == 3 and sys.version_info[1] >= 6:
+    inst_size = 2
+    opt_arg_size = 0
+  else:
+    inst_size = 1
+    opt_arg_size = 2
+
   last_pc = -1
   while pc < end:
     start = pc
-    if sys.version_info[0] == 2:
-      op = ord(code[pc])
+    if is_py3:
+      instruction = ofs_table[pc]
+      op = instruction.opcode
     else:
-      op = code[pc]
+      op = ord(code[pc])
     if debug:
       print('-->' if pc == last_pc else '    ', end=' ')
       print(repr(pc).rjust(4), end=' ')
       print(dis.opname[op].ljust(20), end=' ')
 
-    pc += 1
+    pc += inst_size
     if op >= dis.HAVE_ARGUMENT:
-      if sys.version_info[0] == 2:
-        arg = ord(code[pc]) + ord(code[pc + 1]) * 256 + extended_arg
-      elif sys.version_info[0] == 3 and sys.version_info[1] < 6:
-        arg = code[pc] + code[pc + 1] * 256 + extended_arg
+      if is_py3:
+        arg = instruction.arg
       else:
-        pass # TODO(luke-zhu): Python 3.6 bytecode to wordcode changes
+        arg = ord(code[pc]) + ord(code[pc + 1]) * 256 + extended_arg
       extended_arg = 0
-      pc += 2
+      pc += opt_arg_size
       if op == dis.EXTENDED_ARG:
         extended_arg = arg * 65536
       if debug:
@@ -365,7 +409,7 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
             free = co.co_cellvars + co.co_freevars
           print('(' + free[arg] + ')', end=' ')
 
-    # Acutally emulate the op.
+    # Actually emulate the op.
     if state is None and states[start] is None:
       # No control reaches here (yet).
       if debug:
@@ -375,7 +419,9 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
 
     opname = dis.opname[op]
     jmp = jmp_state = None
-    if opname.startswith('CALL_FUNCTION'):
+    if opname.startswith('CALL_FUNCTION') and (
+        (sys.version_info[0] == 3 and sys.version_info[1] < 6) or
+        sys.version_info[0] == 2):
       # Each keyword takes up two arguments on the stack (name and value).
       standard_args = (arg & 0xFF) + 2 * (arg >> 8)
       var_args = 'VAR' in opname
@@ -398,19 +444,40 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
       else:
         return_type = Any
       state.stack[-pop_count:] = [return_type]
-    elif (opname == 'BINARY_SUBSCR'
-          and isinstance(state.stack[1], Const)
-          and isinstance(state.stack[0], typehints.IndexableTypeConstraint)):
-      if debug:
-        print("Executing special case binary subscript")
-      idx = state.stack.pop()
-      src = state.stack.pop()
-      try:
-        state.stack.append(src._constraint_for_index(idx.value))
-      except Exception as e:
-        if debug:
-          print("Exception {0} during special case indexing".format(e))
-        state.stack.append(Any)
+    elif opname.startswith('CALL_FUNCTION'):  # Python 3.6+
+      if opname == 'CALL_FUNCTION':
+        pop_count = arg + 1
+        if depth <= 0:
+          return_type = Any
+        else:
+          return_type = infer_return_type(state.stack[-pop_count].value,
+                                          state.stack[1 - pop_count:],
+                                          debug=debug,
+                                          depth=depth - 1)
+      elif opname == 'CALL_FUNCTION_KW':
+        # TODO(udim): Handle keyword arguments. Requires passing them by name to
+        #   infer_return_type.
+        pop_count = arg + 2
+        return_type = Any
+      elif opname == 'CALL_FUNCTION_EX':
+        # TODO(udim): Handle variable argument lists. Requires handling kwargs
+        #   first.
+        pop_count = (arg & 1) + 3
+        return_type = Any
+      else:
+        raise TypeInferenceError('unable to handle %s' % opname)
+      state.stack[-pop_count:] = [return_type]
+    elif opname == 'CALL_METHOD':
+      pop_count = 1 + arg
+      # LOAD_METHOD will return a non-Const (Any) if loading from an Any.
+      if isinstance(state.stack[-pop_count], Const) and depth > 0:
+        return_type = infer_return_type(state.stack[-pop_count].value,
+                                        state.stack[1 - pop_count:],
+                                        debug=debug,
+                                        depth=depth - 1)
+      else:
+        return_type = typehints.Any
+      state.stack[-pop_count:] = [return_type]
     elif opname in simple_ops:
       if debug:
         print("Executing simple op " + opname)
@@ -445,7 +512,7 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
       raise TypeInferenceError('unable to handle %s' % opname)
 
     if jmp is not None:
-      # TODO(robertwb): Is this guerenteed to converge?
+      # TODO(robertwb): Is this guaranteed to converge?
       new_state = states[jmp] | jmp_state
       if jmp < pc and new_state != states[jmp] and jumps[pc] < 5:
         jumps[pc] += 1
@@ -461,6 +528,7 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
     result = typehints.Iterable[reduce(union, Const.unwrap_all(yields))]
   else:
     result = reduce(union, Const.unwrap_all(returns))
+  finalize_hints(result)
 
   if debug:
     print(f, id(f), input_types, '->', result)

--- a/sdks/python/apache_beam/typehints/trivial_inference_test.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference_test.py
@@ -118,7 +118,7 @@ class TrivialInferenceTest(unittest.TestCase):
         typehints.List[typehints.Union[int, float]],
         lambda xs: [x for x in xs],
         [typehints.Tuple[int, float]])
-    if sys.version_info[0] == 3 and sys.version_info[1] == 5:
+    if sys.version_info[:2] == (3, 5):
       # A better result requires implementing the MAKE_CLOSURE opcode.
       expected = typehints.Any
     else:
@@ -204,7 +204,7 @@ class TrivialInferenceTest(unittest.TestCase):
 
   def testDictComprehension(self):
     fields = []
-    if sys.version_info[0] == 3 and sys.version_info[1] >= 6:
+    if sys.version_info >= (3, 6):
       expected_type = typehints.Dict[typehints.Any, typehints.Any]
     else:
       # For Python 2, just ensure it doesn't crash.
@@ -234,6 +234,7 @@ class TrivialInferenceTest(unittest.TestCase):
 
     self.assertReturnType(typehints.Any, lambda: A.m(A(), 3.0), depth=0)
     self.assertReturnType(float, lambda: A.m(A(), 3.0), depth=1)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/typehints/trivial_inference_test.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference_test.py
@@ -19,7 +19,6 @@
 
 from __future__ import absolute_import
 
-import os
 import sys
 import unittest
 
@@ -29,14 +28,12 @@ from apache_beam.typehints import typehints
 global_int = 1
 
 
-@unittest.skipIf(sys.version_info >= (3, 6, 0) and
-                 os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                 'This test still needs to be fixed on Python 3.6. '
-                 'See BEAM-6877')
 class TrivialInferenceTest(unittest.TestCase):
 
-  def assertReturnType(self, expected, f, inputs=()):
-    self.assertEqual(expected, trivial_inference.infer_return_type(f, inputs))
+  def assertReturnType(self, expected, f, inputs=(), depth=5):
+    self.assertEqual(
+        expected,
+        trivial_inference.infer_return_type(f, inputs, debug=True, depth=depth))
 
   def testIdentity(self):
     self.assertReturnType(int, lambda x: x, [int])
@@ -112,10 +109,6 @@ class TrivialInferenceTest(unittest.TestCase):
         lambda xs: [x for x in xs],
         [typehints.Tuple[int, ...]])
 
-  @unittest.skipIf(sys.version_info[0] == 3 and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3. '
-                   'See BEAM-6877')
   def testTupleListComprehension(self):
     self.assertReturnType(
         typehints.List[int],
@@ -125,9 +118,13 @@ class TrivialInferenceTest(unittest.TestCase):
         typehints.List[typehints.Union[int, float]],
         lambda xs: [x for x in xs],
         [typehints.Tuple[int, float]])
-    # TODO(luke-zhu): This test fails in Python 3
+    if sys.version_info[0] == 3 and sys.version_info[1] == 5:
+      # A better result requires implementing the MAKE_CLOSURE opcode.
+      expected = typehints.Any
+    else:
+      expected = typehints.List[typehints.Tuple[str, int]]
     self.assertReturnType(
-        typehints.List[typehints.Tuple[str, int]],
+        expected,
         lambda kvs: [(kvs[0], v) for v in kvs[1]],
         [typehints.Tuple[str, typehints.Iterable[int]]])
     self.assertReturnType(
@@ -206,12 +203,37 @@ class TrivialInferenceTest(unittest.TestCase):
         typehints.Dict[typehints.Any, typehints.Any], lambda: {})
 
   def testDictComprehension(self):
-    # Just ensure it doesn't crash.
     fields = []
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 6:
+      expected_type = typehints.Dict[typehints.Any, typehints.Any]
+    else:
+      # For Python 2, just ensure it doesn't crash.
+      expected_type = typehints.Any
     self.assertReturnType(
-        typehints.Any,
+        expected_type,
         lambda row: {f: row[f] for f in fields}, [typehints.Any])
 
+  def testDictComprehensionSimple(self):
+    self.assertReturnType(
+        typehints.Dict[str, int],
+        lambda _list: {'a': 1 for _ in _list}, [])
+
+  def testDepthFunction(self):
+    def f(i):
+      return i
+    self.assertReturnType(typehints.Any, lambda i: f(i), [int], depth=0)
+    self.assertReturnType(int, lambda i: f(i), [int], depth=1)
+
+  def testDepthMethod(self):
+    class A(object):
+      def m(self, x):
+        return x
+
+    self.assertReturnType(typehints.Any, lambda: A().m(3), depth=0)
+    self.assertReturnType(int, lambda: A().m(3), depth=1)
+
+    self.assertReturnType(typehints.Any, lambda: A.m(A(), 3.0), depth=0)
+    self.assertReturnType(float, lambda: A.m(A(), 3.0), depth=1)
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -525,6 +525,7 @@ class UnionHint(CompositeTypeHint):
 
     # Flatten nested Union's and duplicated repeated type hints.
     params = set()
+    dict_union = None
     for t in type_params:
       validate_composite_type_param(
           t, error_msg_prefix='All parameters to a Union hint'
@@ -532,8 +533,17 @@ class UnionHint(CompositeTypeHint):
 
       if isinstance(t, self.UnionConstraint):
         params |= t.union_types
+      elif isinstance(t, DictConstraint):
+        if dict_union is None:
+          dict_union = t
+        else:
+          dict_union.key_type = Union[dict_union.key_type, t.key_type]
+          dict_union.value_type = Union[dict_union.value_type, t.value_type]
       else:
         params.add(t)
+
+    if dict_union is not None:
+      params.add(dict_union)
 
     if Any in params:
       return Any

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -228,6 +228,17 @@ class UnionHintTestCase(TypeHintTestCase):
                      "instead.",
                      e.exception.args[0])
 
+  def test_dict_union(self):
+    hint = Union[typehints.Dict[Any, int],
+                 typehints.Dict[Union[()], Union[()]]]
+    self.assertEqual(typehints.Dict[Any, int], hint)
+
+  def test_empty_union(self):
+    self.assertEqual(typehints.Union[()],
+                     typehints.Union[typehints.Union[()], typehints.Union[()]])
+    self.assertEqual(int,
+                     typehints.Union[typehints.Union[()], int])
+
 
 class OptionalHintTestCase(TypeHintTestCase):
 


### PR DESCRIPTION
- Use `dis.get_instructions` in Python 3. This serves as a convenience (handling EXTENDED_ARG for instance), and is an extra sanity check for `pc` values.

- Added and expanded opcodes:
map_add, build_map, load_method, load_closure, make_function, call_function (call_function_{kw,ex} not supported)

- `Union`s now combine `Dict`s: 
`Union[Dict[k1,v1], Dict[k2, v2], ... ]`
becomes: 
`Union[Dict[Union[k1, k2, ...], Union[v1, v2, ...]]]`

- Empty Unions (`Union[]`) are placeholders for lack of type information. At the end of inference they are finalized (if remaining) to `Any`.
For example: at the end of inference a `Dict[Union[], Union[]]` (no type information for key and value) will be finalized into `Dict[Any, Any]`.

- Enabled debug printouts in tests. This should only appear in test logs in case of an error.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
