### PR TITLE
[BEAM-7798] Revert "[BEAM-7060] Migrate to native typing types where possible."

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -23,7 +23,6 @@ from __future__ import absolute_import
 
 import base64
 import sys
-import typing
 from builtins import object
 
 import google.protobuf.wrappers_pb2
@@ -598,7 +597,7 @@ class PickleCoder(_PickleCoderBase):
     return DeterministicFastPrimitivesCoder(self, step_label)
 
   def to_type_hint(self):
-    return typing.Any
+    return typehints.Any
 
 
 class DillCoder(_PickleCoderBase):
@@ -632,7 +631,7 @@ class DeterministicFastPrimitivesCoder(FastCoder):
     return self
 
   def to_type_hint(self):
-    return typing.Any
+    return typehints.Any
 
 
 class FastPrimitivesCoder(FastCoder):
@@ -657,7 +656,7 @@ class FastPrimitivesCoder(FastCoder):
       return DeterministicFastPrimitivesCoder(self, step_label)
 
   def to_type_hint(self):
-    return typing.Any
+    return typehints.Any
 
   def as_cloud_object(self, coders_context=None, is_pair_like=True):
     value = super(FastCoder, self).as_cloud_object(coders_context)
@@ -1188,4 +1187,4 @@ class RunnerAPICoderHolder(Coder):
     return self._proto
 
   def to_type_hint(self):
-    return typing.Any
+    return typehints.Any

--- a/sdks/python/apache_beam/examples/complete/estimate_pi.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi.py
@@ -33,14 +33,14 @@ import logging
 import random
 from builtins import object
 from builtins import range
-from typing import Any
-from typing import Iterable
-from typing import Tuple
 
 import apache_beam as beam
 from apache_beam.io import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
+from apache_beam.typehints import Any
+from apache_beam.typehints import Iterable
+from apache_beam.typehints import Tuple
 
 
 @beam.typehints.with_output_types(Tuple[int, int, int])

--- a/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
+++ b/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import
 import argparse
 import logging
 import sys
-import typing
 from builtins import object
 
 import apache_beam as beam
@@ -39,6 +38,7 @@ from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
+from apache_beam.typehints import typehints
 from apache_beam.typehints.decorators import with_output_types
 
 
@@ -74,7 +74,7 @@ class PlayerCoder(coders.Coder):
 # Annotate the get_players function so that the typehint system knows that the
 # input to the CombinePerKey operation is a key-value pair of a Player object
 # and an integer.
-@with_output_types(typing.Tuple[Player, int])
+@with_output_types(typehints.KV[Player, int])
 def get_players(descriptor):
   name, points = descriptor.split(',')
   return Player(name), int(points)

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -26,7 +26,6 @@ import logging
 import os
 import sys
 import tempfile
-import typing
 import unittest
 import uuid
 from builtins import map
@@ -322,10 +321,10 @@ class TypeHintsTest(unittest.TestCase):
     # One can assert outputs and apply them to transforms as well.
     # Helps document the contract and checks it at pipeline construction time.
     # [START type_hints_transform]
-    T = typing.TypeVar('T')
+    T = beam.typehints.TypeVariable('T')
 
     @beam.typehints.with_input_types(T)
-    @beam.typehints.with_output_types(typing.Tuple[int, T])
+    @beam.typehints.with_output_types(beam.typehints.Tuple[int, T])
     class MyTransform(beam.PTransform):
       def expand(self, pcoll):
         return pcoll | beam.Map(lambda x: (len(x), x))
@@ -336,7 +335,7 @@ class TypeHintsTest(unittest.TestCase):
     # pylint: disable=expression-not-assigned
     with self.assertRaises(typehints.TypeCheckError):
       words_with_lens | beam.Map(lambda x: x).with_input_types(
-          typing.Tuple[int, int])
+          beam.typehints.Tuple[int, int])
 
   def test_runtime_checks_off(self):
     # We do not run the following pipeline, as it has incorrect type
@@ -392,7 +391,7 @@ class TypeHintsTest(unittest.TestCase):
           lines
           | beam.Map(parse_player_and_score)
           | beam.CombinePerKey(sum).with_input_types(
-              typing.Tuple[Player, int]))
+              beam.typehints.Tuple[Player, int]))
       # [END type_hints_deterministic_key]
 
       assert_that(

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -26,7 +26,6 @@ from __future__ import absolute_import
 import itertools
 import logging
 import time
-import typing
 
 from google.protobuf import wrappers_pb2
 
@@ -130,12 +129,12 @@ class SwitchingDirectRunner(PipelineRunner):
 
 
 # Type variables.
-K = typing.TypeVar('K')
-V = typing.TypeVar('V')
+K = typehints.TypeVariable('K')
+V = typehints.TypeVariable('V')
 
 
-@typehints.with_input_types(typing.Tuple[K, V])
-@typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
+@typehints.with_input_types(typehints.KV[K, V])
+@typehints.with_output_types(typehints.KV[K, typehints.Iterable[V]])
 class _StreamingGroupByKeyOnly(_GroupByKeyOnly):
   """Streaming GroupByKeyOnly placeholder for overriding in DirectRunner."""
   urn = "direct_runner:streaming_gbko:v0.1"
@@ -149,8 +148,8 @@ class _StreamingGroupByKeyOnly(_GroupByKeyOnly):
     return _StreamingGroupByKeyOnly()
 
 
-@typehints.with_input_types(typing.Tuple[K, typing.Iterable[V]])
-@typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
+@typehints.with_input_types(typehints.KV[K, typehints.Iterable[V]])
+@typehints.with_output_types(typehints.KV[K, typehints.Iterable[V]])
 class _StreamingGroupAlsoByWindow(_GroupAlsoByWindow):
   """Streaming GroupAlsoByWindow placeholder for overriding in DirectRunner."""
   urn = "direct_runner:streaming_gabw:v0.1"

--- a/sdks/python/apache_beam/runners/direct/helper_transforms.py
+++ b/sdks/python/apache_beam/runners/direct/helper_transforms.py
@@ -19,9 +19,9 @@ from __future__ import absolute_import
 
 import collections
 import itertools
-import typing
 
 import apache_beam as beam
+from apache_beam import typehints
 from apache_beam.internal.util import ArgumentPlaceholder
 from apache_beam.transforms.combiners import _CurriedFn
 from apache_beam.utils.windowed_value import WindowedValue
@@ -75,14 +75,14 @@ class PartialGroupByKeyCombiningValues(beam.DoFn):
 
   def default_type_hints(self):
     hints = self._combine_fn.get_type_hints().copy()
-    K = typing.TypeVar('K')
+    K = typehints.TypeVariable('K')
     if hints.input_types:
       args, kwargs = hints.input_types
-      args = (typing.Tuple[K, args[0]],) + args[1:]
+      args = (typehints.Tuple[K, args[0]],) + args[1:]
       hints.set_input_types(*args, **kwargs)
     else:
-      hints.set_input_types(typing.Tuple[K, typing.Any])
-    hints.set_output_types(typing.Tuple[K, typing.Any])
+      hints.set_input_types(typehints.Tuple[K, typehints.Any])
+    hints.set_output_types(typehints.Tuple[K, typehints.Any])
     return hints
 
 
@@ -101,9 +101,9 @@ class FinishCombine(beam.DoFn):
 
   def default_type_hints(self):
     hints = self._combine_fn.get_type_hints().copy()
-    K = typing.TypeVar('K')
-    hints.set_input_types(typing.Tuple[K, typing.Any])
+    K = typehints.TypeVariable('K')
+    hints.set_input_types(typehints.Tuple[K, typehints.Any])
     if hints.output_types:
       main_output_type = hints.simple_output_type('')
-      hints.set_output_types(typing.Tuple[K, main_output_type])
+      hints.set_output_types(typehints.Tuple[K, main_output_type])
     return hints

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -23,7 +23,6 @@ import collections
 import logging
 import random
 import time
-import typing
 from builtins import object
 
 from future.utils import iteritems
@@ -31,6 +30,7 @@ from future.utils import iteritems
 import apache_beam.io as io
 from apache_beam import coders
 from apache_beam import pvalue
+from apache_beam import typehints
 from apache_beam.internal import pickler
 from apache_beam.runners import common
 from apache_beam.runners.common import DoFnRunner
@@ -602,11 +602,11 @@ class _ParDoEvaluator(_TransformEvaluator):
     self.user_timer_map = {}
     if is_stateful_dofn(dofn):
       kv_type_hint = self._applied_ptransform.inputs[0].element_type
-      if kv_type_hint and kv_type_hint != typing.Any:
+      if kv_type_hint and kv_type_hint != typehints.Any:
         coder = coders.registry.get_coder(kv_type_hint)
         self.key_coder = coder.key_coder()
       else:
-        self.key_coder = coders.registry.get_coder(typing.Any)
+        self.key_coder = coders.registry.get_coder(typehints.Any)
 
       self.user_state_context = DirectUserStateContext(
           self._step_context, dofn, self.key_coder)
@@ -669,7 +669,7 @@ class _GroupByKeyOnlyEvaluator(_TransformEvaluator):
     assert len(self._outputs) == 1
     self.output_pcollection = list(self._outputs)[0]
 
-    # The output type of a GroupByKey will be Tuple[Any, Any] or more specific.
+    # The output type of a GroupByKey will be KV[Any, Any] or more specific.
     # TODO(BEAM-2717): Infer coders earlier.
     kv_type_hint = (
         self._applied_ptransform.outputs[None].element_type
@@ -759,10 +759,10 @@ class _StreamingGroupByKeyOnlyEvaluator(_TransformEvaluator):
     assert len(self._outputs) == 1
     self.output_pcollection = list(self._outputs)[0]
 
-    # The input type of a GroupByKey will be Tuple[Any, Any] or more specific.
+    # The input type of a GroupByKey will be KV[Any, Any] or more specific.
     kv_type_hint = self._applied_ptransform.inputs[0].element_type
     key_type_hint = (kv_type_hint.tuple_types[0] if kv_type_hint
-                     else typing.Any)
+                     else typehints.Any)
     self.key_coder = coders.registry.get_coder(key_type_hint)
 
   def process_element(self, element):
@@ -815,10 +815,10 @@ class _StreamingGroupAlsoByWindowEvaluator(_TransformEvaluator):
     self.keyed_holds = {}
 
     # The input type (which is the same as the output type) of a
-    # GroupAlsoByWindow will be Tuple[Any, Iter[Any]] or more specific.
+    # GroupAlsoByWindow will be KV[Any, Iter[Any]] or more specific.
     kv_type_hint = self._applied_ptransform.outputs[None].element_type
     key_type_hint = (kv_type_hint.tuple_types[0] if kv_type_hint
-                     else typing.Any)
+                     else typehints.Any)
     self.key_coder = coders.registry.get_coder(key_type_hint)
 
   def process_element(self, element):

--- a/sdks/python/apache_beam/runners/pipeline_context.py
+++ b/sdks/python/apache_beam/runners/pipeline_context.py
@@ -31,7 +31,6 @@ from apache_beam.internal import pickler
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.transforms import core
-from apache_beam.typehints import native_type_compatibility
 
 
 class Environment(object):
@@ -165,8 +164,7 @@ class PipelineContext(object):
     if self.use_fake_coders or coder_id not in self.coders:
       return pickler.loads(coder_id)
     else:
-      return native_type_compatibility.convert_to_beam_type(
-          self.coders[coder_id].to_type_hint())
+      return self.coders[coder_id].to_type_hint()
 
   @staticmethod
   def from_runner_api(proto):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -26,7 +26,6 @@ import tempfile
 import threading
 import time
 import traceback
-import typing
 import unittest
 import uuid
 from builtins import range
@@ -258,10 +257,10 @@ class FnApiRunnerTest(unittest.TestCase):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create(['a', 'b'])
       # The type of this side-input is forced to Any (overriding type
-      # inference). Without type coercion to Tuple[Any, Any], the usage of this
+      # inference). Without type coercion to KV[Any, Any], the usage of this
       # side-input in AsMultiMap() below should fail.
       side = (p | 'side' >> beam.Create([('a', 1), ('b', 2), ('a', 3)])
-              .with_output_types(typing.Any))
+              .with_output_types(beam.typehints.Any))
       assert_that(
           main | beam.Map(lambda k, d: (k, sorted(d[k])),
                           beam.pvalue.AsMultiMap(side)),

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -763,14 +763,14 @@ def expand_sdf(stages, context):
         main_input_id = transform.inputs[main_input_tag]
         element_coder_id = context.components.pcollections[
             main_input_id].coder_id
-        # Tuple[element, restriction]
+        # KV[element, restriction]
         paired_coder_id = context.add_or_get_coder_id(
             beam_runner_api_pb2.Coder(
                 spec=beam_runner_api_pb2.FunctionSpec(
                     urn=common_urns.coders.KV.urn),
                 component_coder_ids=[element_coder_id,
                                      pardo_payload.restriction_coder_id]))
-        # Tuple[Tuple[element, restriction], double]
+        # KV[KV[element, restriction], double]
         sized_coder_id = context.add_or_get_coder_id(
             beam_runner_api_pb2.Coder(
                 spec=beam_runner_api_pb2.FunctionSpec(

--- a/sdks/python/apache_beam/tools/coders_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/coders_microbenchmark.py
@@ -179,7 +179,7 @@ def run_coder_benchmarks(
   random.seed(seed)
 
   # TODO(BEAM-4441): Pick coders using type hints, for example:
-  # tuple_coder = typecoders.registry.get_coder(typing.Tuple[int, ...])
+  # tuple_coder = typecoders.registry.get_coder(typehints.Tuple[int, ...])
   benchmarks = [
       coder_benchmark_factory(
           coders.FastPrimitivesCoder(), small_int),

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -27,22 +27,22 @@ import sys
 import warnings
 from builtins import object
 from builtins import zip
-from typing import Any
-from typing import Dict
-from typing import Iterable
-from typing import List
-from typing import Tuple
-from typing import TypeVar
-from typing import Union
 
 from past.builtins import long
 
-from apache_beam import typehints
 from apache_beam.transforms import core
 from apache_beam.transforms import cy_combiners
 from apache_beam.transforms import ptransform
 from apache_beam.transforms import window
 from apache_beam.transforms.display import DisplayDataItem
+from apache_beam.typehints import KV
+from apache_beam.typehints import Any
+from apache_beam.typehints import Dict
+from apache_beam.typehints import Iterable
+from apache_beam.typehints import List
+from apache_beam.typehints import Tuple
+from apache_beam.typehints import TypeVariable
+from apache_beam.typehints import Union
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
 from apache_beam.utils.timestamp import Duration
@@ -59,9 +59,9 @@ __all__ = [
     ]
 
 # Type variables
-T = TypeVar('T')
-K = TypeVar('K')
-V = TypeVar('V')
+T = TypeVariable('T')
+K = TypeVariable('K')
+V = TypeVariable('V')
 TimestampType = Union[int, long, float, Timestamp, Duration]
 
 
@@ -132,7 +132,7 @@ class Count(object):
     """combiners.Count.PerElement counts how many times each element occurs."""
 
     def expand(self, pcoll):
-      paired_with_void_type = typehints.Tuple[pcoll.element_type, Any]
+      paired_with_void_type = KV[pcoll.element_type, Any]
       return (pcoll
               | ('%s:PairWithVoid' % self.label >> core.Map(lambda x: (x, None))
                  .with_output_types(paired_with_void_type))
@@ -316,7 +316,7 @@ class Top(object):
       """Expands the transform.
 
       Raises TypeCheckError: If the output type of the input PCollection is not
-      compatible with Tuple[A, B].
+      compatible with KV[A, B].
 
       Args:
         pcoll: PCollection to process
@@ -354,7 +354,7 @@ class Top(object):
 
 
 @with_input_types(T)
-@with_output_types(Tuple[None, List[T]])
+@with_output_types(KV[None, List[T]])
 class _TopPerBundle(core.DoFn):
   def __init__(self, n, less_than, key):
     self._n = n
@@ -389,7 +389,7 @@ class _TopPerBundle(core.DoFn):
           (None, self._heap))
 
 
-@with_input_types(Tuple[None, Iterable[List[T]]])
+@with_input_types(KV[None, Iterable[List[T]]])
 @with_output_types(List[T])
 class _MergeTopPerBundle(core.DoFn):
   def __init__(self, n, less_than, key):
@@ -883,8 +883,8 @@ class Latest(object):
               .with_output_types(Tuple[T, TimestampType])
               | core.CombineGlobally(LatestCombineFn()))
 
-  @with_input_types(Tuple[K, V])
-  @with_output_types(Tuple[K, V])
+  @with_input_types(KV[K, V])
+  @with_output_types(KV[K, V])
   class PerKey(ptransform.PTransform):
     """Compute elements with the latest timestamp for each key
     from a keyed PCollection"""
@@ -897,7 +897,7 @@ class Latest(object):
     def expand(self, pcoll):
       return (pcoll
               | core.ParDo(self.add_timestamp)
-              .with_output_types(Tuple[K, Tuple[T, TimestampType]])
+              .with_output_types(KV[K, Tuple[T, TimestampType]])
               | core.CombinePerKey(LatestCombineFn()))
 
 

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -58,7 +58,6 @@ from apache_beam.internal import util
 from apache_beam.portability import python_urns
 from apache_beam.transforms.display import DisplayDataItem
 from apache_beam.transforms.display import HasDisplayData
-from apache_beam.typehints import native_type_compatibility
 from apache_beam.typehints import typehints
 from apache_beam.typehints.decorators import TypeCheckError
 from apache_beam.typehints.decorators import WithTypeHints
@@ -349,8 +348,6 @@ class PTransform(WithTypeHints, HasDisplayData):
       :class:`PTransform` object. This allows chaining type-hinting related
       methods.
     """
-    input_type_hint = native_type_compatibility.convert_to_beam_type(
-        input_type_hint)
     validate_composite_type_param(input_type_hint,
                                   'Type hints for a PTransform')
     return super(PTransform, self).with_input_types(input_type_hint)
@@ -372,7 +369,6 @@ class PTransform(WithTypeHints, HasDisplayData):
       :class:`PTransform` object. This allows chaining type-hinting related
       methods.
     """
-    type_hint = native_type_compatibility.convert_to_beam_type(type_hint)
     validate_composite_type_param(type_hint, 'Type hints for a PTransform')
     return super(PTransform, self).with_output_types(type_hint)
 
@@ -739,11 +735,6 @@ class PTransformWithSideInputs(PTransform):
       methods.
     """
     super(PTransformWithSideInputs, self).with_input_types(input_type_hint)
-
-    side_inputs_arg_hints = native_type_compatibility.convert_to_beam_types(
-        side_inputs_arg_hints)
-    side_input_kwarg_hints = native_type_compatibility.convert_to_beam_types(
-        side_input_kwarg_hints)
 
     for si in side_inputs_arg_hints:
       validate_composite_type_param(si, 'Type hints for a PTransform')

--- a/sdks/python/apache_beam/transforms/stats.py
+++ b/sdks/python/apache_beam/transforms/stats.py
@@ -23,7 +23,6 @@ from __future__ import division
 import heapq
 import math
 import sys
-import typing
 from builtins import round
 
 from apache_beam import coders
@@ -36,9 +35,9 @@ __all__ = [
 ]
 
 # Type variables
-T = typing.TypeVar('T')
-K = typing.TypeVar('K')
-V = typing.TypeVar('V')
+T = typehints.TypeVariable('T')
+K = typehints.TypeVariable('K')
+V = typehints.TypeVariable('V')
 
 
 class ApproximateUnique(object):
@@ -113,8 +112,8 @@ class ApproximateUnique(object):
              >> (CombineGlobally(ApproximateUniqueCombineFn(self._sample_size,
                                                             coder)))
 
-  @typehints.with_input_types(typing.Tuple[K, V])
-  @typehints.with_output_types(typing.Tuple[K, int])
+  @typehints.with_input_types(typehints.KV[K, V])
+  @typehints.with_output_types(typehints.KV[K, int])
   class PerKey(PTransform):
     """ Approximate.PerKey approximate number of unique values per key"""
 

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -25,7 +25,6 @@ import collections
 import contextlib
 import random
 import time
-import typing
 import warnings
 from builtins import object
 from builtins import range
@@ -78,9 +77,9 @@ __all__ = [
     'GroupIntoBatches'
     ]
 
-K = typing.TypeVar('K')
-V = typing.TypeVar('V')
-T = typing.TypeVar('T')
+K = typehints.TypeVariable('K')
+V = typehints.TypeVariable('V')
+T = typehints.TypeVariable('T')
 
 
 class CoGroupByKey(PTransform):
@@ -481,7 +480,7 @@ class _WindowAwareBatchingDoFn(DoFn):
 
 
 @typehints.with_input_types(T)
-@typehints.with_output_types(typing.List[T])
+@typehints.with_output_types(typehints.List[T])
 class BatchElements(PTransform):
   """A Transform that batches elements for amortized processing.
 
@@ -574,8 +573,8 @@ class _IdentityWindowFn(NonMergingWindowFn):
     return self._window_coder
 
 
-@typehints.with_input_types(typing.Tuple[K, V])
-@typehints.with_output_types(typing.Tuple[K, V])
+@typehints.with_input_types(typehints.KV[K, V])
+@typehints.with_output_types(typehints.KV[K, V])
 class ReshufflePerKey(PTransform):
   """PTransform that returns a PCollection equivalent to its input,
   but operationally provides some of the side effects of a GroupByKey,
@@ -683,7 +682,7 @@ def WithKeys(pcoll, k):
 
 
 @experimental()
-@typehints.with_input_types(typing.Tuple[K, V])
+@typehints.with_input_types(typehints.KV[K, V])
 class GroupIntoBatches(PTransform):
   """PTransform that batches the input into desired batch size. Elements are
   buffered until they are equal to batch size provided in the argument at which
@@ -763,7 +762,7 @@ class ToString(object):
       self.delimiter = delimiter or ","
 
     def expand(self, pcoll):
-      input_type = typing.Tuple[typing.Any, typing.Any]
+      input_type = typehints.KV[typehints.Any, typehints.Any]
       output_type = str
       return (pcoll | ('%s:KeyVaueToString' % self.label >> (Map(
           lambda x: "{}{}{}".format(x[0], self.delimiter, x[1])))
@@ -796,7 +795,7 @@ class ToString(object):
       self.delimiter = delimiter or ","
 
     def expand(self, pcoll):
-      input_type = typing.Iterable[typing.Any]
+      input_type = typehints.Iterable[typehints.Any]
       output_type = str
       return (pcoll | ('%s:IterablesToString' % self.label >> (
           Map(lambda x: self.delimiter.join(str(_x) for _x in x)))
@@ -836,8 +835,8 @@ class Reify(object):
     def expand(self, pcoll):
       return pcoll | ParDo(self.add_window_info)
 
-  @typehints.with_input_types(typing.Tuple[K, V])
-  @typehints.with_output_types(typing.Tuple[K, V])
+  @typehints.with_input_types(typehints.KV[K, V])
+  @typehints.with_output_types(typehints.KV[K, V])
   class TimestampInValue(PTransform):
     """PTransform to wrap the Value in a KV pair in a TimestampedValue with
     the element's associated timestamp."""
@@ -850,8 +849,8 @@ class Reify(object):
     def expand(self, pcoll):
       return pcoll | ParDo(self.add_timestamp_info)
 
-  @typehints.with_input_types(typing.Tuple[K, V])
-  @typehints.with_output_types(typing.Tuple[K, V])
+  @typehints.with_input_types(typehints.KV[K, V])
+  @typehints.with_output_types(typehints.KV[K, V])
   class WindowInValue(PTransform):
     """PTransform to convert the Value in a KV pair into a tuple of
     (value, timestamp, window), with the whole element being wrapped inside a

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -217,14 +217,10 @@ class WithTypeHints(object):
     return None
 
   def with_input_types(self, *arg_hints, **kwarg_hints):
-    arg_hints = native_type_compatibility.convert_to_beam_types(arg_hints)
-    kwarg_hints = native_type_compatibility.convert_to_beam_types(kwarg_hints)
     self._get_or_create_type_hints().set_input_types(*arg_hints, **kwarg_hints)
     return self
 
   def with_output_types(self, *arg_hints, **kwarg_hints):
-    arg_hints = native_type_compatibility.convert_to_beam_types(arg_hints)
-    kwarg_hints = native_type_compatibility.convert_to_beam_types(kwarg_hints)
     self._get_or_create_type_hints().set_output_types(*arg_hints, **kwarg_hints)
     return self
 

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -37,8 +37,6 @@ _TypeMapEntry = collections.namedtuple(
 
 
 def _get_compatible_args(typ):
-  if isinstance(typ, typing.TypeVar):
-    return (typ.__name__,)
   # On Python versions < 3.5.3, the Tuple and Union type from typing do
   # not have an __args__ attribute, but a __tuple_params__, and a
   # __union_params__ argument respectively.
@@ -105,15 +103,6 @@ def _match_same_type(match_against):
   return lambda user_type: type(user_type) == type(match_against)
 
 
-def _match_is_exactly_iterable(user_type):
-  # Avoid unintentionally catching all subtypes (e.g. strings and mappings).
-  if sys.version_info < (3, 7):
-    expected_origin = typing.Iterable
-  else:
-    expected_origin = collections.abc.Iterable
-  return getattr(user_type, '__origin__', None) is expected_origin
-
-
 def _match_is_named_tuple(user_type):
   return (_safe_issubclass(user_type, typing.Tuple) and
           hasattr(user_type, '_field_types'))
@@ -138,9 +127,6 @@ def _match_is_union(user_type):
   return False
 
 
-_type_var_cache = {}
-
-
 def convert_to_beam_type(typ):
   """Convert a given typing type to a Beam type.
 
@@ -154,18 +140,6 @@ def convert_to_beam_type(typ):
   Raises:
     ~exceptions.ValueError: The type was malformed.
   """
-  if isinstance(typ, typing.TypeVar):
-    # This is a special case, as it's not parameterized by types.
-    # Also, identity must be preserved through conversion (i.e. the same
-    # TypeVar instance must get converted into the same TypeVariable instance).
-    # A global cache should be OK as the number of distinct type variables
-    # is generally small.
-    if id(typ) not in _type_var_cache:
-      _type_var_cache[id(typ)] = typehints.TypeVariable(typ.__name__)
-    return _type_var_cache[id(typ)]
-  elif getattr(typ, '__module__', None) != 'typing':
-    # Only tranlsate types from the typing module.
-    return typ
 
   type_map = [
       _TypeMapEntry(
@@ -176,10 +150,6 @@ def convert_to_beam_type(typ):
           match=_match_issubclass(typing.Dict),
           arity=2,
           beam_type=typehints.Dict),
-      _TypeMapEntry(
-          match=_match_is_exactly_iterable,
-          arity=1,
-          beam_type=typehints.Iterable),
       _TypeMapEntry(
           match=_match_issubclass(typing.List),
           arity=1,

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -46,14 +46,13 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
         ('simple dict', typing.Dict[bytes, int],
          typehints.Dict[bytes, int]),
         ('simple list', typing.List[int], typehints.List[int]),
-        ('simple iterable', typing.Iterable[int], typehints.Iterable[int]),
         ('simple optional', typing.Optional[int], typehints.Optional[int]),
         ('simple set', typing.Set[float], typehints.Set[float]),
         ('simple unary tuple', typing.Tuple[bytes],
          typehints.Tuple[bytes]),
         ('simple union', typing.Union[int, bytes, float],
          typehints.Union[int, bytes, float]),
-        ('namedtuple', _TestNamedTuple, _TestNamedTuple),
+        ('namedtuple', _TestNamedTuple, typehints.Any),
         ('test class', _TestClass, _TestClass),
         ('test class in list', typing.List[_TestClass],
          typehints.List[_TestClass]),
@@ -67,12 +66,7 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
         ('complex dict',
          typing.Dict[bytes, typing.List[typing.Tuple[bytes, _TestClass]]],
          typehints.Dict[bytes, typehints.List[typehints.Tuple[
-             bytes, _TestClass]]]),
-        ('type var', typing.TypeVar('T'), typehints.TypeVariable('T')),
-        ('nested type var',
-         typing.Tuple[typing.TypeVar('K'), typing.TypeVar('V')],
-         typehints.Tuple[typehints.TypeVariable('K'),
-                         typehints.TypeVariable('V')]),
+             bytes, _TestClass]]])
     ]
 
     for test_case in test_cases:

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -69,7 +69,7 @@ class MainInputTest(unittest.TestCase):
       [1, 2, 3] | beam.Map(str.upper)
 
   def test_loose_bounds(self):
-    @typehints.with_input_types(typing.Union[int, float])
+    @typehints.with_input_types(typehints.Union[int, float])
     @typehints.with_output_types(str)
     def format_number(x):
       return '%g' % x
@@ -224,7 +224,7 @@ class SideInputTest(unittest.TestCase):
       main_input | 'bis' >> beam.Map(repeat, pvalue.AsSingleton(bad_side_input))
 
   def test_deferred_side_input_iterable(self):
-    @typehints.with_input_types(str, typing.Iterable[str])
+    @typehints.with_input_types(str, typehints.Iterable[str])
     def concat(glue, items):
       return glue.join(sorted(items))
     with TestPipeline() as p:

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -31,7 +31,6 @@ from apache_beam.typehints import Any
 from apache_beam.typehints import Tuple
 from apache_beam.typehints import TypeCheckError
 from apache_beam.typehints import Union
-from apache_beam.typehints import native_type_compatibility
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
 from apache_beam.typehints.decorators import GeneratorWrapper
@@ -99,13 +98,11 @@ class SubClass(SuperClass):
 class TypeHintTestCase(unittest.TestCase):
 
   def assertCompatible(self, base, sub):  # pylint: disable=invalid-name
-    base, sub = native_type_compatibility.convert_to_beam_types([base, sub])
     self.assertTrue(
         is_consistent_with(sub, base),
         '%s is not consistent with %s' % (sub, base))
 
   def assertNotCompatible(self, base, sub):  # pylint: disable=invalid-name
-    base, sub = native_type_compatibility.convert_to_beam_type([base, sub])
     self.assertFalse(
         is_consistent_with(sub, base),
         '%s is consistent with %s' % (sub, base))


### PR DESCRIPTION
Reverts apache/beam#9109
Reason: https://issues.apache.org/jira/browse/BEAM-7798