### PR TITLE
[BEAM-7600] borrow SDK harness management code into Spark runner

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
@@ -48,6 +48,7 @@ import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
 import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
+import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStageContextFactory;
 import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStageFunction;
 import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStagePruningFunction;
 import org.apache.beam.runners.flink.translation.functions.FlinkPartialReduceFunction;
@@ -55,7 +56,6 @@ import org.apache.beam.runners.flink.translation.functions.FlinkReduceFunction;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.runners.flink.translation.types.KvKeySelector;
 import org.apache.beam.runners.flink.translation.wrappers.ImpulseInputFormat;
-import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.wire.WireCoders;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
@@ -330,7 +330,7 @@ public class FlinkBatchPortablePipelineTranslator
             stagePayload,
             context.getJobInfo(),
             outputMap,
-            ExecutableStageContext.factory(),
+            FlinkExecutableStageContextFactory.getInstance(),
             getWindowingStrategy(inputPCollectionId, components).getWindowFn().windowCoder());
 
     final String operatorName = generateNameFromStagePayload(stagePayload);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
@@ -48,7 +48,6 @@ import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
 import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
-import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStageContext;
 import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStageFunction;
 import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStagePruningFunction;
 import org.apache.beam.runners.flink.translation.functions.FlinkPartialReduceFunction;
@@ -56,6 +55,7 @@ import org.apache.beam.runners.flink.translation.functions.FlinkReduceFunction;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.runners.flink.translation.types.KvKeySelector;
 import org.apache.beam.runners.flink.translation.wrappers.ImpulseInputFormat;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.wire.WireCoders;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
@@ -330,7 +330,7 @@ public class FlinkBatchPortablePipelineTranslator
             stagePayload,
             context.getJobInfo(),
             outputMap,
-            FlinkExecutableStageContext.factory(context.getPipelineOptions()),
+            ExecutableStageContext.factory(),
             getWindowingStrategy(inputPCollectionId, components).getWindowFn().windowCoder());
 
     final String operatorName = generateNameFromStagePayload(stagePayload);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -49,7 +49,6 @@ import org.apache.beam.runners.core.construction.WindowingStrategyTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
-import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStageContext;
 import org.apache.beam.runners.flink.translation.functions.ImpulseSourceFunction;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator;
@@ -63,6 +62,7 @@ import org.apache.beam.runners.flink.translation.wrappers.streaming.io.DedupingO
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.StreamingImpulseSource;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.TestStreamSource;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.UnboundedSourceWrapper;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
@@ -702,7 +702,7 @@ public class FlinkStreamingPortablePipelineTranslator
             context.getPipelineOptions(),
             stagePayload,
             context.getJobInfo(),
-            FlinkExecutableStageContext.factory(context.getPipelineOptions()),
+            ExecutableStageContext.factory(),
             collectionIdToTupleTag,
             getWindowingStrategy(inputPCollectionId, components),
             keyCoder,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -49,6 +49,7 @@ import org.apache.beam.runners.core.construction.WindowingStrategyTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
+import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStageContextFactory;
 import org.apache.beam.runners.flink.translation.functions.ImpulseSourceFunction;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator;
@@ -62,7 +63,6 @@ import org.apache.beam.runners.flink.translation.wrappers.streaming.io.DedupingO
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.StreamingImpulseSource;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.TestStreamSource;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.UnboundedSourceWrapper;
-import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
@@ -702,7 +702,7 @@ public class FlinkStreamingPortablePipelineTranslator
             context.getPipelineOptions(),
             stagePayload,
             context.getJobInfo(),
-            ExecutableStageContext.factory(),
+            FlinkExecutableStageContextFactory.getInstance(),
             collectionIdToTupleTag,
             getWindowingStrategy(inputPCollectionId, components),
             keyCoder,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContextFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContextFactory.java
@@ -47,7 +47,7 @@ public class FlinkExecutableStageContextFactory implements ExecutableStageContex
 
   @Override
   public ExecutableStageContext get(JobInfo jobInfo) {
-    MultiInstanceFactory state =
+    MultiInstanceFactory jobFactory =
         jobFactories.computeIfAbsent(
             jobInfo.jobId(),
             k -> {
@@ -65,6 +65,6 @@ public class FlinkExecutableStageContextFactory implements ExecutableStageContex
                           != ExecutionEnvironment.class.getClassLoader());
             });
 
-    return state.get(jobInfo);
+    return jobFactory.get(jobInfo);
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContextFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContextFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.functions;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
+import org.apache.beam.runners.fnexecution.control.DefaultExecutableStageContext.MultiInstanceFactory;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
+import org.apache.flink.api.java.ExecutionEnvironment;
+
+/** Singleton class that contains one {@link MultiInstanceFactory} per job. */
+public class FlinkExecutableStageContextFactory implements ExecutableStageContext.Factory {
+
+  private static final FlinkExecutableStageContextFactory instance =
+      new FlinkExecutableStageContextFactory();
+  // This map should only ever have a single element, as each job will have its own
+  // classloader and therefore its own instance of FlinkExecutableStageContextFactory. This
+  // code supports multiple JobInfos in order to provide a sensible implementation of
+  // Factory.get(JobInfo), which in theory could be called with different JobInfos.
+  private static final ConcurrentMap<String, MultiInstanceFactory> jobFactories =
+      new ConcurrentHashMap<>();
+
+  private FlinkExecutableStageContextFactory() {}
+
+  public static FlinkExecutableStageContextFactory getInstance() {
+    return instance;
+  }
+
+  @Override
+  public ExecutableStageContext get(JobInfo jobInfo) {
+    MultiInstanceFactory state =
+        jobFactories.computeIfAbsent(
+            jobInfo.jobId(),
+            k -> {
+              PortablePipelineOptions portableOptions =
+                  PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions())
+                      .as(PortablePipelineOptions.class);
+
+              return new MultiInstanceFactory(
+                  MoreObjects.firstNonNull(portableOptions.getSdkWorkerParallelism(), 1L)
+                      .intValue(),
+                  // Clean up context immediately if its class is not loaded on Flink parent
+                  // classloader.
+                  (caller) ->
+                      caller.getClass().getClassLoader()
+                          != ExecutionEnvironment.class.getClassLoader());
+            });
+
+    return state.get(jobInfo);
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
@@ -32,6 +32,7 @@ import org.apache.beam.runners.core.TimerInternals;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.flink.metrics.FlinkMetricContainer;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
 import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors;
 import org.apache.beam.runners.fnexecution.control.RemoteBundle;
@@ -55,6 +56,7 @@ import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.MapPartitionFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
@@ -84,7 +86,7 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
   private final JobInfo jobInfo;
   // Map from PCollection id to the union tag used to represent this PCollection in the output.
   private final Map<String, Integer> outputMap;
-  private final FlinkExecutableStageContext.Factory contextFactory;
+  private final ExecutableStageContext.Factory contextFactory;
   private final Coder windowCoder;
   // Unique name for namespacing metrics; currently just takes the input ID
   private final String stageName;
@@ -93,7 +95,7 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
   private transient RuntimeContext runtimeContext;
   private transient FlinkMetricContainer container;
   private transient StateRequestHandler stateRequestHandler;
-  private transient FlinkExecutableStageContext stageContext;
+  private transient ExecutableStageContext stageContext;
   private transient StageBundleFactory stageBundleFactory;
   private transient BundleProgressHandler progressHandler;
   // Only initialized when the ExecutableStage is stateful
@@ -106,7 +108,7 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
       RunnerApi.ExecutableStagePayload stagePayload,
       JobInfo jobInfo,
       Map<String, Integer> outputMap,
-      FlinkExecutableStageContext.Factory contextFactory,
+      ExecutableStageContext.Factory contextFactory,
       Coder windowCoder) {
     this.stagePayload = stagePayload;
     this.jobInfo = jobInfo;
@@ -125,7 +127,12 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
     runtimeContext = getRuntimeContext();
     container = new FlinkMetricContainer(getRuntimeContext());
     // TODO: Wire this into the distributed cache and make it pluggable.
-    stageContext = contextFactory.get(jobInfo);
+    stageContext =
+        contextFactory.get(
+            jobInfo,
+            // Clean up context immediately if its class is not loaded on Flink parent classloader.
+            (caller) ->
+                caller.getClass().getClassLoader() != ExecutionEnvironment.class.getClassLoader());
     stageBundleFactory = stageContext.getStageBundleFactory(executableStage);
     // NOTE: It's safe to reuse the state handler between partitions because each partition uses the
     // same backing runtime context and broadcast variables. We use checkState below to catch errors

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunctionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunctionTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.ExecutableStagePayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
 import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors;
 import org.apache.beam.runners.fnexecution.control.RemoteBundle;
@@ -75,7 +76,7 @@ public class FlinkExecutableStageFunctionTest {
   @Mock private RuntimeContext runtimeContext;
   @Mock private DistributedCache distributedCache;
   @Mock private Collector<RawUnionValue> collector;
-  @Mock private FlinkExecutableStageContext stageContext;
+  @Mock private ExecutableStageContext stageContext;
   @Mock private StageBundleFactory stageBundleFactory;
   @Mock private StateRequestHandler stateRequestHandler;
   @Mock private ProcessBundleDescriptors.ExecutableProcessBundleDescriptor processBundleDescriptor;
@@ -252,9 +253,9 @@ public class FlinkExecutableStageFunctionTest {
    * behavior of the stage context itself is unchanged.
    */
   private FlinkExecutableStageFunction<Integer> getFunction(Map<String, Integer> outputMap) {
-    FlinkExecutableStageContext.Factory contextFactory =
-        Mockito.mock(FlinkExecutableStageContext.Factory.class);
-    when(contextFactory.get(any())).thenReturn(stageContext);
+    ExecutableStageContext.Factory contextFactory =
+        Mockito.mock(ExecutableStageContext.Factory.class);
+    when(contextFactory.get(any(), any())).thenReturn(stageContext);
     FlinkExecutableStageFunction<Integer> function =
         new FlinkExecutableStageFunction<>(stagePayload, jobInfo, outputMap, contextFactory, null);
     function.setRuntimeContext(runtimeContext);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunctionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunctionTest.java
@@ -253,9 +253,9 @@ public class FlinkExecutableStageFunctionTest {
    * behavior of the stage context itself is unchanged.
    */
   private FlinkExecutableStageFunction<Integer> getFunction(Map<String, Integer> outputMap) {
-    ExecutableStageContext.Factory contextFactory =
-        Mockito.mock(ExecutableStageContext.Factory.class);
-    when(contextFactory.get(any(), any())).thenReturn(stageContext);
+    FlinkExecutableStageContextFactory contextFactory =
+        Mockito.mock(FlinkExecutableStageContextFactory.class);
+    when(contextFactory.get(any())).thenReturn(stageContext);
     FlinkExecutableStageFunction<Integer> function =
         new FlinkExecutableStageFunction<>(stagePayload, jobInfo, outputMap, contextFactory, null);
     function.setRuntimeContext(runtimeContext);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
@@ -58,9 +58,9 @@ import org.apache.beam.runners.core.StatefulDoFnRunner;
 import org.apache.beam.runners.core.TimerInternals;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.metrics.DoFnRunnerWithMetricsUpdate;
-import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStageContext;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
 import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors;
 import org.apache.beam.runners.fnexecution.control.RemoteBundle;
@@ -119,7 +119,7 @@ public class ExecutableStageDoFnOperatorTest {
 
   @Mock private RuntimeContext runtimeContext;
   @Mock private DistributedCache distributedCache;
-  @Mock private FlinkExecutableStageContext stageContext;
+  @Mock private ExecutableStageContext stageContext;
   @Mock private StageBundleFactory stageBundleFactory;
   @Mock private StateRequestHandler stateRequestHandler;
   @Mock private ProcessBundleDescriptors.ExecutableProcessBundleDescriptor processBundleDescriptor;
@@ -683,7 +683,7 @@ public class ExecutableStageDoFnOperatorTest {
             options,
             stagePayload,
             jobInfo,
-            FlinkExecutableStageContext.factory(options),
+            ExecutableStageContext.factory(),
             createOutputMap(mainOutput, ImmutableList.of(additionalOutput)),
             WindowingStrategy.globalDefault(),
             null,
@@ -720,9 +720,9 @@ public class ExecutableStageDoFnOperatorTest {
       @Nullable Coder keyCoder,
       @Nullable Coder windowedInputCoder) {
 
-    FlinkExecutableStageContext.Factory contextFactory =
-        Mockito.mock(FlinkExecutableStageContext.Factory.class);
-    when(contextFactory.get(any())).thenReturn(stageContext);
+    ExecutableStageContext.Factory contextFactory =
+        Mockito.mock(ExecutableStageContext.Factory.class);
+    when(contextFactory.get(any(), any())).thenReturn(stageContext);
 
     final ExecutableStagePayload stagePayload;
     if (keyCoder != null) {

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
@@ -58,6 +58,7 @@ import org.apache.beam.runners.core.StatefulDoFnRunner;
 import org.apache.beam.runners.core.TimerInternals;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.metrics.DoFnRunnerWithMetricsUpdate;
+import org.apache.beam.runners.flink.translation.functions.FlinkExecutableStageContextFactory;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
 import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
@@ -683,7 +684,7 @@ public class ExecutableStageDoFnOperatorTest {
             options,
             stagePayload,
             jobInfo,
-            ExecutableStageContext.factory(),
+            FlinkExecutableStageContextFactory.getInstance(),
             createOutputMap(mainOutput, ImmutableList.of(additionalOutput)),
             WindowingStrategy.globalDefault(),
             null,
@@ -720,9 +721,9 @@ public class ExecutableStageDoFnOperatorTest {
       @Nullable Coder keyCoder,
       @Nullable Coder windowedInputCoder) {
 
-    ExecutableStageContext.Factory contextFactory =
-        Mockito.mock(ExecutableStageContext.Factory.class);
-    when(contextFactory.get(any(), any())).thenReturn(stageContext);
+    FlinkExecutableStageContextFactory contextFactory =
+        Mockito.mock(FlinkExecutableStageContextFactory.class);
+    when(contextFactory.get(any())).thenReturn(stageContext);
 
     final ExecutableStagePayload stagePayload;
     if (keyCoder != null) {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultExecutableStageContext.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultExecutableStageContext.java
@@ -70,15 +70,14 @@ class DefaultExecutableStageContext implements ExecutableStageContext, AutoClose
       }
     }
 
-    private synchronized ExecutableStageContext.Factory getFactory(
-        SerializableFunction<Object, Boolean> isReleaseSynchronous) {
+    private synchronized ExecutableStageContext.Factory getFactory() {
       ReferenceCountingExecutableStageContextFactory factory;
       // If we haven't yet created maxFactories factories, create a new one. Otherwise use an
       // existing one from factories.
       if (factories.size() < maxFactories) {
         factory =
             ReferenceCountingExecutableStageContextFactory.create(
-                DefaultExecutableStageContext::create, isReleaseSynchronous);
+                DefaultExecutableStageContext::create);
         factories.add(factory);
       } else {
         factory = factories.get(index);
@@ -116,7 +115,7 @@ class DefaultExecutableStageContext implements ExecutableStageContext, AutoClose
                         .intValue());
               });
 
-      return state.getFactory(isReleaseSynchronous).get(jobInfo, isReleaseSynchronous);
+      return state.getFactory().get(jobInfo, isReleaseSynchronous);
     }
   }
 }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ExecutableStageContext.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ExecutableStageContext.java
@@ -15,29 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.flink.translation.functions;
+package org.apache.beam.runners.fnexecution.control;
 
 import java.io.Serializable;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
-import org.apache.beam.runners.flink.FlinkPipelineOptions;
-import org.apache.beam.runners.flink.translation.functions.FlinkDefaultExecutableStageContext.MultiInstanceFactory;
-import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
+import org.apache.beam.runners.fnexecution.control.DefaultExecutableStageContext.MultiInstanceFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 
-/** The Flink context required in order to execute {@link ExecutableStage stages}. */
-public interface FlinkExecutableStageContext extends AutoCloseable {
+/** The context required in order to execute {@link ExecutableStage stages}. */
+public interface ExecutableStageContext extends AutoCloseable {
 
   /**
-   * Creates {@link FlinkExecutableStageContext} instances. Serializable so that factories can be
-   * defined at translation time and distributed to TaskManagers.
+   * Creates {@link ExecutableStageContext} instances. Serializable so that factories can be defined
+   * at translation time and distributed to TaskManagers.
    */
   interface Factory extends Serializable {
 
-    /** Get or create {@link FlinkExecutableStageContext} for given {@link JobInfo}. */
-    FlinkExecutableStageContext get(JobInfo jobInfo);
+    /** Get or create {@link ExecutableStageContext} for given {@link JobInfo}. */
+    ExecutableStageContext get(
+        JobInfo jobInfo, SerializableFunction<Object, Boolean> isReleaseSynchronous);
+
+    default ExecutableStageContext get(JobInfo jobInfo) {
+      return get(jobInfo, (caller) -> true /* always release context synchronously */);
+    }
   }
 
-  static Factory factory(FlinkPipelineOptions options) {
+  static Factory factory() {
     return MultiInstanceFactory.MULTI_INSTANCE;
   }
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ExecutableStageContext.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ExecutableStageContext.java
@@ -37,7 +37,7 @@ public interface ExecutableStageContext extends AutoCloseable {
         JobInfo jobInfo, SerializableFunction<Object, Boolean> isReleaseSynchronous);
 
     default ExecutableStageContext get(JobInfo jobInfo) {
-      return get(jobInfo, (caller) -> true /* always release context synchronously */);
+      return get(jobInfo, (caller) -> false /* always release context asynchronously */);
     }
   }
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ExecutableStageContext.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ExecutableStageContext.java
@@ -19,9 +19,7 @@ package org.apache.beam.runners.fnexecution.control;
 
 import java.io.Serializable;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
-import org.apache.beam.runners.fnexecution.control.DefaultExecutableStageContext.MultiInstanceFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 
 /** The context required in order to execute {@link ExecutableStage stages}. */
 public interface ExecutableStageContext extends AutoCloseable {
@@ -33,16 +31,7 @@ public interface ExecutableStageContext extends AutoCloseable {
   interface Factory extends Serializable {
 
     /** Get or create {@link ExecutableStageContext} for given {@link JobInfo}. */
-    ExecutableStageContext get(
-        JobInfo jobInfo, SerializableFunction<Object, Boolean> isReleaseSynchronous);
-
-    default ExecutableStageContext get(JobInfo jobInfo) {
-      return get(jobInfo, (caller) -> false /* always release context asynchronously */);
-    }
-  }
-
-  static Factory factory() {
-    return MultiInstanceFactory.MULTI_INSTANCE;
+    ExecutableStageContext get(JobInfo jobInfo);
   }
 
   StageBundleFactory getStageBundleFactory(ExecutableStage executableStage);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactory.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.flink.translation.functions;
+package org.apache.beam.runners.fnexecution.control;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -26,42 +26,46 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
-import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.sdk.function.ThrowingFunction;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.java.ExecutionEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link FlinkExecutableStageContext.Factory} which counts FlinkExecutableStageContext reference
- * for book keeping.
+ * {@link ExecutableStageContext.Factory} which counts ExecutableStageContext reference for book
+ * keeping.
  */
-public class ReferenceCountingFlinkExecutableStageContextFactory
-    implements FlinkExecutableStageContext.Factory {
+public class ReferenceCountingExecutableStageContextFactory
+    implements ExecutableStageContext.Factory {
   private static final Logger LOG =
-      LoggerFactory.getLogger(ReferenceCountingFlinkExecutableStageContextFactory.class);
+      LoggerFactory.getLogger(ReferenceCountingExecutableStageContextFactory.class);
   private static final int MAX_RETRY = 3;
 
   private final Creator creator;
   private transient volatile ScheduledExecutorService executor;
   private transient volatile ConcurrentHashMap<String, WrappedContext> keyRegistry;
+  private final SerializableFunction<Object, Boolean> isReleaseSynchronous;
 
-  public static ReferenceCountingFlinkExecutableStageContextFactory create(Creator creator) {
-    return new ReferenceCountingFlinkExecutableStageContextFactory(creator);
+  public static ReferenceCountingExecutableStageContextFactory create(
+      Creator creator, SerializableFunction<Object, Boolean> isReleaseSynchronous) {
+    return new ReferenceCountingExecutableStageContextFactory(creator, isReleaseSynchronous);
   }
 
-  private ReferenceCountingFlinkExecutableStageContextFactory(Creator creator) {
+  private ReferenceCountingExecutableStageContextFactory(
+      Creator creator, SerializableFunction<Object, Boolean> isReleaseSynchronous) {
     this.creator = creator;
+    this.isReleaseSynchronous = isReleaseSynchronous;
   }
 
   @Override
-  public FlinkExecutableStageContext get(JobInfo jobInfo) {
+  public ExecutableStageContext get(
+      JobInfo jobInfo, SerializableFunction<Object, Boolean> isReleaseSynchronous) {
     // Retry is needed in case where an existing wrapper is picked from the cache but by
     // the time we accessed wrapper.referenceCount, the wrapper was tombstoned by a pending
     // release task.
@@ -115,17 +119,11 @@ public class ReferenceCountingFlinkExecutableStageContextFactory
     int environmentCacheTTLMillis =
         pipelineOptions.as(PortablePipelineOptions.class).getEnvironmentCacheMillis();
     if (environmentCacheTTLMillis > 0) {
-      // Do immediate cleanup if this class is not loaded on Flink parent classloader.
-      if (this.getClass().getClassLoader() != ExecutionEnvironment.class.getClassLoader()) {
-        LOG.warn(
-            "{} is not loaded on parent Flink classloader. "
-                + "Falling back to synchronous environment release for job {}.",
-            this.getClass(),
-            jobInfo.jobId());
+      if (isReleaseSynchronous.apply(this)) {
+        // Do immediate cleanup
         release(wrapper);
       } else {
         // Schedule task to clean the container later.
-        // Ensure that this class is loaded in the parent Flink classloader.
         getExecutor()
             .schedule(() -> release(wrapper), environmentCacheTTLMillis, TimeUnit.MILLISECONDS);
       }
@@ -164,7 +162,7 @@ public class ReferenceCountingFlinkExecutableStageContextFactory
   }
 
   @VisibleForTesting
-  void release(FlinkExecutableStageContext context) {
+  void release(ExecutableStageContext context) {
     @SuppressWarnings({"unchecked", "Not exected to be called from outside."})
     WrappedContext wrapper = (WrappedContext) context;
     synchronized (wrapper) {
@@ -175,24 +173,22 @@ public class ReferenceCountingFlinkExecutableStageContextFactory
           try {
             wrapper.closeActual();
           } catch (Throwable t) {
-            LOG.error("Unable to close FlinkExecutableStageContext.", t);
+            LOG.error("Unable to close ExecutableStageContext.", t);
           }
         }
       }
     }
   }
 
-  /**
-   * {@link WrappedContext} does not expose equals of actual {@link FlinkExecutableStageContext}.
-   */
+  /** {@link WrappedContext} does not expose equals of actual {@link ExecutableStageContext}. */
   @VisibleForTesting
-  class WrappedContext implements FlinkExecutableStageContext {
+  class WrappedContext implements ExecutableStageContext {
     private JobInfo jobInfo;
     private AtomicInteger referenceCount;
-    @VisibleForTesting FlinkExecutableStageContext context;
+    @VisibleForTesting ExecutableStageContext context;
 
     /** {@link WrappedContext#equals(Object)} is only based on {@link JobInfo#jobId()}. */
-    WrappedContext(JobInfo jobInfo, FlinkExecutableStageContext context) {
+    WrappedContext(JobInfo jobInfo, ExecutableStageContext context) {
       this.jobInfo = jobInfo;
       this.context = context;
       this.referenceCount = new AtomicInteger(0);
@@ -244,5 +240,5 @@ public class ReferenceCountingFlinkExecutableStageContextFactory
 
   /** Interface for creator which extends Serializable. */
   public interface Creator
-      extends ThrowingFunction<JobInfo, FlinkExecutableStageContext>, Serializable {}
+      extends ThrowingFunction<JobInfo, ExecutableStageContext>, Serializable {}
 }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultExecutableStageContextTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultExecutableStageContextTest.java
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.flink.translation.functions;
+package org.apache.beam.runners.fnexecution.control;
 
 import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
-import org.apache.beam.runners.flink.translation.functions.FlinkDefaultExecutableStageContext.MultiInstanceFactory;
-import org.apache.beam.runners.flink.translation.functions.ReferenceCountingFlinkExecutableStageContextFactory.WrappedContext;
+import org.apache.beam.runners.fnexecution.control.DefaultExecutableStageContext.MultiInstanceFactory;
+import org.apache.beam.runners.fnexecution.control.ReferenceCountingExecutableStageContextFactory.WrappedContext;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
@@ -29,9 +29,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link FlinkDefaultExecutableStageContext}. */
+/** Tests for {@link DefaultExecutableStageContext}. */
 @RunWith(JUnit4.class)
-public class FlinkDefaultExecutableStageContextTest {
+public class DefaultExecutableStageContextTest {
   private static JobInfo constructJobInfo(String jobId, long parallelism) {
     PortablePipelineOptions portableOptions =
         PipelineOptionsFactory.as(PortablePipelineOptions.class);

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactoryTest.java
@@ -15,10 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.flink.translation.functions;
+package org.apache.beam.runners.fnexecution.control;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -26,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import org.apache.beam.runners.flink.translation.functions.ReferenceCountingFlinkExecutableStageContextFactory.Creator;
+import org.apache.beam.runners.fnexecution.control.ReferenceCountingExecutableStageContextFactory.Creator;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Charsets;
 import org.junit.Assert;
@@ -34,31 +33,31 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link ReferenceCountingFlinkExecutableStageContextFactory}. */
+/** Tests for {@link ReferenceCountingExecutableStageContextFactory}. */
 @RunWith(JUnit4.class)
-public class ReferenceCountingFlinkExecutableStageContextFactoryTest {
+public class ReferenceCountingExecutableStageContextFactoryTest {
 
   @Test
   public void testCreateReuseReleaseCreate() throws Exception {
 
     Creator creator = mock(Creator.class);
-    FlinkExecutableStageContext c1 = mock(FlinkExecutableStageContext.class);
-    FlinkExecutableStageContext c2 = mock(FlinkExecutableStageContext.class);
-    FlinkExecutableStageContext c3 = mock(FlinkExecutableStageContext.class);
-    FlinkExecutableStageContext c4 = mock(FlinkExecutableStageContext.class);
+    ExecutableStageContext c1 = mock(ExecutableStageContext.class);
+    ExecutableStageContext c2 = mock(ExecutableStageContext.class);
+    ExecutableStageContext c3 = mock(ExecutableStageContext.class);
+    ExecutableStageContext c4 = mock(ExecutableStageContext.class);
     when(creator.apply(any(JobInfo.class)))
         .thenReturn(c1)
         .thenReturn(c2)
         .thenReturn(c3)
         .thenReturn(c4);
-    ReferenceCountingFlinkExecutableStageContextFactory factory =
-        ReferenceCountingFlinkExecutableStageContextFactory.create(creator);
+    ReferenceCountingExecutableStageContextFactory factory =
+        ReferenceCountingExecutableStageContextFactory.create(creator, (caller) -> true);
     JobInfo jobA = mock(JobInfo.class);
     when(jobA.jobId()).thenReturn("jobA");
     JobInfo jobB = mock(JobInfo.class);
     when(jobB.jobId()).thenReturn("jobB");
-    FlinkExecutableStageContext ac1A = factory.get(jobA); // 1 open jobA
-    FlinkExecutableStageContext ac2B = factory.get(jobB); // 1 open jobB
+    ExecutableStageContext ac1A = factory.get(jobA); // 1 open jobA
+    ExecutableStageContext ac2B = factory.get(jobB); // 1 open jobB
     Assert.assertSame(
         "Context should be cached and reused.", ac1A, factory.get(jobA)); // 2 open jobA
     Assert.assertSame(
@@ -68,7 +67,7 @@ public class ReferenceCountingFlinkExecutableStageContextFactoryTest {
         "Context should be cached and reused.", ac1A, factory.get(jobA)); // 2 open jobA
     factory.release(ac1A); // 1 open jobA
     factory.release(ac1A); // 0 open jobA
-    FlinkExecutableStageContext ac3A = factory.get(jobA); // 1 open jobA
+    ExecutableStageContext ac3A = factory.get(jobA); // 1 open jobA
     Assert.assertNotSame("We should get a new instance.", ac1A, ac3A);
     Assert.assertSame(
         "Context should be cached and reused.", ac3A, factory.get(jobA)); // 2 open jobA
@@ -79,7 +78,7 @@ public class ReferenceCountingFlinkExecutableStageContextFactoryTest {
     factory.release(ac2B); // 2 open jobB
     factory.release(ac2B); // 1 open jobB
     factory.release(ac2B); // 0 open jobB
-    FlinkExecutableStageContext ac4B = factory.get(jobB); // 1 open jobB
+    ExecutableStageContext ac4B = factory.get(jobB); // 1 open jobB
     Assert.assertNotSame("We should get a new instance.", ac2B, ac4B);
     factory.release(ac4B); // 0 open jobB
   }
@@ -93,20 +92,20 @@ public class ReferenceCountingFlinkExecutableStageContextFactoryTest {
     try {
       System.setErr(newErr);
       Creator creator = mock(Creator.class);
-      FlinkExecutableStageContext c1 = mock(FlinkExecutableStageContext.class);
+      ExecutableStageContext c1 = mock(ExecutableStageContext.class);
       when(creator.apply(any(JobInfo.class))).thenReturn(c1);
       // throw an Throwable and ensure that it is caught and logged.
       doThrow(new NoClassDefFoundError()).when(c1).close();
-      ReferenceCountingFlinkExecutableStageContextFactory factory =
-          ReferenceCountingFlinkExecutableStageContextFactory.create(creator);
+      ReferenceCountingExecutableStageContextFactory factory =
+          ReferenceCountingExecutableStageContextFactory.create(creator, (caller) -> true);
       JobInfo jobA = mock(JobInfo.class);
       when(jobA.jobId()).thenReturn("jobA");
-      FlinkExecutableStageContext ac1A = factory.get(jobA);
+      ExecutableStageContext ac1A = factory.get(jobA);
       factory.release(ac1A);
       newErr.flush();
       String output = new String(baos.toByteArray(), Charsets.UTF_8);
       // Ensure that the error is logged
-      assertThat(output.contains("Unable to close FlinkExecutableStageContext"), is(true));
+      assertTrue(output.contains("Unable to close ExecutableStageContext"));
     } finally {
       newErr.flush();
       System.setErr(oldErr);

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactoryTest.java
@@ -51,7 +51,7 @@ public class ReferenceCountingExecutableStageContextFactoryTest {
         .thenReturn(c3)
         .thenReturn(c4);
     ReferenceCountingExecutableStageContextFactory factory =
-        ReferenceCountingExecutableStageContextFactory.create(creator, (caller) -> true);
+        ReferenceCountingExecutableStageContextFactory.create(creator);
     JobInfo jobA = mock(JobInfo.class);
     when(jobA.jobId()).thenReturn("jobA");
     JobInfo jobB = mock(JobInfo.class);
@@ -97,7 +97,7 @@ public class ReferenceCountingExecutableStageContextFactoryTest {
       // throw an Throwable and ensure that it is caught and logged.
       doThrow(new NoClassDefFoundError()).when(c1).close();
       ReferenceCountingExecutableStageContextFactory factory =
-          ReferenceCountingExecutableStageContextFactory.create(creator, (caller) -> true);
+          ReferenceCountingExecutableStageContextFactory.create(creator);
       JobInfo jobA = mock(JobInfo.class);
       when(jobA.jobId()).thenReturn("jobA");
       ExecutableStageContext ac1A = factory.get(jobA);

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactoryTest.java
@@ -51,7 +51,7 @@ public class ReferenceCountingExecutableStageContextFactoryTest {
         .thenReturn(c3)
         .thenReturn(c4);
     ReferenceCountingExecutableStageContextFactory factory =
-        ReferenceCountingExecutableStageContextFactory.create(creator);
+        ReferenceCountingExecutableStageContextFactory.create(creator, (x) -> true);
     JobInfo jobA = mock(JobInfo.class);
     when(jobA.jobId()).thenReturn("jobA");
     JobInfo jobB = mock(JobInfo.class);
@@ -97,7 +97,7 @@ public class ReferenceCountingExecutableStageContextFactoryTest {
       // throw an Throwable and ensure that it is caught and logged.
       doThrow(new NoClassDefFoundError()).when(c1).close();
       ReferenceCountingExecutableStageContextFactory factory =
-          ReferenceCountingExecutableStageContextFactory.create(creator);
+          ReferenceCountingExecutableStageContextFactory.create(creator, (x) -> true);
       JobInfo jobA = mock(JobInfo.class);
       when(jobA.jobId()).thenReturn("jobA");
       ExecutableStageContext ac1A = factory.get(jobA);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkBatchPortablePipelineTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkBatchPortablePipelineTranslator.java
@@ -41,6 +41,7 @@ import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
 import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.wire.WireCoders;
 import org.apache.beam.runners.spark.SparkPipelineOptions;
 import org.apache.beam.runners.spark.metrics.MetricsAccumulator;
@@ -253,6 +254,7 @@ public class SparkBatchPortablePipelineTranslator {
               stagePayload,
               context.jobInfo,
               outputExtractionMap,
+              ExecutableStageContext.factory(),
               broadcastVariablesBuilder.build(),
               MetricsAccumulator.getInstance(),
               windowCoder);
@@ -264,6 +266,7 @@ public class SparkBatchPortablePipelineTranslator {
               stagePayload,
               context.jobInfo,
               outputExtractionMap,
+              ExecutableStageContext.factory(),
               broadcastVariablesBuilder.build(),
               MetricsAccumulator.getInstance(),
               windowCoder);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkBatchPortablePipelineTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkBatchPortablePipelineTranslator.java
@@ -41,7 +41,6 @@ import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
 import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
-import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.wire.WireCoders;
 import org.apache.beam.runners.spark.SparkPipelineOptions;
 import org.apache.beam.runners.spark.metrics.MetricsAccumulator;
@@ -254,7 +253,7 @@ public class SparkBatchPortablePipelineTranslator {
               stagePayload,
               context.jobInfo,
               outputExtractionMap,
-              ExecutableStageContext.factory(),
+              SparkExecutableStageContextFactory.getInstance(),
               broadcastVariablesBuilder.build(),
               MetricsAccumulator.getInstance(),
               windowCoder);
@@ -266,7 +265,7 @@ public class SparkBatchPortablePipelineTranslator {
               stagePayload,
               context.jobInfo,
               outputExtractionMap,
-              ExecutableStageContext.factory(),
+              SparkExecutableStageContextFactory.getInstance(),
               broadcastVariablesBuilder.build(),
               MetricsAccumulator.getInstance(),
               windowCoder);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkExecutableStageContextFactory.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkExecutableStageContextFactory.java
@@ -49,7 +49,7 @@ public class SparkExecutableStageContextFactory implements ExecutableStageContex
 
   @Override
   public ExecutableStageContext get(JobInfo jobInfo) {
-    MultiInstanceFactory state =
+    MultiInstanceFactory jobFactory =
         jobFactories.computeIfAbsent(
             jobInfo.jobId(),
             k -> {
@@ -64,6 +64,6 @@ public class SparkExecutableStageContextFactory implements ExecutableStageContex
                   (caller) -> false);
             });
 
-    return state.get(jobInfo);
+    return jobFactory.get(jobInfo);
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkExecutableStageContextFactory.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkExecutableStageContextFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
+import org.apache.beam.runners.fnexecution.control.DefaultExecutableStageContext.MultiInstanceFactory;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
+
+/**
+ * Singleton class that contains one {@link MultiInstanceFactory} per job. Assumes it is safe to
+ * release the backing environment asynchronously.
+ */
+public class SparkExecutableStageContextFactory implements ExecutableStageContext.Factory {
+
+  private static final SparkExecutableStageContextFactory instance =
+      new SparkExecutableStageContextFactory();
+  // This map should only ever have a single element, as each job will have its own
+  // classloader and therefore its own instance of SparkExecutableStageContextFactory. This
+  // code supports multiple JobInfos in order to provide a sensible implementation of
+  // Factory.get(JobInfo), which in theory could be called with different JobInfos.
+  private static final ConcurrentMap<String, MultiInstanceFactory> jobFactories =
+      new ConcurrentHashMap<>();
+
+  private SparkExecutableStageContextFactory() {}
+
+  public static SparkExecutableStageContextFactory getInstance() {
+    return instance;
+  }
+
+  @Override
+  public ExecutableStageContext get(JobInfo jobInfo) {
+    MultiInstanceFactory state =
+        jobFactories.computeIfAbsent(
+            jobInfo.jobId(),
+            k -> {
+              PortablePipelineOptions portableOptions =
+                  PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions())
+                      .as(PortablePipelineOptions.class);
+
+              return new MultiInstanceFactory(
+                  MoreObjects.firstNonNull(portableOptions.getSdkWorkerParallelism(), 1L)
+                      .intValue(),
+                  // Always release environment asynchronously.
+                  (caller) -> false);
+            });
+
+    return state.get(jobInfo);
+  }
+}

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunction.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunction.java
@@ -37,7 +37,7 @@ import org.apache.beam.runners.core.TimerInternals;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
-import org.apache.beam.runners.fnexecution.control.DefaultJobBundleFactory;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.control.JobBundleFactory;
 import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
 import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors;
@@ -84,12 +84,13 @@ class SparkExecutableStageFunction<InputT, SideInputT>
 
   private final RunnerApi.ExecutableStagePayload stagePayload;
   private final Map<String, Integer> outputMap;
-  private final JobBundleFactoryCreator jobBundleFactoryCreator;
+  private final ExecutableStageContext.Factory contextFactory;
   // map from pCollection id to tuple of serialized bytes and coder to decode the bytes
   private final Map<String, Tuple2<Broadcast<List<byte[]>>, WindowedValueCoder<SideInputT>>>
       sideInputs;
   private final MetricsContainerStepMapAccumulator metricsAccumulator;
   private final Coder windowCoder;
+  private final JobInfo jobInfo;
 
   private transient InMemoryBagUserStateFactory bagUserStateHandlerFactory;
   private transient Object currentTimerKey;
@@ -98,28 +99,14 @@ class SparkExecutableStageFunction<InputT, SideInputT>
       RunnerApi.ExecutableStagePayload stagePayload,
       JobInfo jobInfo,
       Map<String, Integer> outputMap,
-      Map<String, Tuple2<Broadcast<List<byte[]>>, WindowedValueCoder<SideInputT>>> sideInputs,
-      MetricsContainerStepMapAccumulator metricsAccumulator,
-      Coder windowCoder) {
-    this(
-        stagePayload,
-        outputMap,
-        () -> DefaultJobBundleFactory.create(jobInfo),
-        sideInputs,
-        metricsAccumulator,
-        windowCoder);
-  }
-
-  SparkExecutableStageFunction(
-      RunnerApi.ExecutableStagePayload stagePayload,
-      Map<String, Integer> outputMap,
-      JobBundleFactoryCreator jobBundleFactoryCreator,
+      ExecutableStageContext.Factory contextFactory,
       Map<String, Tuple2<Broadcast<List<byte[]>>, WindowedValueCoder<SideInputT>>> sideInputs,
       MetricsContainerStepMapAccumulator metricsAccumulator,
       Coder windowCoder) {
     this.stagePayload = stagePayload;
+    this.jobInfo = jobInfo;
     this.outputMap = outputMap;
-    this.jobBundleFactoryCreator = jobBundleFactoryCreator;
+    this.contextFactory = contextFactory;
     this.sideInputs = sideInputs;
     this.metricsAccumulator = metricsAccumulator;
     this.windowCoder = windowCoder;
@@ -132,9 +119,10 @@ class SparkExecutableStageFunction<InputT, SideInputT>
 
   @Override
   public Iterator<RawUnionValue> call(Iterator<WindowedValue<InputT>> inputs) throws Exception {
-    try (JobBundleFactory jobBundleFactory = jobBundleFactoryCreator.create()) {
+    try (ExecutableStageContext stageContext = contextFactory.get(jobInfo)) {
       ExecutableStage executableStage = ExecutableStage.fromPayload(stagePayload);
-      try (StageBundleFactory stageBundleFactory = jobBundleFactory.forStage(executableStage)) {
+      try (StageBundleFactory stageBundleFactory =
+          stageContext.getStageBundleFactory(executableStage)) {
         ConcurrentLinkedQueue<RawUnionValue> collector = new ConcurrentLinkedQueue<>();
         StateRequestHandler stateRequestHandler =
             getStateRequestHandler(

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunction.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunction.java
@@ -84,7 +84,7 @@ class SparkExecutableStageFunction<InputT, SideInputT>
 
   private final RunnerApi.ExecutableStagePayload stagePayload;
   private final Map<String, Integer> outputMap;
-  private final ExecutableStageContext.Factory contextFactory;
+  private final SparkExecutableStageContextFactory contextFactory;
   // map from pCollection id to tuple of serialized bytes and coder to decode the bytes
   private final Map<String, Tuple2<Broadcast<List<byte[]>>, WindowedValueCoder<SideInputT>>>
       sideInputs;
@@ -99,7 +99,7 @@ class SparkExecutableStageFunction<InputT, SideInputT>
       RunnerApi.ExecutableStagePayload stagePayload,
       JobInfo jobInfo,
       Map<String, Integer> outputMap,
-      ExecutableStageContext.Factory contextFactory,
+      SparkExecutableStageContextFactory contextFactory,
       Map<String, Tuple2<Broadcast<List<byte[]>>, WindowedValueCoder<SideInputT>>> sideInputs,
       MetricsContainerStepMapAccumulator metricsAccumulator,
       Coder windowCoder) {

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunctionTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunctionTest.java
@@ -37,14 +37,13 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
-import org.apache.beam.runners.fnexecution.control.JobBundleFactory;
+import org.apache.beam.runners.fnexecution.control.ExecutableStageContext;
 import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
 import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors;
 import org.apache.beam.runners.fnexecution.control.RemoteBundle;
 import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.beam.runners.spark.metrics.MetricsContainerStepMapAccumulator;
-import org.apache.beam.runners.spark.translation.SparkExecutableStageFunction.JobBundleFactoryCreator;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.transforms.join.RawUnionValue;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -57,8 +56,8 @@ import org.mockito.MockitoAnnotations;
 
 /** Unit tests for {@link SparkExecutableStageFunction}. */
 public class SparkExecutableStageFunctionTest {
-  @Mock private JobBundleFactoryCreator jobBundleFactoryCreator;
-  @Mock private JobBundleFactory jobBundleFactory;
+  @Mock private ExecutableStageContext.Factory contextFactory;
+  @Mock private ExecutableStageContext stageContext;
   @Mock private StageBundleFactory stageBundleFactory;
   @Mock private RemoteBundle remoteBundle;
   @Mock private MetricsContainerStepMapAccumulator metricsAccumulator;
@@ -84,8 +83,8 @@ public class SparkExecutableStageFunctionTest {
   @Before
   public void setUpMocks() throws Exception {
     MockitoAnnotations.initMocks(this);
-    when(jobBundleFactoryCreator.create()).thenReturn(jobBundleFactory);
-    when(jobBundleFactory.forStage(any())).thenReturn(stageBundleFactory);
+    when(contextFactory.get(any())).thenReturn(stageContext);
+    when(stageContext.getStageBundleFactory(any())).thenReturn(stageBundleFactory);
     when(stageBundleFactory.getBundle(any(), any(), any())).thenReturn(remoteBundle);
     @SuppressWarnings("unchecked")
     ImmutableMap<String, FnDataReceiver<WindowedValue<?>>> inputReceiver =
@@ -184,7 +183,7 @@ public class SparkExecutableStageFunctionTest {
           @Override
           public void close() {}
         };
-    when(jobBundleFactory.forStage(any())).thenReturn(stageBundleFactory);
+    when(stageContext.getStageBundleFactory(any())).thenReturn(stageBundleFactory);
 
     SparkExecutableStageFunction<Integer, ?> function = getFunction(outputTagMap);
     Iterator<RawUnionValue> iterator = function.call(Collections.emptyIterator());
@@ -210,8 +209,9 @@ public class SparkExecutableStageFunctionTest {
       Map<String, Integer> outputMap) {
     return new SparkExecutableStageFunction<>(
         stagePayload,
+        null,
         outputMap,
-        jobBundleFactoryCreator,
+        contextFactory,
         Collections.emptyMap(),
         metricsAccumulator,
         null);

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunctionTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/SparkExecutableStageFunctionTest.java
@@ -56,7 +56,7 @@ import org.mockito.MockitoAnnotations;
 
 /** Unit tests for {@link SparkExecutableStageFunction}. */
 public class SparkExecutableStageFunctionTest {
-  @Mock private ExecutableStageContext.Factory contextFactory;
+  @Mock private SparkExecutableStageContextFactory contextFactory;
   @Mock private ExecutableStageContext stageContext;
   @Mock private StageBundleFactory stageBundleFactory;
   @Mock private RemoteBundle remoteBundle;


### PR DESCRIPTION
Now the Spark runner can reuse SDK harnesses, and multiple SDK harness can be used.

The latter will hopefully enable multicore processing on TFX, for example.

------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
