### PR TITLE
[BEAM-7825] Add test showing inconsistent stream processing with DirectRunner

### DIFF
--- a/sdks/python/apache_beam/examples/streaming_wordgroup.py
+++ b/sdks/python/apache_beam/examples/streaming_wordgroup.py
@@ -1,0 +1,123 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""A streaming word-group workflow.
+
+In this somewhat contrived example, we emit a group of words that we accumulate
+in every window.
+
+This example is based on streaming_wordcount.py.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import logging
+
+from past.builtins import unicode
+
+import apache_beam as beam
+import apache_beam.transforms.combiners as combiners
+import apache_beam.transforms.window as window
+from apache_beam.examples.wordcount import WordExtractingDoFn
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+from apache_beam.options.pipeline_options import StandardOptions
+
+
+class FormatPubsubMessage(beam.DoFn):
+
+  def process(self,
+              element,
+              timestamp=beam.DoFn.TimestampParam,
+              window=beam.DoFn.WindowParam):
+    import json
+    from apache_beam.io.gcp.pubsub import PubsubMessage
+
+    data = {
+        "elements": sorted(element),
+        "window_start_ts": window.start.micros // 1000,
+        "window_end_ts": window.end.micros // 1000
+    }
+    message = PubsubMessage(json.dumps(data).encode("utf-8"), {})
+    yield message
+
+
+def run(argv=None):
+  """Build and run the pipeline."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--output_topic',
+      required=True,
+      help=('Output PubSub topic of the form '
+            '"projects/<PROJECT>/topic/<TOPIC>".'))
+  group = parser.add_mutually_exclusive_group(required=True)
+  group.add_argument(
+      '--input_topic',
+      help=('Input PubSub topic of the form '
+            '"projects/<PROJECT>/topics/<TOPIC>".'))
+  group.add_argument(
+      '--input_subscription',
+      help=('Input PubSub subscription of the form '
+            '"projects/<PROJECT>/subscriptions/<SUBSCRIPTION>."'))
+  known_args, pipeline_args = parser.parse_known_args(argv)
+
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_options = PipelineOptions(pipeline_args)
+  pipeline_options.view_as(SetupOptions).save_main_session = True
+  pipeline_options.view_as(StandardOptions).streaming = True
+  p = beam.Pipeline(options=pipeline_options)
+
+  # Read from PubSub into a PCollection.
+  if known_args.input_subscription:
+    messages = (
+        p | beam.io.ReadFromPubSub(
+            subscription=known_args.input_subscription,
+            with_attributes=True,
+            timestamp_attribute="ts",
+        ))
+  else:
+    messages = (
+        p | beam.io.ReadFromPubSub(
+            topic=known_args.input_topic,
+            with_attributes=True,
+            timestamp_attribute="ts",
+        ))
+
+  lines = messages | 'decode' >> beam.Map(lambda x: x.data.decode('utf-8'))
+
+  word_groups = (
+      lines
+      | 'split' >> beam.ParDo(WordExtractingDoFn()).with_output_types(unicode)
+      | beam.WindowInto(window.FixedWindows(1, 0))
+      | 'group' >> beam.CombineGlobally(
+          combiners.ToListCombineFn()).without_defaults())
+
+  output = word_groups | 'encode' >> beam.ParDo(FormatPubsubMessage())
+
+  # Write to PubSub.
+  _ = output | beam.io.WriteToPubSub(
+      known_args.output_topic, with_attributes=True)
+
+  result = p.run()
+  return result
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  run()

--- a/sdks/python/apache_beam/examples/streaming_wordgroup_it_test.py
+++ b/sdks/python/apache_beam/examples/streaming_wordgroup_it_test.py
@@ -1,0 +1,275 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""End-to-end test for the streaming wordgroup example.
+
+Code: beam/sdks/python/apache_beam/examples/streaming_wordgroup.py
+Usage:
+
+  python setup.py nosetests --test-pipeline-options=" \
+      --runner=TestDirectRunner \
+      --project=... \
+      --staging_location=gs://... \
+      --temp_location=gs://... \
+      --sdk_location=... \
+
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import itertools
+import json
+import logging
+import sys
+import time
+import unittest
+import uuid
+from builtins import range
+from collections import Counter
+
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.core.allof import all_of
+from nose.plugins.attrib import attr
+
+from apache_beam.examples import streaming_wordgroup
+from apache_beam.io.gcp.pubsub import PubsubMessage
+from apache_beam.io.gcp.tests import utils as gcp_test_utils
+from apache_beam.runners.runner import PipelineState
+from apache_beam.testing import test_utils
+from apache_beam.testing.pipeline_verifiers import PipelineStateMatcher
+from apache_beam.testing.test_pipeline import TestPipeline
+
+INPUT_TOPIC = 'wg_topic_input'
+OUTPUT_TOPIC = 'wg_topic_output'
+INPUT_SUB = 'wg_subscription_input'
+OUTPUT_SUB = 'wg_subscription_output'
+
+
+def generate_message(timestamp, dummy=False):
+  data = (str(timestamp).replace(".", "'") if not dummy else "").encode("utf-8")
+  attributes = {"ts": str(int(timestamp * 1000))}
+  return PubsubMessage(data, attributes)
+
+
+class PubsubMessagePublisherAndMatcher(BaseMatcher):
+  """Matcher that publishes messages to a given topic and verifies messages
+  from given subscription.
+
+  This matcher can block the test and keep pulling messages from given
+  subscription until all expected messages are shown or timeout.
+  """
+
+  def __init__(self, topic_path, sub_path, message_batches, expected_batches,
+               timestamp_attribute, timeout):
+
+    self.topic_path = topic_path
+    self.sub_path = sub_path
+    self.message_batches = message_batches
+    self.expected_batches = expected_batches
+    self.timestamp_attribute = timestamp_attribute
+    self.timeout = timeout
+
+    self._actual = []
+    self._expected = []
+    self._previous_match = None
+
+  def _matches(self, _):
+    if self._previous_match is False:
+      return False
+
+    from google.cloud import pubsub_v1
+
+    pub_client = pubsub_v1.PublisherClient()
+    sub_client = pubsub_v1.SubscriberClient()
+
+    assert len(self.message_batches) == len(self.expected_batches)
+    for _ in range(len(self.message_batches)):
+      inputs = self.message_batches.pop(0)
+      expected = self.expected_batches.pop(0)
+
+      gcp_test_utils.write_to_pubsub(
+          pub_client, self.topic_path, inputs, with_attributes=True)
+
+      produced = []
+      start_time = time.time()
+      max_timestamp = max(
+          int(message.attributes[self.timestamp_attribute])
+          for message in inputs)
+      max_keepalive = PubsubMessage(
+          data="".encode("utf-8"),
+          attributes={self.timestamp_attribute: str(max_timestamp + 1000)})
+      while ((time.time() - start_time) < self.timeout and
+             len(produced) < len(expected)):
+        gcp_test_utils.write_to_pubsub(
+            pub_client, self.topic_path, [max_keepalive], with_attributes=True)
+        produced += [
+            m.data for m in gcp_test_utils.read_from_pubsub(
+                sub_client,
+                self.sub_path,
+                with_attributes=True,
+                number_of_elements=len(expected) - len(produced),
+                timeout=5)
+        ]
+
+      self._actual = produced
+      self._expected = expected
+      if Counter(self._actual) != Counter(self._expected):
+        self._previous_match = False
+        return False
+    return True
+
+  def describe_to(self, description):
+    description.append_text('Expected %d messages.' % len(self._expected))
+
+  def describe_mismatch(self, _, mismatch_description):
+    c_expected = Counter(self._expected)
+    c_actual = Counter(self._actual)
+    mismatch_description.append_text("Got {} messages.\n".format(
+        len(self._actual)))
+    for key, count in (c_actual - c_expected).items():
+      mismatch_description.append_text("Actual has {} extra: {}\n".format(
+          count, key))
+    for key, count in (c_expected - c_actual).items():
+      mismatch_description.append_text("Expected has {} extra: {}\n".format(
+          count, key))
+
+
+class StreamingWordGroupIT(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
+  def setUp(self):
+    self.maxDiff = None
+    self.test_pipeline = TestPipeline(is_integration_test=True)
+    self.project = self.test_pipeline.get_option('project')
+    self.result = None
+    unique_suffix = "-" + uuid.uuid4().hex[:8]
+
+    # Set up PubSub environment.
+    from google.cloud import pubsub
+    self.pub_client = pubsub.PublisherClient()
+    self.input_topic = self.pub_client.create_topic(
+        self.pub_client.topic_path(self.project, INPUT_TOPIC + unique_suffix))
+    self.output_topic = self.pub_client.create_topic(
+        self.pub_client.topic_path(self.project, OUTPUT_TOPIC + unique_suffix))
+
+    self.sub_client = pubsub.SubscriberClient()
+    self.input_sub = self.sub_client.create_subscription(
+        self.sub_client.subscription_path(self.project,
+                                          INPUT_SUB + unique_suffix),
+        self.input_topic.name)
+    self.output_sub = self.sub_client.create_subscription(
+        self.sub_client.subscription_path(self.project,
+                                          OUTPUT_SUB + unique_suffix),
+        self.output_topic.name,
+        ack_deadline_seconds=60)
+
+  def tearDown(self):
+    if self.result is not None:
+      self.result.cancel()
+    test_utils.cleanup_subscriptions(self.sub_client,
+                                     [self.input_sub, self.output_sub])
+    test_utils.cleanup_topics(self.pub_client,
+                              [self.input_topic, self.output_topic])
+
+  @attr('IT')
+  def test_discard_late_data(self):
+    window_size = 1  # In seconds, same as in a Beam pipeline
+
+    starting_message_events = range(1000, 1010)
+    starting_messages = [generate_message(i) for i in starting_message_events]
+    starting_outputs = [
+        json.dumps({
+            "elements": [str(i)],
+            "window_start_ts": int(i * 1000),
+            "window_end_ts": int((i + window_size) * 1000)
+        }).encode("utf-8") for i in starting_message_events
+    ]
+
+    current_message_events = range(2000, 2010)
+    current_messages = [generate_message(i) for i in current_message_events]
+    current_outputs = [
+        json.dumps({
+            "elements": [str(i)],
+            "window_start_ts": int(i * 1000),
+            "window_end_ts": int((i + window_size) * 1000)
+        }).encode("utf-8") for i in current_message_events
+    ]
+
+    # Set extra options to the pipeline for test purpose
+    state_verifier = PipelineStateMatcher(PipelineState.RUNNING)
+    pubsub_msg_verifier = PubsubMessagePublisherAndMatcher(
+        topic_path=self.input_topic.name,
+        sub_path=self.output_sub.name,
+        message_batches=[
+            starting_messages, starting_messages + current_messages
+        ],
+        expected_batches=[starting_outputs, current_outputs],
+        timestamp_attribute="ts",
+        timeout=7 * 60)
+    extra_opts = {
+        'input_subscription': self.input_sub.name,
+        'output_topic': self.output_topic.name,
+        'on_success_matcher': all_of(state_verifier, pubsub_msg_verifier)
+    }
+
+    # Get pipeline options from command argument: --test-pipeline-options,
+    # and start pipeline job by calling pipeline main function.
+    self.result = streaming_wordgroup.run(
+        self.test_pipeline.get_full_options_as_args(**extra_opts))
+
+  @attr('IT')
+  def test_single_output_per_window(self):
+    window_size = 1  # In seconds, same as in a Beam pipeline
+
+    message_events = [i / 10.0 for i in range(999, 1010)]
+    messages = [generate_message(i) for i in message_events]
+    expected_outputs = [
+        json.dumps({
+            "elements": [str(e).replace(".", "'") for e in sorted(group)],
+            "window_start_ts": int(i * 1000),
+            "window_end_ts": int((i + window_size) * 1000)
+        }).encode("utf-8") for i, group in itertools.groupby(
+            message_events, key=lambda e: e // window_size)
+    ]
+
+    state_verifier = PipelineStateMatcher(PipelineState.RUNNING)
+    pubsub_msg_verifier = PubsubMessagePublisherAndMatcher(
+        topic_path=self.input_topic.name,
+        sub_path=self.output_sub.name,
+        message_batches=[messages],
+        expected_batches=[expected_outputs],
+        timestamp_attribute="ts",
+        timeout=7 * 60)
+    extra_opts = {
+        'input_subscription': self.input_sub.name,
+        'output_topic': self.output_topic.name,
+        'on_success_matcher': all_of(state_verifier, pubsub_msg_verifier)
+    }
+
+    # Get pipeline options from command argument: --test-pipeline-options,
+    # and start pipeline job by calling pipeline main function.
+    self.result = streaming_wordgroup.run(
+        self.test_pipeline.get_full_options_as_args(**extra_opts))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.DEBUG)
+  unittest.main()

--- a/sdks/python/apache_beam/io/gcp/tests/utils.py
+++ b/sdks/python/apache_beam/io/gcp/tests/utils.py
@@ -25,15 +25,16 @@ import random
 import time
 
 from apache_beam.io import filesystems
+from apache_beam.io.gcp.pubsub import PubsubMessage
 from apache_beam.utils import retry
 
 # Protect against environments where bigquery library is not available.
 try:
+  from google.api_core import exceptions as gexc
   from google.cloud import bigquery
-  from google.cloud.exceptions import NotFound
 except ImportError:
+  gexc = None
   bigquery = None
-  NotFound = None
 
 
 class GcpTestIOError(retry.PermanentException):
@@ -98,7 +99,7 @@ def delete_bq_table(project, dataset_id, table_id):
   table_ref = client.dataset(dataset_id).table(table_id)
   try:
     client.delete_table(table_ref)
-  except NotFound:
+  except gexc.NotFound:
     raise GcpTestIOError('BigQuery table does not exist: %s' % table_ref)
 
 
@@ -113,3 +114,53 @@ def delete_directory(directory):
       "gs://mybucket/mydir/", "s3://...", ...)
   """
   filesystems.FileSystems.delete([directory])
+
+
+def write_to_pubsub(pub_client,
+                    topic_path,
+                    messages,
+                    with_attributes=False,
+                    chunk_size=100,
+                    delay_between_chunks=0.1):
+  for start in range(0, len(messages), chunk_size):
+    message_chunk = messages[start:start + chunk_size]
+    if with_attributes:
+      futures = [
+          pub_client.publish(topic_path, message.data, **message.attributes)
+          for message in message_chunk
+      ]
+    else:
+      futures = [
+          pub_client.publish(topic_path, message) for message in message_chunk
+      ]
+    for future in futures:
+      future.result()
+    time.sleep(delay_between_chunks)
+
+
+def read_from_pubsub(sub_client,
+                     subscription_path,
+                     with_attributes=False,
+                     number_of_elements=None,
+                     timeout=None):
+  if number_of_elements is None and timeout is None:
+    raise ValueError("Either number_of_elements or timeout must be specified.")
+  messages = []
+  start_time = time.time()
+
+  while ((number_of_elements is None or len(messages) < number_of_elements) and
+         (timeout is None or (time.time() - start_time) < timeout)):
+    try:
+      response = sub_client.pull(
+          subscription_path, max_messages=1000, retry=None, timeout=10)
+    except (gexc.RetryError, gexc.DeadlineExceeded):
+      continue
+    ack_ids = [msg.ack_id for msg in response.received_messages]
+    sub_client.acknowledge(subscription_path, ack_ids)
+    for msg in response.received_messages:
+      message = PubsubMessage._from_message(msg.message)
+      if with_attributes:
+        messages.append(message)
+      else:
+        messages.append(message.data)
+  return messages

--- a/sdks/python/apache_beam/io/gcp/tests/utils_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/utils_test.py
@@ -24,16 +24,19 @@ import unittest
 
 import mock
 
+from apache_beam.io.gcp.pubsub import PubsubMessage
 from apache_beam.io.gcp.tests import utils
-from apache_beam.testing.test_utils import patch_retry
+from apache_beam.testing import test_utils
 
 # Protect against environments where bigquery library is not available.
 try:
+  from google.api_core import exceptions as gexc
   from google.cloud import bigquery
-  from google.cloud.exceptions import NotFound
+  from google.cloud import pubsub
 except ImportError:
+  gexc = None
   bigquery = None
-  NotFound = None
+  pubsub = None
 
 
 @unittest.skipIf(bigquery is None, 'Bigquery dependencies are not installed.')
@@ -41,7 +44,7 @@ except ImportError:
 class UtilsTest(unittest.TestCase):
 
   def setUp(self):
-    patch_retry(self, utils)
+    test_utils.patch_retry(self, utils)
 
   @mock.patch.object(bigquery, 'Dataset')
   def test_create_bq_dataset(self, mock_dataset, mock_client):
@@ -68,12 +71,199 @@ class UtilsTest(unittest.TestCase):
   def test_delete_table_fails_not_found(self, mock_client):
     mock_client.return_value.dataset.return_value.table.return_value = (
         'table_ref')
-    mock_client.return_value.delete_table.side_effect = NotFound('test')
+    mock_client.return_value.delete_table.side_effect = gexc.NotFound('test')
 
     with self.assertRaisesRegexp(Exception, r'does not exist:.*table_ref'):
       utils.delete_bq_table('unused_project',
                             'unused_dataset',
                             'unused_table')
+
+
+@unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
+class PubSubUtilTest(unittest.TestCase):
+
+  def test_write_to_pubsub(self):
+    mock_pubsub = mock.Mock()
+    topic_path = "project/fakeproj/topics/faketopic"
+    data = b'data'
+    utils.write_to_pubsub(mock_pubsub, topic_path, [data])
+    mock_pubsub.publish.assert_has_calls(
+        [mock.call(topic_path, data),
+         mock.call().result()])
+
+  def test_write_to_pubsub_with_attributes(self):
+    mock_pubsub = mock.Mock()
+    topic_path = "project/fakeproj/topics/faketopic"
+    data = b'data'
+    attributes = {'key': 'value'}
+    message = PubsubMessage(data, attributes)
+    utils.write_to_pubsub(
+        mock_pubsub, topic_path, [message], with_attributes=True)
+    mock_pubsub.publish.assert_has_calls(
+        [mock.call(topic_path, data, **attributes),
+         mock.call().result()])
+
+  def test_write_to_pubsub_delay(self):
+    number_of_elements = 2
+    chunk_size = 1
+    mock_pubsub = mock.Mock()
+    topic_path = "project/fakeproj/topics/faketopic"
+    data = b'data'
+    with mock.patch('apache_beam.io.gcp.tests.utils.time') as mock_time:
+      utils.write_to_pubsub(
+          mock_pubsub,
+          topic_path, [data] * number_of_elements,
+          chunk_size=chunk_size,
+          delay_between_chunks=123)
+    mock_time.sleep.assert_called_with(123)
+    mock_pubsub.publish.assert_has_calls(
+        [mock.call(topic_path, data),
+         mock.call().result()] * number_of_elements)
+
+  def test_write_to_pubsub_many_chunks(self):
+    number_of_elements = 83
+    chunk_size = 11
+    mock_pubsub = mock.Mock()
+    topic_path = "project/fakeproj/topics/faketopic"
+    data_list = [
+        'data {}'.format(i).encode("utf-8") for i in range(number_of_elements)
+    ]
+    utils.write_to_pubsub(
+        mock_pubsub, topic_path, data_list, chunk_size=chunk_size)
+    call_list = []
+    for start in range(0, number_of_elements, chunk_size):
+      # Publish a batch of messages
+      call_list += [
+          mock.call(topic_path, data)
+          for data in data_list[start:start + chunk_size]
+      ]
+      # Wait for those messages to be received
+      call_list += [
+          mock.call().result() for _ in data_list[start:start + chunk_size]
+      ]
+    mock_pubsub.publish.assert_has_calls(call_list)
+
+  def test_read_from_pubsub(self):
+    mock_pubsub = mock.Mock()
+    subscription_path = "project/fakeproj/subscriptions/fakesub"
+    data = b'data'
+    ack_id = 'ack_id'
+    pull_response = test_utils.create_pull_response(
+        [test_utils.PullResponseMessage(data, ack_id=ack_id)])
+    mock_pubsub.pull.return_value = pull_response
+    output = utils.read_from_pubsub(
+        mock_pubsub, subscription_path, number_of_elements=1)
+    self.assertEqual([data], output)
+    mock_pubsub.acknowledge.assert_called_once_with(subscription_path, [ack_id])
+
+  def test_read_from_pubsub_with_attributes(self):
+    mock_pubsub = mock.Mock()
+    subscription_path = "project/fakeproj/subscriptions/fakesub"
+    data = b'data'
+    ack_id = 'ack_id'
+    attributes = {'key': 'value'}
+    message = PubsubMessage(data, attributes)
+    pull_response = test_utils.create_pull_response(
+        [test_utils.PullResponseMessage(data, attributes, ack_id=ack_id)])
+    mock_pubsub.pull.return_value = pull_response
+    output = utils.read_from_pubsub(
+        mock_pubsub,
+        subscription_path,
+        with_attributes=True,
+        number_of_elements=1)
+    self.assertEqual([message], output)
+    mock_pubsub.acknowledge.assert_called_once_with(subscription_path, [ack_id])
+
+  def test_read_from_pubsub_flaky(self):
+    number_of_elements = 10
+    mock_pubsub = mock.Mock()
+    subscription_path = "project/fakeproj/subscriptions/fakesub"
+    data = b'data'
+    ack_id = 'ack_id'
+    pull_response = test_utils.create_pull_response(
+        [test_utils.PullResponseMessage(data, ack_id=ack_id)])
+
+    class FlakyPullResponse(object):
+
+      def __init__(self, pull_response):
+        self.pull_response = pull_response
+        self._state = -1
+
+      def __call__(self, *args, **kwargs):
+        self._state += 1
+        if self._state % 3 == 0:
+          raise gexc.RetryError("", "")
+        if self._state % 3 == 1:
+          raise gexc.DeadlineExceeded("")
+        if self._state % 3 == 2:
+          return self.pull_response
+
+    mock_pubsub.pull.side_effect = FlakyPullResponse(pull_response)
+    output = utils.read_from_pubsub(
+        mock_pubsub, subscription_path, number_of_elements=number_of_elements)
+    self.assertEqual([data] * number_of_elements, output)
+    self._assert_ack_ids_equal(mock_pubsub, [ack_id] * number_of_elements)
+
+  def test_read_from_pubsub_many(self):
+    response_size = 33
+    number_of_elements = 100
+    mock_pubsub = mock.Mock()
+    subscription_path = "project/fakeproj/subscriptions/fakesub"
+    data_list = [
+        'data {}'.format(i).encode("utf-8") for i in range(number_of_elements)
+    ]
+    attributes_list = [{
+        'key': 'value {}'.format(i)
+    } for i in range(number_of_elements)]
+    ack_ids = ['ack_id_{}'.format(i) for i in range(number_of_elements)]
+    messages = [
+        PubsubMessage(data, attributes)
+        for data, attributes in zip(data_list, attributes_list)
+    ]
+    response_messages = [
+        test_utils.PullResponseMessage(data, attributes, ack_id=ack_id)
+        for data, attributes, ack_id in zip(data_list, attributes_list, ack_ids)
+    ]
+
+    class SequentialPullResponse(object):
+
+      def __init__(self, response_messages, response_size):
+        self.response_messages = response_messages
+        self.response_size = response_size
+        self._index = 0
+
+      def __call__(self, *args, **kwargs):
+        start = self._index
+        self._index += self.response_size
+        response = test_utils.create_pull_response(
+            self.response_messages[start:start + self.response_size])
+        return response
+
+    mock_pubsub.pull.side_effect = SequentialPullResponse(
+        response_messages, response_size)
+    output = utils.read_from_pubsub(
+        mock_pubsub,
+        subscription_path,
+        with_attributes=True,
+        number_of_elements=number_of_elements)
+    self.assertEqual(messages, output)
+    self._assert_ack_ids_equal(mock_pubsub, ack_ids)
+
+  def test_read_from_pubsub_invalid_arg(self):
+    sub_client = mock.Mock()
+    subscription_path = "project/fakeproj/subscriptions/fakesub"
+    with self.assertRaisesRegexp(ValueError, "number_of_elements"):
+      utils.read_from_pubsub(sub_client, subscription_path)
+    with self.assertRaisesRegexp(ValueError, "number_of_elements"):
+      utils.read_from_pubsub(
+          sub_client, subscription_path, with_attributes=True)
+
+  def _assert_ack_ids_equal(self, mock_pubsub, ack_ids):
+    actual_ack_ids = [
+        ack_id for args_list in mock_pubsub.acknowledge.call_args_list
+        for ack_id in args_list[0][1]
+    ]
+    self.assertEqual(actual_ack_ids, ack_ids)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/dataflow/test_dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/test_dataflow_runner.py
@@ -59,9 +59,10 @@ class TestDataflowRunner(DataflowRunner):
     try:
       self.wait_until_in_state(PipelineState.RUNNING)
 
-      if is_streaming and not wait_duration:
+      if not is_streaming:
+        self.result.wait_until_finish(duration=wait_duration)
+      else:
         logging.warning('Waiting indefinitely for streaming job.')
-      self.result.wait_until_finish(duration=wait_duration)
 
       if on_success_matcher:
         from hamcrest import assert_that as hc_assert_that

--- a/sdks/python/apache_beam/testing/test_utils.py
+++ b/sdks/python/apache_beam/testing/test_utils.py
@@ -137,6 +137,12 @@ def delete_files(file_paths):
   FileSystems.delete(file_paths)
 
 
+def cleanup_snapshots(sub_client, snaps):
+  """Cleanup PubSub snapshots if exist."""
+  for snap in snaps:
+    sub_client.delete_snapshot(snap.name)
+
+
 def cleanup_subscriptions(sub_client, subs):
   """Cleanup PubSub subscriptions if exist."""
   for sub in subs:

--- a/sdks/python/apache_beam/testing/test_utils_test.py
+++ b/sdks/python/apache_beam/testing/test_utils_test.py
@@ -82,6 +82,13 @@ class TestUtilsTest(unittest.TestCase):
         self.assertEqual(f.readline(), b'line2\n')
         self.assertEqual(f.readline(), b'line3\n')
 
+  def test_cleanup_snapshots(self):
+    sub_client = mock.Mock()
+    snap = mock.Mock()
+    snap.name = 'test_snap'
+    utils.cleanup_subscriptions(sub_client, [snap])
+    sub_client.delete_subscription.assert_called_with(snap.name)
+
   def test_cleanup_subscriptions(self):
     sub_client = mock.Mock()
     sub = mock.Mock()

--- a/sdks/python/test-suites/dataflow/py2/build.gradle
+++ b/sdks/python/test-suites/dataflow/py2/build.gradle
@@ -39,6 +39,8 @@ task preCommitIT(dependsOn: ['sdist', 'installGcpTest']) {
     def precommitTests = [
         "apache_beam.examples.wordcount_it_test:WordCountIT.test_wordcount_it",
         "apache_beam.examples.streaming_wordcount_it_test:StreamingWordCountIT.test_streaming_wordcount_it",
+        "apache_beam.examples.streaming_wordgroup_it_test:StreamingWordGroupIT.test_discard_late_data",
+        "apache_beam.examples.streaming_wordgroup_it_test:StreamingWordGroupIT.test_single_output_per_window",
     ]
     def testOpts = [
         "--tests=${precommitTests.join(',')}",

--- a/sdks/python/test-suites/dataflow/py37/build.gradle
+++ b/sdks/python/test-suites/dataflow/py37/build.gradle
@@ -42,6 +42,8 @@ task preCommitIT(dependsOn: ['sdist', 'installGcpTest']) {
     def precommitTests = [
         "apache_beam.examples.wordcount_it_test:WordCountIT.test_wordcount_it",
         "apache_beam.examples.streaming_wordcount_it_test:StreamingWordCountIT.test_streaming_wordcount_it",
+        "apache_beam.examples.streaming_wordgroup_it_test:StreamingWordGroupIT.test_discard_late_data",
+        "apache_beam.examples.streaming_wordgroup_it_test:StreamingWordGroupIT.test_single_output_per_window",
     ]
     def testOpts = [
         "--tests=${precommitTests.join(',')}",

--- a/sdks/python/test-suites/direct/py2/build.gradle
+++ b/sdks/python/test-suites/direct/py2/build.gradle
@@ -53,6 +53,8 @@ task directRunnerIT(dependsOn: 'installGcpTest') {
   doLast {
     def tests = [
         "apache_beam.examples.wordcount_it_test:WordCountIT.test_wordcount_it",
+        "apache_beam.examples.streaming_wordgroup_it_test:StreamingWordGroupIT.test_discard_late_data",
+        "apache_beam.examples.streaming_wordgroup_it_test:StreamingWordGroupIT.test_single_output_per_window",
         "apache_beam.io.gcp.pubsub_integration_test:PubSubIntegrationTest",
         "apache_beam.io.gcp.bigquery_test:BigQueryStreamingInsertTransformIntegrationTests\
 .test_multiple_destinations_transform",


### PR DESCRIPTION
By inconsistent we mean that:
- Late data may not be discarded.
- The same window may produce multiple "panes".

**Implementation notes:**
- In order for the tests to pass, this PR includes apache/beam#9212. I will rebase this PR once that dependency is merged.

**Example output:**

See the Python PostCommit test logs for the full stack-trace. Example outputs are:

<details><summary><code>StreamingWordGroupIT.test_discard_late_data</code> error</summary>

```
FAIL: test_discard_late_data (apache_beam.examples.streaming_wordgroup_it_test.StreamingWordGroupIT)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Python2_PR/src/sdks/python/apache_beam/examples/streaming_wordgroup_it_test.py", line 236, in test_discard_late_data
    self.test_pipeline.get_full_options_as_args(**extra_opts))
  File "/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Python2_PR/src/sdks/python/apache_beam/examples/streaming_wordgroup.py", line 117, in run
    result = p.run()
  File "/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Python2_PR/src/sdks/python/apache_beam/pipeline.py", line 419, in run
    return self.runner.run_pipeline(self, self._options)
  File "/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Python2_PR/src/sdks/python/apache_beam/runners/direct/test_direct_runner.py", line 51, in run_pipeline
    hc_assert_that(self.result, pickler.loads(on_success_matcher))
AssertionError: 
Expected: (Test pipeline expected terminated in state: RUNNING and Expected 10 messages.)
     but: Expected 10 messages. Got 10 messages.
Actual has 1 extra: {"elements": ["1009"], "window_start_ts": 1009000, "window_end_ts": 1010000}
Actual has 1 extra: {"elements": ["1007"], "window_start_ts": 1007000, "window_end_ts": 1008000}
Actual has 1 extra: {"elements": ["1008"], "window_start_ts": 1008000, "window_end_ts": 1009000}
Actual has 1 extra: {"elements": ["1000"], "window_start_ts": 1000000, "window_end_ts": 1001000}
Actual has 1 extra: {"elements": ["1001"], "window_start_ts": 1001000, "window_end_ts": 1002000}
Actual has 1 extra: {"elements": ["1006"], "window_start_ts": 1006000, "window_end_ts": 1007000}
Actual has 1 extra: {"elements": ["1002"], "window_start_ts": 1002000, "window_end_ts": 1003000}
Actual has 1 extra: {"elements": ["1003"], "window_start_ts": 1003000, "window_end_ts": 1004000}
Actual has 1 extra: {"elements": ["1004"], "window_start_ts": 1004000, "window_end_ts": 1005000}
Actual has 1 extra: {"elements": ["1005"], "window_start_ts": 1005000, "window_end_ts": 1006000}
Expected has 1 extra: {"elements": ["2007"], "window_start_ts": 2007000, "window_end_ts": 2008000}
Expected has 1 extra: {"elements": ["2001"], "window_start_ts": 2001000, "window_end_ts": 2002000}
Expected has 1 extra: {"elements": ["2008"], "window_start_ts": 2008000, "window_end_ts": 2009000}
Expected has 1 extra: {"elements": ["2002"], "window_start_ts": 2002000, "window_end_ts": 2003000}
Expected has 1 extra: {"elements": ["2004"], "window_start_ts": 2004000, "window_end_ts": 2005000}
Expected has 1 extra: {"elements": ["2000"], "window_start_ts": 2000000, "window_end_ts": 2001000}
Expected has 1 extra: {"elements": ["2005"], "window_start_ts": 2005000, "window_end_ts": 2006000}
Expected has 1 extra: {"elements": ["2006"], "window_start_ts": 2006000, "window_end_ts": 2007000}
Expected has 1 extra: {"elements": ["2003"], "window_start_ts": 2003000, "window_end_ts": 2004000}
Expected has 1 extra: {"elements": ["2009"], "window_start_ts": 2009000, "window_end_ts": 2010000}
```
</details>


<details><summary><code>StreamingWordGroupIT.test_single_output_per_window</code> error</summary>

```
FAIL: test_single_output_per_window (apache_beam.examples.streaming_wordgroup_it_test.StreamingWordGroupIT)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Python2_PR/src/sdks/python/apache_beam/examples/streaming_wordgroup_it_test.py", line 270, in test_single_output_per_window
    self.test_pipeline.get_full_options_as_args(**extra_opts))
  File "/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Python2_PR/src/sdks/python/apache_beam/examples/streaming_wordgroup.py", line 117, in run
    result = p.run()
  File "/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Python2_PR/src/sdks/python/apache_beam/pipeline.py", line 419, in run
    return self.runner.run_pipeline(self, self._options)
  File "/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Python2_PR/src/sdks/python/apache_beam/runners/direct/test_direct_runner.py", line 51, in run_pipeline
    hc_assert_that(self.result, pickler.loads(on_success_matcher))
AssertionError: 
Expected: (Test pipeline expected terminated in state: RUNNING and Expected 2 messages.)
     but: Expected 2 messages. Got 2 messages.
Actual has 1 extra: {"elements": ["100'0", "100'1", "100'2", "100'3", "100'4", "100'5", "100'6", "100'7"], "window_start_ts": 100000, "window_end_ts": 101000}
Expected has 1 extra: {"elements": ["100'0", "100'1", "100'2", "100'3", "100'4", "100'5", "100'6", "100'7", "100'8", "100'9"], "window_start_ts": 100000, "window_end_ts": 101000}
```
</details>

CC: @ivant @ananvay 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
