### PR TITLE
[BEAM-7060] Migrate to native typing types where possible.

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import base64
 import sys
+import typing
 from builtins import object
 
 import google.protobuf.wrappers_pb2
@@ -597,7 +598,7 @@ class PickleCoder(_PickleCoderBase):
     return DeterministicFastPrimitivesCoder(self, step_label)
 
   def to_type_hint(self):
-    return typehints.Any
+    return typing.Any
 
 
 class DillCoder(_PickleCoderBase):
@@ -631,7 +632,7 @@ class DeterministicFastPrimitivesCoder(FastCoder):
     return self
 
   def to_type_hint(self):
-    return typehints.Any
+    return typing.Any
 
 
 class FastPrimitivesCoder(FastCoder):
@@ -656,7 +657,7 @@ class FastPrimitivesCoder(FastCoder):
       return DeterministicFastPrimitivesCoder(self, step_label)
 
   def to_type_hint(self):
-    return typehints.Any
+    return typing.Any
 
   def as_cloud_object(self, coders_context=None, is_pair_like=True):
     value = super(FastCoder, self).as_cloud_object(coders_context)
@@ -1187,4 +1188,4 @@ class RunnerAPICoderHolder(Coder):
     return self._proto
 
   def to_type_hint(self):
-    return typehints.Any
+    return typing.Any

--- a/sdks/python/apache_beam/examples/complete/estimate_pi.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi.py
@@ -33,14 +33,14 @@ import logging
 import random
 from builtins import object
 from builtins import range
+from typing import Any
+from typing import Iterable
+from typing import Tuple
 
 import apache_beam as beam
 from apache_beam.io import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-from typing import Any
-from typing import Iterable
-from typing import Tuple
 
 
 @beam.typehints.with_output_types(Tuple[int, int, int])

--- a/sdks/python/apache_beam/examples/complete/estimate_pi.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi.py
@@ -38,9 +38,9 @@ import apache_beam as beam
 from apache_beam.io import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-from apache_beam.typehints import Any
-from apache_beam.typehints import Iterable
-from apache_beam.typehints import Tuple
+from typing import Any
+from typing import Iterable
+from typing import Tuple
 
 
 @beam.typehints.with_output_types(Tuple[int, int, int])

--- a/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
+++ b/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
@@ -39,7 +39,6 @@ from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-from apache_beam.typehints import typehints
 from apache_beam.typehints.decorators import with_output_types
 
 

--- a/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
+++ b/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 import argparse
 import logging
 import sys
+import typing
 from builtins import object
 
 import apache_beam as beam
@@ -74,7 +75,7 @@ class PlayerCoder(coders.Coder):
 # Annotate the get_players function so that the typehint system knows that the
 # input to the CombinePerKey operation is a key-value pair of a Player object
 # and an integer.
-@with_output_types(typehints.KV[Player, int])
+@with_output_types(typing.Tuple[Player, int])
 def get_players(descriptor):
   name, points = descriptor.split(',')
   return Player(name), int(points)

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -26,6 +26,7 @@ import logging
 import os
 import sys
 import tempfile
+import typing
 import unittest
 import uuid
 from builtins import map
@@ -321,10 +322,10 @@ class TypeHintsTest(unittest.TestCase):
     # One can assert outputs and apply them to transforms as well.
     # Helps document the contract and checks it at pipeline construction time.
     # [START type_hints_transform]
-    T = beam.typehints.TypeVariable('T')
+    T = typing.TypeVar('T')
 
     @beam.typehints.with_input_types(T)
-    @beam.typehints.with_output_types(beam.typehints.Tuple[int, T])
+    @beam.typehints.with_output_types(typing.Tuple[int, T])
     class MyTransform(beam.PTransform):
       def expand(self, pcoll):
         return pcoll | beam.Map(lambda x: (len(x), x))
@@ -335,7 +336,7 @@ class TypeHintsTest(unittest.TestCase):
     # pylint: disable=expression-not-assigned
     with self.assertRaises(typehints.TypeCheckError):
       words_with_lens | beam.Map(lambda x: x).with_input_types(
-          beam.typehints.Tuple[int, int])
+          typing.Tuple[int, int])
 
   def test_runtime_checks_off(self):
     # We do not run the following pipeline, as it has incorrect type
@@ -391,7 +392,7 @@ class TypeHintsTest(unittest.TestCase):
           lines
           | beam.Map(parse_player_and_score)
           | beam.CombinePerKey(sum).with_input_types(
-              beam.typehints.Tuple[Player, int]))
+              typing.Tuple[Player, int]))
       # [END type_hints_deterministic_key]
 
       assert_that(

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -52,6 +52,7 @@ import os
 import re
 import shutil
 import tempfile
+import typing
 from builtins import object
 from builtins import zip
 
@@ -550,11 +551,11 @@ class Pipeline(object):
         and isinstance(result_pcollection, pvalue.PCollection)
         and (not result_pcollection.element_type
              # TODO(robertwb): Ideally we'd do intersection here.
-             or result_pcollection.element_type == typehints.Any)):
+             or result_pcollection.element_type == typing.Any)):
       input_element_type = (
           inputs[0].element_type
           if len(inputs) == 1
-          else typehints.Any)
+          else typing.Any)
       type_hints = transform.get_type_hints()
       declared_output_type = type_hints.simple_output_type(transform.label)
       if declared_output_type:

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -52,7 +52,6 @@ import os
 import re
 import shutil
 import tempfile
-import typing
 from builtins import object
 from builtins import zip
 

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -550,11 +550,11 @@ class Pipeline(object):
         and isinstance(result_pcollection, pvalue.PCollection)
         and (not result_pcollection.element_type
              # TODO(robertwb): Ideally we'd do intersection here.
-             or result_pcollection.element_type == typing.Any)):
+             or result_pcollection.element_type == typehints.Any)):
       input_element_type = (
           inputs[0].element_type
           if len(inputs) == 1
-          else typing.Any)
+          else typehints.Any)
       type_hints = transform.get_type_hints()
       declared_output_type = type_hints.simple_output_type(transform.label)
       if declared_output_type:

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -309,7 +309,7 @@ class AsSideInput(object):
 
   @property
   def element_type(self):
-    return typehints.Any
+    return typing.Any
 
   # TODO(robertwb): Get rid of _from_runtime_iterable and _view_options
   # in favor of _side_input_data().
@@ -463,7 +463,7 @@ class AsIter(AsSideInput):
 
   @property
   def element_type(self):
-    return typehints.Iterable[self.pvalue.element_type]
+    return typing.Iterable[self.pvalue.element_type]
 
 
 class AsList(AsSideInput):

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -309,7 +309,7 @@ class AsSideInput(object):
 
   @property
   def element_type(self):
-    return typing.Any
+    return typehints.Any
 
   # TODO(robertwb): Get rid of _from_runtime_iterable and _view_options
   # in favor of _side_input_data().
@@ -463,7 +463,7 @@ class AsIter(AsSideInput):
 
   @property
   def element_type(self):
-    return typing.Iterable[self.pvalue.element_type]
+    return typehints.Iterable[self.pvalue.element_type]
 
 
 class AsList(AsSideInput):

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 import itertools
 import logging
 import time
+import typing
 
 from google.protobuf import wrappers_pb2
 
@@ -129,12 +130,12 @@ class SwitchingDirectRunner(PipelineRunner):
 
 
 # Type variables.
-K = typehints.TypeVariable('K')
-V = typehints.TypeVariable('V')
+K = typing.TypeVar('K')
+V = typing.TypeVar('V')
 
 
-@typehints.with_input_types(typehints.KV[K, V])
-@typehints.with_output_types(typehints.KV[K, typehints.Iterable[V]])
+@typehints.with_input_types(typing.Tuple[K, V])
+@typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _StreamingGroupByKeyOnly(_GroupByKeyOnly):
   """Streaming GroupByKeyOnly placeholder for overriding in DirectRunner."""
   urn = "direct_runner:streaming_gbko:v0.1"
@@ -148,8 +149,8 @@ class _StreamingGroupByKeyOnly(_GroupByKeyOnly):
     return _StreamingGroupByKeyOnly()
 
 
-@typehints.with_input_types(typehints.KV[K, typehints.Iterable[V]])
-@typehints.with_output_types(typehints.KV[K, typehints.Iterable[V]])
+@typehints.with_input_types(typing.Tuple[K, typing.Iterable[V]])
+@typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _StreamingGroupAlsoByWindow(_GroupAlsoByWindow):
   """Streaming GroupAlsoByWindow placeholder for overriding in DirectRunner."""
   urn = "direct_runner:streaming_gabw:v0.1"

--- a/sdks/python/apache_beam/runners/direct/helper_transforms.py
+++ b/sdks/python/apache_beam/runners/direct/helper_transforms.py
@@ -22,7 +22,6 @@ import itertools
 import typing
 
 import apache_beam as beam
-from apache_beam import typehints
 from apache_beam.internal.util import ArgumentPlaceholder
 from apache_beam.transforms.combiners import _CurriedFn
 from apache_beam.utils.windowed_value import WindowedValue

--- a/sdks/python/apache_beam/runners/direct/helper_transforms.py
+++ b/sdks/python/apache_beam/runners/direct/helper_transforms.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 
 import collections
 import itertools
+import typing
 
 import apache_beam as beam
 from apache_beam import typehints
@@ -75,14 +76,14 @@ class PartialGroupByKeyCombiningValues(beam.DoFn):
 
   def default_type_hints(self):
     hints = self._combine_fn.get_type_hints().copy()
-    K = typehints.TypeVariable('K')
+    K = typing.TypeVar('K')
     if hints.input_types:
       args, kwargs = hints.input_types
-      args = (typehints.Tuple[K, args[0]],) + args[1:]
+      args = (typing.Tuple[K, args[0]],) + args[1:]
       hints.set_input_types(*args, **kwargs)
     else:
-      hints.set_input_types(typehints.Tuple[K, typehints.Any])
-    hints.set_output_types(typehints.Tuple[K, typehints.Any])
+      hints.set_input_types(typing.Tuple[K, typing.Any])
+    hints.set_output_types(typing.Tuple[K, typing.Any])
     return hints
 
 
@@ -101,9 +102,9 @@ class FinishCombine(beam.DoFn):
 
   def default_type_hints(self):
     hints = self._combine_fn.get_type_hints().copy()
-    K = typehints.TypeVariable('K')
-    hints.set_input_types(typehints.Tuple[K, typehints.Any])
+    K = typing.TypeVar('K')
+    hints.set_input_types(typing.Tuple[K, typing.Any])
     if hints.output_types:
       main_output_type = hints.simple_output_type('')
-      hints.set_output_types(typehints.Tuple[K, main_output_type])
+      hints.set_output_types(typing.Tuple[K, main_output_type])
     return hints

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -23,6 +23,7 @@ import collections
 import logging
 import random
 import time
+import typing
 from builtins import object
 
 from future.utils import iteritems
@@ -602,11 +603,11 @@ class _ParDoEvaluator(_TransformEvaluator):
     self.user_timer_map = {}
     if is_stateful_dofn(dofn):
       kv_type_hint = self._applied_ptransform.inputs[0].element_type
-      if kv_type_hint and kv_type_hint != typehints.Any:
+      if kv_type_hint and kv_type_hint != typing.Any:
         coder = coders.registry.get_coder(kv_type_hint)
         self.key_coder = coder.key_coder()
       else:
-        self.key_coder = coders.registry.get_coder(typehints.Any)
+        self.key_coder = coders.registry.get_coder(typing.Any)
 
       self.user_state_context = DirectUserStateContext(
           self._step_context, dofn, self.key_coder)
@@ -669,7 +670,7 @@ class _GroupByKeyOnlyEvaluator(_TransformEvaluator):
     assert len(self._outputs) == 1
     self.output_pcollection = list(self._outputs)[0]
 
-    # The output type of a GroupByKey will be KV[Any, Any] or more specific.
+    # The output type of a GroupByKey will be Tuple[Any, Any] or more specific.
     # TODO(BEAM-2717): Infer coders earlier.
     kv_type_hint = (
         self._applied_ptransform.outputs[None].element_type
@@ -759,10 +760,10 @@ class _StreamingGroupByKeyOnlyEvaluator(_TransformEvaluator):
     assert len(self._outputs) == 1
     self.output_pcollection = list(self._outputs)[0]
 
-    # The input type of a GroupByKey will be KV[Any, Any] or more specific.
+    # The input type of a GroupByKey will be Tuple[Any, Any] or more specific.
     kv_type_hint = self._applied_ptransform.inputs[0].element_type
     key_type_hint = (kv_type_hint.tuple_types[0] if kv_type_hint
-                     else typehints.Any)
+                     else typing.Any)
     self.key_coder = coders.registry.get_coder(key_type_hint)
 
   def process_element(self, element):
@@ -815,10 +816,10 @@ class _StreamingGroupAlsoByWindowEvaluator(_TransformEvaluator):
     self.keyed_holds = {}
 
     # The input type (which is the same as the output type) of a
-    # GroupAlsoByWindow will be KV[Any, Iter[Any]] or more specific.
+    # GroupAlsoByWindow will be Tuple[Any, Iter[Any]] or more specific.
     kv_type_hint = self._applied_ptransform.outputs[None].element_type
     key_type_hint = (kv_type_hint.tuple_types[0] if kv_type_hint
-                     else typehints.Any)
+                     else typing.Any)
     self.key_coder = coders.registry.get_coder(key_type_hint)
 
   def process_element(self, element):

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -31,7 +31,6 @@ from future.utils import iteritems
 import apache_beam.io as io
 from apache_beam import coders
 from apache_beam import pvalue
-from apache_beam import typehints
 from apache_beam.internal import pickler
 from apache_beam.runners import common
 from apache_beam.runners.common import DoFnRunner

--- a/sdks/python/apache_beam/runners/pipeline_context.py
+++ b/sdks/python/apache_beam/runners/pipeline_context.py
@@ -31,6 +31,7 @@ from apache_beam.internal import pickler
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.transforms import core
+from apache_beam.typehints import native_type_compatibility
 
 
 class Environment(object):
@@ -164,7 +165,8 @@ class PipelineContext(object):
     if self.use_fake_coders or coder_id not in self.coders:
       return pickler.loads(coder_id)
     else:
-      return self.coders[coder_id].to_type_hint()
+      return native_type_compatibility.convert_to_beam_type(
+          self.coders[coder_id].to_type_hint())
 
   @staticmethod
   def from_runner_api(proto):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -26,6 +26,7 @@ import tempfile
 import threading
 import time
 import traceback
+import typing
 import unittest
 import uuid
 from builtins import range
@@ -257,10 +258,10 @@ class FnApiRunnerTest(unittest.TestCase):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create(['a', 'b'])
       # The type of this side-input is forced to Any (overriding type
-      # inference). Without type coercion to KV[Any, Any], the usage of this
+      # inference). Without type coercion to Tuple[Any, Any], the usage of this
       # side-input in AsMultiMap() below should fail.
       side = (p | 'side' >> beam.Create([('a', 1), ('b', 2), ('a', 3)])
-              .with_output_types(beam.typehints.Any))
+              .with_output_types(typing.Any))
       assert_that(
           main | beam.Map(lambda k, d: (k, sorted(d[k])),
                           beam.pvalue.AsMultiMap(side)),

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -763,14 +763,14 @@ def expand_sdf(stages, context):
         main_input_id = transform.inputs[main_input_tag]
         element_coder_id = context.components.pcollections[
             main_input_id].coder_id
-        # KV[element, restriction]
+        # Tuple[element, restriction]
         paired_coder_id = context.add_or_get_coder_id(
             beam_runner_api_pb2.Coder(
                 spec=beam_runner_api_pb2.FunctionSpec(
                     urn=common_urns.coders.KV.urn),
                 component_coder_ids=[element_coder_id,
                                      pardo_payload.restriction_coder_id]))
-        # KV[KV[element, restriction], double]
+        # Tuple[Tuple[element, restriction], double]
         sized_coder_id = context.add_or_get_coder_id(
             beam_runner_api_pb2.Coder(
                 spec=beam_runner_api_pb2.FunctionSpec(

--- a/sdks/python/apache_beam/tools/coders_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/coders_microbenchmark.py
@@ -36,6 +36,7 @@ import random
 import re
 import string
 import sys
+import typing
 
 from past.builtins import unicode
 
@@ -179,7 +180,7 @@ def run_coder_benchmarks(
   random.seed(seed)
 
   # TODO(BEAM-4441): Pick coders using type hints, for example:
-  # tuple_coder = typecoders.registry.get_coder(typehints.Tuple[int, ...])
+  # tuple_coder = typecoders.registry.get_coder(typing.Tuple[int, ...])
   benchmarks = [
       coder_benchmark_factory(
           coders.FastPrimitivesCoder(), small_int),

--- a/sdks/python/apache_beam/tools/coders_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/coders_microbenchmark.py
@@ -36,7 +36,6 @@ import random
 import re
 import string
 import sys
-import typing
 
 from past.builtins import unicode
 

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -37,6 +37,7 @@ from typing import Union
 
 from past.builtins import long
 
+from apache_beam import typehints
 from apache_beam.transforms import core
 from apache_beam.transforms import cy_combiners
 from apache_beam.transforms import ptransform
@@ -131,7 +132,7 @@ class Count(object):
     """combiners.Count.PerElement counts how many times each element occurs."""
 
     def expand(self, pcoll):
-      paired_with_void_type = Tuple[pcoll.element_type, Any]
+      paired_with_void_type = typehints.Tuple[pcoll.element_type, Any]
       return (pcoll
               | ('%s:PairWithVoid' % self.label >> core.Map(lambda x: (x, None))
                  .with_output_types(paired_with_void_type))

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -35,14 +35,14 @@ from apache_beam.transforms import cy_combiners
 from apache_beam.transforms import ptransform
 from apache_beam.transforms import window
 from apache_beam.transforms.display import DisplayDataItem
-from apache_beam.typehints import KV
-from apache_beam.typehints import Any
-from apache_beam.typehints import Dict
-from apache_beam.typehints import Iterable
-from apache_beam.typehints import List
-from apache_beam.typehints import Tuple
-from apache_beam.typehints import TypeVariable
-from apache_beam.typehints import Union
+from typing import Tuple
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Tuple
+from typing import TypeVar
+from typing import Union
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
 from apache_beam.utils.timestamp import Duration
@@ -59,9 +59,9 @@ __all__ = [
     ]
 
 # Type variables
-T = TypeVariable('T')
-K = TypeVariable('K')
-V = TypeVariable('V')
+T = TypeVar('T')
+K = TypeVar('K')
+V = TypeVar('V')
 TimestampType = Union[int, long, float, Timestamp, Duration]
 
 
@@ -132,7 +132,7 @@ class Count(object):
     """combiners.Count.PerElement counts how many times each element occurs."""
 
     def expand(self, pcoll):
-      paired_with_void_type = KV[pcoll.element_type, Any]
+      paired_with_void_type = Tuple[pcoll.element_type, Any]
       return (pcoll
               | ('%s:PairWithVoid' % self.label >> core.Map(lambda x: (x, None))
                  .with_output_types(paired_with_void_type))
@@ -316,7 +316,7 @@ class Top(object):
       """Expands the transform.
 
       Raises TypeCheckError: If the output type of the input PCollection is not
-      compatible with KV[A, B].
+      compatible with Tuple[A, B].
 
       Args:
         pcoll: PCollection to process
@@ -354,7 +354,7 @@ class Top(object):
 
 
 @with_input_types(T)
-@with_output_types(KV[None, List[T]])
+@with_output_types(Tuple[None, List[T]])
 class _TopPerBundle(core.DoFn):
   def __init__(self, n, less_than, key):
     self._n = n
@@ -389,7 +389,7 @@ class _TopPerBundle(core.DoFn):
           (None, self._heap))
 
 
-@with_input_types(KV[None, Iterable[List[T]]])
+@with_input_types(Tuple[None, Iterable[List[T]]])
 @with_output_types(List[T])
 class _MergeTopPerBundle(core.DoFn):
   def __init__(self, n, less_than, key):
@@ -883,8 +883,8 @@ class Latest(object):
               .with_output_types(Tuple[T, TimestampType])
               | core.CombineGlobally(LatestCombineFn()))
 
-  @with_input_types(KV[K, V])
-  @with_output_types(KV[K, V])
+  @with_input_types(Tuple[K, V])
+  @with_output_types(Tuple[K, V])
   class PerKey(ptransform.PTransform):
     """Compute elements with the latest timestamp for each key
     from a keyed PCollection"""
@@ -897,7 +897,7 @@ class Latest(object):
     def expand(self, pcoll):
       return (pcoll
               | core.ParDo(self.add_timestamp)
-              .with_output_types(KV[K, Tuple[T, TimestampType]])
+              .with_output_types(Tuple[K, Tuple[T, TimestampType]])
               | core.CombinePerKey(LatestCombineFn()))
 
 

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -27,6 +27,13 @@ import sys
 import warnings
 from builtins import object
 from builtins import zip
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Tuple
+from typing import TypeVar
+from typing import Union
 
 from past.builtins import long
 
@@ -35,14 +42,6 @@ from apache_beam.transforms import cy_combiners
 from apache_beam.transforms import ptransform
 from apache_beam.transforms import window
 from apache_beam.transforms.display import DisplayDataItem
-from typing import Tuple
-from typing import Any
-from typing import Dict
-from typing import Iterable
-from typing import List
-from typing import Tuple
-from typing import TypeVar
-from typing import Union
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
 from apache_beam.utils.timestamp import Duration

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -58,6 +58,7 @@ from apache_beam.internal import util
 from apache_beam.portability import python_urns
 from apache_beam.transforms.display import DisplayDataItem
 from apache_beam.transforms.display import HasDisplayData
+from apache_beam.typehints import native_type_compatibility
 from apache_beam.typehints import typehints
 from apache_beam.typehints.decorators import TypeCheckError
 from apache_beam.typehints.decorators import WithTypeHints
@@ -65,7 +66,6 @@ from apache_beam.typehints.decorators import getcallargs_forhints
 from apache_beam.typehints.decorators import getfullargspec
 from apache_beam.typehints.trivial_inference import instance_to_type
 from apache_beam.typehints.typehints import validate_composite_type_param
-from apache_beam.typehints import native_type_compatibility
 from apache_beam.utils import proto_utils
 
 __all__ = [

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -65,6 +65,7 @@ from apache_beam.typehints.decorators import getcallargs_forhints
 from apache_beam.typehints.decorators import getfullargspec
 from apache_beam.typehints.trivial_inference import instance_to_type
 from apache_beam.typehints.typehints import validate_composite_type_param
+from apache_beam.typehints import native_type_compatibility
 from apache_beam.utils import proto_utils
 
 __all__ = [
@@ -348,6 +349,8 @@ class PTransform(WithTypeHints, HasDisplayData):
       :class:`PTransform` object. This allows chaining type-hinting related
       methods.
     """
+    input_type_hint = native_type_compatibility.convert_to_beam_type(
+        input_type_hint)
     validate_composite_type_param(input_type_hint,
                                   'Type hints for a PTransform')
     return super(PTransform, self).with_input_types(input_type_hint)
@@ -369,6 +372,7 @@ class PTransform(WithTypeHints, HasDisplayData):
       :class:`PTransform` object. This allows chaining type-hinting related
       methods.
     """
+    type_hint = native_type_compatibility.convert_to_beam_type(type_hint)
     validate_composite_type_param(type_hint, 'Type hints for a PTransform')
     return super(PTransform, self).with_output_types(type_hint)
 
@@ -735,6 +739,11 @@ class PTransformWithSideInputs(PTransform):
       methods.
     """
     super(PTransformWithSideInputs, self).with_input_types(input_type_hint)
+
+    side_inputs_arg_hints = native_type_compatibility.convert_to_beam_types(
+        side_inputs_arg_hints)
+    side_input_kwarg_hints = native_type_compatibility.convert_to_beam_types(
+        side_input_kwarg_hints)
 
     for si in side_inputs_arg_hints:
       validate_composite_type_param(si, 'Type hints for a PTransform')

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -26,6 +26,7 @@ import operator
 import os
 import re
 import sys
+import typing
 import unittest
 from builtins import map
 from builtins import range
@@ -996,7 +997,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   def test_pardo_does_not_type_check_using_type_hint_decorators(self):
     @with_input_types(a=int)
-    @with_output_types(typehints.List[str])
+    @with_output_types(typing.List[str])
     def int_to_str(a):
       return [str(a)]
 
@@ -1013,7 +1014,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   def test_pardo_properly_type_checks_using_type_hint_decorators(self):
     @with_input_types(a=str)
-    @with_output_types(typehints.List[str])
+    @with_output_types(typing.List[str])
     def to_all_upper_case(a):
       return [a.upper()]
 
@@ -1163,28 +1164,28 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     d = (self.p
          | 'Str' >> beam.Create(['t', 'e', 's', 't']).with_output_types(str)
          | ('Pair' >> beam.Map(lambda x: (x, ord(x)))
-            .with_output_types(typehints.KV[str, str]))
+            .with_output_types(typing.Tuple[str, str]))
          | _GroupByKeyOnly())
 
     # Output type should correctly be deduced.
-    # GBK-only should deduce that KV[A, B] is turned into KV[A, Iterable[B]].
-    self.assertCompatible(typehints.KV[str, typehints.Iterable[str]],
+    # GBK-only should deduce that Tuple[A, B] is turned into Tuple[A, Iterable[B]].
+    self.assertCompatible(typing.Tuple[str, typing.Iterable[str]],
                           d.element_type)
 
   def test_group_by_key_output_type_deduction(self):
     d = (self.p
          | 'Str' >> beam.Create(range(20)).with_output_types(int)
          | ('PairNegative' >> beam.Map(lambda x: (x % 5, -x))
-            .with_output_types(typehints.KV[int, int]))
+            .with_output_types(typing.Tuple[int, int]))
          | beam.GroupByKey())
 
     # Output type should correctly be deduced.
-    # GBK should deduce that KV[A, B] is turned into KV[A, Iterable[B]].
-    self.assertCompatible(typehints.KV[int, typehints.Iterable[int]],
+    # GBK should deduce that Tuple[A, B] is turned into Tuple[A, Iterable[B]].
+    self.assertCompatible(typing.Tuple[int, typing.Iterable[int]],
                           d.element_type)
 
   def test_group_by_key_only_does_not_type_check(self):
-    # GBK will be passed raw int's here instead of some form of KV[A, B].
+    # GBK will be passed raw int's here instead of some form of Tuple[A, B].
     with self.assertRaises(typehints.TypeCheckError) as e:
       (self.p
        | beam.Create([1, 2, 3]).with_output_types(int)
@@ -1196,12 +1197,12 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
                      e.exception.args[0])
 
   def test_group_by_does_not_type_check(self):
-    # Create is returning a List[int, str], rather than a KV[int, str] that is
+    # Create is returning a List[int, str], rather than a Tuple[int, str] that is
     # aliased to Tuple[int, str].
     with self.assertRaises(typehints.TypeCheckError) as e:
       (self.p
        | (beam.Create([[1], [2]])
-          .with_output_types(typehints.Iterable[int]))
+          .with_output_types(typing.Iterable[int]))
        | 'T' >> beam.GroupByKey())
 
     self.assertEqual("Input type hint violation at T: "
@@ -1276,7 +1277,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
     self.p._options.view_as(TypeOptions).runtime_type_check = True
 
-    @with_output_types(typehints.KV[int, str])
+    @with_output_types(typing.Tuple[int, str])
     @with_input_types(x=str)
     def group_with_upper_ord(x):
       return (ord(x.upper()) % 5, x)
@@ -1298,11 +1299,11 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
     self.p._options.view_as(TypeOptions).runtime_type_check = True
 
-    @with_output_types(typehints.KV[bool, int])
+    @with_output_types(typing.Tuple[bool, int])
     @with_input_types(a=int)
     def is_even_as_key(a):
       # Simulate a programming error, should be: return (a % 2 == 0, a)
-      # However this returns KV[int, int]
+      # However this returns Tuple[int, int]
       return (a % 2, a)
 
     (self.p
@@ -1327,7 +1328,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_pipeline_checking_satisfied_run_time_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
 
-    @with_output_types(typehints.KV[bool, int])
+    @with_output_types(typing.Tuple[bool, int])
     @with_input_types(a=int)
     def is_even_as_key(a):
       # The programming error in the above test-case has now been fixed.
@@ -1371,7 +1372,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       (self.p
        | beam.Create([(1, 3.0), (2, 4.9), (3, 9.5)])
        | ('Add' >> beam.FlatMap(lambda x_y: [x_y[0] + x_y[1]])
-          .with_input_types(typehints.Tuple[int, int]).with_output_types(int))
+          .with_input_types(typing.Tuple[int, int]).with_output_types(int))
       )
       self.p.run()
 
@@ -1421,8 +1422,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       (self.p
        | beam.Create([(1, 3.0), (2, 4.9), (3, 9.5)])
        | ('Swap' >> beam.FlatMap(lambda x_y1: [x_y1[0] + x_y1[1]])
-          .with_input_types(typehints.Tuple[int, float])
-          .with_output_types(typehints.Tuple[float, int]))
+          .with_input_types(typing.Tuple[int, float])
+          .with_output_types(typing.Tuple[float, int]))
       )
       self.p.run()
 
@@ -1478,7 +1479,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
                    'See BEAM-6877')
   def test_combine_properly_pipeline_type_checks_using_decorator(self):
     @with_output_types(int)
-    @with_input_types(ints=typehints.Iterable[int])
+    @with_input_types(ints=typing.Iterable[int])
     def sum_ints(ints):
       return sum(ints)
 
@@ -1509,11 +1510,11 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
   def test_combine_pipeline_type_propagation_using_decorators(self):
     @with_output_types(int)
-    @with_input_types(ints=typehints.Iterable[int])
+    @with_input_types(ints=typing.Iterable[int])
     def sum_ints(ints):
       return sum(ints)
 
-    @with_output_types(typehints.List[int])
+    @with_output_types(typing.List[int])
     @with_input_types(n=int)
     def range_from_zero(n):
       return list(range(n+1))
@@ -1531,7 +1532,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
 
     @with_output_types(int)
-    @with_input_types(ints=typehints.Iterable[int])
+    @with_input_types(ints=typing.Iterable[int])
     def iter_mul(ints):
       return reduce(operator.mul, ints, 1)
 
@@ -1548,7 +1549,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     # Combine fn is returning the incorrect type
     @with_output_types(int)
-    @with_input_types(ints=typehints.Iterable[int])
+    @with_input_types(ints=typing.Iterable[int])
     def iter_mul(ints):
       return str(reduce(operator.mul, ints, 1))
 
@@ -1707,10 +1708,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     d = (self.p
          | beam.Create(range(5)).with_output_types(int)
          | ('EvenGroup' >> beam.Map(lambda x: (not x % 2, x))
-            .with_output_types(typehints.KV[bool, int]))
+            .with_output_types(typing.Tuple[bool, int]))
          | 'EvenMean' >> combine.Mean.PerKey())
 
-    self.assertCompatible(typehints.KV[bool, float], d.element_type)
+    self.assertCompatible(typing.Tuple[bool, float], d.element_type)
     assert_that(d, equal_to([(False, 2.0), (True, 2.0)]))
     self.p.run()
 
@@ -1719,7 +1720,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       (self.p
        | beam.Create(map(str, range(5))).with_output_types(str)
        | ('UpperPair' >> beam.Map(lambda x: (x.upper(), x))
-          .with_output_types(typehints.KV[str, str]))
+          .with_output_types(typing.Tuple[str, str]))
        | 'EvenMean' >> combine.Mean.PerKey())
       self.p.run()
 
@@ -1742,10 +1743,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     d = (self.p
          | beam.Create(range(5)).with_output_types(int)
          | ('OddGroup' >> beam.Map(lambda x: (bool(x % 2), x))
-            .with_output_types(typehints.KV[bool, int]))
+            .with_output_types(typing.Tuple[bool, int]))
          | 'OddMean' >> combine.Mean.PerKey())
 
-    self.assertCompatible(typehints.KV[bool, float], d.element_type)
+    self.assertCompatible(typing.Tuple[bool, float], d.element_type)
     assert_that(d, equal_to([(False, 2.0), (True, 2.0)]))
     self.p.run()
 
@@ -1757,7 +1758,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       (self.p
        | beam.Create(range(5)).with_output_types(int)
        | ('OddGroup' >> beam.Map(lambda x: (x, str(bool(x % 2))))
-          .with_output_types(typehints.KV[int, str]))
+          .with_output_types(typing.Tuple[int, str]))
        | 'OddMean' >> combine.Mean.PerKey())
       self.p.run()
 
@@ -1812,10 +1813,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     d = (self.p
          | beam.Create(range(5)).with_output_types(int)
          | ('EvenGroup' >> beam.Map(lambda x: (not x % 2, x))
-            .with_output_types(typehints.KV[bool, int]))
+            .with_output_types(typing.Tuple[bool, int]))
          | 'CountInt' >> combine.Count.PerKey())
 
-    self.assertCompatible(typehints.KV[bool, int], d.element_type)
+    self.assertCompatible(typing.Tuple[bool, int], d.element_type)
     assert_that(d, equal_to([(False, 2), (True, 3)]))
     self.p.run()
 
@@ -1837,10 +1838,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     d = (self.p
          | beam.Create(['t', 'e', 's', 't']).with_output_types(str)
          | 'DupKey' >> beam.Map(lambda x: (x, x))
-         .with_output_types(typehints.KV[str, str])
+         .with_output_types(typing.Tuple[str, str])
          | 'CountDups' >> combine.Count.PerKey())
 
-    self.assertCompatible(typehints.KV[str, int], d.element_type)
+    self.assertCompatible(typing.Tuple[str, int], d.element_type)
     assert_that(d, equal_to([('e', 1), ('s', 1), ('t', 2)]))
     self.p.run()
 
@@ -1849,7 +1850,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create([1, 1, 2, 3]).with_output_types(int)
          | 'CountElems' >> combine.Count.PerElement())
 
-    self.assertCompatible(typehints.KV[int, int], d.element_type)
+    self.assertCompatible(typing.Tuple[int, int], d.element_type)
     assert_that(d, equal_to([(1, 2), (2, 1), (3, 1)]))
     self.p.run()
 
@@ -1874,7 +1875,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          .with_output_types(bool)
          | 'CountElems' >> combine.Count.PerElement())
 
-    self.assertCompatible(typehints.KV[bool, int], d.element_type)
+    self.assertCompatible(typing.Tuple[bool, int], d.element_type)
     assert_that(d, equal_to([(False, 1), (True, 4)]))
     self.p.run()
 
@@ -1883,7 +1884,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create(range(5, 11)).with_output_types(int)
          | 'Top 3' >> combine.Top.Of(3))
 
-    self.assertCompatible(typehints.Iterable[int],
+    self.assertCompatible(typing.Iterable[int],
                           d.element_type)
     assert_that(d, equal_to([[10, 9, 8]]))
     self.p.run()
@@ -1899,7 +1900,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create(list('testing')).with_output_types(str)
          | 'AciiTop' >> combine.Top.Of(3))
 
-    self.assertCompatible(typehints.Iterable[str], d.element_type)
+    self.assertCompatible(typing.Iterable[str], d.element_type)
     assert_that(d, equal_to([['t', 't', 's']]))
     self.p.run()
 
@@ -1920,10 +1921,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     d = (self.p
          | beam.Create(range(100)).with_output_types(int)
          | ('GroupMod 3' >> beam.Map(lambda x: (x % 3, x))
-            .with_output_types(typehints.KV[int, int]))
+            .with_output_types(typing.Tuple[int, int]))
          | 'TopMod' >> combine.Top.PerKey(1))
 
-    self.assertCompatible(typehints.Tuple[int, typehints.Iterable[int]],
+    self.assertCompatible(typing.Tuple[int, typing.Iterable[int]],
                           d.element_type)
     assert_that(d, equal_to([(0, [99]), (1, [97]), (2, [98])]))
     self.p.run()
@@ -1934,10 +1935,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     d = (self.p
          | beam.Create(range(21))
          | ('GroupMod 3' >> beam.Map(lambda x: (x % 3, x))
-            .with_output_types(typehints.KV[int, int]))
+            .with_output_types(typing.Tuple[int, int]))
          | 'TopMod' >> combine.Top.PerKey(1))
 
-    self.assertCompatible(typehints.KV[int, typehints.Iterable[int]],
+    self.assertCompatible(typing.Tuple[int, typing.Iterable[int]],
                           d.element_type)
     assert_that(d, equal_to([(0, [18]), (1, [19]), (2, [20])]))
     self.p.run()
@@ -1947,7 +1948,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create([2, 2, 3, 3]).with_output_types(int)
          | 'Sample' >> combine.Sample.FixedSizeGlobally(3))
 
-    self.assertCompatible(typehints.Iterable[int], d.element_type)
+    self.assertCompatible(typing.Iterable[int], d.element_type)
 
     def matcher(expected_len):
       def match(actual):
@@ -1963,7 +1964,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create([2, 2, 3, 3]).with_output_types(int)
          | 'Sample' >> combine.Sample.FixedSizeGlobally(2))
 
-    self.assertCompatible(typehints.Iterable[int], d.element_type)
+    self.assertCompatible(typing.Iterable[int], d.element_type)
 
     def matcher(expected_len):
       def match(actual):
@@ -1975,10 +1976,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_sample_per_key_pipeline_satisfied(self):
     d = (self.p
          | (beam.Create([(1, 2), (1, 2), (2, 3), (2, 3)])
-            .with_output_types(typehints.KV[int, int]))
+            .with_output_types(typing.Tuple[int, int]))
          | 'Sample' >> combine.Sample.FixedSizePerKey(2))
 
-    self.assertCompatible(typehints.KV[int, typehints.Iterable[int]],
+    self.assertCompatible(typing.Tuple[int, typing.Iterable[int]],
                           d.element_type)
 
     def matcher(expected_len):
@@ -1994,10 +1995,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     d = (self.p
          | (beam.Create([(1, 2), (1, 2), (2, 3), (2, 3)])
-            .with_output_types(typehints.KV[int, int]))
+            .with_output_types(typing.Tuple[int, int]))
          | 'Sample' >> combine.Sample.FixedSizePerKey(1))
 
-    self.assertCompatible(typehints.KV[int, typehints.Iterable[int]],
+    self.assertCompatible(typing.Tuple[int, typing.Iterable[int]],
                           d.element_type)
 
     def matcher(expected_len):
@@ -2013,7 +2014,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create((1, 2, 3, 4)).with_output_types(int)
          | combine.ToList())
 
-    self.assertCompatible(typehints.List[int], d.element_type)
+    self.assertCompatible(typing.List[int], d.element_type)
 
     def matcher(expected):
       def match(actual):
@@ -2029,7 +2030,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | beam.Create(list('test')).with_output_types(str)
          | combine.ToList())
 
-    self.assertCompatible(typehints.List[str], d.element_type)
+    self.assertCompatible(typing.List[str], d.element_type)
 
     def matcher(expected):
       def match(actual):
@@ -2054,10 +2055,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_to_dict_pipeline_check_satisfied(self):
     d = (self.p
          | beam.Create(
-             [(1, 2), (3, 4)]).with_output_types(typehints.Tuple[int, int])
+             [(1, 2), (3, 4)]).with_output_types(typing.Tuple[int, int])
          | combine.ToDict())
 
-    self.assertCompatible(typehints.Dict[int, int], d.element_type)
+    self.assertCompatible(typing.Dict[int, int], d.element_type)
     assert_that(d, equal_to([{1: 2, 3: 4}]))
     self.p.run()
 
@@ -2066,10 +2067,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     d = (self.p
          | (beam.Create([('1', 2), ('3', 4)])
-            .with_output_types(typehints.Tuple[str, int]))
+            .with_output_types(typing.Tuple[str, int]))
          | combine.ToDict())
 
-    self.assertCompatible(typehints.Dict[str, int], d.element_type)
+    self.assertCompatible(typing.Dict[str, int], d.element_type)
     assert_that(d, equal_to([{'1': 2, '3': 4}]))
     self.p.run()
 

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1168,7 +1168,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
          | _GroupByKeyOnly())
 
     # Output type should correctly be deduced.
-    # GBK-only should deduce that Tuple[A, B] is turned into Tuple[A, Iterable[B]].
+    # GBK-only should deduce that Tuple[A, B] is turned into
+    # Tuple[A, Iterable[B]].
     self.assertCompatible(typing.Tuple[str, typing.Iterable[str]],
                           d.element_type)
 
@@ -1197,8 +1198,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
                      e.exception.args[0])
 
   def test_group_by_does_not_type_check(self):
-    # Create is returning a List[int, str], rather than a Tuple[int, str] that is
-    # aliased to Tuple[int, str].
+    # Create is returning a List[int, str], rather than a Tuple[int, str]
+    # that is aliased to Tuple[int, str].
     with self.assertRaises(typehints.TypeCheckError) as e:
       (self.p
        | (beam.Create([[1], [2]])

--- a/sdks/python/apache_beam/transforms/stats.py
+++ b/sdks/python/apache_beam/transforms/stats.py
@@ -23,6 +23,7 @@ from __future__ import division
 import heapq
 import math
 import sys
+import typing
 from builtins import round
 
 from apache_beam import coders
@@ -35,9 +36,9 @@ __all__ = [
 ]
 
 # Type variables
-T = typehints.TypeVariable('T')
-K = typehints.TypeVariable('K')
-V = typehints.TypeVariable('V')
+T = typing.TypeVar('T')
+K = typing.TypeVar('K')
+V = typing.TypeVar('V')
 
 
 class ApproximateUnique(object):
@@ -112,8 +113,8 @@ class ApproximateUnique(object):
              >> (CombineGlobally(ApproximateUniqueCombineFn(self._sample_size,
                                                             coder)))
 
-  @typehints.with_input_types(typehints.KV[K, V])
-  @typehints.with_output_types(typehints.KV[K, int])
+  @typehints.with_input_types(typing.Tuple[K, V])
+  @typehints.with_output_types(typing.Tuple[K, int])
   class PerKey(PTransform):
     """ Approximate.PerKey approximate number of unique values per key"""
 

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -25,6 +25,7 @@ import collections
 import contextlib
 import random
 import time
+import typing
 import warnings
 from builtins import object
 from builtins import range
@@ -77,9 +78,9 @@ __all__ = [
     'GroupIntoBatches'
     ]
 
-K = typehints.TypeVariable('K')
-V = typehints.TypeVariable('V')
-T = typehints.TypeVariable('T')
+K = typing.TypeVar('K')
+V = typing.TypeVar('V')
+T = typing.TypeVar('T')
 
 
 class CoGroupByKey(PTransform):
@@ -480,7 +481,7 @@ class _WindowAwareBatchingDoFn(DoFn):
 
 
 @typehints.with_input_types(T)
-@typehints.with_output_types(typehints.List[T])
+@typehints.with_output_types(typing.List[T])
 class BatchElements(PTransform):
   """A Transform that batches elements for amortized processing.
 
@@ -573,8 +574,8 @@ class _IdentityWindowFn(NonMergingWindowFn):
     return self._window_coder
 
 
-@typehints.with_input_types(typehints.KV[K, V])
-@typehints.with_output_types(typehints.KV[K, V])
+@typehints.with_input_types(typing.Tuple[K, V])
+@typehints.with_output_types(typing.Tuple[K, V])
 class ReshufflePerKey(PTransform):
   """PTransform that returns a PCollection equivalent to its input,
   but operationally provides some of the side effects of a GroupByKey,
@@ -682,7 +683,7 @@ def WithKeys(pcoll, k):
 
 
 @experimental()
-@typehints.with_input_types(typehints.KV[K, V])
+@typehints.with_input_types(typing.Tuple[K, V])
 class GroupIntoBatches(PTransform):
   """PTransform that batches the input into desired batch size. Elements are
   buffered until they are equal to batch size provided in the argument at which
@@ -762,7 +763,7 @@ class ToString(object):
       self.delimiter = delimiter or ","
 
     def expand(self, pcoll):
-      input_type = typehints.KV[typehints.Any, typehints.Any]
+      input_type = typing.Tuple[typing.Any, typing.Any]
       output_type = str
       return (pcoll | ('%s:KeyVaueToString' % self.label >> (Map(
           lambda x: "{}{}{}".format(x[0], self.delimiter, x[1])))
@@ -795,7 +796,7 @@ class ToString(object):
       self.delimiter = delimiter or ","
 
     def expand(self, pcoll):
-      input_type = typehints.Iterable[typehints.Any]
+      input_type = typing.Iterable[typing.Any]
       output_type = str
       return (pcoll | ('%s:IterablesToString' % self.label >> (
           Map(lambda x: self.delimiter.join(str(_x) for _x in x)))
@@ -835,8 +836,8 @@ class Reify(object):
     def expand(self, pcoll):
       return pcoll | ParDo(self.add_window_info)
 
-  @typehints.with_input_types(typehints.KV[K, V])
-  @typehints.with_output_types(typehints.KV[K, V])
+  @typehints.with_input_types(typing.Tuple[K, V])
+  @typehints.with_output_types(typing.Tuple[K, V])
   class TimestampInValue(PTransform):
     """PTransform to wrap the Value in a KV pair in a TimestampedValue with
     the element's associated timestamp."""
@@ -849,8 +850,8 @@ class Reify(object):
     def expand(self, pcoll):
       return pcoll | ParDo(self.add_timestamp_info)
 
-  @typehints.with_input_types(typehints.KV[K, V])
-  @typehints.with_output_types(typehints.KV[K, V])
+  @typehints.with_input_types(typing.Tuple[K, V])
+  @typehints.with_output_types(typing.Tuple[K, V])
   class WindowInValue(PTransform):
     """PTransform to convert the Value in a KV pair into a tuple of
     (value, timestamp, window), with the whole element being wrapped inside a

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -217,10 +217,14 @@ class WithTypeHints(object):
     return None
 
   def with_input_types(self, *arg_hints, **kwarg_hints):
+    arg_hints = native_type_compatibility.convert_to_beam_types(arg_hints)
+    kwarg_hints = native_type_compatibility.convert_to_beam_types(kwarg_hints)
     self._get_or_create_type_hints().set_input_types(*arg_hints, **kwarg_hints)
     return self
 
   def with_output_types(self, *arg_hints, **kwarg_hints):
+    arg_hints = native_type_compatibility.convert_to_beam_types(arg_hints)
+    kwarg_hints = native_type_compatibility.convert_to_beam_types(kwarg_hints)
     self._get_or_create_type_hints().set_output_types(*arg_hints, **kwarg_hints)
     return self
 

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -107,7 +107,7 @@ def _match_same_type(match_against):
 
 def _match_is_exactly_iterable(user_type):
   # Avoid unintentionally catching all subtypes (e.g. strings and mappings).
-  if sys.version_info < (3,7):
+  if sys.version_info < (3, 7):
     expected_origin = typing.Iterable
   else:
     expected_origin = collections.abc.Iterable
@@ -156,14 +156,15 @@ def convert_to_beam_type(typ):
   """
   if isinstance(typ, typing.TypeVar):
     # This is a special case, as it's not parameterized by types.
-    # Also, identity must be preserved through conversion.
+    # Also, identity must be preserved through conversion (i.e. the same
+    # TypeVar instance must get converted into the same TypeVariable instance).
     # A global cache should be OK as the number of distinct type variables
     # is generally small.
     if id(typ) not in _type_var_cache:
       _type_var_cache[id(typ)] = typehints.TypeVariable(typ.__name__)
     return _type_var_cache[id(typ)]
-  elif getattr(typ, '__module__', None) in ('__builtin__', 'builtins'):
-    # Don't translate base types.
+  elif getattr(typ, '__module__', None) != 'typing':
+    # Only tranlsate types from the typing module.
     return typ
 
   type_map = [

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -138,6 +138,9 @@ def _match_is_union(user_type):
   return False
 
 
+_type_var_cache = {}
+
+
 def convert_to_beam_type(typ):
   """Convert a given typing type to a Beam type.
 
@@ -153,7 +156,15 @@ def convert_to_beam_type(typ):
   """
   if isinstance(typ, typing.TypeVar):
     # This is a special case, as it's not parameterized by types.
-    return typehints.TypeVariable(typ.__name__)
+    # Also, identity must be preserved through conversion.
+    # A global cache should be OK as the number of distinct type variables
+    # is generally small.
+    if id(typ) not in _type_var_cache:
+      _type_var_cache[id(typ)] = typehints.TypeVariable(typ.__name__)
+    return _type_var_cache[id(typ)]
+  elif getattr(typ, '__module__', None) in ('__builtin__', 'builtins'):
+    # Don't translate base types.
+    return typ
 
   type_map = [
       _TypeMapEntry(

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -37,6 +37,8 @@ _TypeMapEntry = collections.namedtuple(
 
 
 def _get_compatible_args(typ):
+  if isinstance(typ, typing.TypeVar):
+    return (typ.__name__,)
   # On Python versions < 3.5.3, the Tuple and Union type from typing do
   # not have an __args__ attribute, but a __tuple_params__, and a
   # __union_params__ argument respectively.
@@ -140,6 +142,9 @@ def convert_to_beam_type(typ):
   Raises:
     ~exceptions.ValueError: The type was malformed.
   """
+  if isinstance(typ, typing.TypeVar):
+    # This is a special case, as it's not parameterized by types.
+    return typehints.TypeVariable(typ.__name__)
 
   type_map = [
       _TypeMapEntry(

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -46,6 +46,7 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
         ('simple dict', typing.Dict[bytes, int],
          typehints.Dict[bytes, int]),
         ('simple list', typing.List[int], typehints.List[int]),
+        ('simple iterable', typing.Iterable[int], typehints.Iterable[int]),
         ('simple optional', typing.Optional[int], typehints.Optional[int]),
         ('simple set', typing.Set[float], typehints.Set[float]),
         ('simple unary tuple', typing.Tuple[bytes],

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -53,7 +53,7 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
          typehints.Tuple[bytes]),
         ('simple union', typing.Union[int, bytes, float],
          typehints.Union[int, bytes, float]),
-        ('namedtuple', _TestNamedTuple, typehints.Any),
+        ('namedtuple', _TestNamedTuple, _TestNamedTuple),
         ('test class', _TestClass, _TestClass),
         ('test class in list', typing.List[_TestClass],
          typehints.List[_TestClass]),

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -66,7 +66,12 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
         ('complex dict',
          typing.Dict[bytes, typing.List[typing.Tuple[bytes, _TestClass]]],
          typehints.Dict[bytes, typehints.List[typehints.Tuple[
-             bytes, _TestClass]]])
+             bytes, _TestClass]]]),
+        ('type var', typing.TypeVar('T'), typehints.TypeVariable('T')),
+        ('nested type var',
+         typing.Tuple[typing.TypeVar('K'), typing.TypeVar('V')],
+         typehints.Tuple[typehints.TypeVariable('K'),
+                         typehints.TypeVariable('V')]),
     ]
 
     for test_case in test_cases:

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -69,7 +69,7 @@ class MainInputTest(unittest.TestCase):
       [1, 2, 3] | beam.Map(str.upper)
 
   def test_loose_bounds(self):
-    @typehints.with_input_types(typehints.Union[int, float])
+    @typehints.with_input_types(typing.Union[int, float])
     @typehints.with_output_types(str)
     def format_number(x):
       return '%g' % x
@@ -224,7 +224,7 @@ class SideInputTest(unittest.TestCase):
       main_input | 'bis' >> beam.Map(repeat, pvalue.AsSingleton(bad_side_input))
 
   def test_deferred_side_input_iterable(self):
-    @typehints.with_input_types(str, typehints.Iterable[str])
+    @typehints.with_input_types(str, typing.Iterable[str])
     def concat(glue, items):
       return glue.join(sorted(items))
     with TestPipeline() as p:

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -31,6 +31,7 @@ from apache_beam.typehints import Any
 from apache_beam.typehints import Tuple
 from apache_beam.typehints import TypeCheckError
 from apache_beam.typehints import Union
+from apache_beam.typehints import native_type_compatibility
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
 from apache_beam.typehints.decorators import GeneratorWrapper
@@ -98,11 +99,13 @@ class SubClass(SuperClass):
 class TypeHintTestCase(unittest.TestCase):
 
   def assertCompatible(self, base, sub):  # pylint: disable=invalid-name
+    base, sub = native_type_compatibility.convert_to_beam_types([base, sub])
     self.assertTrue(
         is_consistent_with(sub, base),
         '%s is not consistent with %s' % (sub, base))
 
   def assertNotCompatible(self, base, sub):  # pylint: disable=invalid-name
+    base, sub = native_type_compatibility.convert_to_beam_type([base, sub])
     self.assertFalse(
         is_consistent_with(sub, base),
         '%s is consistent with %s' % (sub, base))


### PR DESCRIPTION
This is a best effort pass to use typing module for our own type hint declarations, along with some small bugfixes to make that possible. We still use typehints internally, but that should be an implementation detail that our users no longer have to worry about. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
