### PR TITLE
[BEAM-7854] Resolve parent folder recursively in LocalFileSystem matc…

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
@@ -275,8 +275,8 @@ class LocalFileSystem extends FileSystem<LocalResourceId> {
   private File getSpecNonGlobPrefixParentFile(String spec) {
     String specNonWildcardPrefix = getNonWildcardPrefix(spec);
     File file = new File(specNonWildcardPrefix);
-    return specNonWildcardPrefix.endsWith(File.separator) ?
-        file
+    return specNonWildcardPrefix.endsWith(File.separator)
+        ? file
         : file.getAbsoluteFile().getParentFile();
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
@@ -275,7 +275,9 @@ class LocalFileSystem extends FileSystem<LocalResourceId> {
   private File getSpecNonGlobPrefixParentFile(String spec) {
     String specNonWildcardPrefix = getNonWildcardPrefix(spec);
     File file = new File(specNonWildcardPrefix);
-    return specNonWildcardPrefix.endsWith(File.separator) ? file : file.getAbsoluteFile().getParentFile();
+    return specNonWildcardPrefix.endsWith(File.separator) ?
+        file
+        : file.getAbsoluteFile().getParentFile();
   }
 
   private Metadata toMetadata(File file) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
@@ -225,7 +225,11 @@ class LocalFileSystem extends FileSystem<LocalResourceId> {
     }
 
     File parent = file.getAbsoluteFile().getParentFile();
-    if (!parent.exists()) {
+    while (parent != null && !parent.exists()) {
+      parent = parent.getParentFile();
+    }
+
+    if (parent == null) {
       return MatchResult.create(Status.NOT_FOUND, Collections.emptyList());
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
@@ -198,7 +198,8 @@ public class LocalFileSystemTest {
     createEmptyFile(expectedFile1);
     createEmptyFile(expectedFile2);
 
-    List<String> expected = ImmutableList.of(expectedFile1.getAbsolutePath(), expectedFile2.getAbsolutePath());
+    List<String> expected =
+        ImmutableList.of(expectedFile1.getAbsolutePath(), expectedFile2.getAbsolutePath());
 
     List<MatchResult> matchResults =
         matchGlobWithPathPrefix(temporaryFolder.getRoot().toPath(), globPattern);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
@@ -198,7 +198,7 @@ public class LocalFileSystemTest {
     createEmptyFile(expectedFile1);
     createEmptyFile(expectedFile2);
 
-    List<String> expected = ImmutableList.of(expectedFile1.toString(), expectedFile2.toString());
+    List<String> expected = ImmutableList.of(expectedFile1.getAbsolutePath(), expectedFile2.getAbsolutePath());
 
     List<MatchResult> matchResults =
         matchGlobWithPathPrefix(temporaryFolder.getRoot().toPath(), globPattern);
@@ -448,7 +448,7 @@ public class LocalFileSystemTest {
   }
 
   private static void createEmptyFile(File file) throws IOException {
-    if (!file.mkdirs() || !file.createNewFile()) {
+    if (!file.getParentFile().mkdirs() || !file.createNewFile()) {
       throw new IOException("Failed creating empty file " + file.getAbsolutePath());
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
@@ -187,13 +187,16 @@ public class LocalFileSystemTest {
   @Test
   public void testMatchWithGlob() throws Exception {
     String globPattern = "/A/a=[0-9][0-9][0-9]/*/*";
-    File folder1 = temporaryFolder.newFolder("A/a=100/data1");
-    File folder2 = temporaryFolder.newFolder("A/a=233/data_dir");
-    File expectedFile1 = new File(folder1, "/file1");
-    File expectedFile2 = new File(folder2, "/data_file2");
+    File baseFolder = temporaryFolder.newFolder("A");
+    File folder1 = new File(baseFolder, "a=100");
+    File folder2 = new File(baseFolder, "a=233");
+    File dataFolder1 = new File(folder1, "data1");
+    File dataFolder2 = new File(folder2, "data_dir");
+    File expectedFile1 = new File(dataFolder1, "file1");
+    File expectedFile2 = new File(dataFolder2, "data_file2");
 
-    expectedFile1.createNewFile();
-    expectedFile2.createNewFile();
+    createEmptyFile(expectedFile1);
+    createEmptyFile(expectedFile2);
 
     List<String> expected = ImmutableList.of(expectedFile1.toString(), expectedFile2.toString());
 
@@ -203,6 +206,12 @@ public class LocalFileSystemTest {
     assertThat(
         toFilenames(matchResults),
         containsInAnyOrder(expected.toArray(new String[expected.size()])));
+  }
+
+  private static void createEmptyFile(File file) throws IOException {
+    if (!file.mkdirs() || !file.createNewFile()) {
+      throw new IOException("Failed creating empty file " + file.getAbsolutePath());
+    }
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
@@ -185,6 +185,27 @@ public class LocalFileSystemTest {
   }
 
   @Test
+  public void testMatchWithGlob() throws Exception {
+    String globPattern = "/A/a=[0-9][0-9][0-9]/*/*";
+    File folder1 = temporaryFolder.newFolder("A/a=100/data1");
+    File folder2 = temporaryFolder.newFolder("A/a=233/data_dir");
+    File expectedFile1 = new File(folder1, "/file1");
+    File expectedFile2 = new File(folder2, "/data_file2");
+
+    expectedFile1.createNewFile();
+    expectedFile2.createNewFile();
+
+    List<String> expected = ImmutableList.of(expectedFile1.toString(), expectedFile2.toString());
+
+    List<MatchResult> matchResults =
+        matchGlobWithPathPrefix(temporaryFolder.getRoot().toPath(), globPattern);
+
+    assertThat(
+        toFilenames(matchResults),
+        containsInAnyOrder(expected.toArray(new String[expected.size()])));
+  }
+
+  @Test
   public void testMatchExact() throws Exception {
     List<String> expected = ImmutableList.of(temporaryFolder.newFile("a").toString());
     temporaryFolder.newFile("aa");
@@ -354,16 +375,6 @@ public class LocalFileSystemTest {
     assertThat(
         toFilenames(matchResults),
         containsInAnyOrder(expected.toArray(new String[expected.size()])));
-  }
-
-  @Test
-  public void testMatchWithoutParentDirectory() throws Exception {
-    Path pattern =
-        LocalResourceId.fromPath(temporaryFolder.getRoot().toPath(), true /* isDirectory */)
-            .resolve("non_existing_dir", StandardResolveOptions.RESOLVE_DIRECTORY)
-            .resolve("*", StandardResolveOptions.RESOLVE_FILE)
-            .getPath();
-    assertTrue(toFilenames(localFileSystem.match(ImmutableList.of(pattern.toString()))).isEmpty());
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
@@ -208,12 +208,6 @@ public class LocalFileSystemTest {
         containsInAnyOrder(expected.toArray(new String[expected.size()])));
   }
 
-  private static void createEmptyFile(File file) throws IOException {
-    if (!file.mkdirs() || !file.createNewFile()) {
-      throw new IOException("Failed creating empty file " + file.getAbsolutePath());
-    }
-  }
-
   @Test
   public void testMatchExact() throws Exception {
     List<String> expected = ImmutableList.of(temporaryFolder.newFile("a").toString());
@@ -387,6 +381,16 @@ public class LocalFileSystemTest {
   }
 
   @Test
+  public void testMatchWithoutParentDirectory() throws Exception {
+    Path pattern =
+        LocalResourceId.fromPath(temporaryFolder.getRoot().toPath(), true /* isDirectory */)
+            .resolve("non_existing_dir", StandardResolveOptions.RESOLVE_DIRECTORY)
+            .resolve("*", StandardResolveOptions.RESOLVE_FILE)
+            .getPath();
+    assertTrue(toFilenames(localFileSystem.match(ImmutableList.of(pattern.toString()))).isEmpty());
+  }
+
+  @Test
   public void testMatchNewResource() throws Exception {
     LocalResourceId fileResource =
         localFileSystem.matchNewResource("/some/test/resource/path", false /* isDirectory */);
@@ -441,5 +445,11 @@ public class LocalFileSystemTest {
             })
         .transform(metadata -> ((LocalResourceId) metadata.resourceId()).getPath().toString())
         .toList();
+  }
+
+  private static void createEmptyFile(File file) throws IOException {
+    if (!file.mkdirs() || !file.createNewFile()) {
+      throw new IOException("Failed creating empty file " + file.getAbsolutePath());
+    }
   }
 }


### PR DESCRIPTION
[BEAM-7854] Fixes LocalFileSystem not matching glob fully by recursively resolving parent folder.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
