### PR TITLE
[BEAM-7680] Removed flaky assertion and separated unit tests in synthetic source test

### DIFF
--- a/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
+++ b/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
@@ -57,7 +57,7 @@ class SyntheticPipelineTest(unittest.TestCase):
 
   # pylint: disable=expression-not-assigned
 
-  def test_count_elements_after_synthetic_step(self):
+  def test_synthetic_step_multiplies_output_elements_count(self):
     with beam.Pipeline() as p:
       pcoll = p | beam.Create(list(range(10))) | beam.ParDo(
           synthetic_pipeline.SyntheticStep(0, 0, 10))
@@ -71,10 +71,9 @@ class SyntheticPipelineTest(unittest.TestCase):
           synthetic_pipeline.SyntheticStep(0, 0.5, 10))
 
     elapsed = time.time() - start
-
     self.assertGreaterEqual(elapsed, 0.5, elapsed)
 
-  def test_count_elements_after_synthetic_sdf_step(self):
+  def test_synthetic_sdf_step_multiplies_output_elements_count(self):
     with beam.Pipeline() as p:
       pcoll = p | beam.Create(list(range(10))) | beam.ParDo(
           synthetic_pipeline.get_synthetic_sdf_step(0, 0, 10))
@@ -88,7 +87,6 @@ class SyntheticPipelineTest(unittest.TestCase):
           synthetic_pipeline.get_synthetic_sdf_step(0, 0.5, 10))
 
     elapsed = time.time() - start
-
     self.assertGreaterEqual(elapsed, 0.5, elapsed)
 
   def test_synthetic_step_split_provider(self):

--- a/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
+++ b/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
@@ -60,7 +60,7 @@ class SyntheticPipelineTest(unittest.TestCase):
   def test_count_elements_after_synthetic_step(self):
     with beam.Pipeline() as p:
       pcoll = p | beam.Create(list(range(10))) | beam.ParDo(
-          synthetic_pipeline.SyntheticStep(0, 0.5, 10))
+          synthetic_pipeline.SyntheticStep(0, 0, 10))
       assert_that(
           pcoll | beam.combiners.Count.Globally(), equal_to([100]))
 
@@ -72,12 +72,12 @@ class SyntheticPipelineTest(unittest.TestCase):
 
     elapsed = time.time() - start
 
-    self.assertTrue(elapsed >= 0.5, elapsed)
+    self.assertGreaterEqual(elapsed, 0.5, elapsed)
 
   def test_count_elements_after_synthetic_sdf_step(self):
     with beam.Pipeline() as p:
       pcoll = p | beam.Create(list(range(10))) | beam.ParDo(
-          synthetic_pipeline.get_synthetic_sdf_step(0, 0.5, 10))
+          synthetic_pipeline.get_synthetic_sdf_step(0, 0, 10))
       assert_that(
           pcoll | beam.combiners.Count.Globally(), equal_to([100]))
 
@@ -89,7 +89,7 @@ class SyntheticPipelineTest(unittest.TestCase):
 
     elapsed = time.time() - start
 
-    self.assertTrue(elapsed >= 0.5, elapsed)
+    self.assertGreaterEqual(elapsed, 0.5, elapsed)
 
   def test_synthetic_step_split_provider(self):
     provider = synthetic_pipeline.SyntheticSDFStepRestrictionProvider(

--- a/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
+++ b/sdks/python/apache_beam/testing/synthetic_pipeline_test.py
@@ -57,29 +57,39 @@ class SyntheticPipelineTest(unittest.TestCase):
 
   # pylint: disable=expression-not-assigned
 
-  def test_synthetic_step(self):
-    start = time.time()
+  def test_count_elements_after_synthetic_step(self):
     with beam.Pipeline() as p:
       pcoll = p | beam.Create(list(range(10))) | beam.ParDo(
           synthetic_pipeline.SyntheticStep(0, 0.5, 10))
       assert_that(
           pcoll | beam.combiners.Count.Globally(), equal_to([100]))
 
-    elapsed = time.time() - start
-    # TODO(chamikaramj): Fix the flaky time based bounds.
-    self.assertTrue(0.5 <= elapsed <= 3, elapsed)
-
-  def test_synthetic_sdf_step(self):
+  def test_minimal_runtime_with_synthetic_step_delay(self):
     start = time.time()
+    with beam.Pipeline() as p:
+      p | beam.Create(list(range(10))) | beam.ParDo(
+          synthetic_pipeline.SyntheticStep(0, 0.5, 10))
+
+    elapsed = time.time() - start
+
+    self.assertTrue(elapsed >= 0.5, elapsed)
+
+  def test_count_elements_after_synthetic_sdf_step(self):
     with beam.Pipeline() as p:
       pcoll = p | beam.Create(list(range(10))) | beam.ParDo(
           synthetic_pipeline.get_synthetic_sdf_step(0, 0.5, 10))
       assert_that(
           pcoll | beam.combiners.Count.Globally(), equal_to([100]))
 
+  def test_minimal_runtime_with_synthetic_sdf_step_bundle_delay(self):
+    start = time.time()
+    with beam.Pipeline() as p:
+      p | beam.Create(list(range(10))) | beam.ParDo(
+          synthetic_pipeline.get_synthetic_sdf_step(0, 0.5, 10))
+
     elapsed = time.time() - start
-    # TODO(chamikaramj): Fix the flaky time based bounds.
-    self.assertTrue(0.5 <= elapsed <= 3, elapsed)
+
+    self.assertTrue(elapsed >= 0.5, elapsed)
 
   def test_synthetic_step_split_provider(self):
     provider = synthetic_pipeline.SyntheticSDFStepRestrictionProvider(


### PR DESCRIPTION
Synthetic step unit tests was split into separate test cases. Removed flaky assertion which was depending on time.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
