### PR TITLE
Add UT to check SdfWrapper overrides ReadFromText

### DIFF
--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1465,6 +1465,7 @@ class _SDFBoundedSourceWrapper(ptransform.PTransform):
     return SDFBoundedSourceDoFn(self.source)
 
   def expand(self, pbegin):
+    assert isinstance(pbegin, pvalue.PBegin)
     return (pbegin
             | core.Impulse()
             | core.ParDo(self._create_sdf_bounded_source_dofn()))

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -154,10 +154,12 @@ class Pipeline(object):
       raise ValueError(
           'Pipeline has validations errors: \n' + '\n'.join(errors))
 
-    # set default experiments for portable runner
+    # set default experiments for portable runner and fnapi runner
     # (needs to occur prior to pipeline construction)
     portable_runners = ['PortableRunner', 'FlinkRunner']
-    if self._options.view_as(StandardOptions).runner in portable_runners:
+    from apache_beam.runners.portability.fn_api_runner import FnApiRunner
+    if (self._options.view_as(StandardOptions).runner in portable_runners or
+        isinstance(runner, FnApiRunner)):
       experiments = (self._options.view_as(DebugOptions).experiments or [])
       if not 'beam_fn_api' in experiments:
         experiments.append('beam_fn_api')

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -339,13 +339,6 @@ class FnApiRunner(runner.PipelineRunner):
     MetricsEnvironment.set_metrics_supported(False)
     RuntimeValueProvider.set_runtime_options({})
 
-    # Setup "beam_fn_api" experiment options if lacked.
-    experiments = (options.view_as(pipeline_options.DebugOptions).experiments
-                   or [])
-    if not 'beam_fn_api' in experiments:
-      experiments.append('beam_fn_api')
-    options.view_as(pipeline_options.DebugOptions).experiments = experiments
-
     # This is sometimes needed if type checking is disabled
     # to enforce that the inputs (and outputs) of GroupByKey operations
     # are known to be KVs.
@@ -359,6 +352,8 @@ class FnApiRunner(runner.PipelineRunner):
     self._profiler_factory = profiler.Profile.factory_from_options(
         options.view_as(pipeline_options.ProfilingOptions))
 
+    experiments = (options.view_as(pipeline_options.DebugOptions).experiments
+                   or [])
     if 'use_sdf_bounded_source' in experiments:
       pipeline.replace_all(DataflowRunner._SDF_PTRANSFORM_OVERRIDES)
 


### PR DESCRIPTION
Add one more unit test case to verify SdfBoundedSourceWrapper also overrides. And set "beam_fn_api" when initializing a pipeline if using FnApiRunner.