### PR TITLE
Add last_attempted_record_start to python OffsetRangeTracker

### DIFF
--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -67,9 +67,7 @@ class LineSource(FileBasedSource):
         start += len(line)
       current = start
       line = f.readline()
-      while line:
-        if not range_tracker.try_claim(current):
-          return
+      while range_tracker.try_claim(current):
         yield line.rstrip(b'\n')
         current += len(line)
         line = f.readline()

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -68,6 +68,10 @@ class LineSource(FileBasedSource):
       current = start
       line = f.readline()
       while range_tracker.try_claim(current):
+        # When the source is unsplittable, try_claim is not enough to determine
+        # whether the file has reached to the end.
+        if not line:
+          return
         yield line.rstrip(b'\n')
         current += len(line)
         line = f.readline()

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -88,10 +88,10 @@ class OffsetRangeTracker(iobase.RangeTracker):
       raise ValueError(
           'This function must only be called under the lock self.lock.')
 
-    if record_start < self._last_attempted_record_start:
+    if record_start <= self._last_attempted_record_start:
       raise ValueError(
-          'Trying to return a record [starting at %d] which is before the '
-          'last-attempted record [starting at %d]' %
+          'Trying to return a record [starting at %d] which is not greater than'
+          'the last-attempted record [starting at %d]' %
           (record_start, self._last_attempted_record_start))
 
     if record_start < self._last_record_start:

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -61,7 +61,6 @@ class OffsetRangeTracker(iobase.RangeTracker):
     self._stop_offset = end
 
     self._last_record_start = -1
-    # Records a position that tried be claimed as long as it's a valid position.
     self._last_attempted_record_start = -1
     self._offset_of_last_split_point = -1
     self._lock = threading.Lock()
@@ -81,6 +80,12 @@ class OffsetRangeTracker(iobase.RangeTracker):
 
   @property
   def last_attempted_record_start(self):
+    """Return current value of last_attempted_record_start.
+
+    last_attempted_record_start records a valid position that tried to be
+    claimed by calling try_claim(). This value is only updated by `try_claim()`
+    no matter `try_claim()` returns `True` or `False`.
+    """
     return self._last_attempted_record_start
 
   def _validate_record_start(self, record_start, split_point):

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -61,6 +61,7 @@ class OffsetRangeTracker(iobase.RangeTracker):
     self._stop_offset = end
 
     self._last_record_start = -1
+    # Records a position that tried be claimed as long as it's a valid position.
     self._last_attempted_record_start = -1
     self._offset_of_last_split_point = -1
     self._lock = threading.Lock()

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -61,6 +61,7 @@ class OffsetRangeTracker(iobase.RangeTracker):
     self._stop_offset = end
 
     self._last_record_start = -1
+    self._last_attempted_record_start = -1
     self._offset_of_last_split_point = -1
     self._lock = threading.Lock()
 
@@ -77,11 +78,21 @@ class OffsetRangeTracker(iobase.RangeTracker):
   def last_record_start(self):
     return self._last_record_start
 
+  @property
+  def last_attempted_record_start(self):
+    return self._last_attempted_record_start
+
   def _validate_record_start(self, record_start, split_point):
     # This function must only be called under the lock self.lock.
     if not self._lock.locked():
       raise ValueError(
           'This function must only be called under the lock self.lock.')
+
+    if record_start < self._last_attempted_record_start:
+      raise ValueError(
+          'Trying to return a record [starting at %d] which is before the '
+          'last-attempted record [starting at %d]' %
+          (record_start, self._last_attempted_record_start))
 
     if record_start < self._last_record_start:
       raise ValueError(
@@ -103,6 +114,7 @@ class OffsetRangeTracker(iobase.RangeTracker):
   def try_claim(self, record_start):
     with self._lock:
       self._validate_record_start(record_start, True)
+      self._last_attempted_record_start = record_start
       if record_start >= self.stop_position():
         return False
       self._offset_of_last_split_point = record_start

--- a/sdks/python/apache_beam/io/range_trackers_test.py
+++ b/sdks/python/apache_beam/io/range_trackers_test.py
@@ -56,6 +56,21 @@ class OffsetRangeTrackerTest(unittest.TestCase):
     self.assertFalse(tracker.try_claim(6))
     self.assertEqual(6, tracker.last_attempted_record_start)
 
+    with self.assertRaises(Exception):
+      tracker.try_claim(6)
+
+  def test_set_current_position(self):
+    tracker = range_trackers.OffsetRangeTracker(0, 6)
+    self.assertTrue(tracker.try_claim(2))
+    # Cannot set current position before successful claimed pos.
+    with self.assertRaises(Exception):
+      tracker.set_current_position(1)
+
+    self.assertFalse(tracker.try_claim(10))
+    tracker.set_current_position(3)
+    self.assertEqual(10, tracker.last_attempted_record_start)
+    self.assertEqual(3, tracker.last_record_start)
+
   def test_try_return_record_continuous_until_split_point(self):
     tracker = range_trackers.OffsetRangeTracker(9, 18)
     # Return records with gaps of 2; every 3rd record is a split point.

--- a/sdks/python/apache_beam/io/range_trackers_test.py
+++ b/sdks/python/apache_beam/io/range_trackers_test.py
@@ -45,6 +45,17 @@ class OffsetRangeTrackerTest(unittest.TestCase):
     self.assertTrue(tracker.try_claim(5))
     self.assertFalse(tracker.try_claim(6))
 
+  def test_try_claim_update_last_attempt(self):
+    tracker = range_trackers.OffsetRangeTracker(1, 2)
+    self.assertTrue(tracker.try_claim(1))
+    self.assertEqual(1, tracker.last_attempted_record_start)
+
+    self.assertFalse(tracker.try_claim(3))
+    self.assertEqual(3, tracker.last_attempted_record_start)
+
+    self.assertFalse(tracker.try_claim(6))
+    self.assertEqual(6, tracker.last_attempted_record_start)
+
   def test_try_return_record_continuous_until_split_point(self):
     tracker = range_trackers.OffsetRangeTracker(9, 18)
     # Return records with gaps of 2; every 3rd record is a split point.

--- a/sdks/python/apache_beam/io/range_trackers_test.py
+++ b/sdks/python/apache_beam/io/range_trackers_test.py
@@ -67,9 +67,9 @@ class OffsetRangeTrackerTest(unittest.TestCase):
       tracker.set_current_position(1)
 
     self.assertFalse(tracker.try_claim(10))
-    tracker.set_current_position(3)
+    tracker.set_current_position(11)
     self.assertEqual(10, tracker.last_attempted_record_start)
-    self.assertEqual(3, tracker.last_record_start)
+    self.assertEqual(11, tracker.last_record_start)
 
   def test_try_return_record_continuous_until_split_point(self):
     tracker = range_trackers.OffsetRangeTracker(9, 18)
@@ -118,7 +118,6 @@ class OffsetRangeTrackerTest(unittest.TestCase):
     # offset.
     self.assertFalse(tracker.try_claim(150))
     self.assertFalse(tracker.try_claim(151))
-    tracker.set_current_position(135)
     # Should accept non-splitpoint records starting after stop offset.
     tracker.set_current_position(152)
     tracker.set_current_position(160)

--- a/sdks/python/apache_beam/io/range_trackers_test.py
+++ b/sdks/python/apache_beam/io/range_trackers_test.py
@@ -118,8 +118,8 @@ class OffsetRangeTrackerTest(unittest.TestCase):
     # offset.
     self.assertFalse(tracker.try_claim(150))
     self.assertFalse(tracker.try_claim(151))
-    # Should accept non-splitpoint records starting after stop offset.
     tracker.set_current_position(135)
+    # Should accept non-splitpoint records starting after stop offset.
     tracker.set_current_position(152)
     tracker.set_current_position(160)
     tracker.set_current_position(171)

--- a/sdks/python/apache_beam/io/sources_test.py
+++ b/sdks/python/apache_beam/io/sources_test.py
@@ -52,6 +52,8 @@ class LineSource(iobase.BoundedSource):
       current = start
       line  = f.readline()
       while range_tracker.try_claim(current):
+        if not line:
+          return
         yield line.rstrip(b'\n')
         current += len(line)
         line = f.readline()

--- a/sdks/python/apache_beam/io/sources_test.py
+++ b/sdks/python/apache_beam/io/sources_test.py
@@ -50,11 +50,11 @@ class LineSource(iobase.BoundedSource):
         start -= 1
         start += len(f.readline())
       current = start
-      for line in f:
-        if not range_tracker.try_claim(current):
-          return
+      line  = f.readline()
+      while range_tracker.try_claim(current):
         yield line.rstrip(b'\n')
         current += len(line)
+        line = f.readline()
 
   def split(self, desired_bundle_size, start_position=None, stop_position=None):
     assert start_position is None
@@ -103,6 +103,8 @@ class SourcesTest(unittest.TestCase):
     result = [line for line in source.read(range_tracker)]
 
     self.assertCountEqual([b'aaaa', b'bbbb', b'cccc', b'dddd'], result)
+    self.assertTrue(range_tracker.last_attempted_record_start
+                    >= range_tracker.stop_position())
 
   def test_run_direct(self):
     file_name = self._create_temp_file(b'aaaa\nbbbb\ncccc\ndddd')

--- a/sdks/python/apache_beam/io/sources_test.py
+++ b/sdks/python/apache_beam/io/sources_test.py
@@ -50,7 +50,7 @@ class LineSource(iobase.BoundedSource):
         start -= 1
         start += len(f.readline())
       current = start
-      line  = f.readline()
+      line = f.readline()
       while range_tracker.try_claim(current):
         if not line:
           return


### PR DESCRIPTION
Similar to Java [OffsetRangeTracker](https://github.com/apache/beam/blob/82cfdb805e4a530443f450f7262ff344d5cc7ede/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java#L36)

R: @chamikaramj 
cc: @lukecwik 