### PR TITLE
[BEAM-7742] Partition files in BQFL to cater to quotas & limits

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -267,6 +267,7 @@ class WriteGroupedRecordsToFile(beam.DoFn):
         yield (destination, (file_path, file_size))
         file_path, writer = None, None
     if writer is not None:
+      writer.close()
       yield (destination, (file_path, file_size))
 
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -700,14 +700,14 @@ class BigQueryBatchFileLoads(beam.PTransform):
     """Load data to BigQuery
 
     Data is loaded into BigQuery in the following two ways:
-      1. Single partition per destination:
+      1. Single partition:
          When there is a single partition of files destined to a single
-         destination, a single load job is triggered for each partition.
-      2. Multiple partitions per destination:
+         destination, a single load job is triggered.
+      2. Multiple partitions and/or Dynamic Destinations:
          When there are multiple partitions of files destined for a single
-         destination, due to load job size constraints, multiple load jobs
-         need to be triggered for each partition. Load Jobs are triggered
-         to temporary tables, and those are later copied to the actual
+         destination or when Dynamic Destinations are used, multiple load jobs
+         need to be triggered for each partition/destination. Load Jobs are
+         triggered to temporary tables, and those are later copied to the actual
          appropriate destination table. This ensures atomicity when only some
          of the load jobs would fail but not other. If any of them fails, then
          copy jobs are not triggered.

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -465,8 +465,9 @@ class PartitionFiles(beam.DoFn):
         latest_partition.add(file_path, file_size)
       else:
         partitions.append(latest_partition.files)
-        latest_partition = PartitionFiles.\
-          Partition(self.max_partition_size, self.max_files_per_partition)
+        latest_partition = PartitionFiles.Partition(
+            self.max_partition_size,
+            self.max_files_per_partition)
         latest_partition.add(file_path, file_size)
     partitions.append(latest_partition.files)
 
@@ -820,10 +821,10 @@ class BigQueryBatchFileLoads(beam.PTransform):
                   .with_outputs(PartitionFiles.MULTIPLE_PARTITIONS_TAG,
                                 PartitionFiles.SINGLE_PARTITION_TAG))
 
-    multiple_partitions_per_destination_pc = partitions[PartitionFiles\
-      .MULTIPLE_PARTITIONS_TAG]
-    single_partition_per_destination_pc = partitions[PartitionFiles\
-      .SINGLE_PARTITION_TAG]
+    multiple_partitions_per_destination_pc = partitions[
+        PartitionFiles.MULTIPLE_PARTITIONS_TAG]
+    single_partition_per_destination_pc = partitions[
+        PartitionFiles.SINGLE_PARTITION_TAG]
 
     # When using dynamic destinations, elements with both single as well as
     # multiple partitions are loaded into BigQuery using temporary tables to

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -447,22 +447,22 @@ class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
     with TestPipeline('DirectRunner') as p:
       outputs = (p
                  | beam.Create(_ELEMENTS)
-                 | bqfl.BigQueryBatchFileLoads(destination,
-                                               custom_gcs_temp_location=self\
-                                                ._new_tempdir(),
-                                               test_client=bq_client,
-                                               validate=False,
-                                               coder=CustomRowCoder(),
-                                               max_file_size=45,
-                                               max_partition_size=80,
-                                               max_files_per_partition=2))
+                 | bqfl.BigQueryBatchFileLoads(
+                     destination,
+                     custom_gcs_temp_location=self._new_tempdir(),
+                     test_client=bq_client,
+                     validate=False,
+                     coder=CustomRowCoder(),
+                     max_file_size=45,
+                     max_partition_size=80,
+                     max_files_per_partition=2))
 
-      dest_files = outputs[bqfl.BigQueryBatchFileLoads\
-          .DESTINATION_FILE_PAIRS]
-      dest_load_jobs = outputs[bqfl.BigQueryBatchFileLoads\
-          .DESTINATION_JOBID_PAIRS]
-      dest_copy_jobs = outputs[bqfl.BigQueryBatchFileLoads\
-          .DESTINATION_COPY_JOBID_PAIRS]
+      dest_files = outputs[
+          bqfl.BigQueryBatchFileLoads.DESTINATION_FILE_PAIRS]
+      dest_load_jobs = outputs[
+          bqfl.BigQueryBatchFileLoads.DESTINATION_JOBID_PAIRS]
+      dest_copy_jobs = outputs[
+          bqfl.BigQueryBatchFileLoads.DESTINATION_COPY_JOBID_PAIRS]
 
       load_jobs = dest_load_jobs | "GetLoadJobs" >> beam.Map(lambda x: x[1])
       copy_jobs = dest_copy_jobs | "GetCopyJobs" >> beam.Map(lambda x: x[1])


### PR DESCRIPTION
Partition files written based on:
1. Total size of load job
2. Max files per load job
This ensures that all load jobs are triggered are respect the
limits.
Temp tables are only used when there are multiple partitions
per destination. For destinations with a single destination,
data is loaded directly to the destination table.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
