### PR TITLE
[BEAM-7629] Go SDK additional Validation for DoFns

### DIFF
--- a/sdks/go/pkg/beam/core/funcx/fn.go
+++ b/sdks/go/pkg/beam/core/funcx/fn.go
@@ -181,16 +181,15 @@ func (u *Fn) Inputs() (pos int, num int, exists bool) {
 	pos = -1
 	exists = false
 	for i, p := range u.Param {
-		if !exists && p.Kind == FnValue {
-			// This executes on hitting the first input, which should be a Value.
+		if !exists && (p.Kind == FnValue || p.Kind == FnIter || p.Kind == FnReIter) {
+			// This executes on hitting the first input.
 			pos = i
 			num = 1
 			exists = true
 		} else if exists && (p.Kind == FnValue || p.Kind == FnIter || p.Kind == FnReIter) {
-			// Subsequent inputs after the first, which can be Value, Iter, or ReIter.
+			// Subsequent inputs after the first.
 			num++
 		} else if exists {
-			// Breaks out when no inputs are left.
 			break
 		}
 	}
@@ -382,7 +381,6 @@ var (
 	errWindowParamPrecedence    = errors.New("may only have a single Window parameter and it must precede the EventTime and main input parameter")
 	errEventTimeParamPrecedence = errors.New("may only have a single beam.EventTime parameter and it must precede the main input parameter")
 	errReflectTypePrecedence    = errors.New("may only have a single reflect.Type parameter and it must precede the main input parameter")
-	errSideInputPrecedence      = errors.New("side input parameters must follow main input parameter")
 	errInputPrecedence          = errors.New("inputs parameters must precede emit function parameters")
 )
 
@@ -455,10 +453,8 @@ func nextParamState(cur paramState, transition FnParamKind) (paramState, error) 
 		return -1, errEventTimeParamPrecedence
 	case FnType:
 		return -1, errReflectTypePrecedence
-	case FnValue:
+	case FnIter, FnReIter, FnValue:
 		return psInput, nil
-	case FnIter, FnReIter:
-		return -1, errSideInputPrecedence
 	case FnEmit:
 		return psOutput, nil
 	default:

--- a/sdks/go/pkg/beam/core/funcx/fn_test.go
+++ b/sdks/go/pkg/beam/core/funcx/fn_test.go
@@ -224,6 +224,157 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestEmits(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Params []FnParamKind
+		Pos    int
+		Num    int
+		Exists bool
+	}{
+		{
+			Name:   "no params",
+			Params: []FnParamKind{},
+			Pos:    -1,
+			Num:    0,
+			Exists: false,
+		},
+		{
+			Name:   "no emits",
+			Params: []FnParamKind{FnContext, FnEventTime, FnType, FnValue},
+			Pos:    -1,
+			Num:    0,
+			Exists: false,
+		},
+		{
+			Name:   "single emit",
+			Params: []FnParamKind{FnValue, FnEmit},
+			Pos:    1,
+			Num:    1,
+			Exists: true,
+		},
+		{
+			Name:   "multiple emits",
+			Params: []FnParamKind{FnValue, FnEmit, FnEmit, FnEmit},
+			Pos:    1,
+			Num:    3,
+			Exists: true,
+		},
+		{
+			Name:   "multiple emits 2",
+			Params: []FnParamKind{FnValue, FnEmit, FnEmit, FnEmit, FnValue},
+			Pos:    1,
+			Num:    3,
+			Exists: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			// Create a Fn with a filled params list.
+			params := make([]FnParam, len(test.Params))
+			for i, kind := range test.Params {
+				params[i].Kind = kind
+				params[i].T = nil
+			}
+			fn := new(Fn)
+			fn.Param = params
+
+			// Validate we get expected results for Emits function.
+			pos, num, exists := fn.Emits()
+			if exists != test.Exists {
+				t.Errorf("Emits() exists: got %v, want %v", exists, test.Exists)
+			}
+			if num != test.Num {
+				t.Errorf("Emits() num: got %v, want %v", num, test.Num)
+			}
+			if pos != test.Pos {
+				t.Errorf("Emits() pos: got %v, want %v", pos, test.Pos)
+			}
+		})
+	}
+}
+
+func TestInputs(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Params []FnParamKind
+		Pos    int
+		Num    int
+		Exists bool
+	}{
+		{
+			Name:   "no params",
+			Params: []FnParamKind{},
+			Pos:    -1,
+			Num:    0,
+			Exists: false,
+		},
+		{
+			Name:   "no inputs",
+			Params: []FnParamKind{FnContext, FnEventTime, FnType, FnEmit},
+			Pos:    -1,
+			Num:    0,
+			Exists: false,
+		},
+		{
+			Name:   "no main input",
+			Params: []FnParamKind{FnContext, FnIter, FnReIter, FnEmit},
+			Pos:    -1,
+			Num:    0,
+			Exists: false,
+		},
+		{
+			Name:   "single input",
+			Params: []FnParamKind{FnContext, FnValue},
+			Pos:    1,
+			Num:    1,
+			Exists: true,
+		},
+		{
+			Name:   "multiple inputs",
+			Params: []FnParamKind{FnContext, FnValue, FnIter, FnReIter},
+			Pos:    1,
+			Num:    3,
+			Exists: true,
+		},
+		{
+			Name:   "multiple inputs 2",
+			Params: []FnParamKind{FnContext, FnValue, FnIter, FnValue, FnReIter, FnEmit},
+			Pos:    1,
+			Num:    4,
+			Exists: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			// Create a Fn with a filled params list.
+			params := make([]FnParam, len(test.Params))
+			for i, kind := range test.Params {
+				params[i].Kind = kind
+				params[i].T = nil
+			}
+			fn := new(Fn)
+			fn.Param = params
+
+			// Validate we get expected results for Inputs function.
+			pos, num, exists := fn.Inputs()
+			if exists != test.Exists {
+				t.Errorf("Inputs() exists: got %v, want %v", exists, test.Exists)
+			}
+			if num != test.Num {
+				t.Errorf("Inputs() num: got %v, want %v", num, test.Num)
+			}
+			if pos != test.Pos {
+				t.Errorf("Inputs() pos: got %v, want %v", pos, test.Pos)
+			}
+		})
+	}
+}
+
 func projectParamKind(u *Fn) []FnParamKind {
 	var ret []FnParamKind
 	for _, p := range u.Param {

--- a/sdks/go/pkg/beam/core/funcx/fn_test.go
+++ b/sdks/go/pkg/beam/core/funcx/fn_test.go
@@ -148,16 +148,6 @@ func TestNew(t *testing.T) {
 			Err: errReflectTypePrecedence,
 		},
 		{
-			Name: "errSideInputPrecedence- Iter before main input",
-			Fn:   func(func(*int) bool, func(*int, *string) bool, int) {},
-			Err:  errSideInputPrecedence,
-		},
-		{
-			Name: "errSideInputPrecedence- ReIter before main input",
-			Fn:   func(func() func(*int) bool, int) {},
-			Err:  errSideInputPrecedence,
-		},
-		{
 			Name: "errInputPrecedence- Iter before after output",
 			Fn:   func(int, func(int), func(*int) bool, func(*int, *string) bool) {},
 			Err:  errInputPrecedence,
@@ -321,9 +311,9 @@ func TestInputs(t *testing.T) {
 		{
 			Name:   "no main input",
 			Params: []FnParamKind{FnContext, FnIter, FnReIter, FnEmit},
-			Pos:    -1,
-			Num:    0,
-			Exists: false,
+			Pos:    1,
+			Num:    2,
+			Exists: true,
 		},
 		{
 			Name:   "single input",
@@ -363,13 +353,13 @@ func TestInputs(t *testing.T) {
 			// Validate we get expected results for Inputs function.
 			pos, num, exists := fn.Inputs()
 			if exists != test.Exists {
-				t.Errorf("Inputs() exists: got %v, want %v", exists, test.Exists)
+				t.Errorf("Inputs(%v) - exists: got %v, want %v", params, exists, test.Exists)
 			}
 			if num != test.Num {
-				t.Errorf("Inputs() num: got %v, want %v", num, test.Num)
+				t.Errorf("Inputs(%v) - num: got %v, want %v", params, num, test.Num)
 			}
 			if pos != test.Pos {
-				t.Errorf("Inputs() pos: got %v, want %v", pos, test.Pos)
+				t.Errorf("Inputs(%v) - pos: got %v, want %v", params, pos, test.Pos)
 			}
 		})
 	}

--- a/sdks/go/pkg/beam/core/graph/fn.go
+++ b/sdks/go/pkg/beam/core/graph/fn.go
@@ -209,6 +209,10 @@ func NewDoFn(fn interface{}) (*DoFn, error) {
 
 // AsDoFn converts a Fn to a DoFn, if possible.
 func AsDoFn(fn *Fn) (*DoFn, error) {
+	addContext := func(err error, fn *Fn) error {
+		return errors.WithContextf(err, "graph.AsDoFn: for Fn named %v", fn.Name())
+	}
+
 	if fn.methods == nil {
 		fn.methods = make(map[string]*funcx.Fn)
 	}
@@ -220,12 +224,148 @@ func AsDoFn(fn *Fn) (*DoFn, error) {
 	}
 
 	if _, ok := fn.methods[processElementName]; !ok {
-		return nil, errors.Errorf("graph.AsDoFn: failed to find %v method: %v", processElementName, fn)
+		err := errors.Errorf("failed to find %v method", processElementName)
+		return nil, addContext(err, fn)
 	}
 
-	// TODO(herohde) 5/18/2017: validate the signatures, incl. consistency.
+	// If the ProcessElement function includes side inputs or emit functions those must also be
+	// present in the signatures of startBundle and finishBundle.
+	processFn := fn.methods[processElementName]
+	pos, num, ok := processFn.Emits()
+	if ok {
+		if startFn, ok := fn.methods[startBundleName]; ok {
+			processFnEmits := processFn.Param[pos : pos+num]
+			if err := validateMethodEmits(processFnEmits, startFn, startBundleName); err != nil {
+				return nil, addContext(err, fn)
+			}
+		}
+		if finishFn, ok := fn.methods[finishBundleName]; ok {
+			processFnEmits := processFn.Param[pos : pos+num]
+			if err := validateMethodEmits(processFnEmits, finishFn, finishBundleName); err != nil {
+				return nil, addContext(err, fn)
+			}
+		}
+	}
+
+	pos, num, ok = processFn.Inputs()
+	if ok && num > 1 {
+		if startFn, ok := fn.methods[startBundleName]; ok {
+			processFnInputs := processFn.Param[pos : pos+num]
+			if err := validateMethodInputs(processFnInputs, startFn, startBundleName); err != nil {
+				return nil, addContext(err, fn)
+			}
+		}
+		if finishFn, ok := fn.methods[finishBundleName]; ok {
+			processFnInputs := processFn.Param[pos : pos+num]
+			if err := validateMethodInputs(processFnInputs, finishFn, finishBundleName); err != nil {
+				return nil, addContext(err, fn)
+			}
+		}
+	}
+
+	// Check that Setup and Teardown have no parameters.
+	for _, name := range []string{setupName, teardownName} {
+		if method, ok := fn.methods[name]; ok && len(method.Param) != 0 {
+			err := errors.Errorf("method %v has parameters, should have no parameters", name)
+			err = errors.SetTopLevelMsgf(err,
+				"Method %v of DoFns should have no parameters, but it has parameters in DoFn %v.",
+				name, fn.Name())
+			return nil, addContext(err, fn)
+		}
+	}
 
 	return (*DoFn)(fn), nil
+}
+
+// validateMethodEmits compares the emits found in a DoFn method signature with the emits found in
+// the signature for ProcessElement, and performs validation that those match. This function
+// should only be used to validate methods that are expected to have the same emit parameters as
+// ProcessElement.
+func validateMethodEmits(processFnEmits []funcx.FnParam, method *funcx.Fn, methodName string) error {
+	methodPos, methodNum, ok := method.Emits()
+	if !ok {
+		err := errors.Errorf("emit parameters expected in method %v", methodName)
+		return errors.SetTopLevelMsgf(err,
+			"Missing emit parameters in the %v method of a DoFn. "+
+				"If emit parameters are present in %v those parameters must also be present in %v.",
+			methodName, processElementName, methodName)
+	}
+
+	processFnNum := len(processFnEmits)
+	if methodNum != processFnNum {
+		err := errors.Errorf("number of emits in method %v does not match method %v: got %d, expected %d",
+			methodName, processElementName, methodNum, processFnNum)
+		return errors.SetTopLevelMsgf(err,
+			"Incorrect number of emit parameters in the %v method of a DoFn. "+
+				"The emit parameters should match those of the %v method.",
+			methodName, processElementName)
+	}
+
+	methodEmits := method.Param[methodPos : methodPos+methodNum]
+	for i := 0; i < processFnNum; i++ {
+		if processFnEmits[i].T != methodEmits[i].T {
+			var err error = &funcx.TypeMismatchError{Got: methodEmits[i].T, Want: processFnEmits[i].T}
+			err = errors.Wrapf(err, "emit parameter in method %v does not match emit parameter in %v",
+				methodName, processElementName)
+			return errors.SetTopLevelMsgf(err,
+				"Incorrect emit parameters in the %v method of a DoFn. "+
+					"The emit parameters should match those of the %v method.",
+				methodName, processElementName)
+		}
+	}
+
+	return nil
+}
+
+// validateMethodInputs compares the inputs found in a DoFn method signature with the inputs found
+// in the signature for ProcessElement, and performs validation to check that the side inputs
+// match. This function should only be used to validate methods that are expected to have matching
+// side inputs to ProcessElement.
+func validateMethodInputs(processFnInputs []funcx.FnParam, method *funcx.Fn, methodName string) error {
+	methodPos, methodNum, ok := method.Inputs()
+
+	// Note: The second input to ProcessElements is not guaranteed to be a side input (it could be
+	// the Value part of a KV main input). Since we can't know whether to interpret it as a main or
+	// side input, some of these checks have to work around it in specific ways.
+	if !ok {
+		if len(processFnInputs) <= 2 {
+			return nil // This case is fine, since both ProcessElement inputs may be main inputs.
+		}
+		err := errors.Errorf("side inputs expected in method %v", methodName)
+		return errors.SetTopLevelMsgf(err,
+			"Missing side inputs in the %v method of a DoFn. "+
+				"If side inputs are present in %v those side inputs must also be present in %v.",
+			methodName, processElementName, methodName)
+	}
+
+	processFnNum := len(processFnInputs)
+	// The number of side inputs is the number of inputs minus 1 or 2 depending on whether the second
+	// input is a main or side input, so that's what we expect in the method's parameters.
+	// Ex. if ProcessElement has 7 inputs, method must have either 5 or 6 inputs.
+	if (methodNum != processFnNum-1) && (methodNum != processFnNum-2) {
+		err := errors.Errorf("number of side inputs in method %v does not match method %v: got %d, expected either %d or %d",
+			methodName, processElementName, methodNum, processFnNum-1, processFnNum-2)
+		return errors.SetTopLevelMsgf(err,
+			"Incorrect number of side inputs in the %v method of a DoFn. "+
+				"The side inputs should match those of the %v method.",
+			methodName, processElementName)
+	}
+
+	methodInputs := method.Param[methodPos : methodPos+methodNum]
+	offset := processFnNum - methodNum // We need an offset to skip the main inputs in ProcessFnInputs
+	for i := 0; i < methodNum; i++ {
+		if processFnInputs[i+offset].T != methodInputs[i].T {
+			var err error = &funcx.TypeMismatchError{Got: methodInputs[i].T, Want: processFnInputs[i+offset].T}
+			err = errors.Wrapf(err, "side input in method %v does not match side input in %v",
+				methodName, processElementName)
+			return errors.SetTopLevelMsgf(err,
+				"Incorrect side inputs in the %v method of a DoFn. "+
+					"The side inputs should match those of the %v method.",
+				methodName, processElementName)
+		}
+	}
+
+	return nil
 }
 
 // CombineFn represents a CombineFn.

--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -19,7 +19,67 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 )
+
+func TestNewDoFn(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		tests := []struct {
+			dfn interface{}
+		}{
+			{dfn: func() int { return 0 }},
+			{dfn: func(string, int) int { return 0 }},
+			{dfn: func(context.Context, typex.Window, typex.EventTime, reflect.Type, string, int, func(*int) bool, func() func(*int) bool, func(int)) (typex.EventTime, int, error) {
+				return 0, 0, nil
+			}},
+			{dfn: &GoodDoFn{}},
+			{dfn: &GoodDoFnOmittedMethods{}},
+			{dfn: &GoodDoFnEmits{}},
+			{dfn: &GoodDoFnSideInputs{}},
+			{dfn: &GoodDoFnKvSideInputs{}},
+			{dfn: &GoodDoFnKvNoSideInputs{}},
+			{dfn: &GoodDoFnAllExtras{}},
+			{dfn: &GoodDoFnUnexportedExtraMethod{}},
+		}
+
+		for _, test := range tests {
+			t.Run(reflect.TypeOf(test.dfn).String(), func(t *testing.T) {
+				if _, err := NewDoFn(test.dfn); err != nil {
+					t.Fatalf("NewCombineFn failed: %v", err)
+				}
+			})
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			dfn interface{}
+		}{
+			// Validate emit parameters.
+			{dfn: &BadDoFnNoEmitsStartBundle{}},
+			{dfn: &BadDoFnMissingEmitsStartBundle{}},
+			{dfn: &BadDoFnMismatchedEmitsStartBundle{}},
+			{dfn: &BadDoFnNoEmitsFinishBundle{}},
+			// Validate side inputs.
+			{dfn: &BadDoFnNoSideInputsStartBundle{}},
+			{dfn: &BadDoFnMissingSideInputsStartBundle{}},
+			{dfn: &BadDoFnMismatchedSideInputsStartBundle{}},
+			{dfn: &BadDoFnNoSideInputsFinishBundle{}},
+			// Validate setup/teardown.
+			{dfn: &BadDoFnParamsInSetup{}},
+			{dfn: &BadDoFnParamsInTeardown{}},
+		}
+		for _, test := range tests {
+			t.Run(reflect.TypeOf(test.dfn).String(), func(t *testing.T) {
+				if cfn, err := NewDoFn(test.dfn); err != nil {
+					t.Logf("NewDoFn failed as expected:\n%v", err)
+				} else {
+					t.Errorf("NewDoFn(%v) = %v, want failure", cfn.Name(), cfn)
+				}
+			})
+		}
+	})
+}
 
 func TestNewCombineFn(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
@@ -96,9 +156,201 @@ func TestNewCombineFn(t *testing.T) {
 // Do not copy. The following types are for testing signatures only.
 // They are not working examples.
 // Keep all test functions Above this point.
-type MyAccum struct{}
+
+// Examples of correct DoFn signatures
+
+type GoodDoFn struct{}
+
+func (fn *GoodDoFn) ProcessElement(int) int {
+	return 0
+}
+
+func (fn *GoodDoFn) StartBundle() {
+}
+
+func (fn *GoodDoFn) FinishBundle() {
+}
+
+func (fn *GoodDoFn) Setup() {
+}
+
+func (fn *GoodDoFn) Teardown() {
+}
+
+type GoodDoFnOmittedMethods struct{}
+
+func (fn *GoodDoFnOmittedMethods) ProcessElement(int) int {
+	return 0
+}
+
+type GoodDoFnEmits struct{}
+
+func (fn *GoodDoFnEmits) ProcessElement(int, func(int), func(string)) int {
+	return 0
+}
+
+func (fn *GoodDoFnEmits) StartBundle(func(int), func(string)) {
+}
+
+func (fn *GoodDoFnEmits) FinishBundle(func(int), func(string)) {
+}
+
+type GoodDoFnSideInputs struct{}
+
+func (fn *GoodDoFnSideInputs) ProcessElement(int, func(*int) bool, string, func() func(*int) bool) int {
+	return 0
+}
+
+func (fn *GoodDoFnSideInputs) StartBundle(func(*int) bool, string, func() func(*int) bool) {
+}
+
+func (fn *GoodDoFnSideInputs) FinishBundle(func(*int) bool, string, func() func(*int) bool) {
+}
+
+type GoodDoFnKvSideInputs struct{}
+
+func (fn *GoodDoFnKvSideInputs) ProcessElement(int, int, string, func(*int) bool, func() func(*int) bool) int {
+	return 0
+}
+
+func (fn *GoodDoFnKvSideInputs) StartBundle(string, func(*int) bool, func() func(*int) bool) {
+}
+
+func (fn *GoodDoFnKvSideInputs) FinishBundle(string, func(*int) bool, func() func(*int) bool) {
+}
+
+type GoodDoFnKvNoSideInputs struct{}
+
+func (fn *GoodDoFnKvNoSideInputs) ProcessElement(int, int) int {
+	return 0
+}
+
+func (fn *GoodDoFnKvNoSideInputs) StartBundle() {
+}
+
+func (fn *GoodDoFnKvNoSideInputs) FinishBundle() {
+}
+
+type GoodDoFnAllExtras struct{}
+
+func (fn *GoodDoFnAllExtras) ProcessElement(context.Context, typex.Window, typex.EventTime, reflect.Type, string, int, func(*int) bool, func() func(*int) bool, func(int)) (typex.EventTime, int, error) {
+	return 0, 0, nil
+}
+
+func (fn *GoodDoFnAllExtras) StartBundle(func(*int) bool, func() func(*int) bool, func(int)) {
+}
+
+func (fn *GoodDoFnAllExtras) FinishBundle(func(*int) bool, func() func(*int) bool, func(int)) {
+}
+
+func (fn *GoodDoFnAllExtras) Setup() {
+}
+
+func (fn *GoodDoFnAllExtras) Teardown() {
+}
+
+type GoodDoFnUnexportedExtraMethod struct{}
+
+func (fn *GoodDoFnUnexportedExtraMethod) ProcessElement(int) int {
+	return 0
+}
+
+func (fn *GoodDoFnUnexportedExtraMethod) StartBundle() {
+}
+
+func (fn *GoodDoFnUnexportedExtraMethod) FinishBundle() {
+}
+
+func (fn *GoodDoFnUnexportedExtraMethod) Setup() {
+}
+
+func (fn *GoodDoFnUnexportedExtraMethod) Teardown() {
+}
+
+func (fn *GoodDoFnUnexportedExtraMethod) unexportedFunction() {
+}
+
+// Examples of incorrect DoFn signatures.
+// Embedding good DoFns avoids repetitive ProcessElement signatures when desired.
+// The immediately following examples are relating to emit parameter mismatches.
+
+type BadDoFnNoEmitsStartBundle struct {
+	*GoodDoFnEmits
+}
+
+func (fn *BadDoFnNoEmitsStartBundle) StartBundle() {
+}
+
+type BadDoFnMissingEmitsStartBundle struct {
+	*GoodDoFnEmits
+}
+
+func (fn *BadDoFnMissingEmitsStartBundle) StartBundle(func(int)) {
+}
+
+type BadDoFnMismatchedEmitsStartBundle struct {
+	*GoodDoFnEmits
+}
+
+func (fn *BadDoFnMismatchedEmitsStartBundle) StartBundle(func(int), func(int)) {
+}
+
+type BadDoFnNoEmitsFinishBundle struct {
+	*GoodDoFnEmits
+}
+
+func (fn *BadDoFnNoEmitsFinishBundle) FinishBundle() {
+}
+
+// Examples of side input mismatches.
+
+type BadDoFnNoSideInputsStartBundle struct {
+	*GoodDoFnSideInputs
+}
+
+func (fn *BadDoFnNoSideInputsStartBundle) StartBundle() {
+}
+
+type BadDoFnMissingSideInputsStartBundle struct {
+	*GoodDoFnSideInputs
+}
+
+func (fn *BadDoFnMissingSideInputsStartBundle) StartBundle(func(*int) bool) {
+}
+
+type BadDoFnMismatchedSideInputsStartBundle struct {
+	*GoodDoFnSideInputs
+}
+
+func (fn *BadDoFnMismatchedSideInputsStartBundle) StartBundle(func(*int) bool, int, func() func(*int)) {
+}
+
+type BadDoFnNoSideInputsFinishBundle struct {
+	*GoodDoFnSideInputs
+}
+
+func (fn *BadDoFnNoSideInputsFinishBundle) FinishBundle() {
+}
+
+// Examples of incorrect Setup/Teardown methods.
+
+type BadDoFnParamsInSetup struct {
+	*GoodDoFn
+}
+
+func (*BadDoFnParamsInSetup) Setup(int) {
+}
+
+type BadDoFnParamsInTeardown struct {
+	*GoodDoFn
+}
+
+func (*BadDoFnParamsInTeardown) Teardown(int) {
+}
 
 // Examples of correct CombineFn signatures
+
+type MyAccum struct{}
 
 type GoodCombineFn struct{}
 
@@ -152,7 +404,7 @@ func (fn *GoodCombineFnUnexportedExtraMethod) unexportedExtraMethod(context.Cont
 
 // Examples of incorrect CombineFn signatures.
 // Embedding *GoodCombineFn avoids repetitive MergeAccumulators signatures when desired.
-// The immeadiately following examples are relating to accumulator mismatches.
+// The immediately following examples are relating to accumulator mismatches.
 
 type BadCombineFnNoMergeAccumulators struct{}
 

--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -46,7 +46,7 @@ func TestNewDoFn(t *testing.T) {
 		for _, test := range tests {
 			t.Run(reflect.TypeOf(test.dfn).String(), func(t *testing.T) {
 				if _, err := NewDoFn(test.dfn); err != nil {
-					t.Fatalf("NewCombineFn failed: %v", err)
+					t.Fatalf("NewDoFn failed: %v", err)
 				}
 			})
 		}
@@ -68,6 +68,11 @@ func TestNewDoFn(t *testing.T) {
 			// Validate setup/teardown.
 			{dfn: &BadDoFnParamsInSetup{}},
 			{dfn: &BadDoFnParamsInTeardown{}},
+			// Validate return values.
+			{dfn: &BadDoFnReturnValuesInStartBundle{}},
+			{dfn: &BadDoFnReturnValuesInFinishBundle{}},
+			{dfn: &BadDoFnReturnValuesInSetup{}},
+			{dfn: &BadDoFnReturnValuesInTeardown{}},
 		}
 		for _, test := range tests {
 			t.Run(reflect.TypeOf(test.dfn).String(), func(t *testing.T) {
@@ -237,16 +242,18 @@ func (fn *GoodDoFnAllExtras) ProcessElement(context.Context, typex.Window, typex
 	return 0, 0, nil
 }
 
-func (fn *GoodDoFnAllExtras) StartBundle(func(*int) bool, func() func(*int) bool, func(int)) {
+func (fn *GoodDoFnAllExtras) StartBundle(context.Context, func(*int) bool, func() func(*int) bool, func(int)) {
 }
 
-func (fn *GoodDoFnAllExtras) FinishBundle(func(*int) bool, func() func(*int) bool, func(int)) {
+func (fn *GoodDoFnAllExtras) FinishBundle(context.Context, func(*int) bool, func() func(*int) bool, func(int)) {
 }
 
-func (fn *GoodDoFnAllExtras) Setup() {
+func (fn *GoodDoFnAllExtras) Setup(context.Context) error {
+	return nil
 }
 
-func (fn *GoodDoFnAllExtras) Teardown() {
+func (fn *GoodDoFnAllExtras) Teardown(context.Context) error {
+	return nil
 }
 
 type GoodDoFnUnexportedExtraMethod struct{}
@@ -346,6 +353,38 @@ type BadDoFnParamsInTeardown struct {
 }
 
 func (*BadDoFnParamsInTeardown) Teardown(int) {
+}
+
+type BadDoFnReturnValuesInStartBundle struct {
+	*GoodDoFn
+}
+
+func (*BadDoFnReturnValuesInStartBundle) StartBundle() int {
+	return 0
+}
+
+type BadDoFnReturnValuesInFinishBundle struct {
+	*GoodDoFn
+}
+
+func (*BadDoFnReturnValuesInFinishBundle) FinishBundle() int {
+	return 0
+}
+
+type BadDoFnReturnValuesInSetup struct {
+	*GoodDoFn
+}
+
+func (*BadDoFnReturnValuesInSetup) Setup() int {
+	return 0
+}
+
+type BadDoFnReturnValuesInTeardown struct {
+	*GoodDoFn
+}
+
+func (*BadDoFnReturnValuesInTeardown) Teardown() int {
+	return 0
 }
 
 // Examples of correct CombineFn signatures


### PR DESCRIPTION
This is the first draft of this CL for additional DoFn validation. It adds validation for Emits and SideInputs in StartBundle and FinishBundle.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
