### PR TITLE
Add "--workerHarnessContainerImage=" to dataflow java11 legacy worker test

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -187,6 +187,7 @@ task validatesRunnerLegacyWorkerJava11Test(type: Test) {
             "--project=${dataflowProject}",
             "--tempRoot=${dataflowValidatesTempRoot}",
             "--dataflowWorkerJar=${dataflowLegacyWorkerJar}",
+            "--workerHarnessContainerImage=",
     ])
     
     systemProperty "java.specification.version", "11"


### PR DESCRIPTION
Without overriding --workerHarnessContainerImage, the pipeline will still use cached worker image, instead of worker jar.

R: @pabloem 



