### PR TITLE
Fix : columns with only 'nulls' raise : buffer is 'None'

### DIFF
--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -478,5 +478,6 @@ class _ParquetSink(filebasedsink.FileBasedSink):
     size = 0
     for x in arrays:
       for b in x.buffers():
-        size = size + b.size
+        if b is not None: 
+          size = size + b.size
     self._record_batches_byte_size = self._record_batches_byte_size + size


### PR DESCRIPTION
The following error is raised, If in a table there exists a column with more null values.
The problem is with the buffer implementation, which is empty if a particular column is with nulls.

Note: The problem vanishes if the pipeline is deployed locally, but fails when deployed to cloud runners as some distributed workers might end up getting a column with only null values. By adding a conditional statement to check whether the buffer is empty solved the issue. 

```
WARNING:root:A task failed with exception: 'NoneType' object has no attribute 'size' [while running 'writetoParquet/Write/WriteImpl/WriteBundles']
....
AttributeError: 'NoneType' object has no attribute 'size' [while running 'writetoParquet/Write/WriteImpl/WriteBundles']
```


