### PR TITLE
Add a PCollectionCache ABC and several file-based implementations

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/caching/__init__.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/__init__.py
@@ -16,4 +16,6 @@
 #
 from __future__ import absolute_import
 
+from apache_beam.runners.interactive.caching.pcollection_cache import PCollectionCache
+from apache_beam.runners.interactive.caching.file_based_cache import FileBasedCache
 from apache_beam.runners.interactive.caching.streaming_cache import StreamingCache

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -1,0 +1,309 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import urllib
+
+from apache_beam import coders
+from apache_beam.io import textio
+from apache_beam.io import tfrecordio
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.runners.interactive.caching import PCollectionCache
+from apache_beam.testing import datatype_inference
+from apache_beam.transforms import PTransform
+
+try:
+  from weakref import finalize
+except ImportError:
+  from backports.weakref import finalize
+
+try:  # Python 3
+  unquote_to_bytes = urllib.parse.unquote_to_bytes
+  quote = urllib.parse.quote
+except AttributeError:  # Python 2
+  # pylint: disable=deprecated-urllib-function
+  unquote_to_bytes = urllib.unquote
+  quote = urllib.quote
+
+__all__ = [
+    "FileBasedCache",
+    "TextBasedCache",
+    "TFRecordBasedCache",
+    "SafeFastPrimitivesCoder",
+]
+
+
+class FileBasedCache(PCollectionCache):
+
+  def __init__(self, location, mode="error", persist=False, **writer_kwargs):
+    """Initialize a PCollectionCache object.
+
+    Args:
+      location (str): A string indicating the location where the cache should
+          be stored. Typically, this includes the folder and the filename
+          prefix for files that will be created.
+      mode (str): Controls the behavior when one or more files matching location
+          already exit. If "error", an IOError will be raised. If "overwrite",
+          the existing files will be removed.
+      persist (bool): A flag indicating whether the underlying data should be
+          destroyed when the cache instance goes out of scope.
+      writer_kwargs (Dict[str, Any]): A dictionary of key-value pairs
+          to be passed to the underlying writer objects.
+
+    Raises:
+      ~exceptions.ValueError: If the specified mode is not supported.
+      ~exceptions.IOError: If one or more files matching `location` already
+          exist and mode == "error".
+    """
+    self.location = location
+    self.element_type = None
+    self.default_coder = writer_kwargs.pop("coder", None)
+    self._writer_kwargs = writer_kwargs
+    self._num_writes = 0
+    self._persist = persist
+    self._finalizer = self._configure_finalizer(persist)
+
+    # TODO(ostrokach): Implement append mode.
+    if mode not in ['error', 'overwrite']:
+      raise ValueError("'mode' must be set to one of: ['error', 'overwrite'].")
+    exitsting_files = list(glob_files(self.file_pattern))
+    if mode == "error" and exitsting_files:
+      raise IOError("The following cache files already exist: {}.".format(
+          exitsting_files))
+    if mode == "overwrite":
+      self.truncate()
+
+    root, _ = FileSystems.split(self._file_path_prefix)
+    try:
+      FileSystems.mkdirs(root)
+    except IOError:
+      pass
+    # It is possible to read from am empty stream, so it should also be possible
+    # to read from an empty file.
+    FileSystems.create(self._file_path_prefix + ".empty").close()
+
+  @property
+  def persist(self):
+    return self._persist
+
+  @persist.setter
+  def persist(self, persist):
+    if self._persist == persist:
+      return
+    self._persist = persist
+    if self._finalizer:
+      self._finalizer.detach()
+    self._finalizer = self._configure_finalizer(persist)
+
+  @property
+  def timestamp(self):
+    timestamp = 0
+    for path in glob_files(self.file_pattern):
+      timestamp = max(timestamp, FileSystems.last_updated(path))
+    return timestamp
+
+  def reader(self, **kwargs):
+    """Returns a reader ``PTransform`` to be used for reading the contents of
+    the cache into a Beam Pipeline.
+
+    Args:
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying reader
+          class.
+    """
+    reader_kwargs = self._reader_kwargs.copy()
+    reader_kwargs.update(kwargs)
+    reader = self._reader_class(self.file_pattern, **reader_kwargs)
+    # Keep a reference to the parent object so that cache does not get garbage
+    # collected while the pipeline is running.
+    reader._cache = self
+    return reader
+
+  def writer(self):
+    """Returns a writer object to be used for writing the contents of a
+    PCollection from a Beam Pipeline into the cache.
+    """
+    self._num_writes += 1
+    writer_kwargs = self._writer_kwargs.copy()
+
+    if self.element_type is None:
+      writer = PatchedWriter(self, self._writer_class,
+                             (self._file_path_prefix,), writer_kwargs)
+      return writer
+
+    if ("coder" in self._reader_passthrough_arguments and
+        "coder" not in writer_kwargs):
+      writer_kwargs["coder"] = (
+          self.default_coder if self.default_coder is not None else
+          coders.registry.get_coder(self.element_type))
+    writer = self._writer_class(self._file_path_prefix, **writer_kwargs)
+    # Keep a reference to the parent object so that cache does not get garbage
+    # collected while the pipeline is running.
+    writer._cache = self
+    return writer
+
+  def read(self, **kwargs):
+    """Returns an iterator over the contents of the cache.
+
+    Args:
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying reader
+          class.
+
+    Returns:
+      An iterator over the elements in the cache.
+    """
+    reader_kwargs = self._reader_kwargs.copy()
+    reader_kwargs.update(kwargs)
+    source = self.reader(**reader_kwargs)._source
+    range_tracker = source.get_range_tracker(None, None)
+    for element in source.read(range_tracker):
+      yield element
+
+  def write(self, elements):
+    """Writes a collection of elements into the cache.
+
+    Args:
+      elements (Iterable[Any]): A collection of elements to be written to cache.
+    """
+    self._num_writes += 1
+    if self.element_type is None:
+      # TODO(ostrokach): We might want to infer the element type from the first
+      # N elements, rather than reading the entire iterator.
+      elements = list(elements)
+      self.element_type = datatype_inference.infer_element_type(elements)
+    sink = self.writer()._sink
+    handle = sink.open(self._file_path_prefix)
+    try:
+      for element in elements:
+        sink.write_record(handle, element)
+    finally:
+      sink.close(handle)
+
+  def truncate(self):
+    """Removes all contents from the cache."""
+    FileSystems.delete(list(glob_files(self.file_pattern)))
+    FileSystems.create(self._file_path_prefix + ".empty").close()
+    self.element_type = None
+
+  def remove(self):
+    """Deletes the cache, including all underlying data.
+
+    The cache should not be used after this method is called.
+    """
+    self._finalizer()
+
+  @property
+  def removed(self):
+    return not self._finalizer.alive
+
+  def __del__(self):
+    self.remove()
+
+  @property
+  def file_pattern(self):
+    return self.location + '**'
+
+  @property
+  def _reader_kwargs(self):
+    reader_kwargs = {
+        k: v for k, v in self._writer_kwargs.items()
+        if k in self._reader_passthrough_arguments
+    }
+    if ("coder" in self._reader_passthrough_arguments and
+        "coder" not in reader_kwargs):
+      if self.default_coder is not None:
+        reader_kwargs["coder"] = self.default_coder
+      elif self.element_type is None:
+        reader_kwargs["coder"] = None
+      else:
+        reader_kwargs["coder"] = coders.registry.get_coder(self.element_type)
+    return reader_kwargs
+
+  @property
+  def _file_path_prefix(self):
+    return self.location + "-{:03d}".format(self._num_writes)
+
+  def _configure_finalizer(self, persist):
+    if persist:
+      return finalize(self, lambda: None)
+    else:
+      return finalize(
+          self, lambda pattern: FileSystems.delete(list(glob_files(pattern))),
+          self.file_pattern)
+
+
+class TextBasedCache(FileBasedCache):
+  """A ``PCollectionCache`` object which uses a text-based file format to store
+  the underlying data.
+  """
+  _reader_class = textio.ReadFromText
+  _writer_class = textio.WriteToText
+  _reader_passthrough_arguments = {"coder", "compression_type"}
+
+  def __init__(self, location, **writer_kwargs):
+    writer_kwargs["coder"] = SafeFastPrimitivesCoder()
+    super(TextBasedCache, self).__init__(location, **writer_kwargs)
+
+
+class TFRecordBasedCache(FileBasedCache):
+  """A ``PCollectionCache`` object which uses the TFRecord file format to store
+  the underlying data.
+  """
+
+  _reader_class = tfrecordio.ReadFromTFRecord
+  _writer_class = tfrecordio.WriteToTFRecord
+  _reader_passthrough_arguments = {"coder", "compression_type"}
+
+
+class PatchedWriter(PTransform):
+  """A wrapper over a write ``PTransform`` which sets the element_type of the
+  parent cache when the writer is expanded into a pipeline.
+  """
+
+  def __init__(self, cache, writer_class, writer_args, writer_kwargs):
+    self._cache = cache
+    self._writer_class = writer_class
+    self._writer_args = writer_args
+    self._writer_kwargs = writer_kwargs
+
+  def expand(self, pcoll):
+    if self._cache.element_type is None:
+      self._cache.element_type = pcoll.element_type
+    writer_kwargs = self._writer_kwargs.copy()
+    if "coder" in self._cache._reader_passthrough_arguments:
+      writer_kwargs["coder"] = (
+          self._cache.default_coder if self._cache.default_coder is not None
+          else coders.registry.get_coder(self._cache.element_type))
+    writer = self._writer_class(*self._writer_args, **writer_kwargs)
+    return pcoll | writer
+
+
+class SafeFastPrimitivesCoder(coders.Coder):
+  """This class add an quote/unquote step to escape special characters."""
+
+  def encode(self, value):
+    return quote(
+        coders.coders.FastPrimitivesCoder().encode(value)).encode('utf-8')
+
+  def decode(self, value):
+    return coders.coders.FastPrimitivesCoder().decode(unquote_to_bytes(value))
+
+
+def glob_files(pattern):
+  match = FileSystems.match([pattern])
+  assert len(match) == 1
+  for metadata in match[0].metadata_list:
+    yield metadata.path

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -87,6 +87,7 @@ class FileBasedCache(PCollectionCache):
     self._num_writes = 0
     self._persist = persist
     self._finalizer = self._configure_finalizer(persist)
+    self._timestamp = 0
 
     exitsting_files = list(glob_files(self.file_pattern))
     if exitsting_files:
@@ -119,10 +120,9 @@ class FileBasedCache(PCollectionCache):
 
   @property
   def timestamp(self):
-    timestamp = 0
     for path in glob_files(self.file_pattern):
-      timestamp = max(timestamp, FileSystems.last_updated(path))
-    return timestamp
+      self._timestamp = max(self._timestamp, FileSystems.last_updated(path))
+    return self._timestamp
 
   def reader(self, **kwargs):
     """Returns a reader ``PTransform`` to be used for reading the contents of

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -248,7 +248,12 @@ class FileBasedCache(PCollectionCache):
     return not self._finalizer.alive
 
   def __del__(self):
-    self.delete()
+    try:
+      self.delete()
+    except AttributeError:
+      # Sometimes the destructor can be called before the finalizer is
+      # configured.
+      pass
 
   @property
   def file_pattern(self):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -51,11 +51,11 @@ __all__ = [
 
 class FileBasedCache(PCollectionCache):
 
-  def __init__(self, location, mode="error", persist=False, **writer_kwargs):
+  def __init__(self, cache_spec, mode="error", persist=False, **writer_kwargs):
     """Initialize a PCollectionCache object.
 
     Args:
-      location (str): A string indicating the location where the cache should
+      cache_spec (str): A string indicating the location where the cache should
           be stored. Typically, this includes the folder and the filename
           prefix for files that will be created.
       mode (str): Controls the behavior when one or more files matching location
@@ -71,7 +71,7 @@ class FileBasedCache(PCollectionCache):
       ~exceptions.IOError: If one or more files matching `location` already
           exist and mode == "error".
     """
-    self.location = location
+    self.cache_spec = cache_spec
     self.element_type = None
     self.default_coder = writer_kwargs.pop("coder", None)
     self._writer_kwargs = writer_kwargs
@@ -216,7 +216,7 @@ class FileBasedCache(PCollectionCache):
 
   @property
   def file_pattern(self):
-    return self.location + '**'
+    return self.cache_spec + '**'
 
   @property
   def _reader_kwargs(self):
@@ -236,7 +236,7 @@ class FileBasedCache(PCollectionCache):
 
   @property
   def _file_path_prefix(self):
-    return self.location + "-{:03d}".format(self._num_writes)
+    return self.cache_spec + "-{:03d}".format(self._num_writes)
 
   def _configure_finalizer(self, persist):
     if persist:
@@ -255,9 +255,9 @@ class TextBasedCache(FileBasedCache):
   _writer_class = textio.WriteToText
   _reader_passthrough_arguments = {"coder", "compression_type"}
 
-  def __init__(self, location, **writer_kwargs):
+  def __init__(self, cache_spec, **writer_kwargs):
     writer_kwargs["coder"] = SafeFastPrimitivesCoder()
-    super(TextBasedCache, self).__init__(location, **writer_kwargs)
+    super(TextBasedCache, self).__init__(cache_spec, **writer_kwargs)
 
 
 class TFRecordBasedCache(FileBasedCache):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -146,8 +146,7 @@ class FileBasedCache(PCollectionCache):
                              (self._file_path_prefix,), writer_kwargs)
       return writer
 
-    if ("coder" in self._reader_passthrough_arguments and
-        "coder" not in writer_kwargs):
+    if "coder" in self._reader_passthrough_arguments:
       writer_kwargs["coder"] = (
           self.default_coder if self.default_coder is not None else
           coders.registry.get_coder(self.element_type))

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -100,8 +100,8 @@ class FileBasedCache(PCollectionCache):
       FileSystems.mkdirs(root)
     except IOError:
       pass
-    # It is possible to read from am empty stream, so it should also be possible
-    # to read from an empty file.
+    # Prevent the reader PTransforms from raising an IOError when reading from
+    # an empty PCollectionCache.
     FileSystems.create(self._file_path_prefix + ".empty").close()
 
   @property

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -187,7 +187,7 @@ class FileBasedCache(PCollectionCache):
     """
     self._num_writes += 1
     if self.element_type is None:
-      # TODO(ostrokach): We might want to infer the element type from the first
+      # TODO(BEAM-8734): We might want to infer the element type from the first
       # N elements, rather than reading the entire iterator.
       elements = list(elements)
       self.element_type = datatype_inference.infer_element_type(elements)

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -200,7 +200,7 @@ class FileBasedCache(PCollectionCache):
     FileSystems.create(self._file_path_prefix + ".empty").close()
     self.element_type = None
 
-  def remove(self):
+  def delete(self):
     """Deletes the cache, including all underlying data.
 
     The cache should not be used after this method is called.
@@ -208,11 +208,11 @@ class FileBasedCache(PCollectionCache):
     self._finalizer()
 
   @property
-  def removed(self):
+  def deleted(self):
     return not self._finalizer.alive
 
   def __del__(self):
-    self.remove()
+    self.delete()
 
   @property
   def file_pattern(self):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """This module defines several file-based implementations of a PCollectionCache.
 
 This module is experimental. No backwards-compatibility guarantees.
@@ -38,7 +37,6 @@ try:
 except ImportError:
   # weakref.finalize is not available in Python 2
   finalize = None
-
 
 try:  # Python 3
   unquote_to_bytes = urllib.parse.unquote_to_bytes
@@ -85,7 +83,7 @@ class FileBasedCache(PCollectionCache):
           `reader_class` and `writer_class` PTransforms take `coder` as an
           argument.
       coder (bool): The coder to pass the underlying `reader_class` and
-          `writer_class` PTransforms in cases where `requires_coder` is 
+          `writer_class` PTransforms in cases where `requires_coder` is
           ``True``. If coder is set to ``False``, it will be inferred from
           the data that is written to cache.
 

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""This module defines several file-based implementations of a PCollectionCache.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
 from __future__ import absolute_import
 
 import urllib

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -29,7 +29,9 @@ from apache_beam.transforms import PTransform
 try:
   from weakref import finalize
 except ImportError:
-  from backports.weakref import finalize
+  # weakref.finalize is not available in Python 2
+  finalize = None
+
 
 try:  # Python 3
   unquote_to_bytes = urllib.parse.unquote_to_bytes

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import logging
+import pickle
+import sys
+import tempfile
+import unittest
+
+import dill
+import numpy as np
+from parameterized import parameterized
+
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.runners.interactive.caching import file_based_cache
+from apache_beam.runners.interactive.caching import file_based_cache_test
+from apache_beam.testing.extra_assertions import ExtraAssertionsMixin
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+
+
+class Validators(unittest.TestCase, ExtraAssertionsMixin):
+
+  def validate_directly(self, cache, expected):
+    actual = list(cache.read())
+    self.assertUnhashableCountEqual(actual, expected)
+
+  def validate_through_pipeline(self, cache, expected):
+
+    def equal_to_expected(actual):
+      self.assertUnhashableCountEqual(actual, expected)
+
+    p = TestPipeline()
+    pcoll = p | "Read" >> cache.reader()
+    assert_that(pcoll, equal_to_expected)
+    p.run()
+
+  if sys.version_info < (3,):
+
+    def runTest(self):
+      pass
+
+
+DATAFRAME_TEST_DATA = [
+    [],
+    [{}],
+    [{}, {}, {}],
+    [{"col1": "abc", "col2": "def"}, {"col1": "hello"}],
+    [{"col1": "abc", "col2": "def"}, {"col1": "hello", "col2": "good bye"}],
+    [{"col1": b"abc", "col2": "def"}, {"col1": b"hello", "col2": "good bye"}],
+    [{"col1": u"abc", "col2": u"±♠Ω"}, {"col1": u"hello", "col2": u"Ωℑ"}],
+    [{"x": 123, "y": 5.55}, {"x": 555, "y": 6.63}],
+    [{"x": 123, "y": 5.55}, {"x": 555, "y": 6.63}],
+    [{"x": np.array([1, 2])}, {"x": np.array([3, 4, 5])}],
+]
+
+
+class TestCase(ExtraAssertionsMixin, unittest.TestCase):
+  pass
+
+
+# #############################################################################
+# Serialization
+# #############################################################################
+
+
+class SerializationTestBase(object):
+
+  # Attributes to be set by child classes.
+  cache_class = None
+  location = None
+
+  def get_writer_kwargs(self, data=None):
+    return {}
+
+  test_data = [{"a": 11, "b": "XXX"}, {"a": 20, "b": "YYY"}]
+
+  def check_serialize_deserialize_empty(self, write_fn, read_fn, serializer):
+    cache = self.cache_class(self.location,
+                             **self.get_writer_kwargs(self.test_data))
+    cache_out = serializer.loads(serializer.dumps(cache))
+    write_fn(cache_out, self.test_data)
+    data_out = list(read_fn(cache_out, limit=len(self.test_data)))
+    self.assertEqual(data_out, self.test_data)
+
+  def check_serialize_deserialize_filled(self, write_fn, read_fn, serializer):
+    cache = self.cache_class(self.location,
+                             **self.get_writer_kwargs(self.test_data))
+    write_fn(cache, self.test_data)
+    cache_out = serializer.loads(serializer.dumps(cache))
+    data_out = list(read_fn(cache_out, limit=len(self.test_data)))
+    self.assertEqual(data_out, self.test_data)
+
+
+class FileSerializationTestBase(SerializationTestBase):
+
+  # Attributes to be set by child classes.
+  cache_class = None
+
+  def setUp(self):
+    self._temp_dir = tempfile.mkdtemp()
+    self.location = FileSystems.join(self._temp_dir, self.cache_class.__name__)
+
+  def tearDown(self):
+    FileSystems.delete([self._temp_dir])
+
+  @parameterized.expand([("pickle", pickle), ("dill", dill)])
+  def test_serialize_deserialize_empty(self, _, serializer):
+    self.check_serialize_deserialize_empty(file_based_cache_test.write_directly,
+                                           file_based_cache_test.read_directly,
+                                           serializer)
+
+  @parameterized.expand([("pickle", pickle), ("dill", dill)])
+  def test_serialize_deserialize_filled(self, _, serializer):
+    self.check_serialize_deserialize_filled(
+        file_based_cache_test.write_directly,
+        file_based_cache_test.read_directly, serializer)
+
+
+class TextBasedCacheSerializationTest(FileSerializationTestBase, TestCase):
+
+  cache_class = file_based_cache.TextBasedCache
+
+
+class TFRecordBasedCacheSerializationTest(FileSerializationTestBase, TestCase):
+
+  cache_class = file_based_cache.TFRecordBasedCache
+
+
+# #############################################################################
+# Roundtrip
+# #############################################################################
+
+
+class RoundtripTestBase(object):
+
+  # Attributes to be set by child classes.
+  cache_class = None
+  location = None
+
+  def get_writer_kwargs(self, data=None):
+    return {}
+
+  def check_roundtrip(self, write_fn, validate_fn, dataset):
+    """Make sure that data can be correctly written using the write_fn function
+    and read using the validate_fn function.
+    """
+    cache = self.cache_class(self.location, **self.get_writer_kwargs(None))
+    for data in dataset:
+      cache._writer_kwargs.update(self.get_writer_kwargs(data))
+      write_fn(cache, data)
+      validate_fn(cache, data)
+      write_fn(cache, data)
+      validate_fn(cache, data * 2)
+      cache.truncate()
+      validate_fn(cache, [])
+    cache.remove()
+
+
+class FileRoundtripTestBase(RoundtripTestBase):
+
+  # Attributes to be set by child classes.
+  cache_class = None
+  dataset = None
+
+  def get_writer_kwargs(self, data=None):
+    return {}
+
+  def setUp(self):
+    self._temp_dir = tempfile.mkdtemp()
+    self.location = FileSystems.join(self._temp_dir, self.cache_class.__name__)
+
+  def tearDown(self):
+    FileSystems.delete([self._temp_dir])
+
+  @parameterized.expand([
+      ("{}-{}".format(write_fn.__name__,
+                      validate_fn.__name__), write_fn, validate_fn)
+      for write_fn in [
+          file_based_cache_test.write_directly,
+          file_based_cache_test.write_through_pipeline
+      ] for validate_fn in
+      [Validators().validate_directly,
+       Validators().validate_through_pipeline]
+  ])
+  def test_roundtrip(self, _, write_fn, validate_fn):
+    return self.check_roundtrip(write_fn, validate_fn, dataset=self.dataset)
+
+
+class TextBasedCacheRoundtripTest(FileRoundtripTestBase, TestCase):
+
+  cache_class = file_based_cache.TextBasedCache
+  dataset = file_based_cache_test.GENERIC_TEST_DATA
+
+
+class TFRecordBasedCacheRoundtripTest(FileRoundtripTestBase, TestCase):
+
+  cache_class = file_based_cache.TFRecordBasedCache
+  dataset = file_based_cache_test.GENERIC_TEST_DATA
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -15,6 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""This module includes integration tests for file-based implementations of a
+PCollectionCache.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
 from __future__ import absolute_import
 
 import logging

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """This module includes integration tests for file-based implementations of a
 PCollectionCache.
 

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -174,7 +174,7 @@ class RoundtripTestBase(object):
       validate_fn(cache, data * 2)
       cache.truncate()
       validate_fn(cache, [])
-    cache.remove()
+    cache.delete()
 
 
 class FileRoundtripTestBase(RoundtripTestBase):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -133,11 +133,15 @@ class FileSerializationTestBase(SerializationTestBase):
         file_based_cache_test.read_directly, serializer)
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class TextBasedCacheSerializationTest(FileSerializationTestBase, TestCase):
 
   cache_class = file_based_cache.TextBasedCache
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class TFRecordBasedCacheSerializationTest(FileSerializationTestBase, TestCase):
 
   cache_class = file_based_cache.TFRecordBasedCache
@@ -203,12 +207,16 @@ class FileRoundtripTestBase(RoundtripTestBase):
     return self.check_roundtrip(write_fn, validate_fn, dataset=self.dataset)
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class TextBasedCacheRoundtripTest(FileRoundtripTestBase, TestCase):
 
   cache_class = file_based_cache.TextBasedCache
   dataset = file_based_cache_test.GENERIC_TEST_DATA
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class TFRecordBasedCacheRoundtripTest(FileRoundtripTestBase, TestCase):
 
   cache_class = file_based_cache.TFRecordBasedCache

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -172,16 +172,15 @@ class RoundtripTestBase(object):
     """Make sure that data can be correctly written using the write_fn function
     and read using the validate_fn function.
     """
-    cache = self.cache_class(self.location, **self.get_writer_kwargs(None))
     for data in dataset:
-      cache._writer_kwargs.update(self.get_writer_kwargs(data))
+      cache = self.cache_class(self.location, **self.get_writer_kwargs(None))
       write_fn(cache, data)
       validate_fn(cache, data)
       write_fn(cache, data)
       validate_fn(cache, data * 2)
       cache.truncate()
       validate_fn(cache, [])
-    cache.delete()
+      cache.delete()
 
 
 class FileRoundtripTestBase(RoundtripTestBase):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import gc
+import itertools
+import logging
+import tempfile
+import time
+import unittest
+import uuid
+
+import mock
+import numpy as np
+
+from apache_beam import coders
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.pipeline import Pipeline
+from apache_beam.pvalue import PCollection
+from apache_beam.runners.interactive.caching import file_based_cache
+from apache_beam.testing import datatype_inference
+
+GENERIC_TEST_DATA = [
+    [],
+    [None],
+    [None, None, None],
+    ["ABC", "DeF"],
+    [u"ABC", u"±♠Ωℑ"],
+    [b"abc123", b"aAaAa"],
+    [1.5],
+    [100, -123.456, 78.9],
+    ["ABC", 1.2, 100, 0, -10, None, b"abc123"],
+    [()],
+    [("a", "b", "c")],
+    [("a", 1, 1.2), ("b", 2, 5.5)],
+    [("a", 1, 1.2), (2.5, "c", None)],
+    [{}],
+    [{"col1": "a", "col2": 1, "col3": 1.5}],
+    [{"col1": "a", "col2": 1, "col3": 1.5},
+     {"col1": "b", "col2": 2, "col3": 4.5}],
+    [{"col1": "a", "col2": 1, "col3": u"±♠Ω"}, {4: 1, 5: 3.4, (6, 7): "a"}],
+    [("a", "b", "c"), ["d", 1], {"col1": 1, 202: 1.234}, None, "abc", b"def",
+     100, (1, 2, 3, "b")],
+    [np.zeros((3, 6)), np.ones((10, 22))],
+]
+
+GENERIC_ELEMENT_TYPES = {
+    datatype_inference.infer_element_type(data) for data in GENERIC_TEST_DATA
+}
+
+
+def read_directly(cache, limit=None, timeout=None):
+  return list(itertools.islice(cache.read(), limit))
+
+
+def write_directly(cache, data_in, timeout=None):
+  """Write elements to cache using the cache API."""
+  cache.write(data_in)
+
+
+def write_through_pipeline(cache, data_in, timeout=None):
+  """Write elements to cache using a Beam pipeline."""
+  import apache_beam as beam
+
+  with beam.Pipeline() as p:
+    _ = (p | "Create" >> beam.Create(data_in) | "Write" >> cache.writer())
+
+
+class FileBasedCacheTest(unittest.TestCase):
+
+  def cache_class(self, location, *args, **kwargs):
+
+    class MockedFileBasedCache(file_based_cache.FileBasedCache):
+
+      _reader_class = mock.MagicMock()
+      _writer_class = mock.MagicMock()
+      _reader_passthrough_arguments = {}
+      requires_coder = False
+
+    return MockedFileBasedCache(location, *args, **kwargs)
+
+  def setUp(self):
+    self.temp_dir = tempfile.mkdtemp()
+    self.location = FileSystems.join(self.temp_dir, self.cache_class.__name__)
+
+  def tearDown(self):
+    FileSystems.delete([self.temp_dir])
+
+  def create_dummy_file(self, location):
+    """Create a dummy file with `location` as the filepath prefix."""
+    filename = location + "-" + uuid.uuid4().hex
+    while FileSystems.exists(filename):
+      filename = location + "-" + uuid.uuid4().hex
+    with open(filename, "wb") as fout:
+      fout.write(b"dummy data")
+    return filename
+
+  def test_init(self):
+    # cache needs to be kept so that resources are not gc-ed immediately.
+    cache = self.cache_class(self.location)  # pylint: disable=unused-variable
+
+    with self.assertRaises(ValueError):
+      _ = self.cache_class(self.location, mode=None)
+
+    with self.assertRaises(ValueError):
+      _ = self.cache_class(self.location, mode="be happy")
+
+  def test_overwrite_cache_0(self):
+    # cache needs to be kept so that resources are not gc-ed immediately.
+    cache = self.cache_class(self.location)  # pylint: disable=unused-variable
+    # Refuse to create a cache with the same data storage location
+    with self.assertRaises(IOError):
+      _ = self.cache_class(self.location)
+
+  def test_overwrite_cache_1(self):
+    # cache needs to be kept so that resources are not gc-ed immediately.
+    cache = self.cache_class(self.location)  # pylint: disable=unused-variable
+    # Refuse to create a cache with the same data storage location
+    _ = self.create_dummy_file(self.location)
+    with self.assertRaises(IOError):
+      _ = self.cache_class(self.location)
+
+  def test_overwrite_cache_2(self):
+    # cache needs to be kept so that resources are not gc-ed immediately.
+    cache = self.cache_class(self.location)  # pylint: disable=unused-variable
+    # OK to overwrite cache when in "overwrite" mode
+    _ = self.cache_class(self.location, mode="overwrite")
+
+  def test_overwrite_cache_3(self):
+    cache = self.cache_class(self.location)
+    # OK to overwrite cleared cache
+    cache.remove()
+    _ = self.cache_class(self.location)
+
+  def test_persist_false_0(self):
+    cache = self.cache_class(self.location, persist=False)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    cache.remove()
+    files = self._glob_files(self.location + "**")
+    self.assertEqual(len(files), 0)
+
+  def test_persist_false_1(self):
+    cache = self.cache_class(self.location, persist=False)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    del cache
+    gc.collect()
+    files = self._glob_files(self.location + "**")
+    self.assertEqual(len(files), 0)
+
+  def test_persist_setter_false(self):
+    cache = self.cache_class(self.location, persist=True)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    cache.persist = False
+    del cache
+    gc.collect()
+    files = self._glob_files(self.location + "**")
+    self.assertEqual(len(files), 0)
+
+  def test_persist_true_0(self):
+    cache = self.cache_class(self.location, persist=True)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    cache.remove()
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+
+  def test_persist_true_1(self):
+    cache = self.cache_class(self.location, persist=True)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    del cache
+    gc.collect()
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+
+  def test_persist_setter_true(self):
+    cache = self.cache_class(self.location, persist=False)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    cache.persist = True
+    del cache
+    gc.collect()
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+
+  def _glob_files(self, pattern):
+    files = [
+        metadata.path for match in FileSystems.match([self.location + "**"])
+        for metadata in match.metadata_list
+    ]
+    return files
+
+  def test_timestamp(self):
+    # Seems to always pass when delay=0.01 but set higher to prevent flakiness
+    cache = self.cache_class(self.location)
+    timestamp0 = cache.timestamp
+    time.sleep(0.1)
+    _ = self.create_dummy_file(self.location)
+    timestamp1 = cache.timestamp
+    self.assertGreater(timestamp1, timestamp0)
+
+  def test_writer_arguments(self):
+    kwargs = {"a": 10, "b": "hello"}
+    cache = self.cache_class(self.location, **kwargs)
+    cache._reader_passthrough_arguments = set()
+    cache.writer().expand(DummyPColl(element_type=None))
+    _, kwargs_out = list(cache._writer_class.call_args)
+    self.assertEqual(kwargs_out, kwargs)
+
+  def test_reader_arguments(self):
+
+    def check_reader_passthrough_kwargs(kwargs, passthrough):
+      cache = self.cache_class(self.location, mode="overwrite", **kwargs)
+      cache._reader_passthrough_arguments = passthrough
+      cache.reader()
+      _, kwargs_out = list(cache._reader_class.call_args)
+      self.assertEqual(kwargs_out, {k: kwargs[k] for k in passthrough})
+
+    check_reader_passthrough_kwargs({"a": 10, "b": "hello world"}, {})
+    check_reader_passthrough_kwargs({"a": 10, "b": "hello world"}, {"b"})
+
+  def test_infer_element_type_with_write(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache.element_type, None)
+    for data in GENERIC_TEST_DATA:
+      element_type = datatype_inference.infer_element_type(data)
+      cache.truncate()
+      self.assertEqual(cache.element_type, None)
+      cache.write(data)
+      self.assertEqual(cache.element_type, element_type)
+
+  def test_infer_element_type_with_writer(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache.element_type, None)
+    for data in GENERIC_TEST_DATA:
+      element_type = datatype_inference.infer_element_type(data)
+      cache.truncate()
+      self.assertEqual(cache.element_type, None)
+      cache.writer().expand(DummyPColl(element_type=element_type))
+      self.assertEqual(cache.element_type, element_type)
+
+  def test_default_coder(self):
+    cache = self.cache_class(
+        self.location, coder=file_based_cache.SafeFastPrimitivesCoder)
+    cache._reader_passthrough_arguments = {"coder"}
+    for element_type in GENERIC_ELEMENT_TYPES:
+      cache.truncate()
+      cache.element_type = element_type
+      cache.writer().expand(PCollection(Pipeline(), element_type=None))
+      _, kwargs_out = list(cache._writer_class.call_args)
+      self.assertEqual(
+          kwargs_out.get("coder"), file_based_cache.SafeFastPrimitivesCoder)
+
+  def test_inferred_coder(self):
+    cache = self.cache_class(self.location)
+    cache._reader_passthrough_arguments = {"coder"}
+    for element_type in GENERIC_ELEMENT_TYPES:
+      cache.truncate()
+      cache.element_type = element_type
+      cache.writer().expand(PCollection(Pipeline(), element_type=None))
+      _, kwargs_out = list(cache._writer_class.call_args)
+      self.assertEqual(
+          kwargs_out.get("coder"), coders.registry.get_coder(element_type))
+
+  def test_writer(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache._writer_class.call_count, 0)
+    cache.writer().expand(DummyPColl(element_type=None))
+    self.assertEqual(cache._writer_class.call_count, 1)
+    cache.writer().expand(DummyPColl(element_type=None))
+    self.assertEqual(cache._writer_class.call_count, 2)
+
+  def test_reader(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache._reader_class.call_count, 0)
+    cache.reader()
+    self.assertEqual(cache._reader_class.call_count, 1)
+    cache.reader()
+    self.assertEqual(cache._reader_class.call_count, 2)
+
+  def test_write(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache._writer_class()._sink.open.call_count, 0)
+    self.assertEqual(cache._writer_class()._sink.write_record.call_count, 0)
+    self.assertEqual(cache._writer_class()._sink.close.call_count, 0)
+
+    cache.write((i for i in range(11)))
+    self.assertEqual(cache._writer_class()._sink.open.call_count, 1)
+    self.assertEqual(cache._writer_class()._sink.write_record.call_count, 11)
+    self.assertEqual(cache._writer_class()._sink.close.call_count, 1)
+
+    cache.write((i for i in range(5)))
+    self.assertEqual(cache._writer_class()._sink.open.call_count, 2)
+    self.assertEqual(cache._writer_class()._sink.write_record.call_count, 16)
+    self.assertEqual(cache._writer_class()._sink.close.call_count, 2)
+
+    class DummyError(Exception):
+      pass
+
+    cache._writer_class()._sink.write_record.side_effect = DummyError
+    with self.assertRaises(DummyError):
+      cache.write((i for i in range(5)))
+    self.assertEqual(cache._writer_class()._sink.open.call_count, 3)
+    self.assertEqual(cache._writer_class()._sink.write_record.call_count, 17)
+    self.assertEqual(cache._writer_class()._sink.close.call_count, 3)
+
+  def test_read(self):
+    cache = self.cache_class(self.location)
+    _ = self.create_dummy_file(self.location)
+    self.assertEqual(cache._reader_class()._source.read.call_count, 0)
+    cache.read()
+    # ._read does not get called unless we get items from iterator
+    self.assertEqual(cache._reader_class()._source.read.call_count, 0)
+    list(cache.read())
+    self.assertEqual(cache._reader_class()._source.read.call_count, 1)
+    list(cache.read())
+    self.assertEqual(cache._reader_class()._source.read.call_count, 2)
+
+  def test_truncate(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 1)
+    _ = self.create_dummy_file(self.location)
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 2)
+    cache.truncate()
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 1)
+
+  def test_clear_data(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 1)
+    _ = self.create_dummy_file(self.location)
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 2)
+    cache.remove()
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 0)
+
+
+class DummyPColl(object):
+
+  def __init__(self, element_type):
+    self.element_type = element_type
+
+  def __or__(self, unused_other):
+    return self
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -147,7 +147,7 @@ class FileBasedCacheTest(unittest.TestCase):
   def test_overwrite_cache_3(self):
     cache = self.cache_class(self.location)
     # OK to overwrite cleared cache
-    cache.remove()
+    cache.delete()
     _ = self.cache_class(self.location)
 
   def test_persist_false_0(self):
@@ -155,7 +155,7 @@ class FileBasedCacheTest(unittest.TestCase):
     _ = self.create_dummy_file(self.location)
     files = self._glob_files(self.location + "**")
     self.assertGreater(len(files), 0)
-    cache.remove()
+    cache.delete()
     files = self._glob_files(self.location + "**")
     self.assertEqual(len(files), 0)
 
@@ -185,7 +185,7 @@ class FileBasedCacheTest(unittest.TestCase):
     _ = self.create_dummy_file(self.location)
     files = self._glob_files(self.location + "**")
     self.assertGreater(len(files), 0)
-    cache.remove()
+    cache.delete()
     files = self._glob_files(self.location + "**")
     self.assertGreater(len(files), 0)
 
@@ -361,7 +361,7 @@ class FileBasedCacheTest(unittest.TestCase):
     _ = self.create_dummy_file(self.location)
     self.assertEqual(
         len(list(file_based_cache.glob_files(cache.file_pattern))), 2)
-    cache.remove()
+    cache.delete()
     self.assertEqual(
         len(list(file_based_cache.glob_files(cache.file_pattern))), 0)
 

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -226,6 +226,10 @@ class FileBasedCacheTest(unittest.TestCase):
     _ = self.create_dummy_file(self.location)
     timestamp1 = cache.timestamp
     self.assertGreater(timestamp1, timestamp0)
+    cache.truncate()
+    time.sleep(0.1)
+    timestamp2 = cache.timestamp
+    self.assertGreaterEqual(timestamp2, timestamp0)
 
   def test_writer_arguments(self):
     kwargs = {"a": 10, "b": "hello"}

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 import gc
 import itertools
 import logging
+import sys
 import tempfile
 import time
 import unittest
@@ -81,6 +82,8 @@ def write_through_pipeline(cache, data_in, timeout=None):
     _ = (p | "Create" >> beam.Create(data_in) | "Write" >> cache.writer())
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class FileBasedCacheTest(unittest.TestCase):
 
   def cache_class(self, location, *args, **kwargs):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -15,6 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""This module includes unit tests for file-based implementations of a
+PCollectionCache.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
 from __future__ import absolute_import
 
 import gc

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """This module includes unit tests for file-based implementations of a
 PCollectionCache.
 

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -124,12 +124,6 @@ class FileBasedCacheTest(unittest.TestCase):
     # cache needs to be kept so that resources are not gc-ed immediately.
     cache = self.cache_class(self.location)  # pylint: disable=unused-variable
 
-    with self.assertRaises(ValueError):
-      _ = self.cache_class(self.location, mode=None)
-
-    with self.assertRaises(ValueError):
-      _ = self.cache_class(self.location, mode="be happy")
-
   def test_overwrite_cache_0(self):
     # cache needs to be kept so that resources are not gc-ed immediately.
     cache = self.cache_class(self.location)  # pylint: disable=unused-variable
@@ -148,8 +142,8 @@ class FileBasedCacheTest(unittest.TestCase):
   def test_overwrite_cache_2(self):
     # cache needs to be kept so that resources are not gc-ed immediately.
     cache = self.cache_class(self.location)  # pylint: disable=unused-variable
-    # OK to overwrite cache when in "overwrite" mode
-    _ = self.cache_class(self.location, mode="overwrite")
+    # OK to overwrite cache when `overwrite=True`
+    _ = self.cache_class(self.location, overwrite=True)
 
   def test_overwrite_cache_3(self):
     cache = self.cache_class(self.location)
@@ -244,7 +238,7 @@ class FileBasedCacheTest(unittest.TestCase):
   def test_reader_arguments(self):
 
     def check_reader_passthrough_kwargs(kwargs, passthrough):
-      cache = self.cache_class(self.location, mode="overwrite", **kwargs)
+      cache = self.cache_class(self.location, overwrite=True, **kwargs)
       cache._reader_passthrough_arguments = passthrough
       cache.reader()
       _, kwargs_out = list(cache._reader_class.call_args)

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -1,0 +1,105 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import abc
+
+from future.utils import with_metaclass
+
+
+class PCollectionCache(with_metaclass(abc.ABCMeta)):
+
+  @abc.abstractmethod
+  def __init__(self, location, **writer_kwargs):
+    """Initialize PCollectionCache.
+
+    Args:
+      location (str): Location where the cache data should be stored.
+      **writer_kwargs: Arguments to pass to the underlying writer class.
+    """
+    raise NotImplementedError
+
+  @property
+  @abc.abstractmethod
+  def persist(self):
+    """Whether to persist the underlying data when the object goes out of scope.
+
+    Returns:
+      bool: ``True`` if the unerlying data will be persisted once the object
+          goes out of scope, ``False`` otherwise.
+    """
+    raise NotImplementedError
+
+  @property
+  @abc.abstractmethod
+  def timestamp(self):
+    """Return a timestamp indicating the last time this instance was modified.
+
+    Returns:
+      float: A non-negative number indicating the last time the cache was
+          modified. Caches that were modified more recently should return
+          a larger number.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def reader(self, **reader_kwargs):
+    """Return a reader PTransform which can read a PCollection from cache.
+
+    Args:
+      **reader_kwargs: Arguments to pass to the underlying reader class.
+
+    Returns:
+      A source from which we can read a PCollection.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def writer(self):
+    """Return a writer PTransform which can write a PCollection to cache.
+
+    Returns:
+      A sink to which we can write a PCollection.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def read(self, limit=None, **reader_kwargs):
+    """Return a list of elements inside the cache.
+
+    Args:
+      limit: Maximum number of elements that should be returned.
+      **reader_kwargs: Arguments to pass to the underlying reader class.
+
+    Returns:
+      List[Any]: A list of elements in the PCollections.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def write(self):
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def truncate(self):
+    """Delete PCollection data from the underlying persistence layer."""
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def remove(self):
+    """Delete all data and metadata from the cache."""
+    raise NotImplementedError

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -31,7 +31,7 @@ from future.utils import with_metaclass
 class PCollectionCache(with_metaclass(abc.ABCMeta)):
 
   @abc.abstractmethod
-  def __init__(self, cache_spec, overwrite, persist, **writer_kwargs):
+  def __init__(self, cache_spec, overwrite, persist, **kwargs):
     """Initialize PCollectionCache.
 
     Args:
@@ -41,7 +41,8 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
           instead.
       persist (bool): A flag indicating whether the underlying data should be
           destroyed when the cache instance goes out of scope.
-      **writer_kwargs: Arguments to pass to the underlying writer class.
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying writer
+          and reader PTransforms.
     """
     raise NotImplementedError
 
@@ -73,7 +74,8 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     """Return a reader PTransform which can read a PCollection from cache.
 
     Args:
-      **reader_kwargs: Arguments to pass to the underlying reader class.
+      reader_kwargs (Dict[str, Any]): Arguments to be passed to the
+          underlying reader PTransform.
 
     Returns:
       A PTransform which reads a PCollection from cache.
@@ -81,8 +83,12 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def writer(self):
+  def writer(self, **writer_kwargs):
     """Return a writer PTransform which can write a PCollection to cache.
+
+    Args:
+      writer_kwargs (Dict[str, Any]): Arguments to be passed to the
+          underlying writer PTransform.
 
     Returns:
       A PTransform which writes a PCollection to cache.
@@ -90,12 +96,12 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def read(self, limit=None, **reader_kwargs):
+  def read(self, **reader_kwargs):
     """Return a list of elements inside the cache.
 
     Args:
-      limit: Maximum number of elements that should be returned.
-      **reader_kwargs: Arguments to pass to the underlying reader class.
+      reader_kwargs (Dict[str, Any]): Arguments to be passed to the
+          underlying reader PTransform.
 
     Returns:
       List[Any]: A list of elements in the PCollections.
@@ -103,7 +109,14 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def write(self):
+  def write(self, elements, **writer_kwargs):
+    """Writes a collection of elements into the cache.
+
+    Args:
+      elements (Iterable[Any]): A collection of elements to be written to cache.
+      writer_kwargs (Dict[str, Any]): Arguments to be passed to the
+          underlying writer PTransform.
+    """
     raise NotImplementedError
 
   @abc.abstractmethod

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """A PCollectionCache abstract base class defines an interface for reading and
 writing bounded and unbounded PCollections.
 

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""A PCollectionCache abstract base class defines an interface for reading and
+writing bounded and unbounded PCollections.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
 from __future__ import absolute_import
 
 import abc

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -24,11 +24,11 @@ from future.utils import with_metaclass
 class PCollectionCache(with_metaclass(abc.ABCMeta)):
 
   @abc.abstractmethod
-  def __init__(self, location, **writer_kwargs):
+  def __init__(self, cache_spec, **writer_kwargs):
     """Initialize PCollectionCache.
 
     Args:
-      location (str): Location where the cache data should be stored.
+      cache_spec (str): Location where the cache data should be stored.
       **writer_kwargs: Arguments to pass to the underlying writer class.
     """
     raise NotImplementedError

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -100,6 +100,6 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def remove(self):
+  def delete(self):
     """Delete all data and metadata from the cache."""
     raise NotImplementedError

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -71,7 +71,7 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
       **reader_kwargs: Arguments to pass to the underlying reader class.
 
     Returns:
-      A source from which we can read a PCollection.
+      A PTransform which reads a PCollection from cache.
     """
     raise NotImplementedError
 
@@ -80,7 +80,7 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     """Return a writer PTransform which can write a PCollection to cache.
 
     Returns:
-      A sink to which we can write a PCollection.
+      A PTransform which writes a PCollection to cache.
     """
     raise NotImplementedError
 

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -31,11 +31,16 @@ from future.utils import with_metaclass
 class PCollectionCache(with_metaclass(abc.ABCMeta)):
 
   @abc.abstractmethod
-  def __init__(self, cache_spec, **writer_kwargs):
+  def __init__(self, cache_spec, overwrite, persist, **writer_kwargs):
     """Initialize PCollectionCache.
 
     Args:
       cache_spec (str): Location where the cache data should be stored.
+      overwrite (bool): If ``True``, raise an IOError if data matching
+          `cache_spec` already exist. If ``False``, remove existing data
+          instead.
+      persist (bool): A flag indicating whether the underlying data should be
+          destroyed when the cache instance goes out of scope.
       **writer_kwargs: Arguments to pass to the underlying writer class.
     """
     raise NotImplementedError

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -137,7 +137,6 @@ else:
 REQUIRED_PACKAGES = [
     'avro>=1.8.1,<2.0.0; python_version < "3.0"',
     'avro-python3>=1.8.1,<2.0.0; python_version >= "3.0"',
-    'backports.weakref>=1.0rc1,<1.1',
     'crcmod>=1.7,<2.0',
     # Dill doesn't have forwards-compatibility guarantees within minor version.
     # Pickles created with a new version of dill may not unpickle using older

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -137,6 +137,7 @@ else:
 REQUIRED_PACKAGES = [
     'avro>=1.8.1,<2.0.0; python_version < "3.0"',
     'avro-python3>=1.8.1,<2.0.0; python_version >= "3.0"',
+    'backports.weakref>=1.0rc1,<1.1',
     'crcmod>=1.7,<2.0',
     # Dill doesn't have forwards-compatibility guarantees within minor version.
     # Pickles created with a new version of dill may not unpickle using older


### PR DESCRIPTION
Currently, the Python SDK lacks a clear API for data inter-op between a Python console and a Beam pipeline. During interactive development and debugging of Beam pipelines, this type of inter-op would be tremendously useful. 

Other "big data" processing tools in the Python ecosystem already have this functionality. For example, PySpark has [`createDataFrame`](https://spark.apache.org/docs/latest/api/python/pyspark.sql.html#pyspark.sql.SparkSession.createDataFrame), which allows the creation of an RDD from a Python list or a Pandas DataFrame, and [`collect()`]() and [`toPandas()`](https://spark.apache.org/docs/latest/api/python/pyspark.sql.html#pyspark.sql.DataFrame.toPandas) methods which make it possible to transfer the data to the Python interpreter. Dask has a similar API using [`dask.compute()`](https://docs.dask.org/en/latest/api.html#dask.compute).

Although Beam has a `Create` `PTransform` which makes it possible to create a `PCollection` from a Python list. However, this has limited . Beam lacks a well-defined API for "materializing" a `PCollection` and loading it into the memory of an interactive Python session. 

The following applications of `PCollectionCache` will be implemented in subsequent PRs:

- Add a stream-based implementation (using Google Cloud Pub/Sub) of the `PCollectionCache` API [#8961].
- Update `InteractiveRunner` and `CacheManager` to use `PCollectionCache` objects for storing cache data. This will add streaming pipeline support to `InteractiveRunner` and allow for more flexibility when optimizing the the interactive user experience.

Demos: 

| Notebook | MyBinder | Colab |
| ------------- | ------------- | -------- |
| [01-demo_explicit_caching.ipynb](https://github.com/ostrokach/beam-notebooks/blob/master/notebooks/01-demo_explicit_caching.ipynb) | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ostrokach/beam-notebooks/master?filepath=notebooks%2F01-demo_explicit_caching.ipynb) | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ostrokach/beam-notebooks/blob/master/notebooks/01-demo_explicit_caching.ipynb)
| [01-demo_pipeline_segmentation.ipynb](https://github.com/ostrokach/beam-notebooks/blob/master/notebooks/01-demo_pipeline_segmentation.ipynb) | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ostrokach/beam-notebooks/master?filepath=notebooks%2F01-demo_pipeline_segmentation.ipynb) | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ostrokach/beam-notebooks/blob/master/notebooks/01-demo_pipeline_segmentation.ipynb)
| [01-demo_pipeline_cloning.ipynb](https://github.com/ostrokach/beam-notebooks/blob/master/notebooks/01-demo_pipeline_cloning.ipynb) | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ostrokach/beam-notebooks/master?filepath=notebooks%2F01-demo_pipeline_cloning.ipynb) | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ostrokach/beam-notebooks/blob/master/notebooks/01-demo_pipeline_cloning.ipynb)

CC: @ivant @ananvay  
R: @aaltay @udim 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
