### PR TITLE
[BEAM-7653] Add PTransformTranslator for Combine.GroupedValues

### DIFF
--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
@@ -84,7 +84,7 @@ public class SparkRunnerDebuggerTest {
             + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())\n"
             + "_.combineByKey(..., new org.apache.beam.sdk.transforms.Count$CountFn(), ...)\n"
             + "_.groupByKey()\n"
-            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Combine$GroupedValues$1())\n"
+            + "_.map(new org.apache.beam.sdk.transforms.Sum$SumLongFn())\n"
             + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())\n"
             + "sparkContext.union(...)\n"
             + "_.mapPartitions("
@@ -141,7 +141,7 @@ public class SparkRunnerDebuggerTest {
             + "SparkRunnerDebuggerTest$FormatKVFn())\n"
             + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())\n"
             + "_.groupByKey()\n"
-            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Combine$GroupedValues$1())\n"
+            + "_.map(new org.apache.beam.sdk.transforms.Combine$IterableCombineFn())\n"
             + "_.mapPartitions(new org.apache.beam.sdk.transforms.Distinct$3())\n"
             + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())\n"
             + "_.<org.apache.beam.sdk.io.kafka.AutoValue_KafkaIO_Write>";


### PR DESCRIPTION
This is a follow up to #8995 but for the case of a runner that wants to have a specific translation of `Combine.GroupedValues`. Notice that this is the case of the Spark runner and this PR is to address a regression on it (since the runner moved to URN based translation instead of class based it is not calling the specialized translation).
R: @lukecwik 