### PR TITLE
[7746] Create a more user friendly external transform API

### DIFF
--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -426,7 +426,12 @@ class BytesCoderImpl(CoderImpl):
 
   A coder for bytes/str objects."""
 
+  def __init__(self, encode_utf8=False):
+    self.encode_utf8 = encode_utf8
+
   def encode_to_stream(self, value, out, nested):
+    if self.encode_utf8:
+      value = value.encode('utf-8')
     out.write(value, nested)
 
   def decode_from_stream(self, in_stream, nested):

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -386,8 +386,14 @@ class FastCoder(Coder):
 class BytesCoder(FastCoder):
   """Byte string coder."""
 
+  def __init__(self, encode_utf8=False):
+    """
+    :param encode_utf8: encode the string value as utf-8.
+    """
+    self.encode_utf8 = encode_utf8
+
   def _create_impl(self):
-    return coder_impl.BytesCoderImpl()
+    return coder_impl.BytesCoderImpl(encode_utf8=self.encode_utf8)
 
   def is_deterministic(self):
     return True

--- a/sdks/python/apache_beam/io/external/generate_sequence.py
+++ b/sdks/python/apache_beam/io/external/generate_sequence.py
@@ -17,15 +17,11 @@
 
 from __future__ import absolute_import
 
-from apache_beam import ExternalTransform
-from apache_beam import pvalue
+from apache_beam.transforms.external import ExternalRead
 from apache_beam.coders import VarIntCoder
-from apache_beam.portability.api.external_transforms_pb2 import ConfigValue
-from apache_beam.portability.api.external_transforms_pb2 import ExternalConfigurationPayload
-from apache_beam.transforms import ptransform
 
 
-class GenerateSequence(ptransform.PTransform):
+class GenerateSequence(ExternalRead):
   """
     An external PTransform which provides a bounded or unbounded stream of
     integers.
@@ -49,46 +45,27 @@ class GenerateSequence(ptransform.PTransform):
 
     Experimental; no backwards compatibility guarantees.
   """
+  _urn = 'beam:external:java:generate_sequence:v1'
 
   def __init__(self, start, stop=None,
                elements_per_period=None, max_read_time=None,
-               expansion_service='localhost:8097'):
-    super(GenerateSequence, self).__init__()
-    self._urn = 'beam:external:java:generate_sequence:v1'
+               expansion_service=None):
+    super(GenerateSequence, self).__init__(expansion_service)
     self.start = start
     self.stop = stop
     self.elements_per_period = elements_per_period
     self.max_read_time = max_read_time
-    self.expansion_service = expansion_service
 
-  def expand(self, pbegin):
-    if not isinstance(pbegin, pvalue.PBegin):
-      raise Exception("GenerateSequence must be a root transform")
-
+  def get_config_args(self):
     coder = VarIntCoder()
-    coder_urn = ['beam:coder:varint:v1']
     args = {
         'start':
-        ConfigValue(
-            coder_urn=coder_urn,
-            payload=coder.encode(self.start))
+        self.config_value(self.start, coder)
     }
     if self.stop:
-      args['stop'] = ConfigValue(
-          coder_urn=coder_urn,
-          payload=coder.encode(self.stop))
+      args['stop'] = self.config_value(self.stop, coder)
     if self.elements_per_period:
-      args['elements_per_period'] = ConfigValue(
-          coder_urn=coder_urn,
-          payload=coder.encode(self.elements_per_period))
+      args['elements_per_period'] = self.config_value(self.elements_per_period, coder)
     if self.max_read_time:
-      args['max_read_time'] = ConfigValue(
-          coder_urn=coder_urn,
-          payload=coder.encode(self.max_read_time))
-
-    payload = ExternalConfigurationPayload(configuration=args)
-    return pbegin.apply(
-        ExternalTransform(
-            self._urn,
-            payload.SerializeToString(),
-            self.expansion_service))
+      args['max_read_time'] = self.config_value(self.max_read_time, coder)
+    return args

--- a/sdks/python/apache_beam/io/external/kafka.py
+++ b/sdks/python/apache_beam/io/external/kafka.py
@@ -37,18 +37,14 @@
 
 from __future__ import absolute_import
 
-from apache_beam import ExternalTransform
-from apache_beam import pvalue
+from apache_beam.transforms.external import External, ExternalRead
 from apache_beam.coders import BytesCoder
 from apache_beam.coders import IterableCoder
 from apache_beam.coders import TupleCoder
 from apache_beam.coders.coders import LengthPrefixCoder
-from apache_beam.portability.api.external_transforms_pb2 import ConfigValue
-from apache_beam.portability.api.external_transforms_pb2 import ExternalConfigurationPayload
-from apache_beam.transforms import ptransform
 
 
-class ReadFromKafka(ptransform.PTransform):
+class ReadFromKafka(ExternalRead):
   """
     An external PTransform which reads from Kafka and returns a KV pair for
     each item in the specified Kafka topics. If no Kafka Deserializer for
@@ -64,11 +60,13 @@ class ReadFromKafka(ptransform.PTransform):
   byte_array_deserializer = 'org.apache.kafka.common.serialization.' \
                             'ByteArrayDeserializer'
 
+  _urn = 'beam:external:java:kafka:read:v1'
+
   def __init__(self, consumer_config,
                topics,
                key_deserializer=byte_array_deserializer,
                value_deserializer=byte_array_deserializer,
-               expansion_service='localhost:8097'):
+               expansion_service=None):
     """
     Initializes a read operation from Kafka.
 
@@ -88,38 +86,29 @@ class ReadFromKafka(ptransform.PTransform):
                                serialization.ByteArrayDeserializer'.
     :param expansion_service: The address (host:port) of the ExpansionService.
     """
-    super(ReadFromKafka, self).__init__()
-    self._urn = 'beam:external:java:kafka:read:v1'
+    super(ReadFromKafka, self).__init__(expansion_service)
     self.consumer_config = consumer_config
     self.topics = topics
     self.key_deserializer = key_deserializer
     self.value_deserializer = value_deserializer
-    self.expansion_service = expansion_service
 
-  def expand(self, pbegin):
-    if not isinstance(pbegin, pvalue.PBegin):
-      raise Exception("ReadFromKafka must be a root transform")
-
-    args = {
+  def get_config_args(self):
+    str_coder = LengthPrefixCoder(BytesCoder(encode_utf8=True))
+    str_list_coder = IterableCoder(str_coder)
+    map_coder = IterableCoder(TupleCoder([str_coder, str_coder]))
+    return {
         'consumer_config':
-            _encode_map(self.consumer_config),
+            self.config_value(self.consumer_config.items(), map_coder),
         'topics':
-            _encode_list(self.topics),
+            self.config_value(self.topics, str_list_coder),
         'key_deserializer':
-            _encode_str(self.key_deserializer),
+            self.config_value(self.key_deserializer, str_coder),
         'value_deserializer':
-            _encode_str(self.value_deserializer),
+            self.config_value(self.value_deserializer, str_coder),
     }
 
-    payload = ExternalConfigurationPayload(configuration=args)
-    return pbegin.apply(
-        ExternalTransform(
-            self._urn,
-            payload.SerializeToString(),
-            self.expansion_service))
 
-
-class WriteToKafka(ptransform.PTransform):
+class WriteToKafka(External):
   """
     An external PTransform which writes KV data to a specified Kafka topic.
     If no Kafka Serializer for key/value is provided, then key/value are
@@ -132,11 +121,13 @@ class WriteToKafka(ptransform.PTransform):
   byte_array_serializer = 'org.apache.kafka.common.serialization.' \
                           'ByteArraySerializer'
 
+  _urn = 'beam:external:java:kafka:write:v1'
+
   def __init__(self, producer_config,
                topic,
                key_serializer=byte_array_serializer,
                value_serializer=byte_array_serializer,
-               expansion_service='localhost:8097'):
+               expansion_service=None):
     """
     Initializes a write operation to Kafka.
 
@@ -156,62 +147,24 @@ class WriteToKafka(ptransform.PTransform):
                                serialization.ByteArraySerializer'.
     :param expansion_service: The address (host:port) of the ExpansionService.
     """
-    super(WriteToKafka, self).__init__()
-    self._urn = 'beam:external:java:kafka:write:v1'
+    super(WriteToKafka, self).__init__(expansion_service)
     self.producer_config = producer_config
     self.topic = topic
     self.key_serializer = key_serializer
     self.value_serializer = value_serializer
-    self.expansion_service = expansion_service
 
-  def expand(self, pvalue):
-    args = {
+  def get_config_args(self):
+    str_coder = LengthPrefixCoder(BytesCoder())
+    map_coder = IterableCoder(TupleCoder(
+                [LengthPrefixCoder(BytesCoder()),
+                 LengthPrefixCoder(BytesCoder())]))
+    return {
         'producer_config':
-            _encode_map(self.producer_config),
+            self.config_value(self.producer_config.items(), map_coder),
         'topic':
-            _encode_str(self.topic),
+            self.config_value(self.topic, str_coder),
         'key_serializer':
-            _encode_str(self.key_serializer),
+            self.config_value(self.key_serializer, str_coder),
         'value_serializer':
-            _encode_str(self.value_serializer),
+            self.config_value(self.value_serializer, str_coder),
     }
-
-    payload = ExternalConfigurationPayload(configuration=args)
-    return pvalue.apply(
-        ExternalTransform(
-            self._urn,
-            payload.SerializeToString(),
-            self.expansion_service))
-
-
-def _encode_map(dict_obj):
-  kv_list = [(key.encode('utf-8'), val.encode('utf-8'))
-             for key, val in dict_obj.items()]
-  coder = IterableCoder(TupleCoder(
-      [LengthPrefixCoder(BytesCoder()), LengthPrefixCoder(BytesCoder())]))
-  coder_urns = ['beam:coder:iterable:v1',
-                'beam:coder:kv:v1',
-                'beam:coder:bytes:v1',
-                'beam:coder:bytes:v1']
-  return ConfigValue(
-      coder_urn=coder_urns,
-      payload=coder.encode(kv_list))
-
-
-def _encode_list(list_obj):
-  encoded_list = [val.encode('utf-8') for val in list_obj]
-  coder = IterableCoder(LengthPrefixCoder(BytesCoder()))
-  coder_urns = ['beam:coder:iterable:v1',
-                'beam:coder:bytes:v1']
-  return ConfigValue(
-      coder_urn=coder_urns,
-      payload=coder.encode(encoded_list))
-
-
-def _encode_str(str_obj):
-  encoded_str = str_obj.encode('utf-8')
-  coder = LengthPrefixCoder(BytesCoder())
-  coder_urns = ['beam:coder:bytes:v1']
-  return ConfigValue(
-      coder_urn=coder_urns,
-      payload=coder.encode(encoded_str))


### PR DESCRIPTION
As a python developer I'd like to have a more opinionated API for implementing external transforms so that A) it can guide me toward more standardized solutions and B) reduce the amount of boilerplate code that I need to write. 

Improvements:

- Create a constant for the expansion service address, to avoid copying it into the `__init__` args of every external transform
- Move the urn to the class-level to enforce consistency (which enables us to reduce boilerplate) and also for the sake of correctness: the value does not vary per instance
- Reduce boilerplate:
  - Provide a helper to create a `ConfigValue` with encoded value
    - Automatically determine the list of coder urns from a compound coder
    - Handle utf-8 encoding, if requested
  - Create the `ExternalTransform` for the user based on the configuration dictionary that they provide


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
