### PR TITLE
[BEAM-7661] Create Python CoGBK load test job on Flink

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Python.groovy
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonJobProperties as commonJobProperties
+import CommonTestProperties
+import LoadTestsBuilder as loadTestsBuilder
+import PhraseTriggeringPostCommitBuilder
+import Infrastructure as infra
+
+String jenkinsJobName = 'beam_LoadTests_Python_coGBK_Flink_Batch'
+String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
+String dockerRegistryRoot = 'gcr.io/apache-beam-testing/beam_portability'
+String dockerTag = 'latest'
+String jobServerImageTag = "${dockerRegistryRoot}/flink-job-server:${dockerTag}"
+String pythonHarnessImageTag = "${dockerRegistryRoot}/python:${dockerTag}"
+
+String flinkVersion = '1.7'
+String flinkDownloadUrl = 'https://archive.apache.org/dist/flink/flink-1.7.0/flink-1.7.0-bin-hadoop28-scala_2.11.tgz'
+
+def loadTestConfigurations = { datasetName -> [
+        [
+                title        : 'CoGroupByKey Python Load test: 2GB of 100B records with a single key',
+                itClass      : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                runner       : CommonTestProperties.Runner.PORTABLE,
+                jobProperties: [
+                        project              : 'apache-beam-testing',
+                        job_name             : 'load-tests-python-flink-batch-cogbk-1-' + now,
+                        temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
+                        publish_to_big_query : true,
+                        metrics_dataset      : datasetName,
+                        metrics_table        : "python_flink_batch_cogbk_1",
+                        input_options        : '\'{' +
+                                '"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 1,' +
+                                '"hot_key_fraction": 1}\'',
+                        co_input_options      : '\'{' +
+                                '"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 1,' +
+                                '"hot_key_fraction": 1}\'',
+                        iterations           : 1,
+                        parallelism          : 5,
+                        job_endpoint         : 'localhost:8099',
+                        environment_config   : pythonHarnessImageTag,
+                        environment_type     : 'DOCKER',
+                ]
+        ],
+        [
+                title        : 'CoGroupByKey Python Load test: 2GB of 100B records with multiple keys',
+                itClass      : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                runner       : CommonTestProperties.Runner.PORTABLE,
+                jobProperties: [
+                        project              : 'apache-beam-testing',
+                        job_name             : 'load-tests-python-flink-batch-cogbk-2-' + now,
+                        temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
+                        publish_to_big_query : true,
+                        metrics_dataset      : datasetName,
+                        metrics_table        : 'python_flink_batch_cogbk_2',
+                        input_options        : '\'{' +
+                                '"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 5,' +
+                                '"hot_key_fraction": 1}\'',
+                        co_input_options      : '\'{' +
+                                '"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 5,' +
+                                '"hot_key_fraction": 1}\'',
+                        iterations           : 1,
+                        parallelism          : 5,
+                        job_endpoint         : 'localhost:8099',
+                        environment_config   : pythonHarnessImageTag,
+                        environment_type     : 'DOCKER',
+                ]
+        ],
+        [
+                title        : 'CoGroupByKey Python Load test: reiterate 4 times 10kB values',
+                itClass      : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                runner       : CommonTestProperties.Runner.PORTABLE,
+                jobProperties: [
+                        project              : 'apache-beam-testing',
+                        job_name             : 'load-tests-python-flink-batch-cogbk-3-' + now,
+                        temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
+                        publish_to_big_query : true,
+                        metrics_dataset      : datasetName,
+                        metrics_table        : "python_flink_batch_cogbk_3",
+                        input_options        : '\'{' +
+                                '"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 200000,' +
+                                '"hot_key_fraction": 1}\'',
+                        co_input_options      : '\'{' +
+                                '"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 200000,' +
+                                '"hot_key_fraction": 1}\'',
+                        iterations           : 4,
+                        parallelism          : 5,
+                        job_endpoint         : 'localhost:8099',
+                        environment_config   : pythonHarnessImageTag,
+                        environment_type     : 'DOCKER',
+                ]
+        ],
+        [
+                title        : 'CoGroupByKey Python Load test: reiterate 4 times 2MB values',
+                itClass      : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                runner       : CommonTestProperties.Runner.PORTABLE,
+                jobProperties: [
+                        project              : 'apache-beam-testing',
+                        job_name             : 'load-tests-python-flink-batch-cogbk-4-' + now,
+                        temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
+                        publish_to_big_query : true,
+                        metrics_dataset      : datasetName,
+                        metrics_table        : 'python_flink_batch_cogbk_4',
+                        input_options        : '\'{' +
+                                '"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 1000,' +
+                                '"hot_key_fraction": 1}\'',
+                        co_input_options      : '\'{' +
+                                '"num_records": 20000000,' +
+                                '"key_size": 10,' +
+                                '"value_size": 90,' +
+                                '"num_hot_keys": 1000,' +
+                                '"hot_key_fraction": 1}\'',
+                        iterations           : 4,
+                        parallelism          : 5,
+                        job_endpoint         : 'localhost:8099',
+                        environment_config   : pythonHarnessImageTag,
+                        environment_type     : 'DOCKER',
+                ]
+        ],
+]}
+
+def loadTest = { scope, triggeringContext ->
+  scope.description('Runs Python coGBK load tests on Flink runner in batch mode')
+  commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
+
+  def numberOfWorkers = 5
+  def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+
+  infra.prepareSDKHarness(scope, CommonTestProperties.SDK.PYTHON, dockerRegistryRoot, dockerTag)
+  infra.prepareFlinkJobServer(scope, flinkVersion, dockerRegistryRoot, dockerTag)
+  infra.setupFlinkCluster(scope, jenkinsJobName, flinkDownloadUrl, pythonHarnessImageTag, jobServerImageTag, numberOfWorkers)
+
+  for (config in loadTestConfigurations(datasetName)) {
+    loadTestsBuilder.loadTest(scope, config.title, config.runner, CommonTestProperties.SDK.PYTHON, config.jobProperties, config.itClass)
+  }
+
+  infra.teardownDataproc(scope, jenkinsJobName)
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_LoadTests_Python_CoGBK_Flink_Batch',
+        'Run Load Tests Python CoGBK Flink Batch',
+        'Load Tests Python CoGBK Flink Batch suite',
+        this
+) {
+  loadTest(delegate, CommonTestProperties.TriggeringContext.PR)
+}
+
+CronJobBuilder.cronJob('beam_LoadTests_Python_CoGBK_Flink_Batch', 'H 16 * * *', this) {
+  loadTest(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT)
+}

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Python.groovy
@@ -46,7 +46,7 @@ def loadTestConfigurations = { datasetName -> [
                                 '"num_records": 20000000,' +
                                 '"key_size": 10,' +
                                 '"value_size": 90,' +
-                                '"num_hot_keys": 5,' +
+                                '"num_hot_keys": 1,' +
                                 '"hot_key_fraction": 1}\'',
                         iterations           : 1,
                         max_num_workers      : 5,
@@ -104,7 +104,7 @@ def loadTestConfigurations = { datasetName -> [
                                 '"num_records": 20000000,' +
                                 '"key_size": 10,' +
                                 '"value_size": 90,' +
-                                '"num_hot_keys": 5,' +
+                                '"num_hot_keys": 200000,' +
                                 '"hot_key_fraction": 1}\'',
                         iterations           : 4,
                         max_num_workers      : 5,
@@ -133,7 +133,7 @@ def loadTestConfigurations = { datasetName -> [
                                 '"num_records": 20000000,' +
                                 '"key_size": 10,' +
                                 '"value_size": 90,' +
-                                '"num_hot_keys": 5,' +
+                                '"num_hot_keys": 1000,' +
                                 '"hot_key_fraction": 1}\'',
                         iterations           : 4,
                         max_num_workers      : 5,


### PR DESCRIPTION
Based on the following proposal: https://s.apache.org/load-test-basic-operations

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
