### PR TITLE
[BEAM-7872] Simpler Flink cluster set up in load tests

### DIFF
--- a/.test-infra/dataproc/flink_cluster.sh
+++ b/.test-infra/dataproc/flink_cluster.sh
@@ -14,9 +14,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-#    Runs init actions for Docker, Portability framework (Beam) and Flink cluster
-#    and opens an SSH tunnel to connect with Flink easily and run Beam jobs.
-#
 #    Provide the following environment to run this script:
 #
 #    GCLOUD_ZONE: Google cloud zone. Optional. Default: "us-central1-a"
@@ -41,7 +38,7 @@
 #    FLINK_NUM_WORKERS=2 \
 #    FLINK_TASKMANAGER_SLOTS=1 \
 #    DETACHED_MODE=false \
-#    ./create_flink_cluster.sh
+#    ./flink_cluster.sh create
 #
 set -Eeuxo pipefail
 
@@ -137,7 +134,9 @@ function create_cluster() {
   gcloud dataproc clusters create $CLUSTER_NAME --num-workers=$num_dataproc_workers --initialization-actions $DOCKER_INIT,$BEAM_INIT,$FLINK_INIT --metadata "${metadata}", --image-version=$image_version --zone=$GCLOUD_ZONE --quiet
 }
 
-function main() {
+# Runs init actions for Docker, Portability framework (Beam) and Flink cluster
+# and opens an SSH tunnel to connect with Flink easily and run Beam jobs.
+function create() {
   upload_init_actions
   create_cluster
   get_leader
@@ -145,4 +144,19 @@ function main() {
   start_tunnel
 }
 
-main "$@"
+# Recreates a Flink cluster.
+function restart() {
+  delete
+  create
+}
+
+# Deletes a Flink cluster.
+function delete() {
+  gcloud dataproc clusters delete $CLUSTER_NAME --quiet
+}
+
+function scale() {
+  restart
+}
+
+"$@"

--- a/.test-infra/dataproc/flink_cluster.sh
+++ b/.test-infra/dataproc/flink_cluster.sh
@@ -155,8 +155,4 @@ function delete() {
   gcloud dataproc clusters delete $CLUSTER_NAME --quiet
 }
 
-function scale() {
-  restart
-}
-
 "$@"

--- a/.test-infra/jenkins/Docker.groovy
+++ b/.test-infra/jenkins/Docker.groovy
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonJobProperties as common
+
+class Docker {
+  private def job
+  private String repositoryRoot
+
+  Docker(job, String repositoryRoot) {
+    this.job = job
+    this.repositoryRoot = repositoryRoot
+  }
+
+  /**
+   * Builds a Docker image from a gradle task and pushes it to the registry.
+   *
+   * @param gradleTask - name of a Gradle task
+   * @param imageName - name of a docker image
+   * @param imageTag - tag of a docker image
+   */
+  final void publish(String gradleTask, String imageName, String imageTag = 'latest') {
+    build(gradleTask, imageTag)
+    push(imageName, imageTag)
+  }
+
+  private void build(String gradleTask, String imageTag) {
+    job.steps {
+      gradle {
+        rootBuildScriptDir(common.checkoutDir)
+        common.setGradleSwitches(delegate)
+        tasks(gradleTask)
+        switches("-Pdocker-repository-root=${repositoryRoot}")
+        switches("-Pdocker-tag=${imageTag}")
+      }
+    }
+  }
+
+  private void push(String imageName, String imageTag) {
+    String image = "${repositoryRoot}/${imageName}"
+    String targetImage = getFullImageName(imageName, imageTag)
+
+    job.steps {
+      shell("echo \"Tagging image\"...")
+      shell("docker tag ${image} ${targetImage}")
+      shell("echo \"Pushing image\"...")
+      shell("docker push ${targetImage}")
+    }
+  }
+
+  /**
+   * Returns the name of a docker image in the following format: <repositoryRoot>/<imageName>:<imageTag>
+   *
+   * @param imageName - name of a docker image
+   * @param imageTag - tag of a docker image
+   */
+  final String getFullImageName(String imageName, String imageTag = 'latest') {
+    String image = "${repositoryRoot}/${imageName}"
+    return "${image}:${imageTag}"
+  }
+}

--- a/.test-infra/jenkins/Flink.groovy
+++ b/.test-infra/jenkins/Flink.groovy
@@ -19,10 +19,68 @@
 import CommonJobProperties as common
 import CommonTestProperties.SDK
 
-class Infrastructure {
+class Flink {
+  private static final String repositoryRoot = 'gcr.io/apache-beam-testing/beam_portability'
+  private static final String dockerTag = 'latest'
+  private static final String jobServerImageTag = "${repositoryRoot}/flink-job-server:${dockerTag}"
+  private static final String flinkVersion = '1.7'
+  private static final String flinkDownloadUrl = 'https://archive.apache.org/dist/flink/flink-1.7.0/flink-1.7.0-bin-hadoop28-scala_2.11.tgz'
+  private def job
+  private String jobName
 
-  static void prepareSDKHarness(def context, SDK sdk, String repositoryRoot, String dockerTag) {
-    context.steps {
+  Flink(job, String jobName) {
+    this.job = job
+    this.jobName = jobName
+  }
+
+ /**
+  * Returns SDK Harness image tag to be used as an environment_config in the job definition.
+  *
+  * @param sdk - SDK
+  */
+  static String getSDKHarnessImageTag(SDK sdk) {
+    switch (sdk) {
+      case CommonTestProperties.SDK.PYTHON:
+        return "${repositoryRoot}/python:${dockerTag}"
+      case CommonTestProperties.SDK.JAVA:
+        return "${repositoryRoot}/java:${dockerTag}"
+      default:
+        String sdkName = sdk.name().toLowerCase()
+        throw new IllegalArgumentException("${sdkName} SDK is not supported")
+    }
+  }
+
+  /**
+   * Creates Flink cluster and specifies cleanup steps.
+   *
+   * @param sdk - SDK
+   * @param workerCount - the initial number of worker nodes
+   * @param slotsPerTaskmanager - the number of slots per Flink task manager
+   */
+  void setUp(SDK sdk, Integer workerCount, Integer slotsPerTaskmanager = 1) {
+    setupFlinkCluster(sdk, workerCount, slotsPerTaskmanager)
+    addTeardownFlinkStep()
+  }
+
+  /**
+   * Updates the number of worker nodes in a cluster.
+   *
+   * @param workerCount - the new number of worker nodes in the cluster
+   */
+  void scaleCluster(Integer workerCount) {
+    job.steps {
+      environmentVariables {
+        env("FLINK_NUM_WORKERS", workerCount)
+      }
+      shell("gcloud dataproc clusters delete ${getClusterName(jobName)} --quiet")
+
+      shell('echo Setting up flink cluster')
+      shell("cd ${common.makePathAbsolute('src/.test-infra/dataproc/')}; ./create_flink_cluster.sh")
+    }
+  }
+
+  void prepareSDKHarness(SDK sdk) {
+    job.steps {
       String sdkName = sdk.name().toLowerCase()
       String image = "${repositoryRoot}/${sdkName}"
       String imageTag = "${image}:${dockerTag}"
@@ -42,8 +100,8 @@ class Infrastructure {
     }
   }
 
-  static void prepareFlinkJobServer(def context, String flinkVersion, String repositoryRoot, String dockerTag) {
-    context.steps {
+  void prepareJobServer() {
+    job.steps {
       String image = "${repositoryRoot}/flink-job-server"
       String imageTag = "${image}:${dockerTag}"
 
@@ -64,12 +122,13 @@ class Infrastructure {
     }
   }
 
-  static void setupFlinkCluster(def context, String clusterNamePrefix, String flinkDownloadUrl, String imagesToPull, String jobServerImage, Integer workerCount, Integer slotsPerTaskmanager = 1) {
+  private void setupFlinkCluster(SDK sdk, Integer workerCount, Integer slotsPerTaskmanager) {
     String gcsBucket = 'gs://beam-flink-cluster'
-    String clusterName = getClusterName(clusterNamePrefix)
-    String artifactsDir="${gcsBucket}/${clusterName}"
+    String clusterName = getClusterName()
+    String artifactsDir = "${gcsBucket}/${clusterName}"
+    String imagesToPull = getSDKHarnessImageTag(sdk)
 
-    context.steps {
+    job.steps {
       environmentVariables {
         env("GCLOUD_ZONE", "us-central1-a")
         env("CLUSTER_NAME", clusterName)
@@ -83,8 +142,8 @@ class Infrastructure {
           env("HARNESS_IMAGES_TO_PULL", imagesToPull)
         }
 
-        if(jobServerImage) {
-          env("JOB_SERVER_IMAGE", jobServerImage)
+        if(jobServerImageTag) {
+          env("JOB_SERVER_IMAGE", jobServerImageTag)
           env("ARTIFACTS_DIR", artifactsDir)
         }
       }
@@ -94,11 +153,11 @@ class Infrastructure {
     }
   }
 
-  static void teardownDataproc(def context, String jobName) {
-    context.publishers {
+  private void addTeardownFlinkStep() {
+    job.publishers {
       postBuildScripts {
         steps {
-          shell("gcloud dataproc clusters delete ${getClusterName(jobName)} --quiet")
+          shell("gcloud dataproc clusters delete ${getClusterName()} --quiet")
         }
         onlyIfBuildSucceeds(false)
         onlyIfBuildFails(false)
@@ -106,19 +165,7 @@ class Infrastructure {
     }
   }
 
-  static void scaleCluster(def context, String jobName, Integer workerCount) {
-    context.steps {
-      environmentVariables {
-        env("FLINK_NUM_WORKERS", workerCount)
-      }
-      shell("gcloud dataproc clusters delete ${getClusterName(jobName)} --quiet")
-
-      shell('echo Setting up flink cluster')
-      shell("cd ${common.makePathAbsolute('src/.test-infra/dataproc/')}; ./create_flink_cluster.sh")
-    }
-  }
-
-  private static GString getClusterName(String jobName) {
+  private GString getClusterName() {
     return "${jobName.toLowerCase().replace("_", "-")}-\$BUILD_ID"
   }
 }

--- a/.test-infra/jenkins/LoadTestsBuilder.groovy
+++ b/.test-infra/jenkins/LoadTestsBuilder.groovy
@@ -22,6 +22,8 @@ import CommonTestProperties.SDK
 import CommonTestProperties.TriggeringContext
 
 class LoadTestsBuilder {
+  final static String DOCKER_CONTAINER_REGISTRY = 'gcr.io/apache-beam-testing/beam_portability'
+
   static void loadTests(scope, CommonTestProperties.SDK sdk, List testConfigurations, String test, String mode){
     scope.description("Runs ${sdk.toString().toLowerCase().capitalize()} ${test} load tests in ${mode} mode")
 

--- a/.test-infra/jenkins/job_LoadTests_GBK_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Flink_Python.groovy
@@ -21,16 +21,15 @@ import CommonTestProperties
 import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import Flink
+import Docker
 
-String pythonHarnessImageTag = Flink.getSDKHarnessImageTag(CommonTestProperties.SDK.PYTHON)
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
-def testConfiguration = { datasetName -> [
+def scenarios = { datasetName, sdkHarnessImageTag -> [
         [
                 title        : 'Load test: 2GB of 10B records',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
                 runner       : CommonTestProperties.Runner.PORTABLE,
-                sdk          : CommonTestProperties.SDK.PYTHON,
                 jobProperties: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_1_${now}",
                         publish_to_big_query: false,
@@ -41,17 +40,15 @@ def testConfiguration = { datasetName -> [
                         iterations          : 1,
                         fanout              : 1,
                         parallelism         : 5,
-                        job_endpoint: 'localhost:8099',
-                        environment_config : pythonHarnessImageTag,
-                        environment_type: 'DOCKER'
-
+                        job_endpoint        : 'localhost:8099',
+                        environment_config  : sdkHarnessImageTag,
+                        environment_type    : 'DOCKER'
                 ]
         ],
         [
                 title        : 'Load test: 2GB of 100B records',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
                 runner       : CommonTestProperties.Runner.PORTABLE,
-                sdk          : CommonTestProperties.SDK.PYTHON,
                 jobProperties: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_2_${now}",
                         publish_to_big_query: false,
@@ -62,17 +59,15 @@ def testConfiguration = { datasetName -> [
                         iterations          : 1,
                         fanout              : 1,
                         parallelism         : 5,
-                        job_endpoint: 'localhost:8099',
-                        environment_config : pythonHarnessImageTag,
-                        environment_type: 'DOCKER'
-
+                        job_endpoint        : 'localhost:8099',
+                        environment_config  : sdkHarnessImageTag,
+                        environment_type    : 'DOCKER'
                 ]
         ],
         [
                 title        : 'Load test: 2GB of 100kB records',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
                 runner       : CommonTestProperties.Runner.PORTABLE,
-                sdk          : CommonTestProperties.SDK.PYTHON,
                 jobProperties: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_3_${now}",
                         publish_to_big_query: false,
@@ -83,17 +78,15 @@ def testConfiguration = { datasetName -> [
                         iterations          : 1,
                         fanout              : 1,
                         parallelism         : 5,
-                        job_endpoint: 'localhost:8099',
-                        environment_config : pythonHarnessImageTag,
-                        environment_type: 'DOCKER'
-
+                        job_endpoint        : 'localhost:8099',
+                        environment_config  : sdkHarnessImageTag,
+                        environment_type    : 'DOCKER'
                 ]
         ],
         [
                 title        : 'Load test: fanout 4 times with 2GB 10-byte records total',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
                 runner       : CommonTestProperties.Runner.PORTABLE,
-                sdk          : CommonTestProperties.SDK.PYTHON,
                 jobProperties: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_4_${now}",
                         publish_to_big_query: false,
@@ -104,17 +97,15 @@ def testConfiguration = { datasetName -> [
                         iterations          : 1,
                         fanout              : 4,
                         parallelism         : 16,
-                        job_endpoint: 'localhost:8099',
-                        environment_config : pythonHarnessImageTag,
-                        environment_type: 'DOCKER'
-
+                        job_endpoint        : 'localhost:8099',
+                        environment_config  : sdkHarnessImageTag,
+                        environment_type    : 'DOCKER'
                 ]
         ],
         [
                 title        : 'Load test: fanout 8 times with 2GB 10-byte records total',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
                 runner       : CommonTestProperties.Runner.PORTABLE,
-                sdk          : CommonTestProperties.SDK.PYTHON,
                 jobProperties: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_5_${now}",
                         publish_to_big_query: false,
@@ -125,17 +116,15 @@ def testConfiguration = { datasetName -> [
                         iterations          : 1,
                         fanout              : 8,
                         parallelism         : 16,
-                        job_endpoint: 'localhost:8099',
-                        environment_config : pythonHarnessImageTag,
-                        environment_type: 'DOCKER'
-
+                        job_endpoint        : 'localhost:8099',
+                        environment_config  : sdkHarnessImageTag,
+                        environment_type    : 'DOCKER'
                 ]
         ],
         [
                 title        : 'Load test: reiterate 4 times 10kB values',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
                 runner       : CommonTestProperties.Runner.PORTABLE,
-                sdk          : CommonTestProperties.SDK.PYTHON,
                 jobProperties: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_6_${now}",
                         publish_to_big_query: false,
@@ -146,17 +135,15 @@ def testConfiguration = { datasetName -> [
                         iterations          : 4,
                         fanout              : 1,
                         parallelism         : 5,
-                        job_endpoint: 'localhost:8099',
-                        environment_config : pythonHarnessImageTag,
-                        environment_type: 'DOCKER'
-
+                        job_endpoint        : 'localhost:8099',
+                        environment_config  : sdkHarnessImageTag,
+                        environment_type    : 'DOCKER'
                 ]
         ],
         [
                 title        : 'Load test: reiterate 4 times 2MB values',
                 itClass      : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
                 runner       : CommonTestProperties.Runner.PORTABLE,
-                sdk          : CommonTestProperties.SDK.PYTHON,
                 jobProperties: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_7_${now}",
                         publish_to_big_query: false,
@@ -167,37 +154,37 @@ def testConfiguration = { datasetName -> [
                         iterations          : 4,
                         fanout              : 1,
                         parallelism         : 5,
-                        job_endpoint: 'localhost:8099',
-                        environment_config : pythonHarnessImageTag,
-                        environment_type: 'DOCKER'
-
+                        job_endpoint        : 'localhost:8099',
+                        environment_config  : sdkHarnessImageTag,
+                        environment_type    : 'DOCKER'
                 ]
         ]
     ]}
 
 
 def loadTest = { scope, triggeringContext ->
-  scope.description('Runs Python GBK load tests on Flink runner in batch mode')
-  commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
+  Docker publisher = new Docker(scope, loadTestsBuilder.DOCKER_CONTAINER_REGISTRY)
+  def sdk = CommonTestProperties.SDK.PYTHON
+  String sdkName = sdk.name().toLowerCase()
+  String pythonHarnessImageTag = publisher.getFullImageName(sdkName)
 
   def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
-  def parametrizedTestConfigurations = testConfiguration(datasetName)
-  def sdkName = CommonTestProperties.SDK.PYTHON
-
   def numberOfWorkers = 16
-  def flink = new Flink(scope, 'beam_LoadTests_Python_GBK_Flink_Batch')
-  flink.prepareSDKHarness(CommonTestProperties.SDK.PYTHON)
-  flink.prepareJobServer()
-  flink.setUp(CommonTestProperties.SDK.PYTHON, numberOfWorkers)
+  List<Map> testScenarios = scenarios(datasetName, pythonHarnessImageTag)
 
-  def currentTestConfiguration = parametrizedTestConfigurations.findAll { it.jobProperties?.parallelism?.value == numberOfWorkers }
-  loadTestsBuilder.loadTests(scope, sdkName, currentTestConfiguration, "GBK", "batch")
+  publisher.publish(":sdks:${sdkName}:container:docker", sdkName)
+  publisher.publish(':runners:flink:1.7:job-server-container:docker', 'flink-job-server')
+  def flink = new Flink(scope, 'beam_LoadTests_Python_GBK_Flink_Batch')
+  flink.setUp([pythonHarnessImageTag], numberOfWorkers, publisher.getFullImageName('flink-job-server'))
+
+  def configurations = testScenarios.findAll { it.jobProperties?.parallelism?.value == numberOfWorkers }
+  loadTestsBuilder.loadTests(scope, sdk, configurations, "GBK", "batch")
 
   numberOfWorkers = 5
   flink.scaleCluster(numberOfWorkers)
 
-  currentTestConfiguration = parametrizedTestConfigurations.findAll { it.jobProperties?.parallelism?.value == numberOfWorkers }
-  loadTestsBuilder.loadTests(scope, sdkName, currentTestConfiguration, "GBK", "batch")
+  configurations = testScenarios.findAll { it.jobProperties?.parallelism?.value == numberOfWorkers }
+  loadTestsBuilder.loadTests(scope, sdk, configurations, "GBK", "batch")
 }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob(

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Python.groovy
@@ -20,17 +20,10 @@ import CommonJobProperties as commonJobProperties
 import CommonTestProperties
 import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
-import Infrastructure as infra
+import Flink
 
-String jenkinsJobName = 'beam_LoadTests_Python_coGBK_Flink_Batch'
+String pythonHarnessImageTag = Flink.getSDKHarnessImageTag(CommonTestProperties.SDK.PYTHON)
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
-String dockerRegistryRoot = 'gcr.io/apache-beam-testing/beam_portability'
-String dockerTag = 'latest'
-String jobServerImageTag = "${dockerRegistryRoot}/flink-job-server:${dockerTag}"
-String pythonHarnessImageTag = "${dockerRegistryRoot}/python:${dockerTag}"
-
-String flinkVersion = '1.7'
-String flinkDownloadUrl = 'https://archive.apache.org/dist/flink/flink-1.7.0/flink-1.7.0-bin-hadoop28-scala_2.11.tgz'
 
 def loadTestConfigurations = { datasetName -> [
         [
@@ -156,21 +149,15 @@ def loadTestConfigurations = { datasetName -> [
 ]}
 
 def loadTest = { scope, triggeringContext ->
-  scope.description('Runs Python coGBK load tests on Flink runner in batch mode')
-  commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
-
   def numberOfWorkers = 5
+  def flink = new Flink(scope, 'beam_LoadTests_Python_CoGBK_Flink_Batch')
+  flink.prepareSDKHarness(CommonTestProperties.SDK.PYTHON)
+  flink.prepareJobServer()
+  flink.setUp(CommonTestProperties.SDK.PYTHON, numberOfWorkers)
+
   def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
-
-  infra.prepareSDKHarness(scope, CommonTestProperties.SDK.PYTHON, dockerRegistryRoot, dockerTag)
-  infra.prepareFlinkJobServer(scope, flinkVersion, dockerRegistryRoot, dockerTag)
-  infra.setupFlinkCluster(scope, jenkinsJobName, flinkDownloadUrl, pythonHarnessImageTag, jobServerImageTag, numberOfWorkers)
-
-  for (config in loadTestConfigurations(datasetName)) {
-    loadTestsBuilder.loadTest(scope, config.title, config.runner, CommonTestProperties.SDK.PYTHON, config.jobProperties, config.itClass)
-  }
-
-  infra.teardownDataproc(scope, jenkinsJobName)
+  def testConfigs = loadTestConfigurations(datasetName)
+  loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.PYTHON, testConfigs, 'CoGBK', 'batch')
 }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob(


### PR DESCRIPTION
Creating a new load test running on Flink runner could be easier by providing a single `setUp` function which would encapsulate the process of creating Flink cluster and registering teardown steps

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
