### PR TITLE
RestrictionTracker.current_watermark returns None

### DIFF
--- a/model/fn-execution/src/main/proto/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/beam_fn_api.proto
@@ -194,7 +194,8 @@ message BundleApplication {
   // are produced by this PTransform into each of its output PCollections
   // when invoked with this application.
   //
-  // If there is no watermark reported, use MIN_TIMESTAMP by default.
+  // If there is no watermark reported from RestrictionTracker, the sdk should
+  // report MIN_TIMESTAMP by default.
   map<string, google.protobuf.Timestamp> output_watermarks = 4;
 
   // (Required) Whether this application potentially produces an unbounded

--- a/model/fn-execution/src/main/proto/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/beam_fn_api.proto
@@ -194,8 +194,8 @@ message BundleApplication {
   // are produced by this PTransform into each of its output PCollections
   // when invoked with this application.
   //
-  // If there is no watermark reported from RestrictionTracker, the sdk should
-  // report MIN_TIMESTAMP by default.
+  // If there is no watermark reported from RestrictionTracker, the runner will
+  // use MIN_TIMESTAMP by default.
   map<string, google.protobuf.Timestamp> output_watermarks = 4;
 
   // (Required) Whether this application potentially produces an unbounded

--- a/model/fn-execution/src/main/proto/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/beam_fn_api.proto
@@ -193,6 +193,8 @@ message BundleApplication {
   // value represents a lower bound on the timestamps of elements that
   // are produced by this PTransform into each of its output PCollections
   // when invoked with this application.
+  //
+  // If there is no watermark reported, use MIN_TIMESTAMP by default.
   map<string, google.protobuf.Timestamp> output_watermarks = 4;
 
   // (Required) Whether this application potentially produces an unbounded

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1137,6 +1137,10 @@ class RestrictionTracker(object):
     """
     raise NotImplementedError
 
+  def current_watermark(self):
+    """Returns current watermark. By default, not report watermark."""
+    return None
+
   def checkpoint(self):
     """Performs a checkpoint of the current restriction.
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1138,7 +1138,10 @@ class RestrictionTracker(object):
     raise NotImplementedError
 
   def current_watermark(self):
-    """Returns current watermark. By default, not report watermark."""
+    """Returns current watermark. By default, not report watermark.
+
+    TODO(BEAM-7473): Provide synchronization guarantee by using a wrapper.
+    """
     return None
 
   def checkpoint(self):

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -44,7 +44,7 @@ from apache_beam.transforms.window import TimestampedValue
 from apache_beam.transforms.window import WindowFn
 from apache_beam.utils.counters import Counter
 from apache_beam.utils.counters import CounterName
-from apache_beam.utils import timestamp
+from apache_beam.utils.timestamp import Timestamp
 from apache_beam.utils.windowed_value import WindowedValue
 
 
@@ -201,7 +201,7 @@ class MethodWrapper(object):
         kwargs[kw] = user_state_context.get_timer(timer_spec, key, window)
 
     if self.timestamp_arg_name:
-      kwargs[self.timestamp_arg_name] = timestamp.Timestamp(seconds=timestamp)
+      kwargs[self.timestamp_arg_name] = Timestamp(seconds=timestamp)
     if self.window_arg_name:
       kwargs[self.window_arg_name] = window
     if self.key_arg_name:

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -700,10 +700,7 @@ class PerWindowInvoker(DoFnInvoker):
       # Temporary workaround for [BEAM-7473]: get current_watermark before
       # split, in case watermark gets advanced before getting split results.
       # In worst case, current_watermark is always stale, which is ok.
-      # If no current watermark reported, use MIN_TIMESTAMP by default.
-      current_watermark = (restriction_tracker.current_watermark()
-                           if restriction_tracker.current_watermark()
-                           else timestamp.MIN_TIMESTAMP)
+      current_watermark = restriction_tracker.current_watermark()
       split = restriction_tracker.try_split(fraction)
       if split:
         primary, residual = split

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -32,7 +32,7 @@ from builtins import next
 from builtins import object
 
 from future.utils import itervalues
-from google import protobuf
+from google.protobuf import timestamp_pb2
 
 import apache_beam as beam
 from apache_beam import coders
@@ -647,12 +647,12 @@ class BundleProcessor(object):
     ptransform_id, main_input_tag, main_input_coder, outputs = op.input_info
     # TODO(SDF): For non-root nodes, need main_input_coder + residual_coder.
     element_and_restriction, watermark = deferred_remainder
-    if watermark:
-      proto_watermark = protobuf.Timestamp()
-      proto_watermark.FromMicroseconds(watermark.micros)
-      output_watermarks = {output: proto_watermark for output in outputs}
-    else:
-      output_watermarks = None
+    # If no current watermark reported, use MIN_TIMESTAMP by default.
+    if not watermark:
+      watermark = timestamp.MIN_TIMESTAMP
+    proto_watermark = timestamp_pb2.Timestamp()
+    proto_watermark.FromMicroseconds(watermark.micros)
+    output_watermarks = {output: proto_watermark for output in outputs}
     return beam_fn_api_pb2.DelayedBundleApplication(
         application=beam_fn_api_pb2.BundleApplication(
             ptransform_id=ptransform_id,

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -647,12 +647,12 @@ class BundleProcessor(object):
     ptransform_id, main_input_tag, main_input_coder, outputs = op.input_info
     # TODO(SDF): For non-root nodes, need main_input_coder + residual_coder.
     element_and_restriction, watermark = deferred_remainder
-    # If no current watermark reported, use MIN_TIMESTAMP by default.
-    if not watermark:
-      watermark = timestamp.MIN_TIMESTAMP
-    proto_watermark = timestamp_pb2.Timestamp()
-    proto_watermark.FromMicroseconds(watermark.micros)
-    output_watermarks = {output: proto_watermark for output in outputs}
+    if watermark:
+      proto_watermark = timestamp_pb2.Timestamp()
+      proto_watermark.FromMicroseconds(watermark.micros)
+      output_watermarks = {output: proto_watermark for output in outputs}
+    else:
+      output_watermarks = None
     return beam_fn_api_pb2.DelayedBundleApplication(
         application=beam_fn_api_pb2.BundleApplication(
             ptransform_id=ptransform_id,


### PR DESCRIPTION
RestrictionTracker.current_watermark returns None by default and treats it as MIN_TIMESTAMP.