### PR TITLE
[BEAM-7437] Add streaming flag to BQ streaming inserts IT test

### DIFF
--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
@@ -27,7 +27,6 @@ from hamcrest.core.base_matcher import BaseMatcher
 from apache_beam.io.gcp import bigquery_tools
 from apache_beam.testing.test_utils import compute_hash
 from apache_beam.utils import retry
-from apache_beam.utils.timestamp import MAX_TIMESTAMP
 
 __all__ = ['BigqueryMatcher', 'BigQueryTableMatcher']
 
@@ -179,15 +178,15 @@ class BigqueryFullResultStreamingMatcher(BigqueryFullResultMatcher):
   A timeout can be specified.
   """
 
-  def __init__(self, project, query, data, timeout=MAX_TIMESTAMP):
+  DEFAULT_TIMEOUT = 5*60
+
+  def __init__(self, project, query, data, timeout=DEFAULT_TIMEOUT):
     super(BigqueryFullResultStreamingMatcher, self).__init__(
         project, query, data)
     self.timeout = timeout
 
   def _get_query_result(self, bigquery_client):
     start_time = time.time()
-    if self.timeout == MAX_TIMESTAMP:
-      logging.warning('Waiting indefinitely')
     while time.time() - start_time <= self.timeout:
       response = self._query_with_retry(bigquery_client)
       if len(response) >= len(self.expected_data):

--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher.py
@@ -20,12 +20,14 @@
 from __future__ import absolute_import
 
 import logging
+import time
 
 from hamcrest.core.base_matcher import BaseMatcher
 
 from apache_beam.io.gcp import bigquery_tools
 from apache_beam.testing.test_utils import compute_hash
 from apache_beam.utils import retry
+from apache_beam.utils.timestamp import MAX_TIMESTAMP
 
 __all__ = ['BigqueryMatcher', 'BigQueryTableMatcher']
 
@@ -128,7 +130,6 @@ class BigqueryFullResultMatcher(BaseMatcher):
     if not query or not isinstance(query, str):
       raise ValueError(
           'Invalid argument: query. Please use non-empty string')
-
     self.project = project
     self.query = query
     self.expected_data = data
@@ -137,7 +138,7 @@ class BigqueryFullResultMatcher(BaseMatcher):
     logging.info('Start verify Bigquery data.')
     # Run query
     bigquery_client = bigquery.Client(project=self.project)
-    response = self._query_with_retry(bigquery_client)
+    response = self._get_query_result(bigquery_client)
     logging.info('Read from given query (%s), total rows %d',
                  self.query, len(response))
 
@@ -145,6 +146,9 @@ class BigqueryFullResultMatcher(BaseMatcher):
 
     # Verify result
     return sorted(self.expected_data) == sorted(self.actual_data)
+
+  def _get_query_result(self, bigquery_client):
+    return self._query_with_retry(bigquery_client)
 
   @retry.with_exponential_backoff(
       num_retries=MAX_RETRIES,
@@ -163,6 +167,33 @@ class BigqueryFullResultMatcher(BaseMatcher):
     mismatch_description \
       .append_text("Actual data is ") \
       .append_text(self.actual_data)
+
+
+class BigqueryFullResultStreamingMatcher(BigqueryFullResultMatcher):
+  """
+  Matcher that verifies Bigquery data with given query.
+
+  Fetch Bigquery data with given query, compare to the expected data.
+  This matcher polls BigQuery until the no. of records in BigQuery is
+  equal to the no. of records in expected data.
+  A timeout can be specified.
+  """
+
+  def __init__(self, project, query, data, timeout=MAX_TIMESTAMP):
+    super(BigqueryFullResultStreamingMatcher, self).__init__(
+        project, query, data)
+    self.timeout = timeout
+
+  def _get_query_result(self, bigquery_client):
+    start_time = time.time()
+    if self.timeout == MAX_TIMESTAMP:
+      logging.warning('Waiting indefinitely')
+    while time.time() - start_time <= self.timeout:
+      response = self._query_with_retry(bigquery_client)
+      if len(response) >= len(self.expected_data):
+        return response
+      time.sleep(1)
+    raise TimeoutError('Timeout exceeded for matcher.')
 
 
 class BigQueryTableMatcher(BaseMatcher):


### PR DESCRIPTION
I missed adding the streaming=True option to the PipelineOptions earlier. 
Since TestStream ends once watermark advances to infinity,
this test passed. 
But, after adding the streaming flag, it failed,
because the BigqueryFullResultMatcher did not poll for changes in a streaming test pipeline.

Added BigqueryFullResultStreamingMatcher to poll BigQuery before matching.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
