### PR TITLE
 [BEAM-7866] Fix python ReadFromMongoDB potential data loss issue

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1944,8 +1944,6 @@ public class StreamingDataflowWorker {
             .setErrors(errors)
             .setCounterUpdates(counterUpdates);
     workUnitClient.reportWorkItemStatus(workItemStatus);
-    LOG.info("WorkItemStatus from streaming dataflow worker " + workItemStatus);
-    LOG.info("CounterUpdates from streaming dataflow worker " + counterUpdates);
 
     // Send any counters appearing more than once in subsequent RPCs:
     while (!counterMultimap.isEmpty()) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1944,6 +1944,8 @@ public class StreamingDataflowWorker {
             .setErrors(errors)
             .setCounterUpdates(counterUpdates);
     workUnitClient.reportWorkItemStatus(workItemStatus);
+    LOG.info("WorkItemStatus from streaming dataflow worker " + workItemStatus);
+    LOG.info("CounterUpdates from streaming dataflow worker " + counterUpdates);
 
     // Send any counters appearing more than once in subsequent RPCs:
     while (!counterMultimap.isEmpty()) {

--- a/sdks/python/apache_beam/io/mongodbio_test.py
+++ b/sdks/python/apache_beam/io/mongodbio_test.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 
 import datetime
 import logging
+import sys
 import unittest
 from unittest import TestCase
 
@@ -42,6 +43,8 @@ from apache_beam.testing.util import equal_to
 
 
 class _MockMongoColl(object):
+  """Fake mongodb collection cursor."""
+
   def __init__(self, docs):
     self.docs = docs
 
@@ -51,6 +54,8 @@ class _MockMongoColl(object):
       return self
     start = filter['_id'].get('$gte')
     end = filter['_id'].get('$lt')
+    assert start is not None
+    assert end is not None
     for doc in self.docs:
       if start and doc['_id'] < start:
         continue
@@ -80,6 +85,8 @@ class _MockMongoColl(object):
 
 
 class _MockMongoDb(object):
+  """Fake Mongo Db."""
+
   def __init__(self, docs):
     self.docs = docs
 
@@ -93,13 +100,15 @@ class _MockMongoDb(object):
       return self.get_split_key(command, *args, **kwargs)
 
   def get_split_key(self, command, ns, min, max, maxChunkSize, **kwargs):
-    # assuming every doc is of size 1mb
+    # simulate mongo db splitVector command, return split keys base on chunk
+    # size, assuming every doc is of size 1mb
     start_id = min['_id']
     end_id = max['_id']
     if start_id >= end_id:
       return []
     start_index = 0
     end_index = 0
+    # get split range of [min, max]
     for doc in self.docs:
       if doc['_id'] < start_id:
         start_index += 1
@@ -107,8 +116,10 @@ class _MockMongoDb(object):
         end_index += 1
       else:
         break
+    # return ids of elements in the range with chunk size skip and exclude
+    # head element.
     return {
-      'splitKeys':
+        'splitKeys':
         [x['_id'] for x in self.docs[start_index:end_index:maxChunkSize]][1:]
     }
 
@@ -131,9 +142,9 @@ class MongoSourceTest(unittest.TestCase):
   @mock.patch('apache_beam.io.mongodbio.MongoClient')
   def setUp(self, mock_client):
     self._ids = [
-      objectid.ObjectId.from_datetime(
-        datetime.datetime(year=2020, month=i + 1, day=i + 1))
-      for i in range(5)
+        objectid.ObjectId.from_datetime(
+            datetime.datetime(year=2020, month=i + 1, day=i + 1))
+        for i in range(5)
     ]
     self._docs = [{'_id': self._ids[i], 'x': i} for i in range(len(self._ids))]
     mock_client.return_value = _MockMongoClient(self._docs)
@@ -151,29 +162,28 @@ class MongoSourceTest(unittest.TestCase):
     mock_client.return_value = _MockMongoClient(self._docs)
     for size in [i * 1024 * 1024 for i in (1, 2, 10)]:
       splits = list(
-        self.mongo_source.split(start_position=None,
-                                stop_position=None,
-                                desired_bundle_size=size))
+          self.mongo_source.split(start_position=None,
+                                  stop_position=None,
+                                  desired_bundle_size=size))
 
       reference_info = (self.mongo_source, None, None)
       sources_info = ([(split.source, split.start_position, split.stop_position)
                        for split in splits])
       source_test_utils.assert_sources_equal_reference_source(
-        reference_info, sources_info)
+          reference_info, sources_info)
 
   @mock.patch('apache_beam.io.mongodbio.MongoClient')
   def test_dynamic_work_rebalancing(self, mock_client):
     mock_client.return_value = _MockMongoClient(self._docs)
     splits = list(
-      self.mongo_source.split(desired_bundle_size=3000 * 1024 * 1024))
+        self.mongo_source.split(desired_bundle_size=3000 * 1024 * 1024))
     assert len(splits) == 1
     source_test_utils.assert_split_at_fraction_exhaustive(
-      splits[0].source, splits[0].start_position, splits[0].stop_position)
+        splits[0].source, splits[0].start_position, splits[0].stop_position)
 
   @mock.patch('apache_beam.io.mongodbio.MongoClient')
   def test_get_range_tracker(self, mock_client):
-    mock_client.return_value.__enter__.return_value.__getitem__.return_value \
-      .__getitem__.return_value = _MockMongoColl(self._docs)
+    mock_client.return_value = _MockMongoClient(self._docs)
     self.assertIsInstance(self.mongo_source.get_range_tracker(None, None),
                           _ObjectIdRangeTracker)
 
@@ -183,8 +193,7 @@ class MongoSourceTest(unittest.TestCase):
     mock_tracker.start_position.return_value = self._ids[0]
     mock_tracker.stop_position.return_value = self._ids[2]
 
-    mock_client.return_value.__enter__.return_value.__getitem__.return_value \
-      .__getitem__.return_value = _MockMongoColl(self._docs)
+    mock_client.return_value = _MockMongoClient(self._docs)
 
     result = list(self.mongo_source.read(mock_tracker))
     self.assertListEqual(self._docs[0:2], result)
@@ -200,13 +209,11 @@ class ReadFromMongoDBTest(unittest.TestCase):
   @mock.patch('apache_beam.io.mongodbio.MongoClient')
   def test_read_from_mongodb(self, mock_client):
     documents = [{'_id': objectid.ObjectId(), 'x': i} for i in range(3)]
-    # use index value as id
-    mock_client.return_value.__enter__.return_value.__getitem__.return_value \
-      .__getitem__.return_value = _MockMongoColl(documents)
+    mock_client.return_value = _MockMongoClient(documents)
 
     with TestPipeline() as p:
       docs = p | 'ReadFromMongoDB' >> ReadFromMongoDB(
-        uri='mongodb://test', db='db', coll='collection')
+          uri='mongodb://test', db='db', coll='collection')
       assert_that(docs, equal_to(documents))
 
 
@@ -214,10 +221,10 @@ class GenerateObjectIdFnTest(unittest.TestCase):
   def test_process(self):
     with TestPipeline() as p:
       output = (p | "Create" >> beam.Create([{
-        'x': 1
+          'x': 1
       }, {
-        'x': 2,
-        '_id': 123
+          'x': 2,
+          '_id': 123
       }])
                 | "Generate ID" >> beam.ParDo(_GenerateObjectIdFn())
                 | "Check" >> beam.Map(lambda x: '_id' in x))
@@ -234,7 +241,7 @@ class WriteMongoFnTest(unittest.TestCase):
       p.run()
 
       self.assertEqual(
-        2, mock_sink.return_value.__enter__.return_value.write.call_count)
+          2, mock_sink.return_value.__enter__.return_value.write.call_count)
 
   def test_display_data(self):
     data = _WriteMongoFn(batch_size=10).display_data()
@@ -267,10 +274,10 @@ class WriteToMongoDBTest(unittest.TestCase):
   def test_write_to_mongodb_with_generated_id(self, mock_client):
     docs = [{'x': 1}]
     expected_update = [
-      ReplaceOne({'_id': mock.ANY}, {
-        'x': 1,
-        '_id': mock.ANY
-      }, True, None)
+        ReplaceOne({'_id': mock.ANY}, {
+            'x': 1,
+            '_id': mock.ANY
+        }, True, None)
     ]
     with TestPipeline() as p:
       _ = (p | "Create" >> beam.Create(docs)
@@ -279,31 +286,46 @@ class WriteToMongoDBTest(unittest.TestCase):
       mock_client.return_value.__getitem__.return_value.__getitem__. \
         return_value.bulk_write.assert_called_with(expected_update)
 
-class ObjectIdHelperTest(TestCase):
 
+class ObjectIdHelperTest(TestCase):
   def test_conversion(self):
     test_cases = [
-      (objectid.ObjectId('000000000000000000000000'), 0),
-      (objectid.ObjectId('000000000000000100000000'), 2 ** 32),
-      (objectid.ObjectId('0000000000000000ffffffff'), 2 ** 32 - 1),
-      (objectid.ObjectId('000000010000000000000000'), 2 ** 64),
-      (objectid.ObjectId('00000000ffffffffffffffff'), 2 ** 64 - 1),
-      (objectid.ObjectId('ffffffffffffffffffffffff'), 2 ** 96 - 1),
+        (objectid.ObjectId('000000000000000000000000'), 0),
+        (objectid.ObjectId('000000000000000100000000'), 2**32),
+        (objectid.ObjectId('0000000000000000ffffffff'), 2**32 - 1),
+        (objectid.ObjectId('000000010000000000000000'), 2**64),
+        (objectid.ObjectId('00000000ffffffffffffffff'), 2**64 - 1),
+        (objectid.ObjectId('ffffffffffffffffffffffff'), 2**96 - 1),
     ]
     for (id, number) in test_cases:
       self.assertEqual(id, _ObjectIdHelper.int_to_id(number))
       self.assertEqual(number, _ObjectIdHelper.id_to_int(id))
 
     # random tests
-    for i in range(100):
+    for _ in range(100):
       id = objectid.ObjectId()
-      number = int(id.binary.encode('hex'), 16)
+      if sys.version_info[0] < 3:
+        number = int(id.binary.encode('hex'), 16)
+      else: # PY3
+        number = int(id.binary.hex(), 16)
       self.assertEqual(id, _ObjectIdHelper.int_to_id(number))
       self.assertEqual(number, _ObjectIdHelper.id_to_int(id))
 
-
   def test_increment_id(self):
-    self.fail()
+    test_cases = [
+        (objectid.ObjectId('000000000000000100000000'),
+         objectid.ObjectId('0000000000000000ffffffff')),
+        (objectid.ObjectId('000000010000000000000000'),
+         objectid.ObjectId('00000000ffffffffffffffff')),
+    ]
+    for (first, second) in test_cases:
+      self.assertEqual(second, _ObjectIdHelper.increment_id(first, -1))
+      self.assertEqual(first, _ObjectIdHelper.increment_id(second, 1))
+
+    for _ in range(100):
+      id = objectid.ObjectId()
+      self.assertLess(id, _ObjectIdHelper.increment_id(id, 1))
+      self.assertGreater(id, _ObjectIdHelper.increment_id(id, -1))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/io/mongodbio_test.py
+++ b/sdks/python/apache_beam/io/mongodbio_test.py
@@ -16,11 +16,13 @@
 
 from __future__ import absolute_import
 
+import datetime
 import logging
 import unittest
 
 import mock
 from bson import objectid
+from pymongo import ASCENDING
 from pymongo import ReplaceOne
 
 import apache_beam as beam
@@ -30,38 +32,102 @@ from apache_beam.io import source_test_utils
 from apache_beam.io.mongodbio import _BoundedMongoSource
 from apache_beam.io.mongodbio import _GenerateObjectIdFn
 from apache_beam.io.mongodbio import _MongoSink
+from apache_beam.io.mongodbio import _ObjectIdRangeTracker
 from apache_beam.io.mongodbio import _WriteMongoFn
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 
 
+class _MockMongoColl(object):
+  def __init__(self, docs):
+    self.docs = docs
+
+  def _filter(self, filter):
+    match = []
+    if not filter:
+      return self
+    start = filter['_id'].get('$gte')
+    end = filter['_id'].get('$lt')
+    for doc in self.docs:
+      if start and doc['_id'] < start:
+        continue
+      if end and doc['_id'] >= end:
+        continue
+      match.append(doc)
+    return match
+
+  def find(self, filter=None, **kwargs):
+    return _MockMongoColl(self._filter(filter))
+
+  def sort(self, sort_items):
+    key, order = sort_items[0]
+    self.docs = sorted(self.docs,
+                       key=lambda x: x[key],
+                       reverse=(order != ASCENDING))
+    return self
+
+  def limit(self, num):
+    return _MockMongoColl(self.docs[0:num])
+
+  def count_documents(self, filter):
+    return len(self._filter(filter))
+
+  def __getitem__(self, item):
+    return self.docs[item]
+
+
 class MongoSourceTest(unittest.TestCase):
-  @mock.patch('apache_beam.io.mongodbio._BoundedMongoSource'
-              '._get_document_count')
-  @mock.patch('apache_beam.io.mongodbio._BoundedMongoSource'
-              '._get_avg_document_size')
-  def setUp(self, mock_size, mock_count):
-    mock_size.return_value = 10
-    mock_count.return_value = 5
+  @mock.patch('apache_beam.io.mongodbio.MongoClient')
+  def setUp(self, mock_client):
+    mock_client.return_value.__enter__.return_value.__getitem__ \
+      .return_value.command.return_value = {'size': 5, 'avgSize': 1}
+    self._ids = [
+        objectid.ObjectId.from_datetime(
+            datetime.datetime(year=2020, month=i + 1, day=i + 1))
+        for i in range(5)
+    ]
+    self._docs = [{'_id': self._ids[i], 'x': i} for i in range(len(self._ids))]
+
     self.mongo_source = _BoundedMongoSource('mongodb://test', 'testdb',
                                             'testcoll')
 
-  def test_estimate_size(self):
-    self.assertEqual(self.mongo_source.estimate_size(), 50)
+  def get_split(self, command, ns, min, max, maxChunkSize, **kwargs):
+    # assuming every doc is of size 1mb
+    start_id = min['_id']
+    end_id = max['_id']
+    if start_id >= end_id:
+      return []
+    start_index = 0
+    end_index = 0
+    for id in self._ids:
+      if id < start_id:
+        start_index += 1
+      if id <= end_id:
+        end_index += 1
+      else:
+        break
+    return {
+        'splitKeys':
+        [x for x in self._ids[start_index:end_index:maxChunkSize]][1:]
+    }
+
+  @mock.patch('apache_beam.io.mongodbio.MongoClient')
+  def test_estimate_size(self, mock_client):
+    mock_client.return_value.__enter__.return_value.__getitem__ \
+      .return_value.command.return_value = {'size': 5, 'avgSize': 1}
+    self.assertEqual(self.mongo_source.estimate_size(), 5)
 
   @mock.patch('apache_beam.io.mongodbio.MongoClient')
   def test_split(self, mock_client):
-    # desired bundle size is 1 times of avg doc size, each bundle contains 1
-    # documents
     mock_client.return_value.__enter__.return_value.__getitem__.return_value \
-      .__getitem__.return_value.find.return_value = [{'x': 1}, {'x': 2},
-                                                     {'x': 3}, {'x': 4},
-                                                     {'x': 5}]
-    for size in [10, 20, 100]:
+      .__getitem__.return_value = _MockMongoColl(self._docs)
+    mock_client.return_value.__enter__.return_value.__getitem__.return_value \
+      .command.side_effect = self.get_split
+    for size in [i * 1024 * 1024 for i in (1, 2, 10)]:
       splits = list(
-          self.mongo_source.split(start_position=0,
-                                  stop_position=5,
+          self.mongo_source.split(start_position=None,
+                                  stop_position=None,
                                   desired_bundle_size=size))
 
       reference_info = (self.mongo_source, None, None)
@@ -71,37 +137,38 @@ class MongoSourceTest(unittest.TestCase):
           reference_info, sources_info)
 
   @mock.patch('apache_beam.io.mongodbio.MongoClient')
-  def test_dynamic_work_rebalancing(self, mock_client):
-    splits = list(self.mongo_source.split(desired_bundle_size=3000))
+  @mock.patch('apache_beam.io.mongodbio._BoundedMongoSource'
+              '._get_last_document_id')
+  def test_dynamic_work_rebalancing(self, mock_last_id, mock_client):
+    mock_last_id.return_value = self._ids[-1]
     mock_client.return_value.__enter__.return_value.__getitem__.return_value \
-      .__getitem__.return_value.find.return_value = [{'x': 1}, {'x': 2},
-                                                     {'x': 3}, {'x': 4},
-                                                     {'x': 5}]
+      .__getitem__.return_value = _MockMongoColl(self._docs)
+    mock_client.return_value.__enter__.return_value.__getitem__.return_value \
+      .command.side_effect = self.get_split
+    splits = list(
+        self.mongo_source.split(desired_bundle_size=3000 * 1024 * 1024))
     assert len(splits) == 1
     source_test_utils.assert_split_at_fraction_exhaustive(
         splits[0].source, splits[0].start_position, splits[0].stop_position)
 
-  @mock.patch('apache_beam.io.mongodbio.OffsetRangeTracker')
-  def test_get_range_tracker(self, mock_tracker):
-    self.mongo_source.get_range_tracker(None, None)
-    mock_tracker.assert_called_with(0, 5)
-    self.mongo_source.get_range_tracker(10, 20)
-    mock_tracker.assert_called_with(10, 20)
+  @mock.patch('apache_beam.io.mongodbio.MongoClient')
+  def test_get_range_tracker(self, mock_client):
+    mock_client.return_value.__enter__.return_value.__getitem__.return_value \
+      .__getitem__.return_value = _MockMongoColl(self._docs)
+    self.assertIsInstance(self.mongo_source.get_range_tracker(None, None),
+                          _ObjectIdRangeTracker)
 
   @mock.patch('apache_beam.io.mongodbio.MongoClient')
   def test_read(self, mock_client):
     mock_tracker = mock.MagicMock()
-    mock_tracker.try_claim.return_value = True
-    mock_tracker.start_position.return_value = 0
-    mock_tracker.stop_position.return_value = 2
+    mock_tracker.start_position.return_value = self._ids[0]
+    mock_tracker.stop_position.return_value = self._ids[2]
 
-    mock_client.return_value.__enter__.return_value.__getitem__.return_value\
-      .__getitem__.return_value.find.return_value = [{'x':1}, {'x':2}]
+    mock_client.return_value.__enter__.return_value.__getitem__.return_value \
+      .__getitem__.return_value = _MockMongoColl(self._docs)
 
-    result = []
-    for i in self.mongo_source.read(mock_tracker):
-      result.append(i)
-    self.assertListEqual([{'x': 1}, {'x': 2}], result)
+    result = list(self.mongo_source.read(mock_tracker))
+    self.assertListEqual(self._docs[0:2], result)
 
   def test_display_data(self):
     data = self.mongo_source.display_data()
@@ -109,35 +176,19 @@ class MongoSourceTest(unittest.TestCase):
     self.assertTrue('database' in data)
     self.assertTrue('collection' in data)
 
-  @mock.patch('apache_beam.io.mongodbio.MongoClient')
-  def test__get_avg_document_size(self, mock_client):
-    mock_client.return_value.__enter__.return_value.__getitem__\
-      .return_value.command.return_value = {'avgObjSize': 5}
-    self.assertEqual(5, self.mongo_source._get_avg_document_size())
-
-  @mock.patch('apache_beam.io.mongodbio.MongoClient')
-  def test_get_document_count(self, mock_client):
-    mock_client.return_value.__enter__.return_value.__getitem__ \
-      .return_value.__getitem__.return_value.count_documents.return_value = 10
-
-    self.assertEqual(10, self.mongo_source._get_document_count())
-
 
 class ReadFromMongoDBTest(unittest.TestCase):
   @mock.patch('apache_beam.io.mongodbio.MongoClient')
   def test_read_from_mongodb(self, mock_client):
-    objects = [{'x': 1}, {'x': 2}]
-    mock_client.return_value.__enter__.return_value.__getitem__.return_value. \
-      command.return_value = {'avgObjSize': 1}
-    mock_client.return_value.__enter__.return_value.__getitem__.return_value. \
-      __getitem__.return_value.find.return_value = objects
-    mock_client.return_value.__enter__.return_value.__getitem__.return_value. \
-      __getitem__.return_value.count_documents.return_value = 2
+    documents = [{'_id': objectid.ObjectId(), 'x': i} for i in range(3)]
+    # use index value as id
+    mock_client.return_value.__enter__.return_value.__getitem__.return_value \
+      .__getitem__.return_value = _MockMongoColl(documents)
 
     with TestPipeline() as p:
       docs = p | 'ReadFromMongoDB' >> ReadFromMongoDB(
           uri='mongodb://test', db='db', coll='collection')
-      assert_that(docs, equal_to(objects))
+      assert_that(docs, equal_to(documents))
 
 
 class GenerateObjectIdFnTest(unittest.TestCase):
@@ -190,7 +241,7 @@ class WriteToMongoDBTest(unittest.TestCase):
       _ = (p | "Create" >> beam.Create(docs)
            | "Write" >> WriteToMongoDB(db='test', coll='test'))
       p.run()
-      mock_client.return_value.__getitem__.return_value.__getitem__.\
+      mock_client.return_value.__getitem__.return_value.__getitem__. \
         return_value.bulk_write.assert_called_with(expected_update)
 
   @mock.patch('apache_beam.io.mongodbio.MongoClient')

--- a/sdks/python/apache_beam/io/mongodbio_test.py
+++ b/sdks/python/apache_beam/io/mongodbio_test.py
@@ -52,8 +52,10 @@ class _MockMongoColl(object):
     match = []
     if not filter:
       return self
-    start = filter['_id'].get('$gte')
-    end = filter['_id'].get('$lt')
+    if '$and' not in filter or not filter['$and']:
+      return self
+    start = filter['$and'][0]['_id'].get('$gte')
+    end = filter['$and'][0]['_id'].get('$lt')
     assert start is not None
     assert end is not None
     for doc in self.docs:
@@ -306,7 +308,7 @@ class ObjectIdHelperTest(TestCase):
       id = objectid.ObjectId()
       if sys.version_info[0] < 3:
         number = int(id.binary.encode('hex'), 16)
-      else: # PY3
+      else:  # PY3
         number = int(id.binary.hex(), 16)
       self.assertEqual(id, _ObjectIdHelper.int_to_id(number))
       self.assertEqual(number, _ObjectIdHelper.id_to_int(id))


### PR DESCRIPTION
Change the liquid sharding split strategy to use splitVector command in mongodb to make sure the split range is deterministic and non-overlapping.
Remove all IO operations in initializing the class to avoid slow startup or unavailability issues.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
