### PR TITLE
Add a Google Cloud PubSub-based implementation of PCollectionCache

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/caching/__init__.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/__init__.py
@@ -16,4 +16,6 @@
 #
 from __future__ import absolute_import
 
+from apache_beam.runners.interactive.caching.pcollection_cache import PCollectionCache
+from apache_beam.runners.interactive.caching.file_based_cache import FileBasedCache
 from apache_beam.runners.interactive.caching.streaming_cache import StreamingCache

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -1,0 +1,309 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import urllib
+
+from apache_beam import coders
+from apache_beam.io import textio
+from apache_beam.io import tfrecordio
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.runners.interactive.caching import PCollectionCache
+from apache_beam.testing import datatype_inference
+from apache_beam.transforms import PTransform
+
+try:
+  from weakref import finalize
+except ImportError:
+  from backports.weakref import finalize
+
+try:  # Python 3
+  unquote_to_bytes = urllib.parse.unquote_to_bytes
+  quote = urllib.parse.quote
+except AttributeError:  # Python 2
+  # pylint: disable=deprecated-urllib-function
+  unquote_to_bytes = urllib.unquote
+  quote = urllib.quote
+
+__all__ = [
+    "FileBasedCache",
+    "TextBasedCache",
+    "TFRecordBasedCache",
+    "SafeFastPrimitivesCoder",
+]
+
+
+class FileBasedCache(PCollectionCache):
+
+  def __init__(self, location, mode="error", persist=False, **writer_kwargs):
+    """Initialize a PCollectionCache object.
+
+    Args:
+      location (str): A string indicating the location where the cache should
+          be stored. Typically, this includes the folder and the filename
+          prefix for files that will be created.
+      mode (str): Controls the behavior when one or more files matching location
+          already exit. If "error", an IOError will be raised. If "overwrite",
+          the existing files will be removed.
+      persist (bool): A flag indicating whether the underlying data should be
+          destroyed when the cache instance goes out of scope.
+      writer_kwargs (Dict[str, Any]): A dictionary of key-value pairs
+          to be passed to the underlying writer objects.
+
+    Raises:
+      ~exceptions.ValueError: If the specified mode is not supported.
+      ~exceptions.IOError: If one or more files matching `location` already
+          exist and mode == "error".
+    """
+    self.location = location
+    self.element_type = None
+    self.default_coder = writer_kwargs.pop("coder", None)
+    self._writer_kwargs = writer_kwargs
+    self._num_writes = 0
+    self._persist = persist
+    self._finalizer = self._configure_finalizer(persist)
+
+    # TODO(ostrokach): Implement append mode.
+    if mode not in ['error', 'overwrite']:
+      raise ValueError("'mode' must be set to one of: ['error', 'overwrite'].")
+    exitsting_files = list(glob_files(self.file_pattern))
+    if mode == "error" and exitsting_files:
+      raise IOError("The following cache files already exist: {}.".format(
+          exitsting_files))
+    if mode == "overwrite":
+      self.truncate()
+
+    root, _ = FileSystems.split(self._file_path_prefix)
+    try:
+      FileSystems.mkdirs(root)
+    except IOError:
+      pass
+    # It is possible to read from am empty stream, so it should also be possible
+    # to read from an empty file.
+    FileSystems.create(self._file_path_prefix + ".empty").close()
+
+  @property
+  def persist(self):
+    return self._persist
+
+  @persist.setter
+  def persist(self, persist):
+    if self._persist == persist:
+      return
+    self._persist = persist
+    if self._finalizer:
+      self._finalizer.detach()
+    self._finalizer = self._configure_finalizer(persist)
+
+  @property
+  def timestamp(self):
+    timestamp = 0
+    for path in glob_files(self.file_pattern):
+      timestamp = max(timestamp, FileSystems.last_updated(path))
+    return timestamp
+
+  def reader(self, **kwargs):
+    """Returns a reader ``PTransform`` to be used for reading the contents of
+    the cache into a Beam Pipeline.
+
+    Args:
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying reader
+          class.
+    """
+    reader_kwargs = self._reader_kwargs.copy()
+    reader_kwargs.update(kwargs)
+    reader = self._reader_class(self.file_pattern, **reader_kwargs)
+    # Keep a reference to the parent object so that cache does not get garbage
+    # collected while the pipeline is running.
+    reader._cache = self
+    return reader
+
+  def writer(self):
+    """Returns a writer object to be used for writing the contents of a
+    PCollection from a Beam Pipeline into the cache.
+    """
+    self._num_writes += 1
+    writer_kwargs = self._writer_kwargs.copy()
+
+    if self.element_type is None:
+      writer = PatchedWriter(self, self._writer_class,
+                             (self._file_path_prefix,), writer_kwargs)
+      return writer
+
+    if ("coder" in self._reader_passthrough_arguments and
+        "coder" not in writer_kwargs):
+      writer_kwargs["coder"] = (
+          self.default_coder if self.default_coder is not None else
+          coders.registry.get_coder(self.element_type))
+    writer = self._writer_class(self._file_path_prefix, **writer_kwargs)
+    # Keep a reference to the parent object so that cache does not get garbage
+    # collected while the pipeline is running.
+    writer._cache = self
+    return writer
+
+  def read(self, **kwargs):
+    """Returns an iterator over the contents of the cache.
+
+    Args:
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying reader
+          class.
+
+    Returns:
+      An iterator over the elements in the cache.
+    """
+    reader_kwargs = self._reader_kwargs.copy()
+    reader_kwargs.update(kwargs)
+    source = self.reader(**reader_kwargs)._source
+    range_tracker = source.get_range_tracker(None, None)
+    for element in source.read(range_tracker):
+      yield element
+
+  def write(self, elements):
+    """Writes a collection of elements into the cache.
+
+    Args:
+      elements (Iterable[Any]): A collection of elements to be written to cache.
+    """
+    self._num_writes += 1
+    if self.element_type is None:
+      # TODO(ostrokach): We might want to infer the element type from the first
+      # N elements, rather than reading the entire iterator.
+      elements = list(elements)
+      self.element_type = datatype_inference.infer_element_type(elements)
+    sink = self.writer()._sink
+    handle = sink.open(self._file_path_prefix)
+    try:
+      for element in elements:
+        sink.write_record(handle, element)
+    finally:
+      sink.close(handle)
+
+  def truncate(self):
+    """Removes all contents from the cache."""
+    FileSystems.delete(list(glob_files(self.file_pattern)))
+    FileSystems.create(self._file_path_prefix + ".empty").close()
+    self.element_type = None
+
+  def remove(self):
+    """Deletes the cache, including all underlying data.
+
+    The cache should not be used after this method is called.
+    """
+    self._finalizer()
+
+  @property
+  def removed(self):
+    return not self._finalizer.alive
+
+  def __del__(self):
+    self.remove()
+
+  @property
+  def file_pattern(self):
+    return self.location + '**'
+
+  @property
+  def _reader_kwargs(self):
+    reader_kwargs = {
+        k: v for k, v in self._writer_kwargs.items()
+        if k in self._reader_passthrough_arguments
+    }
+    if ("coder" in self._reader_passthrough_arguments and
+        "coder" not in reader_kwargs):
+      if self.default_coder is not None:
+        reader_kwargs["coder"] = self.default_coder
+      elif self.element_type is None:
+        reader_kwargs["coder"] = None
+      else:
+        reader_kwargs["coder"] = coders.registry.get_coder(self.element_type)
+    return reader_kwargs
+
+  @property
+  def _file_path_prefix(self):
+    return self.location + "-{:03d}".format(self._num_writes)
+
+  def _configure_finalizer(self, persist):
+    if persist:
+      return finalize(self, lambda: None)
+    else:
+      return finalize(
+          self, lambda pattern: FileSystems.delete(list(glob_files(pattern))),
+          self.file_pattern)
+
+
+class TextBasedCache(FileBasedCache):
+  """A ``PCollectionCache`` object which uses a text-based file format to store
+  the underlying data.
+  """
+  _reader_class = textio.ReadFromText
+  _writer_class = textio.WriteToText
+  _reader_passthrough_arguments = {"coder", "compression_type"}
+
+  def __init__(self, location, **writer_kwargs):
+    writer_kwargs["coder"] = SafeFastPrimitivesCoder()
+    super(TextBasedCache, self).__init__(location, **writer_kwargs)
+
+
+class TFRecordBasedCache(FileBasedCache):
+  """A ``PCollectionCache`` object which uses the TFRecord file format to store
+  the underlying data.
+  """
+
+  _reader_class = tfrecordio.ReadFromTFRecord
+  _writer_class = tfrecordio.WriteToTFRecord
+  _reader_passthrough_arguments = {"coder", "compression_type"}
+
+
+class PatchedWriter(PTransform):
+  """A wrapper over a write ``PTransform`` which sets the element_type of the
+  parent cache when the writer is expanded into a pipeline.
+  """
+
+  def __init__(self, cache, writer_class, writer_args, writer_kwargs):
+    self._cache = cache
+    self._writer_class = writer_class
+    self._writer_args = writer_args
+    self._writer_kwargs = writer_kwargs
+
+  def expand(self, pcoll):
+    if self._cache.element_type is None:
+      self._cache.element_type = pcoll.element_type
+    writer_kwargs = self._writer_kwargs.copy()
+    if "coder" in self._cache._reader_passthrough_arguments:
+      writer_kwargs["coder"] = (
+          self._cache.default_coder if self._cache.default_coder is not None
+          else coders.registry.get_coder(self._cache.element_type))
+    writer = self._writer_class(*self._writer_args, **writer_kwargs)
+    return pcoll | writer
+
+
+class SafeFastPrimitivesCoder(coders.Coder):
+  """This class add an quote/unquote step to escape special characters."""
+
+  def encode(self, value):
+    return quote(
+        coders.coders.FastPrimitivesCoder().encode(value)).encode('utf-8')
+
+  def decode(self, value):
+    return coders.coders.FastPrimitivesCoder().decode(unquote_to_bytes(value))
+
+
+def glob_files(pattern):
+  match = FileSystems.match([pattern])
+  assert len(match) == 1
+  for metadata in match[0].metadata_list:
+    yield metadata.path

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -87,6 +87,7 @@ class FileBasedCache(PCollectionCache):
     self._num_writes = 0
     self._persist = persist
     self._finalizer = self._configure_finalizer(persist)
+    self._timestamp = 0
 
     exitsting_files = list(glob_files(self.file_pattern))
     if exitsting_files:
@@ -119,10 +120,9 @@ class FileBasedCache(PCollectionCache):
 
   @property
   def timestamp(self):
-    timestamp = 0
     for path in glob_files(self.file_pattern):
-      timestamp = max(timestamp, FileSystems.last_updated(path))
-    return timestamp
+      self._timestamp = max(self._timestamp, FileSystems.last_updated(path))
+    return self._timestamp
 
   def reader(self, **kwargs):
     """Returns a reader ``PTransform`` to be used for reading the contents of

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -248,7 +248,12 @@ class FileBasedCache(PCollectionCache):
     return not self._finalizer.alive
 
   def __del__(self):
-    self.delete()
+    try:
+      self.delete()
+    except AttributeError:
+      # Sometimes the destructor can be called before the finalizer is
+      # configured.
+      pass
 
   @property
   def file_pattern(self):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -51,11 +51,11 @@ __all__ = [
 
 class FileBasedCache(PCollectionCache):
 
-  def __init__(self, location, mode="error", persist=False, **writer_kwargs):
+  def __init__(self, cache_spec, mode="error", persist=False, **writer_kwargs):
     """Initialize a PCollectionCache object.
 
     Args:
-      location (str): A string indicating the location where the cache should
+      cache_spec (str): A string indicating the location where the cache should
           be stored. Typically, this includes the folder and the filename
           prefix for files that will be created.
       mode (str): Controls the behavior when one or more files matching location
@@ -71,7 +71,7 @@ class FileBasedCache(PCollectionCache):
       ~exceptions.IOError: If one or more files matching `location` already
           exist and mode == "error".
     """
-    self.location = location
+    self.cache_spec = cache_spec
     self.element_type = None
     self.default_coder = writer_kwargs.pop("coder", None)
     self._writer_kwargs = writer_kwargs
@@ -216,7 +216,7 @@ class FileBasedCache(PCollectionCache):
 
   @property
   def file_pattern(self):
-    return self.location + '**'
+    return self.cache_spec + '**'
 
   @property
   def _reader_kwargs(self):
@@ -236,7 +236,7 @@ class FileBasedCache(PCollectionCache):
 
   @property
   def _file_path_prefix(self):
-    return self.location + "-{:03d}".format(self._num_writes)
+    return self.cache_spec + "-{:03d}".format(self._num_writes)
 
   def _configure_finalizer(self, persist):
     if persist:
@@ -255,9 +255,9 @@ class TextBasedCache(FileBasedCache):
   _writer_class = textio.WriteToText
   _reader_passthrough_arguments = {"coder", "compression_type"}
 
-  def __init__(self, location, **writer_kwargs):
+  def __init__(self, cache_spec, **writer_kwargs):
     writer_kwargs["coder"] = SafeFastPrimitivesCoder()
-    super(TextBasedCache, self).__init__(location, **writer_kwargs)
+    super(TextBasedCache, self).__init__(cache_spec, **writer_kwargs)
 
 
 class TFRecordBasedCache(FileBasedCache):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -146,8 +146,7 @@ class FileBasedCache(PCollectionCache):
                              (self._file_path_prefix,), writer_kwargs)
       return writer
 
-    if ("coder" in self._reader_passthrough_arguments and
-        "coder" not in writer_kwargs):
+    if "coder" in self._reader_passthrough_arguments:
       writer_kwargs["coder"] = (
           self.default_coder if self.default_coder is not None else
           coders.registry.get_coder(self.element_type))

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -100,8 +100,8 @@ class FileBasedCache(PCollectionCache):
       FileSystems.mkdirs(root)
     except IOError:
       pass
-    # It is possible to read from am empty stream, so it should also be possible
-    # to read from an empty file.
+    # Prevent the reader PTransforms from raising an IOError when reading from
+    # an empty PCollectionCache.
     FileSystems.create(self._file_path_prefix + ".empty").close()
 
   @property

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -187,7 +187,7 @@ class FileBasedCache(PCollectionCache):
     """
     self._num_writes += 1
     if self.element_type is None:
-      # TODO(ostrokach): We might want to infer the element type from the first
+      # TODO(BEAM-8734): We might want to infer the element type from the first
       # N elements, rather than reading the entire iterator.
       elements = list(elements)
       self.element_type = datatype_inference.infer_element_type(elements)

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -200,7 +200,7 @@ class FileBasedCache(PCollectionCache):
     FileSystems.create(self._file_path_prefix + ".empty").close()
     self.element_type = None
 
-  def remove(self):
+  def delete(self):
     """Deletes the cache, including all underlying data.
 
     The cache should not be used after this method is called.
@@ -208,11 +208,11 @@ class FileBasedCache(PCollectionCache):
     self._finalizer()
 
   @property
-  def removed(self):
+  def deleted(self):
     return not self._finalizer.alive
 
   def __del__(self):
-    self.remove()
+    self.delete()
 
   @property
   def file_pattern(self):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """This module defines several file-based implementations of a PCollectionCache.
 
 This module is experimental. No backwards-compatibility guarantees.
@@ -38,7 +37,6 @@ try:
 except ImportError:
   # weakref.finalize is not available in Python 2
   finalize = None
-
 
 try:  # Python 3
   unquote_to_bytes = urllib.parse.unquote_to_bytes
@@ -85,7 +83,7 @@ class FileBasedCache(PCollectionCache):
           `reader_class` and `writer_class` PTransforms take `coder` as an
           argument.
       coder (bool): The coder to pass the underlying `reader_class` and
-          `writer_class` PTransforms in cases where `requires_coder` is 
+          `writer_class` PTransforms in cases where `requires_coder` is
           ``True``. If coder is set to ``False``, it will be inferred from
           the data that is written to cache.
 

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""This module defines several file-based implementations of a PCollectionCache.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
 from __future__ import absolute_import
 
 import urllib

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache.py
@@ -29,7 +29,9 @@ from apache_beam.transforms import PTransform
 try:
   from weakref import finalize
 except ImportError:
-  from backports.weakref import finalize
+  # weakref.finalize is not available in Python 2
+  finalize = None
+
 
 try:  # Python 3
   unquote_to_bytes = urllib.parse.unquote_to_bytes

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import logging
+import pickle
+import sys
+import tempfile
+import unittest
+
+import dill
+import numpy as np
+from parameterized import parameterized
+
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.runners.interactive.caching import file_based_cache
+from apache_beam.runners.interactive.caching import file_based_cache_test
+from apache_beam.testing.extra_assertions import ExtraAssertionsMixin
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+
+
+class Validators(unittest.TestCase, ExtraAssertionsMixin):
+
+  def validate_directly(self, cache, expected):
+    actual = list(cache.read())
+    self.assertUnhashableCountEqual(actual, expected)
+
+  def validate_through_pipeline(self, cache, expected):
+
+    def equal_to_expected(actual):
+      self.assertUnhashableCountEqual(actual, expected)
+
+    p = TestPipeline()
+    pcoll = p | "Read" >> cache.reader()
+    assert_that(pcoll, equal_to_expected)
+    p.run()
+
+  if sys.version_info < (3,):
+
+    def runTest(self):
+      pass
+
+
+DATAFRAME_TEST_DATA = [
+    [],
+    [{}],
+    [{}, {}, {}],
+    [{"col1": "abc", "col2": "def"}, {"col1": "hello"}],
+    [{"col1": "abc", "col2": "def"}, {"col1": "hello", "col2": "good bye"}],
+    [{"col1": b"abc", "col2": "def"}, {"col1": b"hello", "col2": "good bye"}],
+    [{"col1": u"abc", "col2": u"±♠Ω"}, {"col1": u"hello", "col2": u"Ωℑ"}],
+    [{"x": 123, "y": 5.55}, {"x": 555, "y": 6.63}],
+    [{"x": 123, "y": 5.55}, {"x": 555, "y": 6.63}],
+    [{"x": np.array([1, 2])}, {"x": np.array([3, 4, 5])}],
+]
+
+
+class TestCase(ExtraAssertionsMixin, unittest.TestCase):
+  pass
+
+
+# #############################################################################
+# Serialization
+# #############################################################################
+
+
+class SerializationTestBase(object):
+
+  # Attributes to be set by child classes.
+  cache_class = None
+  location = None
+
+  def get_writer_kwargs(self, data=None):
+    return {}
+
+  test_data = [{"a": 11, "b": "XXX"}, {"a": 20, "b": "YYY"}]
+
+  def check_serialize_deserialize_empty(self, write_fn, read_fn, serializer):
+    cache = self.cache_class(self.location,
+                             **self.get_writer_kwargs(self.test_data))
+    cache_out = serializer.loads(serializer.dumps(cache))
+    write_fn(cache_out, self.test_data)
+    data_out = list(read_fn(cache_out, limit=len(self.test_data)))
+    self.assertEqual(data_out, self.test_data)
+
+  def check_serialize_deserialize_filled(self, write_fn, read_fn, serializer):
+    cache = self.cache_class(self.location,
+                             **self.get_writer_kwargs(self.test_data))
+    write_fn(cache, self.test_data)
+    cache_out = serializer.loads(serializer.dumps(cache))
+    data_out = list(read_fn(cache_out, limit=len(self.test_data)))
+    self.assertEqual(data_out, self.test_data)
+
+
+class FileSerializationTestBase(SerializationTestBase):
+
+  # Attributes to be set by child classes.
+  cache_class = None
+
+  def setUp(self):
+    self._temp_dir = tempfile.mkdtemp()
+    self.location = FileSystems.join(self._temp_dir, self.cache_class.__name__)
+
+  def tearDown(self):
+    FileSystems.delete([self._temp_dir])
+
+  @parameterized.expand([("pickle", pickle), ("dill", dill)])
+  def test_serialize_deserialize_empty(self, _, serializer):
+    self.check_serialize_deserialize_empty(file_based_cache_test.write_directly,
+                                           file_based_cache_test.read_directly,
+                                           serializer)
+
+  @parameterized.expand([("pickle", pickle), ("dill", dill)])
+  def test_serialize_deserialize_filled(self, _, serializer):
+    self.check_serialize_deserialize_filled(
+        file_based_cache_test.write_directly,
+        file_based_cache_test.read_directly, serializer)
+
+
+class TextBasedCacheSerializationTest(FileSerializationTestBase, TestCase):
+
+  cache_class = file_based_cache.TextBasedCache
+
+
+class TFRecordBasedCacheSerializationTest(FileSerializationTestBase, TestCase):
+
+  cache_class = file_based_cache.TFRecordBasedCache
+
+
+# #############################################################################
+# Roundtrip
+# #############################################################################
+
+
+class RoundtripTestBase(object):
+
+  # Attributes to be set by child classes.
+  cache_class = None
+  location = None
+
+  def get_writer_kwargs(self, data=None):
+    return {}
+
+  def check_roundtrip(self, write_fn, validate_fn, dataset):
+    """Make sure that data can be correctly written using the write_fn function
+    and read using the validate_fn function.
+    """
+    cache = self.cache_class(self.location, **self.get_writer_kwargs(None))
+    for data in dataset:
+      cache._writer_kwargs.update(self.get_writer_kwargs(data))
+      write_fn(cache, data)
+      validate_fn(cache, data)
+      write_fn(cache, data)
+      validate_fn(cache, data * 2)
+      cache.truncate()
+      validate_fn(cache, [])
+    cache.remove()
+
+
+class FileRoundtripTestBase(RoundtripTestBase):
+
+  # Attributes to be set by child classes.
+  cache_class = None
+  dataset = None
+
+  def get_writer_kwargs(self, data=None):
+    return {}
+
+  def setUp(self):
+    self._temp_dir = tempfile.mkdtemp()
+    self.location = FileSystems.join(self._temp_dir, self.cache_class.__name__)
+
+  def tearDown(self):
+    FileSystems.delete([self._temp_dir])
+
+  @parameterized.expand([
+      ("{}-{}".format(write_fn.__name__,
+                      validate_fn.__name__), write_fn, validate_fn)
+      for write_fn in [
+          file_based_cache_test.write_directly,
+          file_based_cache_test.write_through_pipeline
+      ] for validate_fn in
+      [Validators().validate_directly,
+       Validators().validate_through_pipeline]
+  ])
+  def test_roundtrip(self, _, write_fn, validate_fn):
+    return self.check_roundtrip(write_fn, validate_fn, dataset=self.dataset)
+
+
+class TextBasedCacheRoundtripTest(FileRoundtripTestBase, TestCase):
+
+  cache_class = file_based_cache.TextBasedCache
+  dataset = file_based_cache_test.GENERIC_TEST_DATA
+
+
+class TFRecordBasedCacheRoundtripTest(FileRoundtripTestBase, TestCase):
+
+  cache_class = file_based_cache.TFRecordBasedCache
+  dataset = file_based_cache_test.GENERIC_TEST_DATA
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -15,6 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""This module includes integration tests for file-based implementations of a
+PCollectionCache.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
 from __future__ import absolute_import
 
 import logging

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """This module includes integration tests for file-based implementations of a
 PCollectionCache.
 

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -174,7 +174,7 @@ class RoundtripTestBase(object):
       validate_fn(cache, data * 2)
       cache.truncate()
       validate_fn(cache, [])
-    cache.remove()
+    cache.delete()
 
 
 class FileRoundtripTestBase(RoundtripTestBase):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -133,11 +133,15 @@ class FileSerializationTestBase(SerializationTestBase):
         file_based_cache_test.read_directly, serializer)
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class TextBasedCacheSerializationTest(FileSerializationTestBase, TestCase):
 
   cache_class = file_based_cache.TextBasedCache
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class TFRecordBasedCacheSerializationTest(FileSerializationTestBase, TestCase):
 
   cache_class = file_based_cache.TFRecordBasedCache
@@ -203,12 +207,16 @@ class FileRoundtripTestBase(RoundtripTestBase):
     return self.check_roundtrip(write_fn, validate_fn, dataset=self.dataset)
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class TextBasedCacheRoundtripTest(FileRoundtripTestBase, TestCase):
 
   cache_class = file_based_cache.TextBasedCache
   dataset = file_based_cache_test.GENERIC_TEST_DATA
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class TFRecordBasedCacheRoundtripTest(FileRoundtripTestBase, TestCase):
 
   cache_class = file_based_cache.TFRecordBasedCache

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_it_test.py
@@ -172,16 +172,15 @@ class RoundtripTestBase(object):
     """Make sure that data can be correctly written using the write_fn function
     and read using the validate_fn function.
     """
-    cache = self.cache_class(self.location, **self.get_writer_kwargs(None))
     for data in dataset:
-      cache._writer_kwargs.update(self.get_writer_kwargs(data))
+      cache = self.cache_class(self.location, **self.get_writer_kwargs(None))
       write_fn(cache, data)
       validate_fn(cache, data)
       write_fn(cache, data)
       validate_fn(cache, data * 2)
       cache.truncate()
       validate_fn(cache, [])
-    cache.delete()
+      cache.delete()
 
 
 class FileRoundtripTestBase(RoundtripTestBase):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import gc
+import itertools
+import logging
+import tempfile
+import time
+import unittest
+import uuid
+
+import mock
+import numpy as np
+
+from apache_beam import coders
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.pipeline import Pipeline
+from apache_beam.pvalue import PCollection
+from apache_beam.runners.interactive.caching import file_based_cache
+from apache_beam.testing import datatype_inference
+
+GENERIC_TEST_DATA = [
+    [],
+    [None],
+    [None, None, None],
+    ["ABC", "DeF"],
+    [u"ABC", u"±♠Ωℑ"],
+    [b"abc123", b"aAaAa"],
+    [1.5],
+    [100, -123.456, 78.9],
+    ["ABC", 1.2, 100, 0, -10, None, b"abc123"],
+    [()],
+    [("a", "b", "c")],
+    [("a", 1, 1.2), ("b", 2, 5.5)],
+    [("a", 1, 1.2), (2.5, "c", None)],
+    [{}],
+    [{"col1": "a", "col2": 1, "col3": 1.5}],
+    [{"col1": "a", "col2": 1, "col3": 1.5},
+     {"col1": "b", "col2": 2, "col3": 4.5}],
+    [{"col1": "a", "col2": 1, "col3": u"±♠Ω"}, {4: 1, 5: 3.4, (6, 7): "a"}],
+    [("a", "b", "c"), ["d", 1], {"col1": 1, 202: 1.234}, None, "abc", b"def",
+     100, (1, 2, 3, "b")],
+    [np.zeros((3, 6)), np.ones((10, 22))],
+]
+
+GENERIC_ELEMENT_TYPES = {
+    datatype_inference.infer_element_type(data) for data in GENERIC_TEST_DATA
+}
+
+
+def read_directly(cache, limit=None, timeout=None):
+  return list(itertools.islice(cache.read(), limit))
+
+
+def write_directly(cache, data_in, timeout=None):
+  """Write elements to cache using the cache API."""
+  cache.write(data_in)
+
+
+def write_through_pipeline(cache, data_in, timeout=None):
+  """Write elements to cache using a Beam pipeline."""
+  import apache_beam as beam
+
+  with beam.Pipeline() as p:
+    _ = (p | "Create" >> beam.Create(data_in) | "Write" >> cache.writer())
+
+
+class FileBasedCacheTest(unittest.TestCase):
+
+  def cache_class(self, location, *args, **kwargs):
+
+    class MockedFileBasedCache(file_based_cache.FileBasedCache):
+
+      _reader_class = mock.MagicMock()
+      _writer_class = mock.MagicMock()
+      _reader_passthrough_arguments = {}
+      requires_coder = False
+
+    return MockedFileBasedCache(location, *args, **kwargs)
+
+  def setUp(self):
+    self.temp_dir = tempfile.mkdtemp()
+    self.location = FileSystems.join(self.temp_dir, self.cache_class.__name__)
+
+  def tearDown(self):
+    FileSystems.delete([self.temp_dir])
+
+  def create_dummy_file(self, location):
+    """Create a dummy file with `location` as the filepath prefix."""
+    filename = location + "-" + uuid.uuid4().hex
+    while FileSystems.exists(filename):
+      filename = location + "-" + uuid.uuid4().hex
+    with open(filename, "wb") as fout:
+      fout.write(b"dummy data")
+    return filename
+
+  def test_init(self):
+    # cache needs to be kept so that resources are not gc-ed immediately.
+    cache = self.cache_class(self.location)  # pylint: disable=unused-variable
+
+    with self.assertRaises(ValueError):
+      _ = self.cache_class(self.location, mode=None)
+
+    with self.assertRaises(ValueError):
+      _ = self.cache_class(self.location, mode="be happy")
+
+  def test_overwrite_cache_0(self):
+    # cache needs to be kept so that resources are not gc-ed immediately.
+    cache = self.cache_class(self.location)  # pylint: disable=unused-variable
+    # Refuse to create a cache with the same data storage location
+    with self.assertRaises(IOError):
+      _ = self.cache_class(self.location)
+
+  def test_overwrite_cache_1(self):
+    # cache needs to be kept so that resources are not gc-ed immediately.
+    cache = self.cache_class(self.location)  # pylint: disable=unused-variable
+    # Refuse to create a cache with the same data storage location
+    _ = self.create_dummy_file(self.location)
+    with self.assertRaises(IOError):
+      _ = self.cache_class(self.location)
+
+  def test_overwrite_cache_2(self):
+    # cache needs to be kept so that resources are not gc-ed immediately.
+    cache = self.cache_class(self.location)  # pylint: disable=unused-variable
+    # OK to overwrite cache when in "overwrite" mode
+    _ = self.cache_class(self.location, mode="overwrite")
+
+  def test_overwrite_cache_3(self):
+    cache = self.cache_class(self.location)
+    # OK to overwrite cleared cache
+    cache.remove()
+    _ = self.cache_class(self.location)
+
+  def test_persist_false_0(self):
+    cache = self.cache_class(self.location, persist=False)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    cache.remove()
+    files = self._glob_files(self.location + "**")
+    self.assertEqual(len(files), 0)
+
+  def test_persist_false_1(self):
+    cache = self.cache_class(self.location, persist=False)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    del cache
+    gc.collect()
+    files = self._glob_files(self.location + "**")
+    self.assertEqual(len(files), 0)
+
+  def test_persist_setter_false(self):
+    cache = self.cache_class(self.location, persist=True)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    cache.persist = False
+    del cache
+    gc.collect()
+    files = self._glob_files(self.location + "**")
+    self.assertEqual(len(files), 0)
+
+  def test_persist_true_0(self):
+    cache = self.cache_class(self.location, persist=True)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    cache.remove()
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+
+  def test_persist_true_1(self):
+    cache = self.cache_class(self.location, persist=True)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    del cache
+    gc.collect()
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+
+  def test_persist_setter_true(self):
+    cache = self.cache_class(self.location, persist=False)
+    _ = self.create_dummy_file(self.location)
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+    cache.persist = True
+    del cache
+    gc.collect()
+    files = self._glob_files(self.location + "**")
+    self.assertGreater(len(files), 0)
+
+  def _glob_files(self, pattern):
+    files = [
+        metadata.path for match in FileSystems.match([self.location + "**"])
+        for metadata in match.metadata_list
+    ]
+    return files
+
+  def test_timestamp(self):
+    # Seems to always pass when delay=0.01 but set higher to prevent flakiness
+    cache = self.cache_class(self.location)
+    timestamp0 = cache.timestamp
+    time.sleep(0.1)
+    _ = self.create_dummy_file(self.location)
+    timestamp1 = cache.timestamp
+    self.assertGreater(timestamp1, timestamp0)
+
+  def test_writer_arguments(self):
+    kwargs = {"a": 10, "b": "hello"}
+    cache = self.cache_class(self.location, **kwargs)
+    cache._reader_passthrough_arguments = set()
+    cache.writer().expand(DummyPColl(element_type=None))
+    _, kwargs_out = list(cache._writer_class.call_args)
+    self.assertEqual(kwargs_out, kwargs)
+
+  def test_reader_arguments(self):
+
+    def check_reader_passthrough_kwargs(kwargs, passthrough):
+      cache = self.cache_class(self.location, mode="overwrite", **kwargs)
+      cache._reader_passthrough_arguments = passthrough
+      cache.reader()
+      _, kwargs_out = list(cache._reader_class.call_args)
+      self.assertEqual(kwargs_out, {k: kwargs[k] for k in passthrough})
+
+    check_reader_passthrough_kwargs({"a": 10, "b": "hello world"}, {})
+    check_reader_passthrough_kwargs({"a": 10, "b": "hello world"}, {"b"})
+
+  def test_infer_element_type_with_write(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache.element_type, None)
+    for data in GENERIC_TEST_DATA:
+      element_type = datatype_inference.infer_element_type(data)
+      cache.truncate()
+      self.assertEqual(cache.element_type, None)
+      cache.write(data)
+      self.assertEqual(cache.element_type, element_type)
+
+  def test_infer_element_type_with_writer(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache.element_type, None)
+    for data in GENERIC_TEST_DATA:
+      element_type = datatype_inference.infer_element_type(data)
+      cache.truncate()
+      self.assertEqual(cache.element_type, None)
+      cache.writer().expand(DummyPColl(element_type=element_type))
+      self.assertEqual(cache.element_type, element_type)
+
+  def test_default_coder(self):
+    cache = self.cache_class(
+        self.location, coder=file_based_cache.SafeFastPrimitivesCoder)
+    cache._reader_passthrough_arguments = {"coder"}
+    for element_type in GENERIC_ELEMENT_TYPES:
+      cache.truncate()
+      cache.element_type = element_type
+      cache.writer().expand(PCollection(Pipeline(), element_type=None))
+      _, kwargs_out = list(cache._writer_class.call_args)
+      self.assertEqual(
+          kwargs_out.get("coder"), file_based_cache.SafeFastPrimitivesCoder)
+
+  def test_inferred_coder(self):
+    cache = self.cache_class(self.location)
+    cache._reader_passthrough_arguments = {"coder"}
+    for element_type in GENERIC_ELEMENT_TYPES:
+      cache.truncate()
+      cache.element_type = element_type
+      cache.writer().expand(PCollection(Pipeline(), element_type=None))
+      _, kwargs_out = list(cache._writer_class.call_args)
+      self.assertEqual(
+          kwargs_out.get("coder"), coders.registry.get_coder(element_type))
+
+  def test_writer(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache._writer_class.call_count, 0)
+    cache.writer().expand(DummyPColl(element_type=None))
+    self.assertEqual(cache._writer_class.call_count, 1)
+    cache.writer().expand(DummyPColl(element_type=None))
+    self.assertEqual(cache._writer_class.call_count, 2)
+
+  def test_reader(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache._reader_class.call_count, 0)
+    cache.reader()
+    self.assertEqual(cache._reader_class.call_count, 1)
+    cache.reader()
+    self.assertEqual(cache._reader_class.call_count, 2)
+
+  def test_write(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache._writer_class()._sink.open.call_count, 0)
+    self.assertEqual(cache._writer_class()._sink.write_record.call_count, 0)
+    self.assertEqual(cache._writer_class()._sink.close.call_count, 0)
+
+    cache.write((i for i in range(11)))
+    self.assertEqual(cache._writer_class()._sink.open.call_count, 1)
+    self.assertEqual(cache._writer_class()._sink.write_record.call_count, 11)
+    self.assertEqual(cache._writer_class()._sink.close.call_count, 1)
+
+    cache.write((i for i in range(5)))
+    self.assertEqual(cache._writer_class()._sink.open.call_count, 2)
+    self.assertEqual(cache._writer_class()._sink.write_record.call_count, 16)
+    self.assertEqual(cache._writer_class()._sink.close.call_count, 2)
+
+    class DummyError(Exception):
+      pass
+
+    cache._writer_class()._sink.write_record.side_effect = DummyError
+    with self.assertRaises(DummyError):
+      cache.write((i for i in range(5)))
+    self.assertEqual(cache._writer_class()._sink.open.call_count, 3)
+    self.assertEqual(cache._writer_class()._sink.write_record.call_count, 17)
+    self.assertEqual(cache._writer_class()._sink.close.call_count, 3)
+
+  def test_read(self):
+    cache = self.cache_class(self.location)
+    _ = self.create_dummy_file(self.location)
+    self.assertEqual(cache._reader_class()._source.read.call_count, 0)
+    cache.read()
+    # ._read does not get called unless we get items from iterator
+    self.assertEqual(cache._reader_class()._source.read.call_count, 0)
+    list(cache.read())
+    self.assertEqual(cache._reader_class()._source.read.call_count, 1)
+    list(cache.read())
+    self.assertEqual(cache._reader_class()._source.read.call_count, 2)
+
+  def test_truncate(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 1)
+    _ = self.create_dummy_file(self.location)
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 2)
+    cache.truncate()
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 1)
+
+  def test_clear_data(self):
+    cache = self.cache_class(self.location)
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 1)
+    _ = self.create_dummy_file(self.location)
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 2)
+    cache.remove()
+    self.assertEqual(
+        len(list(file_based_cache.glob_files(cache.file_pattern))), 0)
+
+
+class DummyPColl(object):
+
+  def __init__(self, element_type):
+    self.element_type = element_type
+
+  def __or__(self, unused_other):
+    return self
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -147,7 +147,7 @@ class FileBasedCacheTest(unittest.TestCase):
   def test_overwrite_cache_3(self):
     cache = self.cache_class(self.location)
     # OK to overwrite cleared cache
-    cache.remove()
+    cache.delete()
     _ = self.cache_class(self.location)
 
   def test_persist_false_0(self):
@@ -155,7 +155,7 @@ class FileBasedCacheTest(unittest.TestCase):
     _ = self.create_dummy_file(self.location)
     files = self._glob_files(self.location + "**")
     self.assertGreater(len(files), 0)
-    cache.remove()
+    cache.delete()
     files = self._glob_files(self.location + "**")
     self.assertEqual(len(files), 0)
 
@@ -185,7 +185,7 @@ class FileBasedCacheTest(unittest.TestCase):
     _ = self.create_dummy_file(self.location)
     files = self._glob_files(self.location + "**")
     self.assertGreater(len(files), 0)
-    cache.remove()
+    cache.delete()
     files = self._glob_files(self.location + "**")
     self.assertGreater(len(files), 0)
 
@@ -361,7 +361,7 @@ class FileBasedCacheTest(unittest.TestCase):
     _ = self.create_dummy_file(self.location)
     self.assertEqual(
         len(list(file_based_cache.glob_files(cache.file_pattern))), 2)
-    cache.remove()
+    cache.delete()
     self.assertEqual(
         len(list(file_based_cache.glob_files(cache.file_pattern))), 0)
 

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -226,6 +226,10 @@ class FileBasedCacheTest(unittest.TestCase):
     _ = self.create_dummy_file(self.location)
     timestamp1 = cache.timestamp
     self.assertGreater(timestamp1, timestamp0)
+    cache.truncate()
+    time.sleep(0.1)
+    timestamp2 = cache.timestamp
+    self.assertGreaterEqual(timestamp2, timestamp0)
 
   def test_writer_arguments(self):
     kwargs = {"a": 10, "b": "hello"}

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 import gc
 import itertools
 import logging
+import sys
 import tempfile
 import time
 import unittest
@@ -81,6 +82,8 @@ def write_through_pipeline(cache, data_in, timeout=None):
     _ = (p | "Create" >> beam.Create(data_in) | "Write" >> cache.writer())
 
 
+@unittest.skipIf(sys.version_info < (3,),
+                 'PCollectionCache is not supported on Python 2.')
 class FileBasedCacheTest(unittest.TestCase):
 
   def cache_class(self, location, *args, **kwargs):

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -15,6 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""This module includes unit tests for file-based implementations of a
+PCollectionCache.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
 from __future__ import absolute_import
 
 import gc

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """This module includes unit tests for file-based implementations of a
 PCollectionCache.
 

--- a/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/file_based_cache_test.py
@@ -124,12 +124,6 @@ class FileBasedCacheTest(unittest.TestCase):
     # cache needs to be kept so that resources are not gc-ed immediately.
     cache = self.cache_class(self.location)  # pylint: disable=unused-variable
 
-    with self.assertRaises(ValueError):
-      _ = self.cache_class(self.location, mode=None)
-
-    with self.assertRaises(ValueError):
-      _ = self.cache_class(self.location, mode="be happy")
-
   def test_overwrite_cache_0(self):
     # cache needs to be kept so that resources are not gc-ed immediately.
     cache = self.cache_class(self.location)  # pylint: disable=unused-variable
@@ -148,8 +142,8 @@ class FileBasedCacheTest(unittest.TestCase):
   def test_overwrite_cache_2(self):
     # cache needs to be kept so that resources are not gc-ed immediately.
     cache = self.cache_class(self.location)  # pylint: disable=unused-variable
-    # OK to overwrite cache when in "overwrite" mode
-    _ = self.cache_class(self.location, mode="overwrite")
+    # OK to overwrite cache when `overwrite=True`
+    _ = self.cache_class(self.location, overwrite=True)
 
   def test_overwrite_cache_3(self):
     cache = self.cache_class(self.location)
@@ -244,7 +238,7 @@ class FileBasedCacheTest(unittest.TestCase):
   def test_reader_arguments(self):
 
     def check_reader_passthrough_kwargs(kwargs, passthrough):
-      cache = self.cache_class(self.location, mode="overwrite", **kwargs)
+      cache = self.cache_class(self.location, overwrite=True, **kwargs)
       cache._reader_passthrough_arguments = passthrough
       cache.reader()
       _, kwargs_out = list(cache._reader_class.call_args)

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -1,0 +1,105 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import abc
+
+from future.utils import with_metaclass
+
+
+class PCollectionCache(with_metaclass(abc.ABCMeta)):
+
+  @abc.abstractmethod
+  def __init__(self, location, **writer_kwargs):
+    """Initialize PCollectionCache.
+
+    Args:
+      location (str): Location where the cache data should be stored.
+      **writer_kwargs: Arguments to pass to the underlying writer class.
+    """
+    raise NotImplementedError
+
+  @property
+  @abc.abstractmethod
+  def persist(self):
+    """Whether to persist the underlying data when the object goes out of scope.
+
+    Returns:
+      bool: ``True`` if the unerlying data will be persisted once the object
+          goes out of scope, ``False`` otherwise.
+    """
+    raise NotImplementedError
+
+  @property
+  @abc.abstractmethod
+  def timestamp(self):
+    """Return a timestamp indicating the last time this instance was modified.
+
+    Returns:
+      float: A non-negative number indicating the last time the cache was
+          modified. Caches that were modified more recently should return
+          a larger number.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def reader(self, **reader_kwargs):
+    """Return a reader PTransform which can read a PCollection from cache.
+
+    Args:
+      **reader_kwargs: Arguments to pass to the underlying reader class.
+
+    Returns:
+      A source from which we can read a PCollection.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def writer(self):
+    """Return a writer PTransform which can write a PCollection to cache.
+
+    Returns:
+      A sink to which we can write a PCollection.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def read(self, limit=None, **reader_kwargs):
+    """Return a list of elements inside the cache.
+
+    Args:
+      limit: Maximum number of elements that should be returned.
+      **reader_kwargs: Arguments to pass to the underlying reader class.
+
+    Returns:
+      List[Any]: A list of elements in the PCollections.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def write(self):
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def truncate(self):
+    """Delete PCollection data from the underlying persistence layer."""
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def remove(self):
+    """Delete all data and metadata from the cache."""
+    raise NotImplementedError

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -31,7 +31,7 @@ from future.utils import with_metaclass
 class PCollectionCache(with_metaclass(abc.ABCMeta)):
 
   @abc.abstractmethod
-  def __init__(self, cache_spec, overwrite, persist, **writer_kwargs):
+  def __init__(self, cache_spec, overwrite, persist, **kwargs):
     """Initialize PCollectionCache.
 
     Args:
@@ -41,7 +41,8 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
           instead.
       persist (bool): A flag indicating whether the underlying data should be
           destroyed when the cache instance goes out of scope.
-      **writer_kwargs: Arguments to pass to the underlying writer class.
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying writer
+          and reader PTransforms.
     """
     raise NotImplementedError
 
@@ -73,7 +74,8 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     """Return a reader PTransform which can read a PCollection from cache.
 
     Args:
-      **reader_kwargs: Arguments to pass to the underlying reader class.
+      reader_kwargs (Dict[str, Any]): Arguments to be passed to the
+          underlying reader PTransform.
 
     Returns:
       A PTransform which reads a PCollection from cache.
@@ -81,8 +83,12 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def writer(self):
+  def writer(self, **writer_kwargs):
     """Return a writer PTransform which can write a PCollection to cache.
+
+    Args:
+      writer_kwargs (Dict[str, Any]): Arguments to be passed to the
+          underlying writer PTransform.
 
     Returns:
       A PTransform which writes a PCollection to cache.
@@ -90,12 +96,12 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def read(self, limit=None, **reader_kwargs):
+  def read(self, **reader_kwargs):
     """Return a list of elements inside the cache.
 
     Args:
-      limit: Maximum number of elements that should be returned.
-      **reader_kwargs: Arguments to pass to the underlying reader class.
+      reader_kwargs (Dict[str, Any]): Arguments to be passed to the
+          underlying reader PTransform.
 
     Returns:
       List[Any]: A list of elements in the PCollections.
@@ -103,7 +109,14 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def write(self):
+  def write(self, elements, **writer_kwargs):
+    """Writes a collection of elements into the cache.
+
+    Args:
+      elements (Iterable[Any]): A collection of elements to be written to cache.
+      writer_kwargs (Dict[str, Any]): Arguments to be passed to the
+          underlying writer PTransform.
+    """
     raise NotImplementedError
 
   @abc.abstractmethod

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """A PCollectionCache abstract base class defines an interface for reading and
 writing bounded and unbounded PCollections.
 

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""A PCollectionCache abstract base class defines an interface for reading and
+writing bounded and unbounded PCollections.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
 from __future__ import absolute_import
 
 import abc

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -24,11 +24,11 @@ from future.utils import with_metaclass
 class PCollectionCache(with_metaclass(abc.ABCMeta)):
 
   @abc.abstractmethod
-  def __init__(self, location, **writer_kwargs):
+  def __init__(self, cache_spec, **writer_kwargs):
     """Initialize PCollectionCache.
 
     Args:
-      location (str): Location where the cache data should be stored.
+      cache_spec (str): Location where the cache data should be stored.
       **writer_kwargs: Arguments to pass to the underlying writer class.
     """
     raise NotImplementedError

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -100,6 +100,6 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def remove(self):
+  def delete(self):
     """Delete all data and metadata from the cache."""
     raise NotImplementedError

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -71,7 +71,7 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
       **reader_kwargs: Arguments to pass to the underlying reader class.
 
     Returns:
-      A source from which we can read a PCollection.
+      A PTransform which reads a PCollection from cache.
     """
     raise NotImplementedError
 
@@ -80,7 +80,7 @@ class PCollectionCache(with_metaclass(abc.ABCMeta)):
     """Return a writer PTransform which can write a PCollection to cache.
 
     Returns:
-      A sink to which we can write a PCollection.
+      A PTransform which writes a PCollection to cache.
     """
     raise NotImplementedError
 

--- a/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pcollection_cache.py
@@ -31,11 +31,16 @@ from future.utils import with_metaclass
 class PCollectionCache(with_metaclass(abc.ABCMeta)):
 
   @abc.abstractmethod
-  def __init__(self, cache_spec, **writer_kwargs):
+  def __init__(self, cache_spec, overwrite, persist, **writer_kwargs):
     """Initialize PCollectionCache.
 
     Args:
       cache_spec (str): Location where the cache data should be stored.
+      overwrite (bool): If ``True``, raise an IOError if data matching
+          `cache_spec` already exist. If ``False``, remove existing data
+          instead.
+      persist (bool): A flag indicating whether the underlying data should be
+          destroyed when the cache instance goes out of scope.
       **writer_kwargs: Arguments to pass to the underlying writer class.
     """
     raise NotImplementedError

--- a/sdks/python/apache_beam/runners/interactive/caching/stream_based_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/stream_based_cache.py
@@ -1,0 +1,604 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import contextlib
+import functools
+import time
+import uuid
+from datetime import datetime
+
+import pytz
+from future.moves import queue
+
+import apache_beam as beam
+import apache_beam.io.gcp.pubsub as beam_pubsub
+from apache_beam import coders
+from apache_beam.io.gcp.pubsub import PubsubMessage
+from apache_beam.io.gcp.pubsub import ReadFromPubSub
+from apache_beam.io.gcp.pubsub import WriteToPubSub
+from apache_beam.runners.direct.direct_runner import _DirectWriteToPubSubFn
+from apache_beam.runners.interactive.caching import PCollectionCache
+from apache_beam.testing import datatype_inference
+from apache_beam.transforms import PTransform
+from apache_beam.transforms.window import TimestampedValue
+from apache_beam.utils.timestamp import Timestamp
+
+try:
+  from weakref import finalize
+except ImportError:
+  from backports.weakref import finalize
+
+try:
+  from google import api_core
+  from google.cloud import pubsub
+  from google.api_core import exceptions as gexc
+except ImportError:
+  api_core = None
+  pubsub = None
+  gexc = None
+
+__all__ = [
+    "PubSubBasedCache",
+]
+
+
+class PubSubBasedCache(PCollectionCache):
+  """A ``PCollectionCache`` object which uses Google Cloud PubSub to store
+  the underlying stream of data.
+
+  ``PubSubBasedCache`` allows the storage of an unbounded PCollection of objects
+  in a stream backed by Google Cloud Pubsub. By default, elements are converted
+  to bytes using a compatible coder and are written as `PubsubMessage` objects
+  with an attribute ("ts" by default) containing the timestamp of the original
+  message. If 'timestamp_attribute_fn' is provided, instead of using the
+  pipeline timestmap, we use this function to map each element to an appropriate
+  timestamp. If 'with_attributes' is set to ``True``, the encoding of elements
+  to and from ``PubsubMessage`` objects is relegated to the user.
+
+  If the underlying system supports snapshots (e.g. Google Cloud Pubsub), a
+  snapshot of the root subscription is created when the cache object is
+  instantiated. Every time that elements are read from the cache (with
+  'seek_to_start' set to ``True``), a new subscription is created and set to
+  the snapshot of the root subscription. This allows us to repeatedly read all
+  elements from the time that the subscription was created.
+
+  If the underlying system does *not* support snapshots (e.g. Google PubSub
+  Emulator), we can read all elements that have ever been written to the cache
+  only once. However, we can perform multiple reads with 'seek_to_start' set to
+  ``False``, in which case we will obtain only those elements that have been
+  written since the start of the reading process.
+  """
+
+  _reader_passthrough_arguments = {
+      "id_label",
+      "with_attributes",
+      "timestamp_attribute",
+  }
+  _default_timestamp_attribute = "ts"
+
+  def __init__(self,
+               location,
+               mode="error",
+               persist=False,
+               timestamp_attribute_fn=None,
+               **writer_kwargs):
+    """Initialize a PCollectionCache object.
+
+    Args:
+      location (str): A string containing the path of the topic to which cached
+          messages will be published. It should have the format:
+          'projects/{project_name}/topics/{topic_name}'.
+      mode (str): Controls the behavior when the topic specified by location
+          already exit. If "error", an IOError will be raised. If "overwrite",
+          the existing topic will be removed and a new topic with the same
+          name will be created. If "append", messages will be published to the
+          existing topic.
+      persist (bool): A flag indicating whether the underlying data should be
+          destroyed when the cache instance goes out of scope.
+      timestamp_attribute_fn (Callable[[Any], int): A function which takes
+          as input an element of a PCollection and returns the timestamp,
+          *in milliseconds*, associated with that element. This timestamp will
+          be assigned to the timestamp attribute of each message published to
+          Cloud PubSub.
+      writer_kwargs (Dict[str, Any]): A dictionary of key-value pairs
+          to be passed to the underlying writer objects.
+
+    Raises:
+      ~exceptions.ValueError: If the specified mode is not supported.
+      ~exceptions.IOError: If a topic matching `location` already exist and
+          mode == "error".
+    """
+    self.location = location
+    self.timestamp_attribute_fn = timestamp_attribute_fn
+    self.element_type = None
+    self.default_coder = writer_kwargs.pop("coder", None)
+    if "timestamp_attribute" not in writer_kwargs:
+      writer_kwargs["timestamp_attribute"] = self._default_timestamp_attribute
+    self._writer_kwargs = writer_kwargs
+    self._persist = persist
+    self._timestamp = 0
+    self._finalizers = []
+    self._child_subscriptions = []
+    self._primary_sub_exhausted = False
+
+    if mode not in ["error", "append", "overwrite"]:
+      raise ValueError("mode must be set to 'error', 'append', or 'overwrite'.")
+
+    # Initialize PubSub resources. Note that we cannot save pub_client and
+    # sub_client as class attributes because they fail to serialize using
+    # pickle.
+    pub_client = pubsub.PublisherClient()
+    sub_client = pubsub.SubscriberClient()
+
+    self.project, self.topic_name = beam_pubsub.parse_topic(self.location)
+
+    topic_path = pub_client.topic_path(self.project, self.topic_name)
+    try:
+      self.topic = pub_client.create_topic(topic_path)
+    except gexc.AlreadyExists:
+      if mode == "error":
+        raise IOError("Topic '{}' already exists.".format(topic_path))
+      elif mode == "overwrite":
+        pub_client.delete_topic(topic_path)
+        self.topic = pub_client.create_topic(topic_path)
+      else:
+        self.topic = pub_client.get_topic(topic_path)
+
+    subscription_path = sub_client.subscription_path(self.project,
+                                                     self.topic_name)
+    try:
+      self.subscription = sub_client.create_subscription(
+          subscription_path, self.topic.name)
+    except gexc.AlreadyExists:
+      if mode == "error":
+        raise IOError(
+            "Subscription '{}' already exists.".format(subscription_path))
+      elif mode == "overwrite":
+        sub_client.delete_subscription(subscription_path)
+        self.subscription = sub_client.create_subscription(
+            subscription_path, self.topic.name)
+      else:
+        self.subscription = sub_client.get_subscription(subscription_path)
+
+    snapshot_path = sub_client.snapshot_path(self.project, self.topic_name)
+    try:
+      self.snapshot = sub_client.create_snapshot(snapshot_path,
+                                                 self.subscription.name)
+    except gexc.AlreadyExists:
+      if mode == "error":
+        raise IOError("Snapshot '{}' already exists.".format(snapshot_path))
+      elif mode == "overwrite":
+        sub_client.delete_snapshot(snapshot_path)
+        self.snapshot = sub_client.create_snapshot(snapshot_path,
+                                                   self.subscription.name)
+      else:
+        # See: https://github.com/googleapis/google-cloud-python/issues/8554
+        self.snapshot = pubsub.types.Snapshot()
+        self.snapshot.name = snapshot_path
+    except gexc.MethodNotImplemented:
+      self.snapshot = None
+
+    self._child_subscriptions.append(self.subscription)
+    self._finalizers = self._configure_finalizers(persist)
+
+  @property
+  def timestamp(self):
+    return self._timestamp
+
+  @property
+  def persist(self):
+    return self._persist
+
+  @persist.setter
+  def persist(self, persist):
+    if self._persist == persist:
+      return
+    self._persist = persist
+    for finalizer in self._finalizers:
+      finalizer.detach()
+    self._finalizers = self._configure_finalizers(persist)
+
+  def reader(self, seek_to_start=True, **kwargs):
+    """Returns a reader ``PTransform`` to be used for reading the contents of
+    the cache into a Beam Pipeline.
+
+    Args:
+      seek_to_start (bool): If ``True``, read all data that was written to the
+          cache since it was created. If ``False``, only read data that is
+          written to the cache *after* this method is called.
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying reader
+          class.
+    """
+    self._assert_topic_exists()
+
+    reader_kwargs = self._reader_kwargs.copy()
+    reader_kwargs.update(kwargs)
+
+    if "subscription" not in reader_kwargs:
+      reader_kwargs["subscription"] = self._create_child_subscription(
+          seek_to_start=seek_to_start).name
+
+    reader = PatchedPubSubReader(self, **reader_kwargs)
+    return reader
+
+  def writer(self):
+    """Returns a writer ``PTransform`` to be used for writing the contents of a
+    PCollection from a Beam Pipeline into the cache.
+    """
+    self._timestamp = time.time()
+    writer = PatchedPubSubWriter(self, self.location, **self._writer_kwargs)
+    return writer
+
+  @contextlib.contextmanager
+  def read_to_queue(self, seek_to_start=True, **kwargs):
+    """Starts a worker thread which reads the contents of the cache into a
+    queue.
+
+    Args:
+      seek_to_start (bool): If ``True``, read all data that was written to the
+          cache since it was created. If ``False``, only read data that is
+          written to the cache *after* this method is called.
+      delay (float): Number of seconds to wait before returning collected
+          messages. A longer delay may result in messages being more accurately
+          ordered according to their timestamp.
+      timeout (float): If no new messags arrive within the specified number of
+          seconds, the reading process will be terminated.
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying reader
+          class.
+
+    Returns:
+      A priority queue that is being populated with the contents of the cache.
+    """
+    self._assert_topic_exists()
+
+    reader_kwargs = self._reader_kwargs.copy()
+    reader_kwargs.update(kwargs)
+
+    if "subscription" in reader_kwargs:
+      created_subsciption = None
+    else:
+      created_subsciption = self._create_child_subscription(
+          seek_to_start=seek_to_start)
+      reader_kwargs["subscription"] = created_subsciption.name
+      assert created_subsciption in self._child_subscriptions
+
+    @functools.total_ordering
+    class PrioritizedTimestampedValue(TimestampedValue):
+
+      def __lt__(self, other):
+        return self.timestamp < other.timestamp
+
+    # Set arbitrary queue size limit to prevent OOM errors.
+    parsed_message_queue = queue.PriorityQueue(1000)
+    coder = (
+        self.default_coder if self.default_coder is not None else
+        coders.registry.get_coder(self.element_type))
+    if reader_kwargs.get("with_attributes"):
+      decoder = beam.Map(lambda e: e)
+    else:
+      decoder = DecodeFromPubSub(
+          coder, timestamp_attribute=reader_kwargs["timestamp_attribute"])
+
+    def callback(msg):
+      msg.ack()
+      message = PubsubMessage._from_message(msg)
+      timestamped_value = next(decoder.process(message))
+      ordered_timestamped_value = PrioritizedTimestampedValue(
+          timestamped_value.value, timestamped_value.timestamp)
+      parsed_message_queue.put(ordered_timestamped_value)
+
+    sub_client = pubsub.SubscriberClient()
+    future = sub_client.subscribe(
+        reader_kwargs["subscription"], callback=callback)
+    try:
+      yield parsed_message_queue
+    finally:
+      future.cancel()
+      if created_subsciption is not None:
+        sub_client.delete_subscription(created_subsciption.name)
+        self._child_subscriptions.remove(created_subsciption)
+
+  def read(self, seek_to_start=True, delay=0, timeout=5, **kwargs):
+    """Returns an iterator over the contents of the cache.
+
+    Args:
+      seek_to_start (bool): If ``True``, read all data that was written to the
+          cache since it was created. If ``False``, only read data that is
+          written to the cache *after* this method is called.
+      delay (float): Number of seconds to wait before returning collected
+          messages. A longer delay may result in messages being more accurately
+          ordered according to their timestamp.
+      timeout (float): If no new messags arrive within the specified number of
+          seconds, the reading process will be terminated.
+      kwargs (Dict[str, Any]): Arguments to be passed to the underlying reader
+          class.
+
+    Returns:
+      An iterator over the elements in the cache.
+    """
+    with self.read_to_queue(
+        seek_to_start=seek_to_start, **kwargs) as message_queue:
+      time.sleep(delay)
+      while True:
+        try:
+          element = message_queue.get(timeout=timeout)
+          yield element
+        except queue.Empty:
+          return
+
+  def write(self, elements):
+    """Writes a collection of elements into the cache.
+
+    Args:
+      elements (Iterable[Any]): A collection of elements to be written to cache.
+    """
+    if self.element_type is None:
+      # TODO(ostrokach): We might want to infer the element type from the first
+      # N elements, rather than reading the entire iterator.
+      elements = list(elements)
+      self.element_type = datatype_inference.infer_element_type(elements)
+
+    coder = (
+        self.default_coder if self.default_coder is not None else
+        coders.registry.get_coder(self.element_type))
+    writer_kwargs = self._writer_kwargs.copy()
+    # DirectRunner does not support timestamp_attribute
+    timestamp_attribute = writer_kwargs.pop("timestamp_attribute")
+
+    if writer_kwargs.get("with_attributes"):
+      encoder = None
+      if self.timestamp_attribute_fn:
+        raise ValueError(
+            "Only one of 'with_attributes' and 'timestamp_attribute_fn' "
+            "can be provided.")
+    else:
+      writer_kwargs["with_attributes"] = True
+      encoder = EncodeToPubSub(coder, timestamp_attribute,
+                               self.timestamp_attribute_fn)
+
+    writer = WriteToPubSub(self.location, **writer_kwargs)
+
+    do_fn = _DirectWriteToPubSubFn(writer._sink)
+    do_fn.start_bundle()
+    try:
+      for message in elements:
+        if encoder is not None:
+          current_timestamp = Timestamp.from_utc_datetime(
+              datetime.utcnow().replace(tzinfo=pytz.UTC))
+          message = next(encoder.process(message, timestamp=current_timestamp))
+        do_fn.process(message)
+    finally:
+      do_fn.finish_bundle()
+
+  def truncate(self):
+    """Removes all contents from the cache."""
+    self.element_type = None
+    self._primary_sub_exhausted = False
+    sub_client = pubsub.SubscriberClient()
+    try:
+      sub_client.delete_subscription(self.subscription.name)
+    except gexc.NotFound:
+      pass
+    _ = sub_client.create_subscription(self.subscription.name, self.location)
+    if self.snapshot is not None:
+      try:
+        sub_client.delete_snapshot(self.snapshot.name)
+      except gexc.NotFound:
+        pass
+      _ = sub_client.create_snapshot(self.snapshot.name, self.subscription.name)
+
+  def remove(self):
+    """Deletes the cache, including all underlying data.
+
+    The cache should not be used after this method is called.
+    """
+    for finalizer in self._finalizers:
+      finalizer()
+
+  @property
+  def removed(self):
+    return not any(finalizer.alive for finalizer in self._finalizers)
+
+  def __del__(self):
+    self.remove()
+
+  @property
+  def _reader_kwargs(self):
+    reader_kwargs = {
+        k: v for k, v in self._writer_kwargs.items()
+        if k in self._reader_passthrough_arguments
+    }
+    return reader_kwargs
+
+  def _configure_finalizers(self, persist):
+    if persist:
+      return []
+
+    pub_client = pubsub.PublisherClient()
+    sub_client = pubsub.SubscriberClient()
+
+    def delete_subscriptions(subscriptions):
+      for sub in subscriptions:
+        sub_client.delete_subscription(sub.name)
+
+    finalizers = []
+    if self.snapshot is not None:
+      finalizers += [
+          finalize(self, sub_client.delete_snapshot, self.snapshot.name)
+      ]
+    finalizers += [
+        finalize(self, delete_subscriptions, self._child_subscriptions),
+        finalize(self, pub_client.delete_topic, self.topic.name),
+    ]
+    return finalizers
+
+  def _assert_topic_exists(self):
+    pub_client = pubsub.PublisherClient()
+    try:
+      _ = pub_client.get_topic(self.topic.name)
+    except gexc.NotFound:
+      raise IOError("Pubsub topic '{}' does not exist.".format(self.topic.name))
+
+  def _create_child_subscription(self, seek_to_start=True):
+    sub_client = pubsub.SubscriberClient()
+    sub_path = None
+    existing_sub_paths = [
+        sub.name for sub in ([self.subscription] + self._child_subscriptions)
+    ]
+    while sub_path is None or sub_path in existing_sub_paths:
+      sub_path = sub_client.subscription_path(
+          self.project, self.topic_name + '-' + uuid.uuid4().hex)
+    if not seek_to_start or self.snapshot is not None:
+      subscription = sub_client.create_subscription(sub_path, self.location)
+      self._child_subscriptions.append(subscription)
+      if seek_to_start:
+        sub_client.seek(
+            subscription.name,
+            snapshot=self.snapshot.name,
+            retry=api_core.retry.Retry())
+    elif not self._primary_sub_exhausted:
+      subscription = self.subscription
+      self._primary_sub_exhausted = True
+    else:
+      raise ValueError(
+          "Cannot seek_to_start more than once in an environment where "
+          "snapshots are not supported.")
+    return subscription
+
+
+class PatchedPubSubReader(PTransform):
+  """A wrapper over :class:`~apache_beam.io.gcp.ReadFromPubSub`.
+
+  If 'with_attributes' is ``False``, ``PatchedPubSubReader`` decodes the
+  messages using the same coder that was used to encode them and assigns to the
+  resulting elements a timestamp from the 'timestamp_attribute' of the message.
+
+  If 'with_attributes' is ``True``, the behavior is identical to that of
+  :class:`~apache_beam.io.gcp.ReadFromPubSub`.
+  """
+
+  def __init__(self, cache, *reader_args, **reader_kwargs):
+    self._cache = cache
+    self._reader_args = reader_args
+    self._reader_kwargs = reader_kwargs
+
+    if "timestamp_attribute" not in reader_kwargs:
+      raise ValueError(
+          "timestamp_attribute must be specified when reading from cache.")
+
+  def expand(self, pbegin):
+    reader_kwargs = self._reader_kwargs.copy()
+
+    reader = ReadFromPubSub(*self._reader_args, **reader_kwargs)
+    if reader_kwargs.get("with_attributes"):
+      return pbegin | reader
+    else:
+      coder = (
+          self._cache.default_coder if self._cache.default_coder is not None
+          else coders.registry.get_coder(self._cache.element_type))
+      decoder = DecodeFromPubSub(coder, reader_kwargs["timestamp_attribute"])
+      return pbegin | reader | beam.ParDo(decoder)
+
+
+class DecodeFromPubSub(beam.DoFn):
+  """``DecodeFromPubSub`` decodes ``PubsubMessage`` objects using the provided
+  coder and wraps the resulting elements inside ``TimestampedValue`` objects,
+  with the timestamp of those objects defined by 'timestamp_attribute' of the
+  incoming messages.
+  """
+
+  def __init__(self, coder, timestamp_attribute):
+    super(DecodeFromPubSub, self).__init__()
+    self.coder = coder
+    self.timestamp_attribute = timestamp_attribute
+
+  def process(self, message):
+    rfc3339_or_milli = message.attributes[self.timestamp_attribute]
+    try:
+      timestamp = Timestamp(micros=int(rfc3339_or_milli) * 1000.0)
+    except ValueError:
+      timestamp = Timestamp.from_rfc3339(rfc3339_or_milli)
+    element = self.coder.decode(message.data)
+    yield TimestampedValue(element, timestamp)
+
+
+class PatchedPubSubWriter(PTransform):
+  """A wrapper over :class:`~apache_beam.io.gcp.WriteToPubSub`.
+
+  When ``PatchedPubSubWriter`` is expanded onto a Beam Pipeline, it assigns
+  to the cache the element_type of the parent PCollection.
+
+  If 'with_attributes' is ``False``, ``PatchedPubSubWriter`` encodes the
+  elements of the parent PCollection using an appropriate coder and converts
+  those elements into ``PubsubMessage`` objects with a 'timestamp_attribute'
+  that either is obtained using 'timestamp_attribute_fn' or is inferred from
+  the timestamp of the element.
+
+  If 'with_attributes' is ``True``, the behavior of ``PatchedPubSubWriter`` is
+  identical to that of :class:`~apache_beam.io.gcp.WriteToPubSub`.
+  """
+
+  def __init__(self, cache, *writer_args, **writer_kwargs):
+    self._cache = cache
+    self._writer_args = writer_args
+    self._writer_kwargs = writer_kwargs
+
+  def expand(self, pcoll):
+    if self._cache.element_type is None:
+      self._cache.element_type = pcoll.element_type
+
+    writer_kwargs = self._writer_kwargs.copy()
+    # DirectRunner does not support timestamp_attribute
+    timestamp_attribute = writer_kwargs.pop("timestamp_attribute")
+
+    if writer_kwargs.get("with_attributes"):
+      writer = WriteToPubSub(*self._writer_args, **writer_kwargs)
+      return pcoll | writer
+    else:
+      # Encode the element as a PubsubMessage ourselves
+      writer_kwargs["with_attributes"] = True
+      coder = (
+          self._cache.default_coder if self._cache.default_coder is not None
+          else coders.registry.get_coder(self._cache.element_type))
+      encoder = EncodeToPubSub(coder, timestamp_attribute,
+                               self._cache.timestamp_attribute_fn)
+      writer = WriteToPubSub(*self._writer_args, **writer_kwargs)
+      return pcoll | beam.ParDo(encoder) | writer
+
+
+class EncodeToPubSub(beam.DoFn):
+  """``EncodeToPubSub`` encodes elements using the provided coder and converts
+  those elements into ``PubsubMessage`` objects, with the 'timestamp_attribute'
+  attribute of those objects either obtained using 'timestamp_attribute_fn'
+  or inferred from the timestamp of the incoming elements.
+  """
+
+  def __init__(self, coder, timestamp_attribute, timestamp_attribute_fn=None):
+    self.coder = coder
+    self.timestamp_attribute = timestamp_attribute
+    self.timestamp_attribute_fn = timestamp_attribute_fn
+
+  def process(self, element, timestamp=beam.DoFn.TimestampParam):
+    if self.timestamp_attribute_fn is None:
+      timestamp = int(timestamp.micros / 1000.0)
+    else:
+      timestamp = self.timestamp_attribute_fn(element)
+    attributes = {self.timestamp_attribute: str(timestamp)}
+    element_bytes = self.coder.encode(element)
+    message = PubsubMessage(element_bytes, attributes)
+    yield message

--- a/sdks/python/apache_beam/runners/interactive/caching/stream_based_cache_it_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/stream_based_cache_it_test.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+from __future__ import print_function
+
+import functools
+import itertools
+import logging
+import pickle
+import sys
+import unittest
+import uuid
+
+import dill
+import numpy as np
+from nose.plugins.attrib import attr
+from parameterized import parameterized
+
+import apache_beam as beam
+from apache_beam import coders
+from apache_beam import transforms
+from apache_beam.io.gcp import pubsub as beam_pubsub
+from apache_beam.io.gcp.tests import utils as gcp_test_utils
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.runners.interactive.caching import file_based_cache_it_test
+from apache_beam.runners.interactive.caching import file_based_cache_test
+from apache_beam.runners.interactive.caching import stream_based_cache
+from apache_beam.testing.extra_assertions import ExtraAssertionsMixin
+from apache_beam.testing.test_pipeline import TestPipeline
+
+# Protect against environments where the PubSub library is not available.
+try:
+  from google.cloud import pubsub_v1
+except ImportError:
+  pubsub_v1 = None
+
+
+def read_directly(cache, limit=None, timeout=None, return_timestamp=False):
+  """Read elements from cache using the cache API."""
+  for element in itertools.islice(cache.read(timeout=timeout), limit):
+    if return_timestamp:
+      yield element
+    else:
+      yield element.value
+
+
+def write_directly(cache, data_in):
+  """Write elements to cache directly."""
+  cache.write(data_in)
+
+
+def write_through_pipeline(cache, data_in):
+  """Write elements to cache using a Beam pipeline."""
+  options = PipelineOptions(streaming=True)
+  # Create is an "impulse source", so it terminates the streaming pipeline
+  with beam.Pipeline(options=options) as p:
+    _ = p | transforms.Create(data_in) | cache.writer()
+
+
+class Validators(unittest.TestCase, ExtraAssertionsMixin):
+
+  def validate_directly(self, cache, expected):
+    """Validate the contents of a cache by reading it directly."""
+    actual = list(read_directly(cache, limit=len(expected), timeout=10))
+    self.assertUnhashableCountEqual(actual, expected)
+
+  def validate_through_pipeline(self, cache, expected):
+    """Validate the contents of cache by writing it out into a Beam pipeline."""
+    project, topic_name = beam_pubsub.parse_topic(cache.location)
+
+    pub_client = pubsub_v1.PublisherClient()
+    introspect_topic = pub_client.create_topic(
+        pub_client.topic_path(project, topic_name + "-introspec"))
+
+    sub_client = pubsub_v1.SubscriberClient()
+    introspect_sub = sub_client.create_subscription(
+        sub_client.subscription_path(project, topic_name + "-introspec"),
+        introspect_topic.name,
+        ack_deadline_seconds=60,
+    )
+
+    options = PipelineOptions(runner="DirectRunner", streaming=True)
+    p = beam.Pipeline(options=options)
+    pr = None
+    try:
+      _ = (
+          p
+          | "Read" >> cache.reader(with_attributes=True)
+          | "Write" >> beam.io.WriteToPubSub(
+              topic=introspect_topic.name, with_attributes=True))
+      pr = p.run()
+      output_messages = gcp_test_utils.read_from_pubsub(
+          sub_client,
+          introspect_sub.name,
+          number_of_elements=len(expected),
+          timeout=3 * 60,
+          with_attributes=True)
+      coder = (
+          cache.default_coder if cache.default_coder is not None else
+          coders.registry.get_coder(cache.element_type))
+      actual = [coder.decode(message.data) for message in output_messages]
+      self.assertUnhashableCountEqual(actual, expected)
+    finally:
+      if pr is not None:
+        pr.cancel()
+      sub_client.delete_subscription(introspect_sub.name)
+      pub_client.delete_topic(introspect_topic.name)
+
+  if sys.version_info < (3,):
+
+    def runTest(self):
+      pass
+
+
+def retry_flakes(fn):
+
+  @functools.wraps(fn)
+  def resilient_fn(self, *args, **kwargs):
+    max_tries = 3
+    error = None
+    for _ in range(max_tries):
+      try:
+        return fn(self, *args, **kwargs)
+      except AssertionError as e:
+        error = e
+        self.tearDown()
+        self.setUp()
+    raise error  # pylint: disable=raising-bad-type
+
+  return resilient_fn
+
+
+class TestCase(ExtraAssertionsMixin, unittest.TestCase):
+  pass
+
+
+@unittest.skipIf(pubsub_v1 is None, 'GCP dependencies are not installed.')
+class PubSubBasedCacheSerializationTest(
+    file_based_cache_it_test.SerializationTestBase, TestCase):
+
+  cache_class = stream_based_cache.PubSubBasedCache
+
+  def setUp(self):
+    test_pipeline = TestPipeline(is_integration_test=True)
+    project = test_pipeline.get_option('project')
+    topic_name = "{}-{}".format(self.cache_class.__name__, uuid.uuid4().hex)
+    self.location = pubsub_v1.PublisherClient.topic_path(project, topic_name)
+
+  @parameterized.expand([("pickle", pickle), ("dill", dill)])
+  @attr('IT')
+  @retry_flakes
+  def test_serialize_deserialize_empty(self, _, serializer):
+    self.check_serialize_deserialize_empty(write_directly, read_directly,
+                                           serializer)
+
+  @parameterized.expand([("pickle", pickle), ("dill", dill)])
+  @attr('IT')
+  @retry_flakes
+  def test_serialize_deserialize_filled(self, _, serializer):
+    self.check_serialize_deserialize_filled(write_directly, read_directly,
+                                            serializer)
+
+
+@unittest.skipIf(pubsub_v1 is None, 'GCP dependencies are not installed.')
+class PubSubBasedCacheRoundtripTest(file_based_cache_it_test.RoundtripTestBase,
+                                    TestCase):
+
+  cache_class = stream_based_cache.PubSubBasedCache
+  dataset = file_based_cache_test.GENERIC_TEST_DATA
+
+  def setUp(self):
+    test_pipeline = TestPipeline(is_integration_test=True)
+    project = test_pipeline.get_option('project')
+    topic_name = "{}-{}".format(self.cache_class.__name__, uuid.uuid4().hex)
+    self.location = pubsub_v1.PublisherClient.topic_path(project, topic_name)
+
+  @parameterized.expand([
+      ("{}-{}".format(
+          write_fn.__name__,
+          validate_fn.__name__,
+      ), write_fn, validate_fn)
+      for write_fn in [write_directly, write_through_pipeline]
+      for validate_fn in
+      [Validators().validate_directly,
+       Validators().validate_through_pipeline]
+  ])
+  @attr('IT')
+  @retry_flakes
+  def test_roundtrip(self, _, write_fn, validate_fn):
+    # Ideally, we would run this test with batches of different data types and
+    # different coders. However, the test takes several seconds, so running it
+    # for all possible writers, validators, and data types is not feasible.
+    data = [
+        None,
+        100,
+        1.23,
+        "abc",
+        b"def",
+        u"±♠Ωℑ",
+        ["d", 1],
+        ("a", "b", "c"),
+        (1, 2, 3, "b"),
+        {"a": 1, 123: 1.234},
+        np.zeros((3, 6)),
+    ]
+    self.check_roundtrip(write_fn, validate_fn, dataset=[data])
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/caching/stream_based_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/stream_based_cache_test.py
@@ -1,0 +1,670 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import gc
+import logging
+import sys
+import time
+import unittest
+from queue import Queue
+
+import mock
+
+import apache_beam as beam
+from apache_beam import coders
+from apache_beam.io.gcp.pubsub import PubsubMessage
+from apache_beam.pipeline import Pipeline
+from apache_beam.pvalue import PBegin
+from apache_beam.pvalue import PCollection
+from apache_beam.runners.interactive.caching import file_based_cache
+from apache_beam.runners.interactive.caching import file_based_cache_test
+from apache_beam.runners.interactive.caching import stream_based_cache
+from apache_beam.testing import datatype_inference
+from apache_beam.testing import test_utils
+from apache_beam.testing.extra_assertions import ExtraAssertionsMixin
+
+# Protect against environments where the PubSub library is not available.
+try:
+  from google.cloud import pubsub  # pylint: disable=ungrouped-imports
+  from google.cloud import pubsub_v1  # pylint: disable=ungrouped-imports
+  from google.api_core import exceptions as gexc
+except ImportError:
+  pubsub = None
+  pubsub_v1 = None
+  gexc = None
+
+
+class FakePublisherClient(object):
+  """A class to mock basic Google Cloud PubSub CRUD operations."""
+
+  def __init__(self, topics, subscriptions, snapshots):
+    self._topics = topics
+    self._subscriptions = subscriptions
+    self._snapshots = snapshots
+
+  def __setattr__(self, item, value):
+    # These attributes should be shared with the parent class.
+    protected_attributes = ["_topics", "_subscriptions", "_snapshots"]
+    if item in protected_attributes and hasattr(self, item):
+      raise ValueError("Attributes {} should not be overwritten.".format(
+          protected_attributes))
+    super(FakePublisherClient, self).__setattr__(item, value)
+
+  @staticmethod
+  def topic_path(*args, **kwargs):
+    return pubsub.PublisherClient.topic_path(*args, **kwargs)
+
+  def create_topic(self, name, *args, **kwargs):
+    if name in self._topics:
+      raise gexc.AlreadyExists("Topic '{}' already exists.".format(name))
+    self._topics.append(name)
+    topic_proto = pubsub.types.Topic()
+    topic_proto.name = name
+    return topic_proto
+
+  def delete_topic(self, topic, *args, **kwargs):
+    if topic not in self._topics:
+      raise gexc.NotFound("Topic '{}' was not found.".format(topic))
+    self._topics.remove(topic)
+
+  def get_topic(self, topic, *args, **kwargs):
+    if topic not in self._topics:
+      raise gexc.NotFound("Topic '{}' was not found.".format(topic))
+    topic_proto = pubsub.types.Topic()
+    topic_proto.name = topic
+    return topic_proto
+
+  def list_topics(self, project, *args, **kwargs):
+    topic_protos = []
+    for topic in self._topics:
+      topic_project = "/".join(topic.split("/")[:2])
+      if topic_project == project:
+        topic_proto = pubsub.types.Topic()
+        topic_proto.name = topic
+        topic_protos.append(topic_proto)
+    return topic_protos
+
+  def list_topic_subscriptions(self, topic, *args, **kwargs):
+    topic_project = topic.split("/")[1]
+    subscriptions = []
+    for sub_name, _ in self._subscriptions:
+      sub_project = sub_name.split("/")[1]
+      if sub_project == topic_project:
+        subscriptions.append(sub_name)
+    return subscriptions
+
+  def topic_path(self, project, topic_name):
+    return "projects/{}/topics/{}".format(project, topic_name)
+
+  def publish(self, *args, **kwargs):
+
+    class Future(object):
+
+      def __init__(self, result):
+        self._result = result
+
+      def result(self, *args, **kwargs):
+        return self._result
+
+    return Future(None)
+
+
+class FakeSubscriberClient(object):
+
+  def __init__(self, topics, subscriptions, snapshots):
+    self._topics = topics
+    self._subscriptions = subscriptions
+    self._snapshots = snapshots
+
+  def __setattr__(self, item, value):
+    # These attributes should be shared with the parent class.
+    protected_attributes = ["_topics", "_subscriptions", "_snapshots"]
+    if item in protected_attributes and hasattr(self, item):
+      raise ValueError("Attributes {} should not be overwritten.".format(
+          protected_attributes))
+    super(FakeSubscriberClient, self).__setattr__(item, value)
+
+  @staticmethod
+  def subscription_path(*args, **kwargs):
+    return pubsub.SubscriberClient.subscription_path(*args, **kwargs)
+
+  @staticmethod
+  def snapshot_path(*args, **kwargs):
+    return pubsub.SubscriberClient.snapshot_path(*args, **kwargs)
+
+  def create_subscription(self, name, topic, *args, **kwargs):
+    if name in [s for s, _ in self._subscriptions]:
+      raise gexc.AlreadyExists("Subscription '{}' already exists.".format(name))
+    self._subscriptions.append((name, topic))
+    sub_proto = pubsub.types.Subscription()
+    sub_proto.name = name
+    sub_proto.topic = topic
+    return sub_proto
+
+  def delete_subscription(self, subscription, *args, **kwargs):
+    if subscription not in [s for s, _ in self._subscriptions]:
+      raise gexc.NotFound(
+          "Subscription '{}' does not exist.".format(subscription))
+    topic = next(t for s, t in self._subscriptions if s == subscription)
+    self._subscriptions.remove((subscription, topic))
+
+  def get_subscription(self, subscription, *args, **kwargs):
+    for sub_name, sub_topic in self._subscriptions:
+      if sub_name == subscription:
+        sub_proto = pubsub.types.Subscription()
+        sub_proto.name = sub_name
+        sub_proto.topic = sub_topic
+        return sub_proto
+    raise gexc.NotFound(
+        "Subscription '{}' does not exist.".format(subscription))
+
+  def list_subscriptions(self, project, *args, **kwargs):
+    sub_protos = []
+    for sub_name, sub_topic in self._subscriptions:
+      sub_project = "/".join(sub_name.split("/")[:2])
+      if sub_project == project:
+        sub_proto = pubsub.types.Subscription()
+        sub_proto.name = sub_name
+        sub_proto.topic = sub_topic
+        sub_proto.append(sub_proto)
+    return sub_protos
+
+  def create_snapshot(self, name, subscription, *args, **kwargs):
+    if name in [s for s, _ in self._snapshots]:
+      raise gexc.AlreadyExists("Snapshot '{}' already exists.".format(name))
+    topic = self.get_subscription(subscription).topic
+    self._snapshots.append((name, topic))
+    snap_proto = pubsub.types.Snapshot()
+    snap_proto.name = name
+    snap_proto.topic = topic
+    return snap_proto
+
+  def delete_snapshot(self, snapshot, *args, **kwargs):
+    if snapshot not in [s for s, _ in self._snapshots]:
+      raise gexc.NotFound("Snapshot '{}' does not exist.".format(snapshot))
+    topic = next(t for s, t in self._snapshots if s == snapshot)
+    self._snapshots.remove((snapshot, topic))
+
+  def get_snapshot(self, snapshot, *args, **kwargs):
+    # Blocked by: https://github.com/googleapis/google-cloud-python/issues/8554
+    raise NotImplementedError
+
+  def list_snapshots(self, project, *args, **kwargs):
+    snap_protos = []
+    for snap_name, snap_topic in self._snapshots:
+      snap_project = "/".join(snap_name.split("/")[:2])
+      if snap_project == project:
+        snap_proto = pubsub.types.Snapshot()
+        snap_proto.name = snap_name
+        snap_proto.topic = snap_topic
+        snap_protos.append(snap_proto)
+    return snap_protos
+
+  def seek(self, *args, **kwargs):
+    pass
+
+
+class FakePubSub(object):
+
+  def __init__(self):
+    self._topics = []
+    self._subscriptions = []
+    self._snapshots = []
+    self.types = pubsub.types if pubsub is not None else None
+
+  def PublisherClient(self):
+    return FakePublisherClient(self._topics, self._subscriptions,
+                               self._snapshots)
+
+  def SubscriberClient(self):
+    return FakeSubscriberClient(self._topics, self._subscriptions,
+                                self._snapshots)
+
+
+@unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
+@mock.patch(
+    "apache_beam.runners.interactive.caching.stream_based_cache.pubsub",
+    new_callable=FakePubSub)
+class PubSubBasedCacheTest(ExtraAssertionsMixin, unittest.TestCase):
+
+  cache_class = stream_based_cache.PubSubBasedCache
+
+  def setUp(self):
+    project_id = "test-project-id"
+    topic_name = "test-topic-name"
+    self.location = "projects/{}/topics/{}".format(project_id, topic_name)
+
+  def tearDown(self):
+    pass
+
+  def test_init(self, mock_pubsub):
+    _, project_id, _, topic_name = self.location.split("/")
+    subscription_path = "projects/{}/subscriptions/{}".format(
+        project_id, topic_name)
+    snapshot_path = "projects/{}/snapshots/{}".format(project_id, topic_name)
+
+    cache = self.cache_class(self.location)
+
+    self.assertEqual(cache.location, self.location)
+    self.assertEqual(cache.subscription.name, subscription_path)
+    self.assertEqual(cache.snapshot.name, snapshot_path)
+
+    self.assertCountEqual(mock_pubsub._topics, [self.location])
+    self.assertCountEqual(mock_pubsub._subscriptions,
+                          [(subscription_path, self.location)])
+    self.assertCountEqual(mock_pubsub._snapshots,
+                          [(snapshot_path, self.location)])
+
+  def test_init_mode_invalid(self, unused_mock_pubsub):
+    with self.assertRaises(ValueError):
+      _ = self.cache_class(self.location, mode=None)
+
+    with self.assertRaises(ValueError):
+      _ = self.cache_class(self.location, mode="")
+
+    with self.assertRaises(ValueError):
+      _ = self.cache_class(self.location, mode="be happy")
+
+  def test_init_mode_error(self, mock_pubsub):
+    _ = self.cache_class(self.location)
+    with self.assertRaises(IOError):
+      _ = self.cache_class(self.location, mode="error")
+
+  def test_init_mode_overwrite(self, mock_pubsub):
+    location_copy = "".join(self.location)
+    self.assertEqual(self.location, location_copy)
+    self.assertNotEqual(id(self.location), id(location_copy))
+
+    _ = self.cache_class(self.location, persist=True)
+    topic = mock_pubsub._topics[0]
+    subscription = mock_pubsub._subscriptions[0]
+    snapshot = mock_pubsub._snapshots[0]
+
+    # cache2 needs to be kept so that resources are not gc-ed immediately.
+    cache2 = self.cache_class(location_copy, mode="overwrite")  # pylint: disable=unused-variable
+    self.assertCountEqual([topic], mock_pubsub._topics)
+    self.assertCountEqual([subscription], mock_pubsub._subscriptions)
+    self.assertCountEqual([snapshot], mock_pubsub._snapshots)
+    self.assertNotEqual(id(topic), id(mock_pubsub._topics[0]))
+    self.assertNotEqual(id(subscription), id(mock_pubsub._subscriptions[0]))
+    self.assertNotEqual(id(snapshot), id(mock_pubsub._snapshots[0]))
+
+  def test_init_mode_append(self, mock_pubsub):
+    location_copy = "".join(self.location)
+    self.assertEqual(self.location, location_copy)
+    self.assertNotEqual(id(self.location), id(location_copy))
+
+    _ = self.cache_class(self.location, persist=True)
+    topic = mock_pubsub._topics[0]
+    subscription = mock_pubsub._subscriptions[0]
+    snapshot = mock_pubsub._snapshots[0]
+
+    # cache2 needs to be kept so that resources are not gc-ed immediately.
+    cache2 = self.cache_class(location_copy, mode="append")  # pylint: disable=unused-variable
+    self.assertCountEqual([topic], mock_pubsub._topics)
+    self.assertCountEqual([subscription], mock_pubsub._subscriptions)
+    self.assertCountEqual([snapshot], mock_pubsub._snapshots)
+    self.assertEqual(id(topic), id(mock_pubsub._topics[0]))
+    self.assertEqual(id(subscription), id(mock_pubsub._subscriptions[0]))
+    self.assertEqual(id(snapshot), id(mock_pubsub._snapshots[0]))
+
+  def test_persist_false_0(self, mock_pubsub):
+    cache = self.cache_class(self.location, persist=False)
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+    cache.remove()
+    self.assertEqual(len(mock_pubsub._topics), 0)
+    self.assertEqual(len(mock_pubsub._subscriptions), 0)
+    self.assertEqual(len(mock_pubsub._snapshots), 0)
+
+  def test_persist_false_1(self, mock_pubsub):
+    cache = self.cache_class(self.location, persist=False)
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+    del cache
+    gc.collect()
+    self.assertEqual(len(mock_pubsub._topics), 0)
+    self.assertEqual(len(mock_pubsub._subscriptions), 0)
+    self.assertEqual(len(mock_pubsub._snapshots), 0)
+
+  def test_persist_setter_false(self, mock_pubsub):
+    cache = self.cache_class(self.location, persist=True)
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+    cache.persist = False
+    del cache
+    gc.collect()
+    self.assertEqual(len(mock_pubsub._topics), 0)
+    self.assertEqual(len(mock_pubsub._subscriptions), 0)
+    self.assertEqual(len(mock_pubsub._snapshots), 0)
+
+  def test_persist_true_0(self, mock_pubsub):
+    cache = self.cache_class(self.location, persist=True)
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+    cache.remove()
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+
+  def test_persist_true_1(self, mock_pubsub):
+    cache = self.cache_class(self.location, persist=True)
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+    del cache
+    gc.collect()
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+
+  def test_persist_setter_true(self, mock_pubsub):
+    cache = self.cache_class(self.location, persist=False)
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+    cache.persist = True
+    del cache
+    gc.collect()
+    self.assertGreater(len(mock_pubsub._topics), 0)
+    self.assertGreater(len(mock_pubsub._subscriptions), 0)
+    self.assertGreater(len(mock_pubsub._snapshots), 0)
+
+  def test_timestamp(self, unused_mock_pubsub):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache.timestamp, 0)
+    cache.writer()
+    timestamp1 = cache.timestamp
+    self.assertGreater(timestamp1, 0)
+    time.sleep(0.01)
+    cache.writer()
+    timestamp2 = cache.timestamp
+    self.assertGreater(timestamp2, timestamp1)
+
+  def test_writer_arguments(self, unused_mock_pubsub):
+    kwargs = {"a": 10, "b": "hello"}
+    dummy_ptransfrom = beam.Map(lambda e: e)
+    dummy_pcoll = PCollection(pipeline=Pipeline(), element_type=str)
+    with mock.patch("apache_beam.runners.interactive.caching.stream_based_cache"
+                    ".WriteToPubSub") as mock_writer:
+      mock_writer.return_value = dummy_ptransfrom
+      cache = self.cache_class(self.location, **kwargs)
+      cache.writer().expand(dummy_pcoll)
+    _, kwargs_out = list(mock_writer.call_args)
+    # Arguments known to be assigned by the cache
+    kwargs_out.pop("with_attributes", None)
+    self.assertEqual(kwargs_out, kwargs)
+
+  def test_reader_arguments(self, unused_mock_pubsub):
+
+    def get_reader_kwargs(kwargs, passthrough):
+      dummy_ptransfrom = beam.Map(lambda e: e)
+      with mock.patch(
+          "apache_beam.runners.interactive.caching.stream_based_cache"
+          ".ReadFromPubSub") as mock_reader:
+        mock_reader.return_value = dummy_ptransfrom
+        cache = self.cache_class(
+            self.location, mode="overwrite", coder=DummyCoder(), **kwargs)
+        cache._reader_passthrough_arguments = (
+            cache._reader_passthrough_arguments | passthrough)
+        cache.reader().expand(PBegin(Pipeline()))
+      _, kwargs_out = list(mock_reader.call_args)
+      # Arguments known to be assigned by the cache
+      kwargs_out.pop("subscription", None)
+      kwargs_out.pop("timestamp_attribute", None)
+      return kwargs_out
+
+    kwargs = {"a": 10, "b": "hello world", "c": b"xxx"}
+    kwargs_out = get_reader_kwargs(kwargs, set())
+    self.assertEqual(kwargs_out, {})
+
+    kwargs_out = get_reader_kwargs(kwargs, {"a", "b"})
+    self.assertEqual(kwargs_out, {"a": 10, "b": "hello world"})
+
+  def test_infer_element_type_with_write(self, unused_mock_pubsub):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache.element_type, None)
+    for data in file_based_cache_test.GENERIC_TEST_DATA:
+      element_type = datatype_inference.infer_element_type(data)
+      cache.truncate()
+      self.assertEqual(cache.element_type, None)
+      with mock.patch("google.cloud.pubsub"):
+        cache.write(data)
+      self.assertEqual(cache.element_type, element_type)
+
+  def test_infer_element_type_with_writer(self, unused_mock_pubsub):
+    cache = self.cache_class(self.location)
+    self.assertEqual(cache.element_type, None)
+    for data in file_based_cache_test.GENERIC_TEST_DATA:
+      element_type = datatype_inference.infer_element_type(data)
+      cache.truncate()
+      self.assertEqual(cache.element_type, None)
+      cache.writer().expand(PCollection(Pipeline(), element_type=element_type))
+      self.assertEqual(cache.element_type, element_type)
+
+  def test_default_coder(self, unused_mock_pubsub):
+    cache = self.cache_class(
+        self.location, coder=file_based_cache.SafeFastPrimitivesCoder)
+    for element_type in file_based_cache_test.GENERIC_ELEMENT_TYPES:
+      cache.truncate()
+      cache.element_type = element_type
+
+      # We need to specify new=DummyEncoder instead of using MagicMock
+      # to prevent StackOverflow errors caused by recursive pickling.
+      with mock.patch(
+          "apache_beam.runners.interactive.caching.stream_based_cache"
+          ".EncodeToPubSub",
+          new=generate_dummy_encoder(file_based_cache.SafeFastPrimitivesCoder)):
+        cache.writer().expand(PCollection(Pipeline(), element_type=str))
+
+  def test_inferred_coder(self, unused_mock_pubsub):
+    cache = self.cache_class(self.location)
+    for element_type in file_based_cache_test.GENERIC_ELEMENT_TYPES:
+      cache.truncate()
+      cache.element_type = element_type
+
+      # We need to specify new=DummyEncoder instead of using MagicMock
+      # to prevent StackOverflow errors caused by recursive pickling.
+      with mock.patch(
+          "apache_beam.runners.interactive.caching.stream_based_cache"
+          ".EncodeToPubSub",
+          new=generate_dummy_encoder(coders.registry.get_coder(element_type))):
+        cache.writer().expand(PCollection(Pipeline(), element_type=str))
+
+  @mock.patch("apache_beam.runners.interactive.caching.stream_based_cache"
+              ".WriteToPubSub")
+  def test_writer(self, mock_writer, unused_mock_pubsub):
+    dummy_ptransfrom = beam.Map(lambda e: e)
+    mock_writer.return_value = dummy_ptransfrom
+    cache = self.cache_class(self.location)
+    self.assertEqual(mock_writer.call_count, 0)
+    cache.writer().expand(PCollection(Pipeline(), element_type=str))
+    self.assertEqual(mock_writer.call_count, 1)
+    cache.writer().expand(PCollection(Pipeline(), element_type=str))
+    self.assertEqual(mock_writer.call_count, 2)
+
+  @mock.patch("apache_beam.runners.interactive.caching.stream_based_cache"
+              ".ReadFromPubSub")
+  def test_reader(self, mock_reader, unused_mock_pubsub):
+    dummy_ptransfrom = beam.Map(lambda e: e)
+    mock_reader.return_value = dummy_ptransfrom
+    cache = self.cache_class(self.location, coder=DummyCoder())
+    self.assertEqual(mock_reader.call_count, 0)
+    cache.reader().expand(PBegin(Pipeline()))
+    self.assertEqual(mock_reader.call_count, 1)
+    cache.reader().expand(PBegin(Pipeline()))
+    self.assertEqual(mock_reader.call_count, 2)
+
+  def test_write(self, unused_mock_pubsub):
+    num_elements = 10
+    data_list = [
+        'data {}'.format(i).encode("utf-8") for i in range(num_elements)
+    ]
+    cache = self.cache_class(self.location)
+    with mock.patch("google.cloud.pubsub") as mock_publisher:
+      cache.write(data_list)
+    expected_attributes = {
+        self.cache_class._default_timestamp_attribute: mock.ANY
+    }
+    call_list = ([
+        mock.call(mock.ANY, data, **expected_attributes) for data in data_list
+    ] + [mock.call().result(mock.ANY) for _ in data_list])
+    mock_publisher.PublisherClient().publish.assert_has_calls(call_list)
+
+  def test_write_with_attributes(self, unused_mock_pubsub):
+    num_elements = 10
+    data_list = [
+        'data {}'.format(i).encode("utf-8") for i in range(num_elements)
+    ]
+    attributes_list = [{
+        'key': 'value {}'.format(i), 'custom_timestmap': '{}'.format(i)
+    } for i in range(num_elements)]
+    messages = [
+        PubsubMessage(data, attributes)
+        for data, attributes in zip(data_list, attributes_list)
+    ]
+    cache = self.cache_class(
+        self.location,
+        with_attributes=True,
+        timestamp_attribute="custom_timestmap")
+    with mock.patch("google.cloud.pubsub") as mock_publisher:
+      cache.write(messages)
+    call_list = ([
+        mock.call(mock.ANY, data, **attributes)
+        for data, attributes in zip(data_list, attributes_list)
+    ] + [mock.call().result(mock.ANY) for _ in data_list])
+    mock_publisher.PublisherClient().publish.assert_has_calls(call_list)
+
+  def test_read_to_queue(self, mock_pubsub):
+
+    num_elements = 10
+    data_list = [
+        'data {}'.format(i).encode("utf-8") for i in range(num_elements)
+    ]
+    attributes_list = [{
+        'key': 'value {}'.format(i),
+        self.cache_class._default_timestamp_attribute: '0'
+    } for i in range(num_elements)]
+    ack_ids = ['ack_id_{}'.format(i) for i in range(num_elements)]
+    response_messages = [
+        test_utils.PullResponseMessage(data, attributes, ack_id=ack_id)
+        for data, attributes, ack_id in zip(data_list, attributes_list, ack_ids)
+    ]
+    response = test_utils.create_pull_response(response_messages)
+    request_queue = Queue()
+    mock_subscribe_future = mock.MagicMock()
+
+    def push_test_items(subscription, callback):
+      for msg in response.received_messages:
+        msg = pubsub_v1.subscriber.message.Message(msg.message, msg.ack_id,
+                                                   request_queue)
+        callback(msg)
+      return mock_subscribe_future
+
+    FakeSubscriberClient.subscribe = mock.MagicMock(side_effect=push_test_items)
+
+    cache = self.cache_class(self.location, coder=DummyCoder())
+    self.assertEqual(len(mock_pubsub._subscriptions), 1)
+    with cache.read_to_queue() as message_queue:
+      self.assertEqual(len(mock_pubsub._subscriptions), 2)
+      received_messages = []
+      for _ in range(num_elements):
+        timestamped_value = message_queue.get()
+        received_messages.append(timestamped_value.value)
+    self.assertEqual(len(mock_pubsub._subscriptions), 1)
+    self.assertCountEqual(received_messages, data_list)
+    mock_subscribe_future.cancel.assert_called_once_with()
+
+  def test_read(self, mock_pubsub):
+    input_data = [0, 1, 2, 3, "4"]
+
+    message_queue = Queue()
+    for element in input_data:
+      message_queue.put(element)
+
+    mock_queue_context = mock.MagicMock()
+    mock_queue_context.__enter__.side_effect = lambda: message_queue
+    mock_read_to_queue = mock.MagicMock(
+        side_effect=lambda *args, **kwargs: mock_queue_context)
+
+    cache = self.cache_class(self.location)
+    cache.read_to_queue = mock_read_to_queue
+    produced_data = []
+    for element in cache.read(delay=0, timeout=0):
+      produced_data.append(element)
+    mock_queue_context.__exit__.assert_called_once()
+    self.assertEqual(input_data, produced_data)
+
+  def test_truncate(self, mock_pubsub):
+    cache = self.cache_class(self.location, persist=True)
+    subscriptions = mock_pubsub._subscriptions[:]
+    snapshots = mock_pubsub._snapshots[:]
+    cache.truncate()
+    self.assertEqual(subscriptions, mock_pubsub._subscriptions)
+    self.assertNotEqual([id(t) for t in subscriptions],
+                        [id(t) for t in mock_pubsub._subscriptions])
+    self.assertEqual(snapshots, mock_pubsub._snapshots)
+    self.assertNotEqual([id(t) for t in snapshots],
+                        [id(t) for t in mock_pubsub._snapshots])
+
+  def test_remove(self, mock_pubsub):
+    cache = self.cache_class(self.location)
+    cache.remove()
+    self.assertCountEqual([], mock_pubsub._topics)
+    self.assertCountEqual([], mock_pubsub._subscriptions)
+    self.assertCountEqual([], mock_pubsub._snapshots)
+
+
+def generate_dummy_encoder(default_coder):
+
+  class DummyEncoder(beam.DoFn, unittest.TestCase):
+
+    default_coder = None
+
+    def __init__(self, coder, *args, **kwargs):
+      unittest.TestCase.__init__(self)
+      self.coder = coder
+      self.assertEqual(self.coder, self.default_coder)
+
+    def process(self, element):
+      yield element
+
+    if sys.version_info < (3,):
+
+      def runTest(self):
+        pass
+
+  DummyEncoder.default_coder = default_coder
+
+  return DummyEncoder
+
+
+class DummyCoder(object):
+
+  def decode(self, element):
+    return element
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/scripts/generate_pydoc.sh
+++ b/sdks/python/scripts/generate_pydoc.sh
@@ -135,6 +135,7 @@ ignore_identifiers = [
   'List',
   'Set',
   'Tuple',
+  'Callable',
 
   # Ignore broken built-in type references
   'tuple',

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -137,7 +137,6 @@ else:
 REQUIRED_PACKAGES = [
     'avro>=1.8.1,<2.0.0; python_version < "3.0"',
     'avro-python3>=1.8.1,<2.0.0; python_version >= "3.0"',
-    'backports.weakref>=1.0rc1,<1.1',
     'crcmod>=1.7,<2.0',
     # Dill doesn't have forwards-compatibility guarantees within minor version.
     # Pickles created with a new version of dill may not unpickle using older

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -137,6 +137,7 @@ else:
 REQUIRED_PACKAGES = [
     'avro>=1.8.1,<2.0.0; python_version < "3.0"',
     'avro-python3>=1.8.1,<2.0.0; python_version >= "3.0"',
+    'backports.weakref>=1.0rc1,<1.1',
     'crcmod>=1.7,<2.0',
     # Dill doesn't have forwards-compatibility guarantees within minor version.
     # Pickles created with a new version of dill may not unpickle using older

--- a/sdks/python/test-suites/direct/py2/build.gradle
+++ b/sdks/python/test-suites/direct/py2/build.gradle
@@ -62,6 +62,7 @@ task directRunnerIT {
 .test_multiple_destinations_transform",
         "apache_beam.io.gcp.bigquery_test:PubSubBigQueryIT",
         "apache_beam.io.gcp.bigquery_file_loads_test:BigQueryFileLoadsIT.test_bqfl_streaming",
+        "apache_beam.runners.interactive.caching.stream_based_cache_it_test",
     ]
     def streamingTestOpts = basicTestOpts + ["--tests=${tests.join(',')}"]
     def argMap = ["runner": "TestDirectRunner",

--- a/sdks/python/test-suites/direct/py35/build.gradle
+++ b/sdks/python/test-suites/direct/py35/build.gradle
@@ -37,6 +37,7 @@ task postCommitIT {
         "apache_beam.io.gcp.bigquery_read_it_test",
         "apache_beam.io.gcp.bigquery_write_it_test",
         "apache_beam.io.gcp.datastore.v1new.datastore_write_it_test",
+        "apache_beam.runners.interactive.caching.stream_based_cache_it_test",
     ]
     def testOpts = [
         "--tests=${batchTests.join(',')}",

--- a/sdks/python/test-suites/direct/py36/build.gradle
+++ b/sdks/python/test-suites/direct/py36/build.gradle
@@ -37,6 +37,7 @@ task postCommitIT {
         "apache_beam.io.gcp.bigquery_read_it_test",
         "apache_beam.io.gcp.bigquery_write_it_test",
         "apache_beam.io.gcp.datastore.v1new.datastore_write_it_test",
+        "apache_beam.runners.interactive.caching.stream_based_cache_it_test",
     ]
     def testOpts = [
         "--tests=${batchTests.join(',')}",

--- a/sdks/python/test-suites/direct/py37/build.gradle
+++ b/sdks/python/test-suites/direct/py37/build.gradle
@@ -37,6 +37,7 @@ task postCommitIT {
         "apache_beam.io.gcp.bigquery_read_it_test",
         "apache_beam.io.gcp.bigquery_write_it_test",
         "apache_beam.io.gcp.datastore.v1new.datastore_write_it_test",
+        "apache_beam.runners.interactive.caching.stream_based_cache_it_test",
     ]
     def testOpts = [
         "--tests=${batchTests.join(',')}",


### PR DESCRIPTION
Add a `PubSubBasedCache` implementation of the `PCollectionCache` ABC. 

Demos:

| Notebook | MyBinder | Colab |
| ------------- | ------------- | -------- |
| [03-streaming_demo_explicit_caching.ipynb](https://github.com/ostrokach/beam-notebooks/blob/master/notebooks/03-streaming_demo_explicit_caching.ipynb) | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ostrokach/beam-notebooks/master?filepath=notebooks%2F03-streaming_demo_explicit_caching.ipynb) | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ostrokach/beam-notebooks/blob/master/notebooks/03-streaming_demo_explicit_caching.ipynb)
| [04-streaming_demo_explicit_caching_taxirides.ipynb](https://github.com/ostrokach/beam-notebooks/blob/master/notebooks/04-streaming_demo_explicit_caching_taxirides.ipynb) | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ostrokach/beam-notebooks/master?filepath=notebooks%2F04-streaming_demo_explicit_caching_taxirides.ipynb) | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ostrokach/beam-notebooks/blob/master/notebooks/04-streaming_demo_explicit_caching_taxirides.ipynb)

CC: @ivant @ananvay  
R: @aaltay @udim 

-----------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
