### PR TITLE
[BEAM-7829] Add schema names when converting with AvroUtils.toAvroSchema

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -61,6 +61,7 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.CaseFormat;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.joda.time.Days;
@@ -161,8 +162,8 @@ public class AvroUtils {
     }
 
     /** Convert to an AVRO type. */
-    public org.apache.avro.Schema toAvroType() {
-      return org.apache.avro.Schema.createFixed(null, "", "", size);
+    public org.apache.avro.Schema toAvroType(String name, String namespace) {
+      return org.apache.avro.Schema.createFixed(name, null, namespace, size);
     }
   }
 
@@ -174,12 +175,11 @@ public class AvroUtils {
   }
 
   /** Get Avro Field from Beam Field. */
-  public static org.apache.avro.Schema.Field toAvroField(Schema.Field field) {
-    org.apache.avro.Schema fieldSchema = getFieldSchema(field.getName(), field.getType());
-    org.apache.avro.Schema.Field avroField =
-        new org.apache.avro.Schema.Field(
-            field.getName(), fieldSchema, field.getDescription(), (Object) null);
-    return avroField;
+  public static org.apache.avro.Schema.Field toAvroField(Schema.Field field, String namespace) {
+    org.apache.avro.Schema fieldSchema =
+        getFieldSchema(field.getType(), field.getName(), namespace);
+    return new org.apache.avro.Schema.Field(
+        field.getName(), fieldSchema, field.getDescription(), (Object) null);
   }
 
   private AvroUtils() {}
@@ -204,18 +204,22 @@ public class AvroUtils {
   }
 
   /** Converts a Beam Schema into an AVRO schema. */
-  private static org.apache.avro.Schema toAvroSchema(@Nullable String name, Schema beamSchema) {
-    final String schemaName = (name == null) ? "topLevelRecord" : name;
+  private static org.apache.avro.Schema toAvroSchema(
+      Schema beamSchema, @Nullable String name, @Nullable String namespace) {
+    final String schemaName = Strings.isNullOrEmpty(name) ? "topLevelRecord" : name;
+    final String schemaNamespace = namespace == null ? "" : namespace;
+    String childNamespace =
+        !"".equals(schemaNamespace) ? schemaNamespace + "." + schemaName : schemaName;
     List<org.apache.avro.Schema.Field> fields = Lists.newArrayList();
     for (Schema.Field field : beamSchema.getFields()) {
-      org.apache.avro.Schema.Field recordField = toAvroField(field);
+      org.apache.avro.Schema.Field recordField = toAvroField(field, childNamespace);
       fields.add(recordField);
     }
-    return org.apache.avro.Schema.createRecord(schemaName, null, null, false, fields);
+    return org.apache.avro.Schema.createRecord(schemaName, null, schemaNamespace, false, fields);
   }
 
   public static org.apache.avro.Schema toAvroSchema(Schema beamSchema) {
-    return toAvroSchema(null, beamSchema);
+    return toAvroSchema(beamSchema, null, null);
   }
 
   /**
@@ -543,7 +547,7 @@ public class AvroUtils {
   }
 
   private static org.apache.avro.Schema getFieldSchema(
-      String fieldName, Schema.FieldType fieldType) {
+      Schema.FieldType fieldType, String fieldName, String namespace) {
     org.apache.avro.Schema baseType;
     switch (fieldType.getTypeName()) {
       case BYTE:
@@ -592,7 +596,7 @@ public class AvroUtils {
       case LOGICAL_TYPE:
         FixedBytesField fixedBytesField = FixedBytesField.fromBeamFieldType(fieldType);
         if (fixedBytesField != null) {
-          baseType = fixedBytesField.toAvroType();
+          baseType = fixedBytesField.toAvroType("fixed", namespace + "." + fieldName);
         } else {
           throw new RuntimeException(
               "Unhandled logical type " + fieldType.getLogicalType().getIdentifier());
@@ -602,7 +606,7 @@ public class AvroUtils {
       case ARRAY:
         baseType =
             org.apache.avro.Schema.createArray(
-                getFieldSchema(fieldName, fieldType.getCollectionElementType()));
+                getFieldSchema(fieldType.getCollectionElementType(), fieldName, namespace));
         break;
 
       case MAP:
@@ -610,14 +614,14 @@ public class AvroUtils {
           // Avro only supports string keys in maps.
           baseType =
               org.apache.avro.Schema.createMap(
-                  getFieldSchema(fieldName, fieldType.getMapValueType()));
+                  getFieldSchema(fieldType.getMapValueType(), fieldName, namespace));
         } else {
           throw new IllegalArgumentException("Avro only supports maps with string keys");
         }
         break;
 
       case ROW:
-        baseType = toAvroSchema(fieldName, fieldType.getRowSchema());
+        baseType = toAvroSchema(fieldType.getRowSchema(), fieldName, namespace);
         break;
 
       default:

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/AvroUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/AvroUtilsTest.java
@@ -187,8 +187,8 @@ public class AvroUtilsTest {
     return fields;
   }
 
-  private static org.apache.avro.Schema getAvroSubSchema() {
-    return org.apache.avro.Schema.createRecord(getAvroSubSchemaFields());
+  private static org.apache.avro.Schema getAvroSubSchema(String name) {
+    return org.apache.avro.Schema.createRecord(name, null, null, false, getAvroSubSchemaFields());
   }
 
   private static org.apache.avro.Schema getAvroSchema() {
@@ -227,14 +227,17 @@ public class AvroUtilsTest {
             LogicalTypes.timestampMillis().addToSchema(org.apache.avro.Schema.create(Type.LONG)),
             "",
             (Object) null));
-    fields.add(new org.apache.avro.Schema.Field("row", getAvroSubSchema(), "", (Object) null));
+    fields.add(new org.apache.avro.Schema.Field("row", getAvroSubSchema("row"), "", (Object) null));
     fields.add(
         new org.apache.avro.Schema.Field(
-            "array", org.apache.avro.Schema.createArray(getAvroSubSchema()), "", (Object) null));
+            "array",
+            org.apache.avro.Schema.createArray(getAvroSubSchema("array")),
+            "",
+            (Object) null));
     fields.add(
         new org.apache.avro.Schema.Field(
-            "map", org.apache.avro.Schema.createMap(getAvroSubSchema()), "", (Object) null));
-    return org.apache.avro.Schema.createRecord(fields);
+            "map", org.apache.avro.Schema.createMap(getAvroSubSchema("map")), "", (Object) null));
+    return org.apache.avro.Schema.createRecord("topLevelRecord", null, null, false, fields);
   }
 
   private static Schema getBeamSubSchema() {
@@ -285,9 +288,14 @@ public class AvroUtilsTest {
         .build();
   }
 
+  private static GenericRecord getSubGenericRecord(String name) {
+    return new GenericRecordBuilder(getAvroSubSchema(name))
+        .set("bool", true)
+        .set("int", 42)
+        .build();
+  }
+
   private static GenericRecord getGenericRecord() {
-    GenericRecord subRecord =
-        new GenericRecordBuilder(getAvroSubSchema()).set("bool", true).set("int", 42).build();
 
     LogicalType decimalType =
         LogicalTypes.decimal(Integer.MAX_VALUE)
@@ -306,9 +314,15 @@ public class AvroUtilsTest {
         .set("bytes", ByteBuffer.wrap(BYTE_ARRAY))
         .set("decimal", encodedDecimal)
         .set("timestampMillis", DATE_TIME.getMillis())
-        .set("row", subRecord)
-        .set("array", ImmutableList.of(subRecord, subRecord))
-        .set("map", ImmutableMap.of(new Utf8("k1"), subRecord, new Utf8("k2"), subRecord))
+        .set("row", getSubGenericRecord("row"))
+        .set("array", ImmutableList.of(getSubGenericRecord("array"), getSubGenericRecord("array")))
+        .set(
+            "map",
+            ImmutableMap.of(
+                new Utf8("k1"),
+                getSubGenericRecord("map"),
+                new Utf8("k2"),
+                getSubGenericRecord("map")))
         .build();
   }
 
@@ -322,6 +336,14 @@ public class AvroUtilsTest {
     Schema beamSchema = getBeamSchema();
     org.apache.avro.Schema avroSchema = AvroUtils.toAvroSchema(beamSchema);
     assertEquals(getAvroSchema(), avroSchema);
+  }
+
+  @Test
+  public void testAvroSchemaFromBeamSchemaCanBeParsed() {
+    Schema beamSchema = getBeamSchema();
+    String stringSchema = AvroUtils.toAvroSchema(getBeamSchema()).toString();
+    org.apache.avro.Schema schema = new org.apache.avro.Schema.Parser().parse(stringSchema);
+    assertEquals(stringSchema, schema.toString());
   }
 
   @Test
@@ -344,7 +366,8 @@ public class AvroUtilsTest {
                 ReflectData.makeNullable(org.apache.avro.Schema.create(Type.INT))),
             "",
             null));
-    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord(fields);
+    org.apache.avro.Schema avroSchema =
+        org.apache.avro.Schema.createRecord("topLevelRecord", null, null, false, fields);
 
     Schema expectedSchema =
         Schema.builder()
@@ -398,7 +421,8 @@ public class AvroUtilsTest {
                 ReflectData.makeNullable(org.apache.avro.Schema.create(Type.INT))),
             "",
             null));
-    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord(fields);
+    org.apache.avro.Schema avroSchema =
+        org.apache.avro.Schema.createRecord("topLevelRecord", null, null, false, fields);
     assertEquals(avroSchema, AvroUtils.toAvroSchema(beamSchema));
 
     Map<Utf8, Object> nullMapUtf8 = Maps.newHashMap();
@@ -445,7 +469,7 @@ public class AvroUtilsTest {
             false,
             getAvroSubSchemaFields());
     GenericRecord record =
-        new GenericRecordBuilder(getAvroSubSchema()).set("bool", true).set("int", 42).build();
+        new GenericRecordBuilder(getAvroSubSchema("simple")).set("bool", true).set("int", 42).build();
 
     PCollection<GenericRecord> records =
         pipeline.apply(Create.of(record).withCoder(AvroCoder.of(schema)));


### PR DESCRIPTION
There's a subtle problem with unnamed records in Avro and Java -- they can be used to correctly serialize/deserialize binary data as long as nobody counts on serializing/deserializing the actual Avro schema as a JSON string.

This *can* work if both reader and writer can infer the schema from another source (like the Beam Schema), but is certain to break when passing the schema or record to a transform that expects the schema to meet the Avro specification.

More discussion at: https://issues.apache.org/jira/browse/AVRO-2492

This change ensures that no anonymous Avro records will be created as part of translating a Beam schema.

*N.B.* Credit goes to @iemejia for this implementation, I just cleaned up the tests.

*N.B.2* I get _some_ minor credit :D  There were some bugs with potential namespace collisions.  The internal implementation here should be very close to what Spark does with auto-generated Avro schemas.

R: @reuvenlax @kanterov 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
