### PR TITLE
Make OffsetRangeTracker.try_split() try best to split when suggested split is invalid

### DIFF
--- a/sdks/python/apache_beam/io/concat_source_test.py
+++ b/sdks/python/apache_beam/io/concat_source_test.py
@@ -94,7 +94,7 @@ class ConcatSourceTest(unittest.TestCase):
   def test_range_source(self):
     source_test_utils.assert_split_at_fraction_exhaustive(RangeSource(0, 10, 3))
 
-  def test_conact_source(self):
+  def test_concat_source(self):
     source = ConcatSource([RangeSource(0, 4),
                            RangeSource(4, 8),
                            RangeSource(8, 12),
@@ -119,17 +119,15 @@ class ConcatSourceTest(unittest.TestCase):
     self.assertEqual(range_tracker.sub_range_tracker(1).try_claim(6), True)
     self.assertEqual(range_tracker.fraction_consumed(), 0.375)
     self.assertEqual(range_tracker.try_split((0, 1)), None)
+    self.assertEqual(range_tracker.sub_range_tracker(1).try_claim(7), True)
     self.assertEqual(range_tracker.try_split((1, 5)), None)
 
     self.assertEqual(range_tracker.try_split((3, 14)), ((3, None), 0.75))
     self.assertEqual(range_tracker.try_claim((3, None)), False)
-    self.assertEqual(range_tracker.sub_range_tracker(1).try_claim(7), True)
     self.assertEqual(range_tracker.try_claim((2, None)), True)
-    self.assertEqual(range_tracker.sub_range_tracker(2).try_claim(9), True)
-
-    self.assertEqual(range_tracker.try_split((2, 8)), None)
-    self.assertEqual(range_tracker.try_split((2, 11)), ((2, 11), 11. / 12))
     self.assertEqual(range_tracker.sub_range_tracker(2).try_claim(10), True)
+
+    self.assertEqual(range_tracker.try_split((2, 8)), ((2, 11), 11. / 12))
     self.assertEqual(range_tracker.sub_range_tracker(2).try_claim(11), False)
 
   def test_estimate_size(self):

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -140,7 +140,7 @@ class OffsetRangeTracker(iobase.RangeTracker):
           'already past proposed stop offset', split_offset, self)
       return False
     if (split_offset < self.start_position()
-          or split_offset >= self.stop_position()):
+        or split_offset >= self.stop_position()):
       logging.debug(
           'Split position %s at %s is not valid: '
           'proposed split position out of range', split_offset, self)

--- a/sdks/python/apache_beam/io/source_test_utils.py
+++ b/sdks/python/apache_beam/io/source_test_utils.py
@@ -281,6 +281,13 @@ def _assert_split_at_fraction_behavior(
   reader_iter = iter(reader)
   for _ in range(num_items_to_read_before_split):
     current_items.append(next(reader_iter))
+  # When expected to read the whole file, invoke try_claim() one more time to
+  # claim the whole range.
+  if len(expected_items) == num_items_to_read_before_split:
+    try:
+      next(reader_iter)
+    except StopIteration:
+      pass
 
   suggested_split_position = range_tracker.position_at_fraction(
       split_fraction)

--- a/sdks/python/apache_beam/io/source_test_utils_test.py
+++ b/sdks/python/apache_beam/io/source_test_utils_test.py
@@ -100,12 +100,10 @@ class SourceTestUtilsTest(unittest.TestCase):
   def test_split_at_fraction_fails(self):
     data = self._create_data(100)
     source = self._create_source(data)
-
     result = source_test_utils.assert_split_at_fraction_behavior(
-        source, 90, 0.1, source_test_utils.ExpectedSplitOutcome.MUST_FAIL)
+        source, 100, 0.1, source_test_utils.ExpectedSplitOutcome.MUST_FAIL)
     self.assertEqual(result[0], 100)
     self.assertEqual(result[1], -1)
-
     with self.assertRaises(ValueError):
       source_test_utils.assert_split_at_fraction_behavior(
           source, 10, 0.5, source_test_utils.ExpectedSplitOutcome.MUST_FAIL)

--- a/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
+++ b/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
@@ -184,7 +184,7 @@ class SyntheticPipelineTest(unittest.TestCase):
   def test_split_at_fraction(self):
     source = synthetic_pipeline.SyntheticSource(input_spec(10, 1, 1))
     source_test_utils.assert_split_at_fraction_exhaustive(source)
-    source_test_utils.assert_split_at_fraction_fails(source, 5, 0.3)
+    source_test_utils.assert_split_at_fraction_fails(source, 10, 0.3)
     source_test_utils.assert_split_at_fraction_succeeds_and_consistent(
         source, 1, 0.3)
 


### PR DESCRIPTION
When OffsetRangeTracker.try_split() cannot perform split at suggested position, try best to split as soon as possible, aka, at current_processing_position + 1.

R: @lukecwik 