### PR TITLE
[BEAM-7499] Workaround for tricky Reify testing issue

### DIFF
--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -575,6 +575,12 @@ class ReifyTest(unittest.TestCase):
                                   [GlobalWindow()])]
     with TestPipeline() as p:
       pc = p | beam.Create(l)
+      # Map(lambda x: x) PTransform is added after Create here, because when
+      # a PCollection of WindowedValues is created with Create PTransform,
+      # the windows are not assigned to it. Adding a Map forces the
+      # PCollection to go through a DoFn so that the PCollection consists of
+      # the elements with timestamps assigned to them instead of a PCollection
+      # of WindowedValue(element, timestamp, window).
       pc = pc | beam.Map(lambda x: x)
       reified_pc = pc | util.Reify.Window()
       assert_that(reified_pc, equal_to(expected), reify_windows=True)

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -575,6 +575,7 @@ class ReifyTest(unittest.TestCase):
                                   [GlobalWindow()])]
     with TestPipeline() as p:
       pc = p | beam.Create(l)
+      pc = pc | beam.Map(lambda x: x)
       reified_pc = pc | util.Reify.Window()
       assert_that(reified_pc, equal_to(expected), reify_windows=True)
 


### PR DESCRIPTION
r: @ttanay 

Hi Tanay! I've seen issues with this test in some environments that are fixed by doing this. My guess is that there's some odd codepath where Create(...)'d elements need to go through a ptransform before having all their attributes (timestamp, window) populated properly?

I'm not making any sense, but please review this change : )