### PR TITLE
Add assertArrayCountEqual, which checks if two containers have the same elements

### DIFF
--- a/sdks/python/apache_beam/testing/extra_assertions.py
+++ b/sdks/python/apache_beam/testing/extra_assertions.py
@@ -1,0 +1,102 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import itertools
+import sys
+
+import numpy as np
+from past.builtins import unicode
+
+
+class ExtraAssertionsMixin(object):
+
+  if sys.version_info[0] < 3:
+
+    def assertCountEqual(self, first, second, msg=None):
+      """Assert that two containers have the same number of the same items in
+      any order.
+      """
+      return self.assertItemsEqual(first, second, msg=msg)
+
+  def assertArrayCountEqual(self, data1, data2):
+    """Assert that two containers have the same items, with special treatment
+    for numpy arrays.
+    """
+    try:
+      self.assertEqual(type(data1), type(data2))
+    except AssertionError:
+      # Since 'a' == u'a', we should not automatically treat strings of
+      # different type as different.
+      self.assertTrue(isinstance(data1, (str, unicode)))
+      self.assertTrue(isinstance(data2, (str, unicode)))
+
+    # self.assertCountEqual is much faster, so try it first.
+    try:
+      return self.assertCountEqual(data1, data2)
+    except (TypeError, ValueError):
+      pass
+
+    try:
+      data1 = list(data1)
+      data2 = list(data2)
+    except TypeError:
+      # Elements are not iterable.
+      return self.assertEqual(data1, data2)
+    else:
+      # Containers must have the same length.
+      self.assertEqual(len(data1), len(data2))
+
+    # We can check for equality much faster for hashable objects
+    data1_hashable, data1 = self._split_into_hash_nonhash(data1)
+    data2_hashable, data2 = self._split_into_hash_nonhash(data2)
+    self.assertCountEqual(data1_hashable, data2_hashable)
+
+    if isinstance(data1, (str, bytes, unicode)):
+      return self.assertEqual(data1, data2)
+
+    if isinstance(data1, dict):
+      self.assertCountEqual(list(data1.keys()), list(data2.keys()))
+      for key in data1:
+        self.assertArrayCountEqual(data1[key], data2[key])
+      return
+
+    if isinstance(data1, np.ndarray):
+      return np.testing.assert_array_almost_equal(data1, data2)
+
+    # Performance here is terrible: O(n!), and larger for nested containers.
+    for data2_perm in itertools.permutations(data2):
+      try:
+        for d1, d2 in zip(data1, data2_perm):
+          self.assertArrayCountEqual(d1, d2)
+      except AssertionError:
+        continue
+      return
+    raise AssertionError(
+        "The two objects '{}' and '{}' do not contain the same elements.".
+        format(data1, data2))
+
+  def _split_into_hash_nonhash(self, data):
+    data_hash = []
+    data_nonhash = []
+    for value in data:
+      try:
+        hash(value)
+        data_hash.append(value)
+      except TypeError:
+        data_nonhash.append(value)
+    return data_hash, data_nonhash

--- a/sdks/python/apache_beam/testing/extra_assertions_test.py
+++ b/sdks/python/apache_beam/testing/extra_assertions_test.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import logging
+import unittest
+
+import numpy as np
+
+from apache_beam.testing.extra_assertions import ExtraAssertionsMixin
+
+
+class ExtraAssertionsMixinTest(ExtraAssertionsMixin, unittest.TestCase):
+
+  def test_assert_array_count_equal_strings(self):
+    data1 = [u"±♠Ωℑ", u"hello", "world"]
+    data2 = ["hello", u"±♠Ωℑ", u"world"]
+    self.assertArrayCountEqual(data1, data2)
+
+  def test_assert_array_count_equal_mixed(self):
+    # TODO(ostrokach): Add a timeout, since if assertArrayCountEqual is not
+    # implemented efficiently, this test has the potential to run for a very
+    # long time.
+    data1 = [
+        #
+        {'a': 1, 123: 1.234},
+        ['d', 1],
+        u"±♠Ωℑ",
+        np.zeros((3, 6)),
+        (1, 2, 3, 'b'),
+        'def',
+        100,
+        'abc',
+        ('a', 'b', 'c'),
+        None
+    ]
+    data2 = [
+        #
+        {'a': 1, 123: 1.234},
+        ('a', 'b', 'c'),
+        ['d', 1],
+        None,
+        'abc',
+        'def',
+        u"±♠Ωℑ",
+        100,
+        (1, 2, 3, 'b'),
+        np.zeros((3, 6))
+    ]
+    self.assertArrayCountEqual(data1, data2)
+    self.assertArrayCountEqual(data1 * 2, data2 * 2)
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()


### PR DESCRIPTION
Add `assertArrayCountEqual`, which is similar to [`assertCountEqual`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertCountEqual) but also supports numpy arrays. This is useful for integration and end-to-end tests where we want to validate PCollections which contain numpy arrays among other data types.

For examples of where these functions are used, see: apache/beam#8884, apache/beam#8961.

R: @aaltay

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
