### PR TITLE
[BEAM-6740] Add PTransformTranslator for Combine.Globally

### DIFF
--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CombineTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CombineTranslationTest.java
@@ -80,13 +80,13 @@ public class CombineTranslationTest {
     public void testToProto() throws Exception {
       PCollection<Integer> input = pipeline.apply(Create.of(1, 2, 3));
       input.apply(Combine.globally(combineFn));
-      final AtomicReference<AppliedPTransform<?, ?, Combine.PerKey<?, ?, ?>>> combine =
+      final AtomicReference<AppliedPTransform<?, ?, Combine.Globally<?, ?>>> combine =
           new AtomicReference<>();
       pipeline.traverseTopologically(
           new PipelineVisitor.Defaults() {
             @Override
             public void leaveCompositeTransform(Node node) {
-              if (node.getTransform() instanceof Combine.PerKey) {
+              if (node.getTransform() instanceof Combine.Globally) {
                 checkState(combine.get() == null);
                 combine.set((AppliedPTransform) node.toAppliedPTransform(getPipeline()));
               }
@@ -121,13 +121,13 @@ public class CombineTranslationTest {
       PCollection<Integer> input = pipeline.apply(Create.of(1, 2, 3));
       CombineFnWithContext<Integer, int[], Integer> combineFn = new TestCombineFnWithContext();
       input.apply(Combine.globally(combineFn).withoutDefaults());
-      final AtomicReference<AppliedPTransform<?, ?, Combine.PerKey<?, ?, ?>>> combine =
+      final AtomicReference<AppliedPTransform<?, ?, Combine.Globally<?, ?>>> combine =
           new AtomicReference<>();
       pipeline.traverseTopologically(
           new PipelineVisitor.Defaults() {
             @Override
             public void leaveCompositeTransform(Node node) {
-              if (node.getTransform() instanceof Combine.PerKey) {
+              if (node.getTransform() instanceof Combine.Globally) {
                 checkState(combine.get() == null);
                 combine.set((AppliedPTransform) node.toAppliedPTransform(getPipeline()));
               }
@@ -168,13 +168,13 @@ public class CombineTranslationTest {
           };
 
       input.apply(Combine.globally(combineFn).withSideInputs(sideInputs).withoutDefaults());
-      final AtomicReference<AppliedPTransform<?, ?, Combine.PerKey<?, ?, ?>>> combine =
+      final AtomicReference<AppliedPTransform<?, ?, Combine.Globally<?, ?>>> combine =
           new AtomicReference<>();
       pipeline.traverseTopologically(
           new PipelineVisitor.Defaults() {
             @Override
             public void leaveCompositeTransform(Node node) {
-              if (node.getTransform() instanceof Combine.PerKey) {
+              if (node.getTransform() instanceof Combine.Globally) {
                 checkState(combine.get() == null);
                 combine.set((AppliedPTransform) node.toAppliedPTransform(getPipeline()));
               }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CombineTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CombineTranslationTest.java
@@ -97,7 +97,9 @@ public class CombineTranslationTest {
 
       SdkComponents sdkComponents = SdkComponents.create();
       sdkComponents.registerEnvironment(Environments.createDockerEnvironment("java"));
-      CombinePayload combineProto = CombineTranslation.toProto(combine.get(), sdkComponents);
+      CombinePayload combineProto =
+          CombineTranslation.CombineGloballyPayloadTranslator.payloadForCombineGlobally(
+              (AppliedPTransform) combine.get(), sdkComponents);
       RunnerApi.Components componentsProto = sdkComponents.toComponents();
 
       assertEquals(
@@ -138,7 +140,9 @@ public class CombineTranslationTest {
 
       SdkComponents sdkComponents = SdkComponents.create();
       sdkComponents.registerEnvironment(Environments.createDockerEnvironment("java"));
-      CombinePayload combineProto = CombineTranslation.toProto(combine.get(), sdkComponents);
+      CombinePayload combineProto =
+          CombineTranslation.CombineGloballyPayloadTranslator.payloadForCombineGlobally(
+              (AppliedPTransform) combine.get(), sdkComponents);
       RunnerApi.Components componentsProto = sdkComponents.toComponents();
 
       assertEquals(
@@ -183,7 +187,9 @@ public class CombineTranslationTest {
 
       SdkComponents sdkComponents = SdkComponents.create();
       sdkComponents.registerEnvironment(Environments.createDockerEnvironment("java"));
-      CombinePayload payload = CombineTranslation.toProto(combine.get(), sdkComponents);
+      CombinePayload payload =
+          CombineTranslation.CombineGloballyPayloadTranslator.payloadForCombineGlobally(
+              (AppliedPTransform) combine.get(), sdkComponents);
     }
   }
 


### PR DESCRIPTION
It seems that we missed the payloads for Combine.Globally that can have specific translations as is the case of the spark runner.

R: @lukecwik 