### PR TITLE
[BEAM-7776] Stop Using Perfkit in IOIT

### DIFF
--- a/.test-infra/jenkins/Kubernetes.groovy
+++ b/.test-infra/jenkins/Kubernetes.groovy
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** Facilitates creation of jenkins steps to setup and cleanup Kubernetes infrastructure. */
+class Kubernetes {
+
+  private static final String KUBERNETES_DIR = '"$WORKSPACE/src/.test-infra/kubernetes"'
+
+  private static final String KUBERNETES_SCRIPT = "${KUBERNETES_DIR}/kubernetes.sh"
+
+  private static def job
+
+  private static String kubeconfigLocation
+
+  private static String namespace
+
+  private Kubernetes(job, String kubeconfigLocation, String namespace) {
+    this.job = job
+    this.kubeconfigLocation = kubeconfigLocation
+    this.namespace = namespace
+  }
+
+  /**
+   * Creates separate kubeconfig, kubernetes namespace and specifies related cleanup steps.
+   *
+   * @param job - jenkins job
+   * @param kubeconfigLocation - place where kubeconfig will be created
+   * @param namepsace - kubernetes namespace
+   */
+  static Kubernetes create(job, String kubeconfigLocation, String namespace) {
+    Kubernetes kubernetes = new Kubernetes(job, kubeconfigLocation, namespace)
+    setupKubeconfig()
+    setupNamespace()
+    addCleanupSteps()
+    return kubernetes
+  }
+
+  private static void setupKubeconfig() {
+    job.steps {
+      shell("cp /home/jenkins/.kube/config ${kubeconfigLocation}")
+      environmentVariables {
+        env('KUBECONFIG', kubeconfigLocation)
+      }
+    }
+  }
+
+  private static void setupNamespace() {
+    job.steps {
+      shell("${KUBERNETES_SCRIPT} createNamespace ${namespace}")
+      environmentVariables {
+        env('KUBERNETES_NAMESPACE', namespace)
+      }
+    }
+  }
+
+  private static void addCleanupSteps() {
+    job.publishers {
+      postBuildScripts {
+        steps {
+          shell("${KUBERNETES_SCRIPT} deleteNamespace ${namespace}")
+          shell("rm ${kubeconfigLocation}")
+        }
+        onlyIfBuildSucceeds(false)
+        onlyIfBuildFails(false)
+      }
+    }
+  }
+
+  /**
+   * Specifies steps to run Kubernetes .yaml script.
+   */
+  void apply(String pathToScript) {
+    job.steps {
+      shell("${KUBERNETES_SCRIPT} apply ${pathToScript}")
+    }
+  }
+
+  /**
+   * Specifies steps that will save specified load balancer serivce address
+   * as an environment variable that can be used in later steps if needed.
+   *
+   * @param serviceName - name of the load balancer Kubernetes service
+   * @param referenceName - name of the environment variable
+   */
+  void loadBalancerIP(String serviceName, String referenceName) {
+    job.steps {
+      String command = "${KUBERNETES_SCRIPT} loadBalancerIP ${serviceName}"
+      shell("set -eo pipefail; eval ${command} | sed 's/^/${referenceName}=/' > job.properties")
+      environmentVariables {
+        propertiesFile('job.properties')
+      }
+    }
+  }
+}

--- a/.test-infra/jenkins/job_PerformanceTests_MongoDBIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_MongoDBIO_IT.groovy
@@ -15,52 +15,70 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import CommonJobProperties as common
 
-import CommonJobProperties as commonJobProperties
-
+String kubernetesDir = '"$WORKSPACE/src/.test-infra/kubernetes"'
+String kubernetesScript = "${kubernetesDir}/kubernetes.sh"
 String jobName = "beam_PerformanceTests_MongoDBIO_IT"
 
+Map pipelineOptions = [
+        tempRoot       : 'gs://temp-storage-for-perf-tests',
+        project        : 'apache-beam-testing',
+        numberOfRecords: '10000000',
+        bigQueryDataset: 'beam_performance',
+        bigQueryTable  : 'mongodbioit_results',
+        mongoDBDatabaseName: 'beam',
+        mongoDBHostName: "\$LOAD_BALANCER_IP",
+        mongoDBPort: 27017,
+        runner: 'DataflowRunner'
+]
+String namespace = common.getKubernetesNamespace(jobName)
+String kubeconfigPath = common.getKubeconfigLocationForNamespace(namespace)
+
 job(jobName) {
-    // Set default Beam job properties.
-    commonJobProperties.setTopLevelMainJobProperties(delegate)
+  common.setTopLevelMainJobProperties(delegate)
+  common.setAutoJob(delegate,'H */6 * * *')
+  common.enablePhraseTriggeringFromPullRequest(
+          delegate,
+          'Java MongoDBIO Performance Test',
+          'Run Java MongoDBIO Performance Test')
 
-    // Run job in postcommit every 6 hours, don't trigger every push, and
-    // don't email individual committers.
-    commonJobProperties.setAutoJob(
-            delegate,
-            'H */6 * * *')
+  steps {
+    shell("cp /home/jenkins/.kube/config ${kubeconfigPath}")
 
-    commonJobProperties.enablePhraseTriggeringFromPullRequest(
-            delegate,
-            'Java MongoDBIO Performance Test',
-            'Run Java MongoDBIO Performance Test')
+    environmentVariables {
+      env('KUBECONFIG', kubeconfigPath)
+      env('KUBERNETES_NAMESPACE', namespace)
+    }
 
-    def pipelineOptions = [
-            tempRoot       : 'gs://temp-storage-for-perf-tests',
-            project        : 'apache-beam-testing',
-            numberOfRecords: '10000000',
-            bigQueryDataset: 'beam_performance',
-            bigQueryTable  : 'mongodbioit_results'
-    ]
+    shell("${kubernetesScript} createNamespace ${namespace}")
+    shell("${kubernetesScript} apply ${kubernetesDir}/mongodb/load-balancer/mongo.yml")
 
-    String namespace = commonJobProperties.getKubernetesNamespace(jobName)
-    String kubeconfig = commonJobProperties.getKubeconfigLocationForNamespace(namespace)
+    String variableName = "LOAD_BALANCER_IP"
+    String command = "${kubernetesScript} loadBalancerIP mongo-load-balancer-service"
+    shell("set -eo pipefail; eval ${command} | sed 's/^/${variableName}=/' > job.properties")
+    environmentVariables {
+      propertiesFile('job.properties')
+    }
 
-    def testArgs = [
-            kubeconfig              : kubeconfig,
-            beam_it_timeout         : '1800',
-            benchmarks              : 'beam_integration_benchmark',
-            beam_prebuilt           : 'false',
-            beam_sdk                : 'java',
-            beam_it_module          : ':sdks:java:io:mongodb',
-            beam_it_class           : 'org.apache.beam.sdk.io.mongodb.MongoDBIOIT',
-            beam_it_options         : commonJobProperties.joinPipelineOptions(pipelineOptions),
-            beam_kubernetes_scripts : commonJobProperties.makePathAbsolute('src/.test-infra/kubernetes/mongodb/load-balancer/mongo.yml'),
-            beam_options_config_file: commonJobProperties.makePathAbsolute('src/.test-infra/kubernetes/mongodb/load-balancer/pkb-config.yml'),
-            bigquery_table          : 'beam_performance.mongodbioit_pkb_results'
-    ]
+    gradle {
+      rootBuildScriptDir(common.checkoutDir)
+      common.setGradleSwitches(delegate)
+      switches("--info")
+      switches("-DintegrationTestPipelineOptions=\'${common.joinPipelineOptions(pipelineOptions)}\'")
+      switches("-DintegrationTestRunner=dataflow")
+      tasks(":sdks:java:io:mongodb:integrationTest --tests org.apache.beam.sdk.io.mongodb.MongoDBIOIT")
+    }
+  }
 
-    commonJobProperties.setupKubernetes(delegate, namespace, kubeconfig)
-    commonJobProperties.buildPerformanceTest(delegate, testArgs)
-    commonJobProperties.cleanupKubernetes(delegate, namespace, kubeconfig)
+  publishers {
+    postBuildScripts {
+      steps {
+        shell("${kubernetesScript} deleteNamespace ${namespace}")
+        shell("rm ${kubeconfigPath}")
+      }
+      onlyIfBuildSucceeds(false)
+      onlyIfBuildFails(false)
+    }
+  }
 }

--- a/.test-infra/kubernetes/kubernetes.sh
+++ b/.test-infra/kubernetes/kubernetes.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Set of common operations that CI needs to invoke when using Kubernetes.
+#    The operations can be invoked using a provided kubeconfig file
+#    and kubernetes namespace.
+#
+#    Specify the following environment variables to override defaults:
+#    - KUBECONFIG: path to .kube/config file (default: $HOME/.kube/config)
+#    - KUBERNETES_NAMESPACE: namespace to be used (default: default)
+set -euxo pipefail
+
+KUBECONFIG="${KUBECONFIG:=$HOME/.kube/config}"
+KUBERNETES_NAMESPACE="${KUBERNETES_NAMESPACE:=default}"
+KUBECTL="kubectl --kubeconfig=$KUBECONFIG --namespace=$KUBERNETES_NAMESPACE"
+
+function retry() {
+  local command=$1
+  local max_retries=$2
+  local sleep_time=$3
+
+  for ((i = 1; i <= max_retries; i++)); do
+    local output
+    output=$(eval "${command}")
+
+    local status=$?
+
+    if [[ ${status} == 0 ]] && [[ -n  ${output} ]]; then
+      echo "${output}"
+      return 0
+    fi
+
+    if [[ $i == "${max_retries}" ]]; then
+      echo "Command failed after ${max_retries} retries" >&2
+      return 1
+    fi
+
+    sleep "${sleep_time}"
+  done
+}
+
+# Invokes "kubectl apply" using specified kubeconfig and namespace.
+#
+# Usage: ./kubernetes.sh apply <path to .yaml file>
+function apply() {
+  eval "$KUBECTL apply -R -f $1"
+}
+
+# Invokes "kubectl delete" using specified kubeconfig and namespace.
+#
+# Usage: ./kubernetes.sh delete <path to .yaml file>
+function delete() {
+  eval "$KUBECTL delete -R -f $1"
+}
+
+# Creates a namespace.
+#
+# Usage: ./kubernetes.sh createNamespace <namespace name>
+function createNamespace() {
+  eval "kubectl --kubeconfig=${KUBECONFIG} create namespace $1"
+}
+
+# Deletes whole namespace with all its contents.
+#
+# Usage: ./kubernetes.sh deleteNamespace <namespace name>
+function deleteNamespace() {
+  eval "kubectl --kubeconfig=${KUBECONFIG} delete namespace $1"
+}
+
+# Gets Load Balancer Ingress IP address.
+# Blocks and retries until the IP is present or retry limit is exceeded.
+#
+# Usage: ./kubernetes.sh loadBalancerIP <name of the load balancer service>
+function loadBalancerIP() {
+  local name=$1
+  local command="$KUBECTL get svc $name -ojsonpath='{.status.loadBalancer.ingress[0].ip}'"
+  retry "${command}" 36 10
+}
+
+"$@"


### PR DESCRIPTION
I replaced Perfkit's ability to setup/teardown kubernetes with a simple bash script. Thanks to this: 

 - the tests will not be dependant on an external dependency (perfkit) and complexity is reduced
 - all logs are visible (perfkit used to hide some of them, eg from the gradle command)
 - we have more elasticity and can run multiple tests in sequence on the same k8s infrastructure
 - the bash script for kubernetes can be reused for local setup without jenkins

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)] (https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)] (https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)] (https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)] (https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
