### PR TITLE
Make LineSource claim the right position not the left position

### DIFF
--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -65,14 +65,14 @@ class LineSource(FileBasedSource):
         f.seek(start)
         line = f.readline()
         start += len(line)
-      current = start
       line = f.readline()
+      current = start + len(line) - 1
       while line:
         if not range_tracker.try_claim(current):
           return
         yield line.rstrip(b'\n')
-        current += len(line)
         line = f.readline()
+        current = current + len(line) if line else current
     finally:
       f.close()
 


### PR DESCRIPTION
Assuming there is a LineSource like:
'11\n' '222\n', '333\n'], when trying to claim the second element '222\n', the claim position in previous implementation is 3 (0 + len('11\n')), with my change, the claimed position will be 6 (0 + len('11\n') + len('222\n') - 1).
The reason to do this is to avoid the situation like, when reading to the end of range, the range_tracker doesn't claim till the end position.