### PR TITLE
[BEAM-6883] Improve long-running spark streaming test.

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricResultsMatchers.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricResultsMatchers.java
@@ -44,8 +44,49 @@ public class MetricResultsMatchers {
   }
 
   /**
+   * Matches a {@link MetricResult} with the given namespace, name and step, and a matcher for the
+   * value for either committed or attempted (based on {@code isCommitted}) metrics.
+   */
+  public static <T> Matcher<MetricResult<T>> metricsResult(
+      final String namespace,
+      final String name,
+      final String step,
+      final Matcher<T> valueMatcher,
+      final boolean isCommitted) {
+
+    final String metricState = isCommitted ? "committed" : "attempted";
+    return new MatchNameAndKey<T>(namespace, name, step) {
+      @Override
+      protected boolean matchesSafely(MetricResult<T> item) {
+        final T metricValue = isCommitted ? item.getCommitted() : item.getAttempted();
+        return super.matchesSafely(item) && valueMatcher.matches(metricValue);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        super.describeTo(description);
+        description.appendText(String.format(", %s=", metricState));
+        valueMatcher.describeTo(description);
+        description.appendText("}");
+      }
+
+      @Override
+      protected void describeMismatchSafely(MetricResult<T> item, Description mismatchDescription) {
+        final T metricValue = isCommitted ? item.getCommitted() : item.getAttempted();
+        super.describeMismatchSafely(item, mismatchDescription);
+        mismatchDescription.appendText(String.format("%s: ", metricState));
+        valueMatcher.describeMismatch(metricValue, mismatchDescription);
+        mismatchDescription.appendText("}");
+      }
+    };
+  }
+
+  /**
    * Matches a {@link MetricResult} with the given namespace, name and step, and whose value equals
    * the given value for either committed or attempted (based on {@code isCommitted}) metrics.
+   *
+   * <p>For metrics with a {@link {@link GaugeResult}}, only the value is matched and the timestamp
+   * is ignored.
    */
   public static <T> Matcher<MetricResult<T>> metricsResult(
       final String namespace,
@@ -54,24 +95,17 @@ public class MetricResultsMatchers {
       final T value,
       final boolean isCommitted) {
     final String metricState = isCommitted ? "committed" : "attempted";
-    return new TypeSafeMatcher<MetricResult<T>>() {
+    return new MatchNameAndKey<T>(namespace, name, step) {
       @Override
       protected boolean matchesSafely(MetricResult<T> item) {
         final T metricValue = isCommitted ? item.getCommitted() : item.getAttempted();
-        return MetricFiltering.matches(MetricsFilter.builder().addStep(step).build(), item.getKey())
-            && Objects.equals(MetricName.named(namespace, name), item.getName())
-            && metricResultsEqual(value, metricValue);
+        return super.matchesSafely(item) && metricResultsEqual(value, metricValue);
       }
 
       @Override
       public void describeTo(Description description) {
+        super.describeTo(description);
         description
-            .appendText("MetricResult{inNamespace=")
-            .appendValue(namespace)
-            .appendText(", name=")
-            .appendValue(name)
-            .appendText(", step=")
-            .appendValue(step)
             .appendText(String.format(", %s=", metricState))
             .appendValue(value)
             .appendText("}");
@@ -79,11 +113,8 @@ public class MetricResultsMatchers {
 
       @Override
       protected void describeMismatchSafely(MetricResult<T> item, Description mismatchDescription) {
-        mismatchDescription.appendText("MetricResult{");
         final T metricValue = isCommitted ? item.getCommitted() : item.getAttempted();
-
-        describeMetricsResultMembersMismatch(item, mismatchDescription, namespace, name, step);
-
+        super.describeMismatchSafely(item, mismatchDescription);
         if (!Objects.equals(value, metricValue)) {
           mismatchDescription
               .appendText(String.format("%s: ", metricState))
@@ -94,15 +125,15 @@ public class MetricResultsMatchers {
 
         mismatchDescription.appendText("}");
       }
-    };
-  }
 
-  private static <T> boolean metricResultsEqual(T result1, T result2) {
-    if (result1 instanceof GaugeResult) {
-      return (((GaugeResult) result1).getValue()) == (((GaugeResult) result2).getValue());
-    } else {
-      return Objects.equals(result1, result2);
-    }
+      private boolean metricResultsEqual(T result1, T result2) {
+        if (result1 instanceof GaugeResult) {
+          return (((GaugeResult) result1).getValue()) == (((GaugeResult) result2).getValue());
+        } else {
+          return Objects.equals(result1, result2);
+        }
+      }
+    };
   }
 
   static Matcher<MetricResult<DistributionResult>> distributionAttemptedMinMax(
@@ -131,25 +162,20 @@ public class MetricResultsMatchers {
       final Long max,
       final boolean isCommitted) {
     final String metricState = isCommitted ? "committed" : "attempted";
-    return new TypeSafeMatcher<MetricResult<DistributionResult>>() {
+    return new MatchNameAndKey<DistributionResult>(namespace, name, step) {
       @Override
       protected boolean matchesSafely(MetricResult<DistributionResult> item) {
-        DistributionResult metricValue = isCommitted ? item.getCommitted() : item.getAttempted();
-        return MetricFiltering.matches(MetricsFilter.builder().addStep(step).build(), item.getKey())
-            && Objects.equals(MetricName.named(namespace, name), item.getName())
+        final DistributionResult metricValue =
+            isCommitted ? item.getCommitted() : item.getAttempted();
+        return super.matchesSafely(item)
             && Objects.equals(min, metricValue.getMin())
             && Objects.equals(max, metricValue.getMax());
       }
 
       @Override
       public void describeTo(Description description) {
+        super.describeTo(description);
         description
-            .appendText("MetricResult{inNamespace=")
-            .appendValue(namespace)
-            .appendText(", name=")
-            .appendValue(name)
-            .appendText(", step=")
-            .appendValue(step)
             .appendText(String.format(", %sMin=", metricState))
             .appendValue(min)
             .appendText(String.format(", %sMax=", metricState))
@@ -160,11 +186,9 @@ public class MetricResultsMatchers {
       @Override
       protected void describeMismatchSafely(
           MetricResult<DistributionResult> item, Description mismatchDescription) {
-        mismatchDescription.appendText("MetricResult{");
-
-        describeMetricsResultMembersMismatch(item, mismatchDescription, namespace, name, step);
-        DistributionResult metricValue = isCommitted ? item.getCommitted() : item.getAttempted();
-
+        final DistributionResult metricValue =
+            isCommitted ? item.getCommitted() : item.getAttempted();
+        super.describeMismatchSafely(item, mismatchDescription);
         if (!Objects.equals(min, metricValue.getMin())) {
           mismatchDescription
               .appendText(String.format("%sMin: ", metricState))
@@ -186,19 +210,53 @@ public class MetricResultsMatchers {
     };
   }
 
-  private static <T> void describeMetricsResultMembersMismatch(
-      MetricResult<T> item,
-      Description mismatchDescription,
-      String namespace,
-      String name,
-      String step) {
-    MetricKey key = MetricKey.create(step, MetricName.named(namespace, name));
-    if (!Objects.equals(key, item.getKey())) {
-      mismatchDescription
-          .appendText("inKey: ")
-          .appendValue(key)
-          .appendText(" != ")
-          .appendValue(item.getKey());
+  private static class MatchNameAndKey<T> extends TypeSafeMatcher<MetricResult<T>> {
+
+    private final String namespace;
+    private final String name;
+    private final String step;
+
+    MatchNameAndKey(String namespace, String name, String step) {
+      this.namespace = namespace;
+      this.name = name;
+      this.step = step;
+    }
+
+    @Override
+    protected boolean matchesSafely(MetricResult<T> item) {
+      return MetricFiltering.matches(MetricsFilter.builder().addStep(step).build(), item.getKey())
+          && Objects.equals(MetricName.named(namespace, name), item.getName());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description
+          .appendText("MetricResult{inNamespace=")
+          .appendValue(namespace)
+          .appendText(", name=")
+          .appendValue(name)
+          .appendText(", step=")
+          .appendValue(step);
+      if (this.getClass() == MatchNameAndKey.class) {
+        description.appendText("}");
+      }
+    }
+
+    @Override
+    protected void describeMismatchSafely(MetricResult<T> item, Description mismatchDescription) {
+      mismatchDescription.appendText("MetricResult{");
+      MetricKey key = MetricKey.create(step, MetricName.named(namespace, name));
+      if (!Objects.equals(key, item.getKey())) {
+        mismatchDescription
+            .appendText("inKey: ")
+            .appendValue(key)
+            .appendText(" != ")
+            .appendValue(item.getKey());
+      }
+
+      if (this.getClass() == MatchNameAndKey.class) {
+        mismatchDescription.appendText("}");
+      }
     }
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BEAM-6883

Currently, this test takes 10 minutes, and unfortunately doesn't test what is intended.  The transformation under test is an extremely long-lived BoundedSource, not an unbounded source.

I changed the transformation to an UnboundedSource, and  modified the MetricsResultMatchers to be able to apply any arbitrary Matcher to a metrics value.  This may be useful for BEAM-1169

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
