### PR TITLE
[BEAM-7060] Type hints from Python 3 annotations

### DIFF
--- a/sdks/python/apache_beam/internal/util.py
+++ b/sdks/python/apache_beam/internal/util.py
@@ -62,7 +62,7 @@ class ArgumentPlaceholder(object):
     return hash(type(self))
 
 
-def remove_objects_from_args(args, kwargs, pvalue_classes):
+def remove_objects_from_args(args, kwargs, pvalue_class):
   """For internal use only; no backwards-compatibility guarantees.
 
   Replaces all objects of a given type in args/kwargs with a placeholder.
@@ -70,9 +70,8 @@ def remove_objects_from_args(args, kwargs, pvalue_classes):
   Args:
     args: A list of positional arguments.
     kwargs: A dictionary of keyword arguments.
-    pvalue_classes: A tuple of class objects representing the types of the
-      arguments that must be replaced with a placeholder value (instance of
-      ArgumentPlaceholder)
+    pvalue_class: A class object representing the types of arguments that must
+      be replaced with a placeholder value (instance of ArgumentPlaceholder).
 
   Returns:
     A 3-tuple containing a modified list of positional arguments, a modified
@@ -84,11 +83,11 @@ def remove_objects_from_args(args, kwargs, pvalue_classes):
   def swapper(value):
     pvals.append(value)
     return ArgumentPlaceholder()
-  new_args = [swapper(v) if isinstance(v, pvalue_classes) else v for v in args]
+  new_args = [swapper(v) if isinstance(v, pvalue_class) else v for v in args]
   # Make sure the order in which we process the dictionary keys is predictable
   # by sorting the entries first. This will be important when putting back
   # PValues.
-  new_kwargs = dict((k, swapper(v)) if isinstance(v, pvalue_classes) else (k, v)
+  new_kwargs = dict((k, swapper(v)) if isinstance(v, pvalue_class) else (k, v)
                     for k, v in sorted(kwargs.items()))
   return (new_args, new_kwargs, pvals)
 

--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -40,6 +40,8 @@ cdef class MethodWrapper(object):
   cdef object timestamp_arg_name
   cdef object window_arg_name
   cdef object key_arg_name
+  cdef object restriction_provider
+  cdef object restriction_provider_arg_name
 
 
 cdef class DoFnSignature(object):

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -263,10 +263,6 @@ class DoFnSignature(object):
 
   def get_restriction_provider(self):
     return self.process_method.restriction_provider
-    # TODO: test and remove
-    # result = _find_param_with_default(self.process_method,
-    #                                   default_as_type=DoFn.RestrictionParam)
-    # return result[1].restriction_provider if result else None
 
   def _validate(self):
     self._validate_process()
@@ -277,7 +273,6 @@ class DoFnSignature(object):
   def _validate_process(self):
     """Validate that none of the DoFnParameters are repeated in the function
     """
-    # TODO: test defaults usage
     param_ids = [d.param_id for d in self.process_method.defaults
                  if isinstance(d, core._DoFnParam)]
     if len(param_ids) != len(set(param_ids)):
@@ -289,7 +284,6 @@ class DoFnSignature(object):
     """Validate that none of the DoFnParameters are used in the function
     """
     for param in core.DoFn.DoFnProcessParams:
-      # TODO: test defaults usage
       if param in method_wrapper.defaults:
         raise ValueError(
             'DoFn.process() method-only parameter %s cannot be used in %s.' %
@@ -299,8 +293,6 @@ class DoFnSignature(object):
     userstate.validate_stateful_dofn(self.do_fn)
 
   def is_splittable_dofn(self):
-    # TODO: test defaults usage
-    # TODO: swap impl with this, need to test
     return self.get_restriction_provider() is not None
 
   def is_stateful_dofn(self):
@@ -363,7 +355,6 @@ class DoFnInvoker(object):
                                 allows a callback to be registered.
     """
     side_inputs = side_inputs or []
-    # TODO: test defaults usage
     default_arg_values = signature.process_method.defaults
     use_simple_invoker = not process_invocation or (
         not side_inputs and not input_args and not input_kwargs and
@@ -460,7 +451,6 @@ class PerWindowInvoker(DoFnInvoker):
     self.side_inputs = side_inputs
     self.context = context
     self.process_method = signature.process_method.method_value
-    # TODO: test defaults usage
     default_arg_values = signature.process_method.defaults
     self.has_windowed_inputs = (
         not all(si.is_globally_windowed() for si in side_inputs) or
@@ -571,10 +561,6 @@ class PerWindowInvoker(DoFnInvoker):
         # the upstream pair-with-restriction.
         raise NotImplementedError(
             'SDFs in multiply-windowed values with windowed arguments.')
-      # TODO: remove
-      # restriction_tracker_param = _find_param_with_default(
-      #     self.signature.process_method,
-      #     default_as_type=DoFn.RestrictionParam)[0]
       restriction_tracker_param = (
           self.signature.process_method.restriction_provider_arg_name)
       if not restriction_tracker_param:

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -233,6 +233,7 @@ class DataflowRunnerTest(unittest.TestCase):
       def display_data(self):
         return {'dofn_value': 42}
 
+      # TODO: why is this failing in this PR?
       def process(self):
         pass
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -233,7 +233,6 @@ class DataflowRunnerTest(unittest.TestCase):
       def display_data(self):
         return {'dofn_value': 42}
 
-      # TODO: why is this failing in this PR?
       def process(self):
         pass
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -670,7 +670,7 @@ class CallableWrapperDoFn(DoFn):
       try:
         fn_type_hints.strip_iterable()
       except ValueError as e:
-        raise ValueError('Return value not iterable: %s: %s' % (self, e))
+        raise ValueError('Return value not iterable: %s: %s' % (self._fn, e))
     type_hints = get_type_hints(self._fn).with_defaults(fn_type_hints)
     # If the fn was a DoFn annotated with a type-hint that hinted a return
     # type compatible with Iterable[Any], then we strip off the outer

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1511,7 +1511,7 @@ def Filter(fn, *args, **kwargs):  # pylint: disable=invalid-name
   elements.
 
   Args:
-    fn (Callable[..., bool]): a callable object. First argument will be an
+    fn (``Callable[..., bool]``): a callable object. First argument will be an
       element.
     *args: positional arguments passed to the transform callable.
     **kwargs: keyword arguments passed to the transform callable.

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -645,7 +645,7 @@ class CallableWrapperDoFn(DoFn):
     else:
       # For cases such as set / list where fn is callable but not a function
       self.process = lambda element: fn(element)
-      
+
     super(CallableWrapperDoFn, self).__init__()
 
   def display_data(self):

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -574,7 +574,10 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   def default_type_hints(self):
     fn_type_hints = typehints.decorators.IOTypeHints.from_callable(self.process)
     if fn_type_hints is not None:
-      fn_type_hints.strip_iterable()
+      try:
+        fn_type_hints.strip_iterable()
+      except ValueError as e:
+        raise ValueError('Return value not iterable: %s: %s' % (self, e))
     return fn_type_hints
 
   # TODO(sourabhbajaj): Do we want to remove the responsibility of these from
@@ -664,7 +667,10 @@ class CallableWrapperDoFn(DoFn):
   def default_type_hints(self):
     fn_type_hints = typehints.decorators.IOTypeHints.from_callable(self._fn)
     if fn_type_hints is not None:
-      fn_type_hints.strip_iterable()
+      try:
+        fn_type_hints.strip_iterable()
+      except ValueError as e:
+        raise ValueError('Return value not iterable: %s: %s' % (self, e))
     type_hints = get_type_hints(self._fn).with_defaults(fn_type_hints)
     # If the fn was a DoFn annotated with a type-hint that hinted a return
     # type compatible with Iterable[Any], then we strip off the outer

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -823,8 +823,6 @@ class _PTransformFnPTransform(PTransform):
 
     # TODO(BEAM-5878) Support keyword-only arguments.
     try:
-      # TODO(udim): This looks like unused code. When is 'type_hints' used as an
-      #   argument name?
       if 'type_hints' in get_signature(self._fn).parameters:
         args = (self.get_type_hints(),) + args
     except TypeError:
@@ -853,7 +851,7 @@ def ptransform_fn(fn):
   This wrapper provides an alternative, simpler way to define a PTransform.
   The standard method is to subclass from PTransform and override the expand()
   method. An equivalent effect can be obtained by defining a function that
-  an input PCollection and additional optional arguments and returns a
+  accepts an input PCollection and additional optional arguments and returns a
   resulting PCollection. For example::
 
     @ptransform_fn

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -767,10 +767,8 @@ class PTransformWithSideInputs(PTransform):
       arg_types = [pvalueish.element_type] + [element_type(v) for v in args]
       kwargs_types = {k: element_type(v) for (k, v) in kwargs.items()}
       argspec_fn = self._process_argspec_fn()
-      bindings = getcallargs_forhints(
-          False, argspec_fn, *arg_types, **kwargs_types)
-      hints = getcallargs_forhints(
-          True, argspec_fn, *type_hints[0], **type_hints[1])
+      bindings = getcallargs_forhints(argspec_fn, *arg_types, **kwargs_types)
+      hints = getcallargs_forhints(argspec_fn, *type_hints[0], **type_hints[1])
       for arg, hint in hints.items():
         if arg.startswith('__unknown__'):
           continue

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -395,12 +395,10 @@ class PTransform(WithTypeHints, HasDisplayData):
           'PTransform cannot have both positional and keyword type hints '
           'without overriding %s._type_check_%s()' % (
               self.__class__, input_or_output))
-    # TODO: what is root_hint?
     root_hint = (
         arg_hints[0] if len(arg_hints) == 1 else arg_hints or kwarg_hints)
     for context, pvalue_, hint in _ZipPValues().visit(pvalueish, root_hint):
       if pvalue_.element_type is None:
-        # TODO: remove this comment. We do get here
         # TODO(robertwb): It's a bug that we ever get here. (typecheck)
         continue
       if hint and not typehints.is_consistent_with(pvalue_.element_type, hint):
@@ -759,7 +757,6 @@ class PTransformWithSideInputs(PTransform):
   def type_check_inputs(self, pvalueish):
     type_hints = self.get_type_hints().input_types
     if type_hints:
-      # TODO: test when kwargs is not empty
       args, kwargs = self.raw_side_inputs
 
       def element_type(side_input):
@@ -770,13 +767,12 @@ class PTransformWithSideInputs(PTransform):
       arg_types = [pvalueish.element_type] + [element_type(v) for v in args]
       kwargs_types = {k: element_type(v) for (k, v) in kwargs.items()}
       argspec_fn = self._process_argspec_fn()
-      # TODO: test with non-empty kwargs_types (kwonly, var_keyword)
       bindings = getcallargs_forhints(
           False, argspec_fn, *arg_types, **kwargs_types)
       hints = getcallargs_forhints(
           True, argspec_fn, *type_hints[0], **type_hints[1])
       for arg, hint in hints.items():
-        if arg.startswith('__unknown__'):  # TODO: remove if unused
+        if arg.startswith('__unknown__'):
           continue
         if hint is None:
           continue
@@ -827,20 +823,10 @@ class _PTransformFnPTransform(PTransform):
 
     # TODO(BEAM-5878) Support keyword-only arguments.
     try:
-      # TODO: what is 'type_hints'? looking for a fn that has that arg?
+      # TODO(udim): This looks like unused code. When is 'type_hints' used as an
+      #   argument name?
       if 'type_hints' in get_signature(self._fn).parameters:
-        # TODO: coverage?
-        assert False
-        # TODO: what does this actually do? check coverage
-        # TODO: remove
-        # print('\n\n!!!!! weird magic detected !!!!!\n\n')
-        # TODO: remove
-        # print('args before:', args)
         args = (self.get_type_hints(),) + args
-        # TODO: remove
-        # print('args after:', args)
-        # TODO: remove
-        assert False
     except TypeError:
       # Might not be a function.
       pass

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 
 import collections
 import operator
-import os
 import re
 import sys
 import typing
@@ -845,7 +844,7 @@ class PTransformLabelsTest(unittest.TestCase):
     self.check_label(beam.CombinePerKey(sum), r'CombinePerKey(sum)')
 
     class MyDoFn(beam.DoFn):
-      def process(self):
+      def process(self, unused_element):
         pass
 
     self.check_label(beam.ParDo(MyDoFn()), r'ParDo(MyDoFn)')
@@ -859,7 +858,7 @@ class PTransformLabelsTest(unittest.TestCase):
     self.check_label('TestCPK' >> beam.CombinePerKey(sum), r'TestCPK')
 
     class MyDoFn(beam.DoFn):
-      def process(self):
+      def process(self, unused_element):
         pass
 
     self.check_label('TestParDo' >> beam.ParDo(MyDoFn()), r'TestParDo')
@@ -1870,10 +1869,6 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     assert_that(d, equal_to([[10, 9, 8]]))
     self.p.run()
 
-  @unittest.skipIf(sys.version_info >= (3, 7, 0) and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.7. '
-                   'See BEAM-6986')
   def test_top_of_runtime_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
 

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -193,6 +193,11 @@ def get_signature(func):
       params[0] = params[0].replace(annotation=func.__objclass__)
       signature = signature.replace(parameters=params)
 
+  # This is a specialization to hint the return value of type callables.
+  if (signature.return_annotation == signature.empty and
+      isinstance(func, type)):
+    signature = signature.replace(return_annotation=typehints.normalize(func))
+
   return signature
 
 
@@ -452,7 +457,7 @@ def getcallargs_forhints_impl_py2(func, typeargs, typekwargs):
         callargs[var] = typehints.Any
   # Patch up varargs and keywords
   if argspec.varargs:
-    # TODO(udim): This will always assign _ANY_VAR_POSITIONAL. Should be
+    # TODO(BEAM-8122): This will always assign _ANY_VAR_POSITIONAL. Should be
     #   "callargs.get(...) or _ANY_VAR_POSITIONAL".
     callargs[argspec.varargs] = typekwargs.get(
         argspec.varargs, _ANY_VAR_POSITIONAL)

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -344,8 +344,8 @@ class WithTypeHints(object):
 
     If type hints have not been set, attempts to initialize type hints in this
     order:
-      - Using self.default_type_hints().
-      - Using self.__class__ type hints.
+    - Using self.default_type_hints().
+    - Using self.__class__ type hints.
     """
     return (self._get_or_create_type_hints()
             .with_defaults(self.default_type_hints())

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -62,12 +62,12 @@ class IOTypeHintsTest(unittest.TestCase):
     # from_callable() injects an annotation in this special type of builtin.
     th = decorators.IOTypeHints.from_callable(str.strip)
     if sys.version_info >= (3, 7):
-      self.assertEqual(th.input_types, ([str, Any], {}))
+      self.assertEqual(th.input_types, ((str, Any), {}))
     else:
       self.assertEqual(th.input_types,
-                       ([str, decorators._ANY_VAR_POSITIONAL],
+                       ((str, decorators._ANY_VAR_POSITIONAL),
                         {'__unknown__keywords': decorators._ANY_VAR_KEYWORD}))
-    self.assertEqual(th.output_types, ([Any], {}))
+    self.assertEqual(th.output_types, ((Any,), {}))
 
 
 class WithTypeHintsTest(unittest.TestCase):

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -1,0 +1,127 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for decorators module."""
+
+from __future__ import absolute_import
+
+import sys
+import unittest
+
+from apache_beam.typehints import Any
+from apache_beam.typehints import TypeVariable
+from apache_beam.typehints import WithTypeHints
+from apache_beam.typehints import decorators
+
+
+class IOTypeHintsTest(unittest.TestCase):
+
+  def test_get_signature(self):
+    # Basic coverage only to make sure function works in Py2 and Py3.
+    def fn(a, b=1, *c, **d):
+      return a, b, c, d
+    s = decorators.get_signature(fn)
+    self.assertListEqual(list(s.parameters), ['a', 'b', 'c', 'd'])
+
+  def test_get_signature_builtin(self):
+    # Tests a builtin function for 3.7+ and fallback result for older versions.
+    s = decorators.get_signature(list)
+    if sys.version_info < (3, 7):
+      self.assertListEqual(list(s.parameters),
+                           ['_', '__unknown__varargs', '__unknown__keywords'])
+    else:
+      self.assertListEqual(list(s.parameters),
+                           ['iterable'])
+
+  def test_from_callable_without_annotations(self):
+    # Python 2 doesn't support annotations. See decorators_test_py3.py for that.
+    def fn(a, b=None, *args, **kwargs):
+      return a, b, args, kwargs
+    th = decorators.IOTypeHints.from_callable(fn)
+    self.assertIsNone(th)
+
+  def test_from_callable_builtin(self):
+    th = decorators.IOTypeHints.from_callable(len)
+    self.assertIsNone(th)
+
+  def test_from_callable_method_descriptor(self):
+    # from_callable() injects an annotation in this special type of builtin.
+    th = decorators.IOTypeHints.from_callable(str.strip)
+    if sys.version_info >= (3, 7):
+      self.assertEqual(th.input_types, ([str, Any], {}))
+    else:
+      self.assertEqual(th.input_types,
+                       ([str, decorators._ANY_VAR_POSITIONAL],
+                        {'__unknown__keywords': decorators._ANY_VAR_KEYWORD}))
+    self.assertEqual(th.output_types, ([Any], {}))
+
+
+class WithTypeHintsTest(unittest.TestCase):
+  def test_get_type_hints_no_settings(self):
+    class Base(WithTypeHints):
+      pass
+
+    th = Base().get_type_hints()
+    self.assertEqual(th.input_types, None)
+    self.assertEqual(th.output_types, None)
+
+  def test_get_type_hints_class_decorators(self):
+    @decorators.with_input_types(int, str)
+    @decorators.with_output_types(int)
+    class Base(WithTypeHints):
+      pass
+
+    th = Base().get_type_hints()
+    self.assertEqual(th.input_types, ((int, str), {}))
+    self.assertEqual(th.output_types, ((int, ), {}))
+
+  def test_get_type_hints_class_defaults(self):
+    class Base(WithTypeHints):
+      def default_type_hints(self):
+        return decorators.IOTypeHints(
+            input_types=((int, str), {}),
+            output_types=((int, ), {}))
+
+    th = Base().get_type_hints()
+    self.assertEqual(th.input_types, ((int, str), {}))
+    self.assertEqual(th.output_types, ((int, ), {}))
+
+  def test_get_type_hints_precedence_defaults_over_decorators(self):
+    @decorators.with_input_types(int)
+    @decorators.with_output_types(str)
+    class Base(WithTypeHints):
+      def default_type_hints(self):
+        return decorators.IOTypeHints(
+            input_types=((float, ), {}))
+
+    th = Base().get_type_hints()
+    self.assertEqual(th.input_types, ((float, ), {}))
+    self.assertEqual(th.output_types, ((str, ), {}))
+
+  def test_get_type_hints_precedence_instance_over_defaults(self):
+    class Base(WithTypeHints):
+      def default_type_hints(self):
+        return decorators.IOTypeHints(
+            input_types=((float, ), {}), output_types=((str, ), {}))
+
+    th = Base().with_input_types(int).get_type_hints()
+    self.assertEqual(th.input_types, ((int, ), {}))
+    self.assertEqual(th.output_types, ((str, ), {}))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -23,7 +23,6 @@ import sys
 import unittest
 
 from apache_beam.typehints import Any
-from apache_beam.typehints import TypeVariable
 from apache_beam.typehints import WithTypeHints
 from apache_beam.typehints import decorators
 

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -23,6 +23,7 @@ import sys
 import unittest
 
 from apache_beam.typehints import Any
+from apache_beam.typehints import List
 from apache_beam.typehints import WithTypeHints
 from apache_beam.typehints import decorators
 
@@ -45,6 +46,7 @@ class IOTypeHintsTest(unittest.TestCase):
     else:
       self.assertListEqual(list(s.parameters),
                            ['iterable'])
+    self.assertEqual(s.return_annotation, List[Any])
 
   def test_from_callable_without_annotations(self):
     # Python 2 doesn't support annotations. See decorators_test_py3.py for that.

--- a/sdks/python/apache_beam/typehints/decorators_test_py3.py
+++ b/sdks/python/apache_beam/typehints/decorators_test_py3.py
@@ -58,7 +58,7 @@ class IOTypeHintsTest(unittest.TestCase):
 
     th = decorators.IOTypeHints.from_callable(Class)
     self.assertEqual(th.input_types, ((int,), {}))
-    self.assertEqual(th.output_types, ((Any,), {}))
+    self.assertEqual(th.output_types, ((Class,), {}))
 
   def test_from_callable_method(self):
     class Class(object):
@@ -77,7 +77,7 @@ class IOTypeHintsTest(unittest.TestCase):
     def fn(a: int, b: str = None, *args: Tuple[T], foo: List[int],
            **kwargs: Dict[str, str]) -> Tuple:
       return a, b, args, foo, kwargs
-    callargs = decorators.getcallargs_forhints(False, fn, float, foo=List[str])
+    callargs = decorators.getcallargs_forhints(fn, float, foo=List[str])
     self.assertDictEqual(callargs,
                          {'a': float,
                           'b': str,
@@ -89,7 +89,7 @@ class IOTypeHintsTest(unittest.TestCase):
     # Default args are not necessarily types, so they should be ignored.
     def fn(a=List[int], b=None, *args, foo=(), **kwargs) -> Tuple:
       return a, b, args, foo, kwargs
-    callargs = decorators.getcallargs_forhints(False, fn)
+    callargs = decorators.getcallargs_forhints(fn)
     self.assertDictEqual(callargs,
                          {'a': Any,
                           'b': Any,
@@ -102,9 +102,9 @@ class IOTypeHintsTest(unittest.TestCase):
       return a, b, args, foo, kwargs
 
     with self.assertRaisesRegexp(decorators.TypeCheckError, "missing.*'a'"):
-      decorators.getcallargs_forhints(False, fn, foo=List[int])
+      decorators.getcallargs_forhints(fn, foo=List[int])
     with self.assertRaisesRegexp(decorators.TypeCheckError, "missing.*'foo'"):
-      decorators.getcallargs_forhints(False, fn, 5)
+      decorators.getcallargs_forhints(fn, 5)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/typehints/decorators_test_py3.py
+++ b/sdks/python/apache_beam/typehints/decorators_test_py3.py
@@ -1,0 +1,111 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for decorators module with Python 3 syntax not supported by 2.7."""
+
+from __future__ import absolute_import
+
+import unittest
+
+from apache_beam.typehints import Any
+from apache_beam.typehints import Dict
+from apache_beam.typehints import List
+from apache_beam.typehints import Tuple
+from apache_beam.typehints import TypeVariable
+from apache_beam.typehints import decorators
+
+T = TypeVariable('T')
+
+
+class IOTypeHintsTest(unittest.TestCase):
+
+  def test_from_callable(self):
+    def fn(a: int, b: str = None, *args: Tuple[T], foo: List[int],
+           **kwargs: Dict[str, str]) -> Tuple:
+      return a, b, args, foo, kwargs
+    th = decorators.IOTypeHints.from_callable(fn)
+    self.assertEqual(th.input_types, (
+        [int, str, Tuple[T]], {'foo': List[int], 'kwargs': Dict[str, str]}))
+    self.assertEqual(th.output_types, ([Tuple], {}))
+
+  def test_from_callable_partial_annotations(self):
+    def fn(a: int, b=None, *args, foo: List[int], **kwargs):
+      return a, b, args, foo, kwargs
+    th = decorators.IOTypeHints.from_callable(fn)
+    self.assertEqual(th.input_types,
+                     ([int, Any, Tuple[Any, ...]],
+                      {'foo': List[int], 'kwargs': Dict[Any, Any]}))
+    self.assertEqual(th.output_types, ([Any], {}))
+
+  def test_from_callable_class(self):
+    class Class(object):
+      def __init__(self, unused_arg: int):
+        pass
+
+    th = decorators.IOTypeHints.from_callable(Class)
+    self.assertEqual(th.input_types, ([int], {}))
+    self.assertEqual(th.output_types, ([Any], {}))
+
+  def test_from_callable_method(self):
+    class Class(object):
+      def method(self, arg: T = None) -> None:
+        pass
+
+    th = decorators.IOTypeHints.from_callable(Class.method)
+    self.assertEqual(th.input_types, ([Any, T], {}))
+    self.assertEqual(th.output_types, ([None], {}))
+
+    th = decorators.IOTypeHints.from_callable(Class().method)
+    self.assertEqual(th.input_types, ([T], {}))
+    self.assertEqual(th.output_types, ([None], {}))
+
+  def test_getcallargs_forhints(self):
+    def fn(a: int, b: str = None, *args: Tuple[T], foo: List[int],
+           **kwargs: Dict[str, str]) -> Tuple:
+      return a, b, args, foo, kwargs
+    callargs = decorators.getcallargs_forhints(False, fn, float, foo=List[str])
+    self.assertDictEqual(callargs,
+                         {'a': float,
+                          'b': str,
+                          'args': Tuple[T],
+                          'foo': List[str],
+                          'kwargs': Dict[str, str]})
+
+  def test_getcallargs_forhints_default_arg(self):
+    # Default args are not necessarily types, so they should be ignored.
+    def fn(a=List[int], b=None, *args, foo=(), **kwargs) -> Tuple:
+      return a, b, args, foo, kwargs
+    callargs = decorators.getcallargs_forhints(False, fn)
+    self.assertDictEqual(callargs,
+                         {'a': Any,
+                          'b': Any,
+                          'args': Tuple[Any, ...],
+                          'foo': Any,
+                          'kwargs': Dict[Any, Any]})
+
+  def test_getcallargs_forhints_missing_arg(self):
+    def fn(a, b=None, *args, foo, **kwargs):
+      return a, b, args, foo, kwargs
+
+    with self.assertRaisesRegexp(decorators.TypeCheckError, "missing.*'a'"):
+      decorators.getcallargs_forhints(False, fn, foo=List[int])
+    with self.assertRaisesRegexp(decorators.TypeCheckError, "missing.*'foo'"):
+      decorators.getcallargs_forhints(False, fn, 5)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/typehints/decorators_test_py3.py
+++ b/sdks/python/apache_beam/typehints/decorators_test_py3.py
@@ -39,17 +39,17 @@ class IOTypeHintsTest(unittest.TestCase):
       return a, b, args, foo, kwargs
     th = decorators.IOTypeHints.from_callable(fn)
     self.assertEqual(th.input_types, (
-        [int, str, Tuple[T]], {'foo': List[int], 'kwargs': Dict[str, str]}))
-    self.assertEqual(th.output_types, ([Tuple], {}))
+        (int, str, Tuple[T]), {'foo': List[int], 'kwargs': Dict[str, str]}))
+    self.assertEqual(th.output_types, ((Tuple,), {}))
 
   def test_from_callable_partial_annotations(self):
     def fn(a: int, b=None, *args, foo: List[int], **kwargs):
       return a, b, args, foo, kwargs
     th = decorators.IOTypeHints.from_callable(fn)
     self.assertEqual(th.input_types,
-                     ([int, Any, Tuple[Any, ...]],
+                     ((int, Any, Tuple[Any, ...]),
                       {'foo': List[int], 'kwargs': Dict[Any, Any]}))
-    self.assertEqual(th.output_types, ([Any], {}))
+    self.assertEqual(th.output_types, ((Any,), {}))
 
   def test_from_callable_class(self):
     class Class(object):
@@ -57,8 +57,8 @@ class IOTypeHintsTest(unittest.TestCase):
         pass
 
     th = decorators.IOTypeHints.from_callable(Class)
-    self.assertEqual(th.input_types, ([int], {}))
-    self.assertEqual(th.output_types, ([Any], {}))
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((Any,), {}))
 
   def test_from_callable_method(self):
     class Class(object):
@@ -66,12 +66,12 @@ class IOTypeHintsTest(unittest.TestCase):
         pass
 
     th = decorators.IOTypeHints.from_callable(Class.method)
-    self.assertEqual(th.input_types, ([Any, T], {}))
-    self.assertEqual(th.output_types, ([None], {}))
+    self.assertEqual(th.input_types, ((Any, T), {}))
+    self.assertEqual(th.output_types, ((None,), {}))
 
     th = decorators.IOTypeHints.from_callable(Class().method)
-    self.assertEqual(th.input_types, ([T], {}))
-    self.assertEqual(th.output_types, ([None], {}))
+    self.assertEqual(th.input_types, ((T,), {}))
+    self.assertEqual(th.output_types, ((None,), {}))
 
   def test_getcallargs_forhints(self):
     def fn(a: int, b: str = None, *args: Tuple[T], foo: List[int],

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -61,6 +61,8 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
             bytes, typing.Union[int, bytes, float]]]],
          typehints.Tuple[bytes, typehints.List[typehints.Tuple[
              bytes, typehints.Union[int, bytes, float]]]]),
+        ('arbitrary-length tuple', typing.Tuple[int, ...],
+         typehints.Tuple[int, ...]),
         ('flat alias', _TestFlatAlias, typehints.Tuple[bytes, float]),
         ('nested alias', _TestNestedAlias,
          typehints.List[typehints.Tuple[bytes, float]]),

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -61,8 +61,9 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
             bytes, typing.Union[int, bytes, float]]]],
          typehints.Tuple[bytes, typehints.List[typehints.Tuple[
              bytes, typehints.Union[int, bytes, float]]]]),
-        ('arbitrary-length tuple', typing.Tuple[int, ...],
-         typehints.Tuple[int, ...]),
+        # TODO(BEAM-7713): This case seems to fail on Py3.5.2 but not 3.5.4.
+        # ('arbitrary-length tuple', typing.Tuple[int, ...],
+        #  typehints.Tuple[int, ...]),
         ('flat alias', _TestFlatAlias, typehints.Tuple[bytes, float]),
         ('nested alias', _TestNestedAlias,
          typehints.List[typehints.Tuple[bytes, float]]),

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -115,7 +115,7 @@ class TypeCheckWrapperDoFn(AbstractDoFnWrapper):
     if type_hints.input_types:
       input_args, input_kwargs = type_hints.input_types
       self._input_hints = getcallargs_forhints(
-          False, self._process_fn, *input_args, **input_kwargs)
+          self._process_fn, *input_args, **input_kwargs)
     else:
       self._input_hints = None
     # TODO(robertwb): Multi-output.

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -71,9 +71,6 @@ class AbstractDoFnWrapper(DoFn):
   def finish_bundle(self, *args, **kwargs):
     return self.wrapper(self.dofn.finish_bundle, args, kwargs)
 
-  def is_process_bounded(self):
-    return self.dofn.is_process_bounded()
-
 
 class OutputCheckWrapperDoFn(AbstractDoFnWrapper):
   """A DoFn that verifies against common errors in the output type."""
@@ -118,7 +115,7 @@ class TypeCheckWrapperDoFn(AbstractDoFnWrapper):
     if type_hints.input_types:
       input_args, input_kwargs = type_hints.input_types
       self._input_hints = getcallargs_forhints(
-          self._process_fn, *input_args, **input_kwargs)
+          False, self._process_fn, *input_args, **input_kwargs)
     else:
       self._input_hints = None
     # TODO(robertwb): Multi-output.
@@ -130,6 +127,8 @@ class TypeCheckWrapperDoFn(AbstractDoFnWrapper):
 
   def process(self, *args, **kwargs):
     if self._input_hints:
+      # TODO: use get_signature and bind
+      # TODO: try using decorators.getcallargs_forhints, or similar?
       actual_inputs = inspect.getcallargs(self._process_fn, *args, **kwargs)
       for var, hint in self._input_hints.items():
         if hint is actual_inputs[var]:

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -37,7 +37,6 @@ from apache_beam.transforms.window import WindowedValue
 from apache_beam.typehints.decorators import GeneratorWrapper
 from apache_beam.typehints.decorators import TypeCheckError
 from apache_beam.typehints.decorators import _check_instance_type
-from apache_beam.typehints.decorators import get_signature
 from apache_beam.typehints.decorators import getcallargs_forhints
 from apache_beam.typehints.typehints import CompositeTypeHintError
 from apache_beam.typehints.typehints import SimpleTypeHintError

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -37,6 +37,7 @@ from apache_beam.transforms.window import WindowedValue
 from apache_beam.typehints.decorators import GeneratorWrapper
 from apache_beam.typehints.decorators import TypeCheckError
 from apache_beam.typehints.decorators import _check_instance_type
+from apache_beam.typehints.decorators import get_signature
 from apache_beam.typehints.decorators import getcallargs_forhints
 from apache_beam.typehints.typehints import CompositeTypeHintError
 from apache_beam.typehints.typehints import SimpleTypeHintError
@@ -127,8 +128,6 @@ class TypeCheckWrapperDoFn(AbstractDoFnWrapper):
 
   def process(self, *args, **kwargs):
     if self._input_hints:
-      # TODO: use get_signature and bind
-      # TODO: try using decorators.getcallargs_forhints, or similar?
       actual_inputs = inspect.getcallargs(self._process_fn, *args, **kwargs)
       for var, hint in self._input_hints.items():
         if hint is actual_inputs[var]:

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -320,9 +320,14 @@ class AnnotationsTest(unittest.TestCase):
 
   def test_pardo_wrapper_builtin_type(self):
     th = beam.ParDo(list).get_type_hints()
-    self.assertEqual(th.input_types, (
-        (typehints.Any, typehints.decorators._ANY_VAR_POSITIONAL),
-        {'__unknown__keywords': typehints.decorators._ANY_VAR_KEYWORD}))
+    if sys.version_info < (3, 7):
+      self.assertEqual(th.input_types, (
+          (typehints.Any, typehints.decorators._ANY_VAR_POSITIONAL),
+          {'__unknown__keywords': typehints.decorators._ANY_VAR_KEYWORD}))
+    else:
+      # Python 3.7+ supports signatures for builtins like 'list'.
+      self.assertEqual(th.input_types, ((typehints.Any, ), {}))
+
     self.assertEqual(th.output_types, ((typehints.Any,), {}))
 
   def test_pardo_wrapper_builtin_func(self):

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -94,15 +94,17 @@ class MainInputTest(unittest.TestCase):
                                  r'requires.*int.*got.*str'):
       [1, 2, 3] | (beam.ParDo(MyDoFn()) | 'again' >> beam.ParDo(MyDoFn()))
 
-  # TODO(BEAM-7981): Iterable in output type should not be removed.
-  # def test_typed_callable_iterable_output(self):
-  #   @typehints.with_input_types(int)
-  #   @typehints.with_output_types(typehints.Iterable[str])
-  #   def do_fn(element):
-  #     return [[str(element)] * 2]
-  #
-  #   result = [1, 2] | beam.ParDo(do_fn)
-  #   self.assertEqual([['1', '1'], ['2', '2']], sorted(result))
+  @unittest.skip('BEAM-7981: Iterable in output type should not be removed.')
+  def test_typed_callable_iterable_output(self):
+    # TODO(BEAM-7981): 2.7 and 3.x both erroneously strip the Iterable, but the
+    #   test only fails in 3.x.
+    @typehints.with_input_types(int)
+    @typehints.with_output_types(typehints.Iterable[str])
+    def do_fn(element):
+      return [[str(element)] * 2]
+
+    result = [1, 2] | beam.ParDo(do_fn)
+    self.assertEqual([['1', '1'], ['2', '2']], sorted(result))
 
   def test_typed_dofn_instance(self):
     class MyDoFn(beam.DoFn):

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -308,7 +308,7 @@ class CustomTransformTest(unittest.TestCase):
 
 class AnnotationsTest(unittest.TestCase):
 
-  def test_pardo_wrapper_builtin(self):
+  def test_pardo_wrapper_builtin_method(self):
     th = beam.ParDo(str.strip).get_type_hints()
     if sys.version_info < (3, 7):
       self.assertEqual(th.input_types, ((str,), {}))
@@ -318,10 +318,14 @@ class AnnotationsTest(unittest.TestCase):
       self.assertEqual(th.input_types, ((str, typehints.Any), {}))
     self.assertEqual(th.output_types, ((typehints.Any,), {}))
 
+  def test_pardo_wrapper_builtin_type(self):
     th = beam.ParDo(list).get_type_hints()
-    self.assertIsNone(th.input_types)
-    self.assertIsNone(th.output_types)
+    self.assertEqual(th.input_types, (
+        (typehints.Any, typehints.decorators._ANY_VAR_POSITIONAL),
+        {'__unknown__keywords': typehints.decorators._ANY_VAR_KEYWORD}))
+    self.assertEqual(th.output_types, ((typehints.Any,), {}))
 
+  def test_pardo_wrapper_builtin_func(self):
     th = beam.ParDo(len).get_type_hints()
     self.assertIsNone(th.input_types)
     self.assertIsNone(th.output_types)

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -89,15 +89,16 @@ class MainInputTest(unittest.TestCase):
                                 r'requires.*int.*got.*str'):
       [1, 2, 3] | (pardo | 'again' >> pardo)
 
-  # TODO(BEAM-7981): Both Iterables get stripped in
-  #   CallableWrapperDoFn.default_type_hints, but only one should.
-  # def test_typed_callable_iterable_output(self):
-  #   def do_fn(element: int) -> typehints.Iterable[typehints.Iterable[str]]:
-  #     return [[str(element)] * 2]
-  #
-  #   print(beam.ParDo(do_fn).get_type_hints())
-  #   result = [1, 2] | beam.ParDo(do_fn)
-  #   self.assertEqual([['1', '1'], ['2', '2']], sorted(result))
+  @unittest.skip('BEAM-7981: Iterable in output type should not be removed.')
+  def test_typed_callable_iterable_output(self):
+    # TODO(BEAM-7981): Both Iterables get stripped in
+    #   CallableWrapperDoFn.default_type_hints, but only one should.
+    def do_fn(element: int) -> typehints.Iterable[typehints.Iterable[str]]:
+      return [[str(element)] * 2]
+
+    print(beam.ParDo(do_fn).get_type_hints())
+    result = [1, 2] | beam.ParDo(do_fn)
+    self.assertEqual([['1', '1'], ['2', '2']], sorted(result))
 
   def test_typed_dofn_method_not_iterable(self):
     class MyDoFn(beam.DoFn):

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -155,6 +155,14 @@ class AnnotationsTest(unittest.TestCase):
     self.assertEqual(th.input_types, ((int,), {}))
     self.assertEqual(th.output_types, ((str,), {}))
 
+  def test_pardo_dofn_not_iterable(self):
+    class MyDoFn(beam.DoFn):
+      def process(self, element: int) -> str:
+        return str(element)
+
+    with self.assertRaisesRegexp(ValueError, r'Return value not iterable'):
+      _ = beam.ParDo(MyDoFn()).get_type_hints()
+
   def test_pardo_wrapper(self):
     def do_fn(element: int) -> typehints.Iterable[str]:
       return [str(element)]
@@ -162,6 +170,13 @@ class AnnotationsTest(unittest.TestCase):
     th = beam.ParDo(do_fn).get_type_hints()
     self.assertEqual(th.input_types, ((int,), {}))
     self.assertEqual(th.output_types, ((str,), {}))
+
+  def test_pardo_wrapper_not_iterable(self):
+    def do_fn(element: int) -> str:
+      return str(element)
+
+    with self.assertRaisesRegexp(ValueError, r'Return value not iterable'):
+      _ = beam.ParDo(do_fn).get_type_hints()
 
   def test_flat_map_wrapper(self):
     def map_fn(element: int) -> typehints.Iterable[int]:

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -20,25 +20,10 @@
 
 from __future__ import absolute_import
 
-import sys
-import typing
 import unittest
 
 import apache_beam as beam
-from apache_beam import pvalue
 from apache_beam import typehints
-from apache_beam.options.pipeline_options import OptionsContext
-from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
-from apache_beam.typehints import WithTypeHints
-from apache_beam.typehints.decorators import get_signature
-
-
-# T1 = typehints.TypeVariable('T1')
-# T2 = typehints.TypeVariable('T2')
-# T3 = typehints.TypeVariable('T3')
-# T4 = typehints.TypeVariable('T4')
 
 
 class MainInputTest(unittest.TestCase):
@@ -48,8 +33,8 @@ class MainInputTest(unittest.TestCase):
     @typehints.with_input_types(typehints.Tuple[int, int])
     @typehints.with_output_types(int)
     class MyDoFn(beam.DoFn):
-      def process(self, element: int) -> str:
-        return str(element)
+      def process(self, element: int) -> typehints.Tuple[str]:
+        return tuple(str(element))
 
     result = [1, 2, 3] | beam.ParDo(MyDoFn())
     self.assertEqual(['1', '2', '3'], sorted(result))
@@ -68,8 +53,9 @@ class MainInputTest(unittest.TestCase):
     @typehints.with_input_types(typehints.Tuple[int, int])
     @typehints.with_output_types(int)
     class MyDoFn(beam.DoFn):
-      def process(self, element: typehints.Tuple[int, int]) -> int:
-        return str(element)
+      def process(self, element: typehints.Tuple[int, int]) -> \
+          typehints.List[int]:
+        return [str(element)]
     my_do_fn = MyDoFn().with_input_types(int).with_output_types(str)
 
     result = [1, 2, 3] | beam.ParDo(my_do_fn)
@@ -88,8 +74,8 @@ class MainInputTest(unittest.TestCase):
     # decorators and annotations.
     @typehints.with_input_types(typehints.Tuple[int, int])
     @typehints.with_output_types(int)
-    def do_fn(element: typehints.Tuple[int, int]) -> int:
-      return str(element)
+    def do_fn(element: typehints.Tuple[int, int]) -> typehints.Generator[int]:
+      yield str(element)
     pardo = beam.ParDo(do_fn).with_input_types(int).with_output_types(str)
 
     result = [1, 2, 3] | pardo
@@ -103,54 +89,116 @@ class MainInputTest(unittest.TestCase):
                                 r'requires.*int.*got.*str'):
       [1, 2, 3] | (pardo | 'again' >> pardo)
 
+  # TODO(BEAM-7981): Both Iterables get stripped in
+  #   CallableWrapperDoFn.default_type_hints, but only one should.
+  # def test_typed_callable_iterable_output(self):
+  #   def do_fn(element: int) -> typehints.Iterable[typehints.Iterable[str]]:
+  #     return [[str(element)] * 2]
+  #
+  #   print(beam.ParDo(do_fn).get_type_hints())
+  #   result = [1, 2] | beam.ParDo(do_fn)
+  #   self.assertEqual([['1', '1'], ['2', '2']], sorted(result))
 
-class AnnotationsTest(unittest.TestCase):
-
-  def test_dofn(self):
+  def test_typed_dofn_method_not_iterable(self):
     class MyDoFn(beam.DoFn):
       def process(self, element: int) -> str:
         return str(element)
 
-    th = beam.ParDo(MyDoFn()).get_type_hints()
-    self.assertEqual(th.input_types, ([int], {}))
-    self.assertEqual(th.output_types, ([str], {}))
+    with self.assertRaisesRegex(ValueError, r'str.*is not iterable'):
+      [1, 2, 3] | beam.ParDo(MyDoFn())
 
-  def test_dofn_wrapper(self):
-    def do_fn(element: int) -> str:
-      return str(element)
+  def test_typed_callable_not_iterable(self):
+    def do_fn(element: typehints.Tuple[int, int]) -> int:
+      return element[0]
+    with self.assertRaisesRegex(ValueError, r'int.*is not iterable'):
+      [1, 2, 3] | beam.ParDo(do_fn)
+
+  def test_typed_dofn_kwonly(self):
+    class MyDoFn(beam.DoFn):
+      # TODO(BEAM-5878): A kwonly argument like
+      #   timestamp=beam.DoFn.TimestampParam would not work here.
+      def process(self, element: int, *, side_input: str) -> \
+          typehints.Generator[typehints.Optional[int]]:
+        yield str(element) if side_input else None
+    my_do_fn = MyDoFn()
+
+    result = [1, 2, 3] | beam.ParDo(my_do_fn, side_input='abc')
+    self.assertEqual(['1', '2', '3'], sorted(result))
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'requires.*str.*got.*int.*side_input'):
+      [1, 2, 3] | beam.ParDo(my_do_fn, side_input=1)
+
+  def test_type_dofn_var_kwargs(self):
+    class MyDoFn(beam.DoFn):
+      def process(self, element: int, **side_inputs: typehints.Dict[str, str]) \
+          -> typehints.Generator[typehints.Optional[int]]:
+        yield str(element) if side_inputs else None
+    my_do_fn = MyDoFn()
+
+    result = [1, 2, 3] | beam.ParDo(my_do_fn, foo='abc', bar='def')
+    self.assertEqual(['1', '2', '3'], sorted(result))
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'requires.*str.*got.*int.*side_inputs'):
+      [1, 2, 3] | beam.ParDo(my_do_fn, a=1)
+
+
+class AnnotationsTest(unittest.TestCase):
+
+  def test_pardo_dofn(self):
+    class MyDoFn(beam.DoFn):
+      def process(self, element: int) -> typehints.Generator[str]:
+        yield str(element)
+
+    th = beam.ParDo(MyDoFn()).get_type_hints()
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((str,), {}))
+
+  def test_pardo_wrapper(self):
+    def do_fn(element: int) -> typehints.Iterable[str]:
+      return [str(element)]
 
     th = beam.ParDo(do_fn).get_type_hints()
-    self.assertEqual(th.input_types, ([int], {}))
-    self.assertEqual(th.output_types, ([str], {}))
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((str,), {}))
 
-  # TODO: test all other transforms that accept user functions?
-  #   'CombineFn',
-  #   'PartitionFn',
-  #   'ParDo',
-  #   'FlatMap',
-  #   'FlatMapTuple',
-  #   'Map',
-  #   'MapTuple',
+  def test_flat_map_wrapper(self):
+    def map_fn(element: int) -> typehints.Iterable[int]:
+      return [element, element + 1]
 
+    th = beam.FlatMap(map_fn).get_type_hints()
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((int,), {}))
 
-  # def test_filter_wrapper(self):
-  #   def filter_fn(element: int) -> bool:
-  #     return bool(element % 2)
-  #
-  #   # TODO: self._fn in CallableWrapperDoFn points to a lambda (no annotations). what does pardo do?
-  #   th = beam.Filter(filter_fn).get_type_hints()
-  #   self.assertEqual(th.input_types, ([int], {}))
-  #   self.assertEqual(th.output_types, ([bool], {}))
+  def test_flat_map_tuple_wrapper(self):
+    def tuple_map_fn(a: str, b: str, c: str) -> typehints.Iterable[str]:
+      return [a, b, c]
 
-  # TODO: test all other transforms that accept user functions?
-  #   'CombineGlobally',
-  #   'CombinePerKey',
-  #   'CombineValues',
-  #   'GroupByKey',
-  #   'Partition',
-  #   'Windowing',
-  #   'WindowInto',
-  #   'Flatten',
-  #   'Create',
-  #   'Impulse',
-  #   'RestrictionProvider'
+    th = beam.FlatMapTuple(tuple_map_fn).get_type_hints()
+    self.assertEqual(th.input_types, ((str, str, str), {}))
+    self.assertEqual(th.output_types, ((str,), {}))
+
+  def test_map_wrapper(self):
+    def map_fn(unused_element: int) -> int:
+      return 1
+
+    th = beam.Map(map_fn).get_type_hints()
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((int,), {}))
+
+  def test_map_tuple(self):
+    def tuple_map_fn(a: str, b: str, c: str) -> str:
+      return a + b + c
+
+    th = beam.MapTuple(tuple_map_fn).get_type_hints()
+    self.assertEqual(th.input_types, ((str, str, str), {}))
+    self.assertEqual(th.output_types, ((str,), {}))
+
+  def test_filter_wrapper(self):
+    def filter_fn(element: int) -> bool:
+      return bool(element % 2)
+
+    th = beam.Filter(filter_fn).get_type_hints()
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((bool,), {}))

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -202,3 +202,7 @@ class AnnotationsTest(unittest.TestCase):
     th = beam.Filter(filter_fn).get_type_hints()
     self.assertEqual(th.input_types, ((int,), {}))
     self.assertEqual(th.output_types, ((bool,), {}))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -1,0 +1,156 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for type-hint objects and decorators - Python 3 syntax specific.
+"""
+
+from __future__ import absolute_import
+
+import sys
+import typing
+import unittest
+
+import apache_beam as beam
+from apache_beam import pvalue
+from apache_beam import typehints
+from apache_beam.options.pipeline_options import OptionsContext
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+from apache_beam.typehints import WithTypeHints
+from apache_beam.typehints.decorators import get_signature
+
+
+# T1 = typehints.TypeVariable('T1')
+# T2 = typehints.TypeVariable('T2')
+# T3 = typehints.TypeVariable('T3')
+# T4 = typehints.TypeVariable('T4')
+
+
+class MainInputTest(unittest.TestCase):
+
+  def test_typed_dofn_method(self):
+    # process annotations are recognized and take precedence over decorators.
+    @typehints.with_input_types(typehints.Tuple[int, int])
+    @typehints.with_output_types(int)
+    class MyDoFn(beam.DoFn):
+      def process(self, element: int) -> str:
+        return str(element)
+
+    result = [1, 2, 3] | beam.ParDo(MyDoFn())
+    self.assertEqual(['1', '2', '3'], sorted(result))
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'requires.*int.*got.*str'):
+      ['a', 'b', 'c'] | beam.ParDo(MyDoFn())
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'requires.*int.*got.*str'):
+      [1, 2, 3] | (beam.ParDo(MyDoFn()) | 'again' >> beam.ParDo(MyDoFn()))
+
+  def test_typed_dofn_instance(self):
+    # Type hints applied to DoFn instance take precedence over decorators and
+    # process annotations.
+    @typehints.with_input_types(typehints.Tuple[int, int])
+    @typehints.with_output_types(int)
+    class MyDoFn(beam.DoFn):
+      def process(self, element: typehints.Tuple[int, int]) -> int:
+        return str(element)
+    my_do_fn = MyDoFn().with_input_types(int).with_output_types(str)
+
+    result = [1, 2, 3] | beam.ParDo(my_do_fn)
+    self.assertEqual(['1', '2', '3'], sorted(result))
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'requires.*int.*got.*str'):
+      ['a', 'b', 'c'] | beam.ParDo(my_do_fn)
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'requires.*int.*got.*str'):
+      [1, 2, 3] | (beam.ParDo(my_do_fn) | 'again' >> beam.ParDo(my_do_fn))
+
+  def test_typed_callable_instance(self):
+    # Type hints applied to ParDo instance take precedence over callable
+    # decorators and annotations.
+    @typehints.with_input_types(typehints.Tuple[int, int])
+    @typehints.with_output_types(int)
+    def do_fn(element: typehints.Tuple[int, int]) -> int:
+      return str(element)
+    pardo = beam.ParDo(do_fn).with_input_types(int).with_output_types(str)
+
+    result = [1, 2, 3] | pardo
+    self.assertEqual(['1', '2', '3'], sorted(result))
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'requires.*int.*got.*str'):
+      ['a', 'b', 'c'] | pardo
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'requires.*int.*got.*str'):
+      [1, 2, 3] | (pardo | 'again' >> pardo)
+
+
+class AnnotationsTest(unittest.TestCase):
+
+  def test_dofn(self):
+    class MyDoFn(beam.DoFn):
+      def process(self, element: int) -> str:
+        return str(element)
+
+    th = beam.ParDo(MyDoFn()).get_type_hints()
+    self.assertEqual(th.input_types, ([int], {}))
+    self.assertEqual(th.output_types, ([str], {}))
+
+  def test_dofn_wrapper(self):
+    def do_fn(element: int) -> str:
+      return str(element)
+
+    th = beam.ParDo(do_fn).get_type_hints()
+    self.assertEqual(th.input_types, ([int], {}))
+    self.assertEqual(th.output_types, ([str], {}))
+
+  # TODO: test all other transforms that accept user functions?
+  #   'CombineFn',
+  #   'PartitionFn',
+  #   'ParDo',
+  #   'FlatMap',
+  #   'FlatMapTuple',
+  #   'Map',
+  #   'MapTuple',
+
+
+  # def test_filter_wrapper(self):
+  #   def filter_fn(element: int) -> bool:
+  #     return bool(element % 2)
+  #
+  #   # TODO: self._fn in CallableWrapperDoFn points to a lambda (no annotations). what does pardo do?
+  #   th = beam.Filter(filter_fn).get_type_hints()
+  #   self.assertEqual(th.input_types, ([int], {}))
+  #   self.assertEqual(th.output_types, ([bool], {}))
+
+  # TODO: test all other transforms that accept user functions?
+  #   'CombineGlobally',
+  #   'CombinePerKey',
+  #   'CombineValues',
+  #   'GroupByKey',
+  #   'Partition',
+  #   'Windowing',
+  #   'WindowInto',
+  #   'Flatten',
+  #   'Create',
+  #   'Impulse',
+  #   'RestrictionProvider'

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -96,7 +96,6 @@ class MainInputTest(unittest.TestCase):
     def do_fn(element: int) -> typehints.Iterable[typehints.Iterable[str]]:
       return [[str(element)] * 2]
 
-    print(beam.ParDo(do_fn).get_type_hints())
     result = [1, 2] | beam.ParDo(do_fn)
     self.assertEqual([['1', '1'], ['2', '2']], sorted(result))
 

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -807,7 +807,7 @@ class DictHint(CompositeTypeHint):
     def _consistent_with_check_(self, sub):
       return (isinstance(sub, self.__class__)
               and is_consistent_with(sub.key_type, self.key_type)
-              and is_consistent_with(sub.key_type, self.key_type))
+              and is_consistent_with(sub.value_type, self.value_type))
 
     def _raise_hint_exception_or_inner_exception(self, is_key,
                                                  incorrect_instance,
@@ -1143,6 +1143,31 @@ def is_consistent_with(sub, base):
     # Nothing but object lives above any type constraints.
     return base == object
   return issubclass(sub, base)
+
+
+def get_yielded_type(type_hint):
+  """Obtains the type of elements yielded by an iterable.
+
+  Note that "iterable" here means: can be iterated over in a for loop.
+
+  Args:
+    type_hint: (TypeConstraint) The iterable in question.
+
+  Returns:
+    Yielded type of the iterable.
+
+  Raises:
+    ValueError if not iterable.
+  """
+  if isinstance(type_hint, AnyTypeConstraint):
+    return type_hint
+  if is_consistent_with(type_hint, Iterator[Any]):
+    return type_hint.yielded_type
+  if is_consistent_with(type_hint, Tuple[Any, ...]):
+    return Union[type_hint.tuple_types]
+  if is_consistent_with(type_hint, Iterable[Any]):
+    return type_hint.inner_type
+  raise ValueError('%s is not iterable' % type_hint)
 
 
 def coerce_to_kv_type(element_type, label=None, side_input_producer=None):

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1151,7 +1151,7 @@ def get_yielded_type(type_hint):
   Note that "iterable" here means: can be iterated over in a for loop.
 
   Args:
-    type_hint: (TypeConstraint) The iterable in question.
+    type_hint: (TypeConstraint) The iterable in question. Must be normalize()-d.
 
   Returns:
     Yielded type of the iterable.

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -1169,7 +1169,7 @@ class DecoratorHelpers(TypeHintTestCase):
                              e=Dict[str, Union[int, str]]))
 
   def test_getcallargs_forhints_builtins(self):
-    if sys.version_info.major < 3:
+    if sys.version_info < (3, ):
       self.assertEqual(
           {'_': str,
            '__unknown__varargs': Tuple[Any, ...],
@@ -1184,12 +1184,24 @@ class DecoratorHelpers(TypeHintTestCase):
           {'_': str,
            '__unknown__varargs': Tuple[Any, ...],
            '__unknown__keywords': typehints.Dict[Any, Any]},
-          getcallargs_forhints(False, str.join, str, list))
-    elif sys.version_info.minor < 7:
+          getcallargs_forhints(False, str.join, str, typehints.List[int]))
+    elif sys.version_info < (3, 7):
       # Signatures for builtins are not supported in 3.5 and 3.6.
-      self.assertEqual({}, getcallargs_forhints(False, str.upper, str))
-      self.assertEqual({}, getcallargs_forhints(False, str.strip, str, str))
-      self.assertEqual({}, getcallargs_forhints(False, str.join, str, list))
+      self.assertEqual(
+          {'_': str,
+           '__unknown__varargs': Tuple[Any, ...],
+           '__unknown__keywords': typehints.Dict[Any, Any]},
+          getcallargs_forhints(False, str.upper, str))
+      self.assertEqual(
+          {'_': str,
+           '__unknown__varargs': Tuple[str, ...],
+           '__unknown__keywords': typehints.Dict[Any, Any]},
+          getcallargs_forhints(False, str.strip, str, str))
+      self.assertEqual(
+          {'_': str,
+           '__unknown__varargs': Tuple[typehints.List[int], ...],
+           '__unknown__keywords': typehints.Dict[Any, Any]},
+          getcallargs_forhints(False, str.join, str, typehints.List[int]))
     else:
       self.assertEqual(
           {'self': str},
@@ -1197,8 +1209,9 @@ class DecoratorHelpers(TypeHintTestCase):
       # str.strip has an optional second argument.
       self.assertEqual({'self': str, 'chars': Any},
                        getcallargs_forhints(False, str.strip, str))
-      self.assertEqual({'self': str, 'iterable': list},
-                       getcallargs_forhints(False, str.join, str, list))
+      self.assertEqual(
+          {'self': str, 'iterable': typehints.List[int]},
+          getcallargs_forhints(False, str.join, str, typehints.List[int]))
 
 
 class TestGetYieldedType(unittest.TestCase):

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -19,8 +19,6 @@
 
 from __future__ import absolute_import
 
-import functools
-import inspect
 import sys
 import unittest
 from builtins import next
@@ -28,56 +26,15 @@ from builtins import range
 
 import apache_beam.typehints.typehints as typehints
 from apache_beam.typehints import Any
+from apache_beam.typehints import Dict
 from apache_beam.typehints import Tuple
-from apache_beam.typehints import TypeCheckError
 from apache_beam.typehints import Union
 from apache_beam.typehints import native_type_compatibility
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
 from apache_beam.typehints.decorators import GeneratorWrapper
-from apache_beam.typehints.decorators import _check_instance_type
-from apache_beam.typehints.decorators import _interleave_type_check
-from apache_beam.typehints.decorators import _positional_arg_hints
-from apache_beam.typehints.decorators import get_type_hints
 from apache_beam.typehints.decorators import getcallargs_forhints
-from apache_beam.typehints.decorators import getfullargspec
 from apache_beam.typehints.typehints import is_consistent_with
-
-
-def check_or_interleave(hint, value, var):
-  if hint is None:
-    return value
-  elif isinstance(hint, typehints.IteratorHint.IteratorTypeConstraint):
-    return _interleave_type_check(hint, var)(value)
-  _check_instance_type(hint, value, var)
-  return value
-
-
-def check_type_hints(f):
-  @functools.wraps(f)
-  def wrapper(*args, **kwargs):
-    hints = get_type_hints(f)
-    if hints.input_types:  # pylint: disable=too-many-nested-blocks
-      input_hints = getcallargs_forhints(
-          f, *hints.input_types[0], **hints.input_types[1])
-      inputs = inspect.getcallargs(f, *args, **kwargs)
-      for var, hint in input_hints.items():
-        value = inputs[var]
-        new_value = check_or_interleave(hint, value, var)
-        if new_value is not value:
-          if var in kwargs:
-            kwargs[var] = new_value
-          else:
-            args = list(args)
-            for ix, pvar in enumerate(getfullargspec(f).args):
-              if pvar == var:
-                args[ix] = new_value
-                break
-            else:
-              raise NotImplementedError('Iterable in nested argument %s' % var)
-    res = f(*args, **kwargs)
-    return check_or_interleave(hints.simple_output_type('typecheck'), res, None)
-  return wrapper
 
 
 class DummyTestClass1(object):
@@ -753,150 +710,51 @@ class GeneratorHintTestCase(TypeHintTestCase):
     self.assertCompatible(typehints.Iterator[int], typehints.Iterator[int])
     self.assertNotCompatible(typehints.Iterator[str], typehints.Iterator[float])
 
-  def test_generator_return_hint_invalid_yield_type(self):
-    @check_type_hints
-    @with_output_types(typehints.Iterator[int])
-    def all_upper(s):
-      for e in s:
-        yield e.upper()
 
-    with self.assertRaises(TypeCheckError) as e:
-      next(all_upper('hello'))
-
-    self.assertEqual('Type-hint for return type violated: Iterator[int] '
-                     'hint type-constraint violated. Expected a iterator '
-                     'of type int. Instead received a iterator of type '
-                     'str.',
-                     e.exception.args[0])
-
-  def test_generator_argument_hint_invalid_yield_type(self):
-    def wrong_yield_gen():
-      for e in ['a', 'b']:
-        yield e
-
-    @check_type_hints
-    @with_input_types(a=typehints.Iterator[int])
-    def increment(a):
-      return [e + 1 for e in a]
-
-    with self.assertRaises(TypeCheckError) as e:
-      increment(wrong_yield_gen())
-
-    self.assertEqual("Type-hint for argument: 'a' violated: Iterator[int] "
-                     "hint type-constraint violated. Expected a iterator "
-                     "of type int. Instead received a iterator of type "
-                     "str.",
-                     e.exception.args[0])
-
-
-class TakesDecoratorTestCase(TypeHintTestCase):
-
-  def test_must_be_primitive_type_or_constraint(self):
-    with self.assertRaises(TypeError) as e:
-      t = [1, 2]
-
-      @with_input_types(a=t)
-      def unused_foo(a):
-        pass
-
-    self.assertEqual('All type hint arguments must be a non-sequence, a '
-                     'type, or a TypeConstraint. [1, 2] is an instance of '
-                     'list.',
-                     e.exception.args[0])
-
-    with self.assertRaises(TypeError) as e:
-      t = 5
-
-      @check_type_hints
-      @with_input_types(a=t)
-      def unused_foo(a):
-        pass
-
-    self.assertEqual('All type hint arguments must be a non-sequence, a type, '
-                     'or a TypeConstraint. 5 is an instance of int.',
-                     e.exception.args[0])
-
-  def test_basic_type_assertion(self):
-    @check_type_hints
-    @with_input_types(a=int)
-    def foo(a):
-      return a + 1
-
-    with self.assertRaises(TypeCheckError) as e:
-      m = 'a'
-      foo(m)
-    self.assertEqual("Type-hint for argument: 'a' violated. Expected an "
-                     "instance of {}, instead found an instance of "
-                     "{}.".format(int, type(m)),
-                     e.exception.args[0])
-
-  def test_composite_type_assertion(self):
-    @check_type_hints
-    @with_input_types(a=typehints.List[int])
-    def foo(a):
-      a.append(1)
-      return a
-
-    with self.assertRaises(TypeCheckError) as e:
-      m = ['f', 'f']
-      foo(m)
-      self.assertEqual("Type-hint for argument: 'a' violated: List[int] hint "
-                       "type-constraint violated. The type of element #0 in "
-                       "the passed list is incorrect. Expected an instance of "
-                       "type int, instead received an instance of type str.",
-                       e.exception.args[0])
-
-  def test_valid_simple_type_arguments(self):
-    @with_input_types(a=str)
-    def upper(a):
-      return a.upper()
-
-    # Type constraints should pass, and function will be evaluated as normal.
-    self.assertEqual('M', upper('m'))
-
-  def test_any_argument_type_hint(self):
-    @check_type_hints
-    @with_input_types(a=typehints.Any)
-    def foo(a):
-      return 4
-
-    self.assertEqual(4, foo('m'))
-
-  def test_valid_mix_positional_and_keyword_arguments(self):
-    @check_type_hints
-    @with_input_types(typehints.List[int], elem=typehints.List[int])
-    def combine(container, elem):
-      return container + elem
-
-    self.assertEqual([1, 2, 3], combine([1, 2], [3]))
-
-  def test_invalid_only_positional_arguments(self):
-    @check_type_hints
+class InputDecoratorTestCase(TypeHintTestCase):
+  def test_valid_hint(self):
     @with_input_types(int, int)
-    def sub(a, b):
-      return a - b
-
-    with self.assertRaises(TypeCheckError) as e:
-      m = 'two'
-      sub(1, m)
-
-    self.assertEqual("Type-hint for argument: 'b' violated. Expected an "
-                     "instance of {}, instead found an instance of "
-                     "{}.".format(int, type(m)),
-                     e.exception.args[0])
-
-  def test_valid_only_positional_arguments(self):
-    @with_input_types(int, int)
-    def add(a, b):
+    def unused_add(a, b):
       return a + b
 
-    self.assertEqual(3, add(1, 2))
+    @with_input_types(int, b=int)
+    def unused_add2(a, b):
+      return a + b
+
+    @with_input_types(a=int, b=int)
+    def unused_add3(a, b):
+      return a + b
+
+  def test_invalid_kw_hint(self):
+    with self.assertRaisesRegexp(TypeError, r'\[1, 2\]'):
+      @with_input_types(a=[1, 2])
+      def unused_foo(a):
+        pass
+
+  def test_invalid_pos_hint(self):
+    with self.assertRaisesRegexp(TypeError, r'\[1, 2\]'):
+      @with_input_types([1, 2])
+      def unused_foo(a):
+        pass
 
 
-class ReturnsDecoratorTestCase(TypeHintTestCase):
+class OutputDecoratorTestCase(TypeHintTestCase):
+
+  def test_valid_hint(self):
+    @with_output_types(int)
+    def unused_foo():
+      return 5
+
+    @with_output_types(None)
+    def unused_foo():
+      return 5
+
+    @with_output_types(Tuple[int, str])
+    def unused_foo():
+      return 5, 'bar'
 
   def test_no_kwargs_accepted(self):
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegexp(ValueError, r'must be positional'):
       @with_output_types(m=int)
       def unused_foo():
         return 5
@@ -918,138 +776,15 @@ class ReturnsDecoratorTestCase(TypeHintTestCase):
       def unused_foo():
         return 4, 'f'
 
-  def test_type_check_violation(self):
-    @check_type_hints
-    @with_output_types(int)
-    def foo(a):
-      return 'test'
-    with self.assertRaises(TypeCheckError) as e:
-      m = 4
-      foo(m)
-
-    self.assertEqual("Type-hint for return type violated. Expected an "
-                     "instance of {}, instead found an instance of "
-                     "{}.".format(int, type('test')),
-                     e.exception.args[0])
-
-  def test_type_check_simple_type(self):
-    @with_output_types(str)
-    def upper(a):
-      return a.upper()
-    self.assertEqual('TEST', upper('test'))
-
   def test_type_check_composite_type(self):
     @with_output_types(typehints.List[typehints.Tuple[int, int]])
-    def bar():
+    def unused_bar():
       return [(i, i+1) for i in range(5)]
-
-    self.assertEqual([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)], bar())
 
   def test_any_return_type_hint(self):
     @with_output_types(typehints.Any)
-    def bar():
+    def unused_bar():
       return 'foo'
-
-    self.assertEqual('foo', bar())
-
-
-class CombinedReturnsAndTakesTestCase(TypeHintTestCase):
-
-  def test_enable_and_disable_type_checking_takes(self):
-    @with_input_types(a=int)
-    def int_to_str(a):
-      return str(a)
-
-    # The function call below violates the argument type-hint above, but won't
-    # result in an exception since run-time type-checking was disabled above.
-    self.assertEqual('a', int_to_str('a'))
-
-    # Must re-define since the conditional is in the (maybe)wrapper.
-    @check_type_hints
-    @with_input_types(a=int)
-    def int_to_str(a):
-      return str(a)
-
-    # With run-time type checking enabled once again the same call-atttempt
-    # should result in a TypeCheckError.
-    with self.assertRaises(TypeCheckError):
-      int_to_str('a')
-
-  def test_enable_and_disable_type_checking_returns(self):
-    @with_output_types(str)
-    def int_to_str(a):
-      return a
-
-    # The return value of the function above violates the return-type
-    # type-hint above, but won't result in an exception since run-time
-    # type-checking was disabled above.
-    self.assertEqual(9, int_to_str(9))
-
-    # Must re-define since the conditional is in the (maybe)wrapper.
-    @check_type_hints
-    @with_output_types(str)
-    def int_to_str(a):
-      return a
-
-    # With type-checking enabled once again we should get a TypeCheckError here.
-    with self.assertRaises(TypeCheckError):
-      int_to_str(9)
-
-  def test_valid_mix_pos_and_keyword_with_both_orders(self):
-    @with_input_types(str, start=int)
-    @with_output_types(str)
-    def to_upper_with_slice(string, start):
-      return string.upper()[start:]
-
-    self.assertEqual('ELLO', to_upper_with_slice('hello', 1))
-
-  def test_simple_takes_and_returns_hints(self):
-    @check_type_hints
-    @with_output_types(str)
-    @with_input_types(a=str)
-    def to_lower(a):
-      return a.lower()
-
-    # Return type and argument type satisfied, should work as normal.
-    self.assertEqual('m', to_lower('M'))
-
-    # Invalid argument type should raise a TypeCheckError
-    with self.assertRaises(TypeCheckError):
-      to_lower(5)
-
-    @check_type_hints
-    @with_output_types(str)
-    @with_input_types(a=str)
-    def to_lower(a):
-      return 9
-
-    # Modified function now has an invalid return type.
-    with self.assertRaises(TypeCheckError):
-      to_lower('a')
-
-  def test_composite_takes_and_returns_hints(self):
-    @check_type_hints
-    @with_input_types(it=typehints.List[int])
-    @with_output_types(typehints.List[typehints.Tuple[int, int]])
-    def expand_ints(it):
-      return [(i, i + 1) for i in it]
-
-    # Return type and argument type satisfied, should work as normal.
-    self.assertEqual([(0, 1), (1, 2), (2, 3)], expand_ints(list(range(3))))
-
-    # Invalid argument, list of str instead of int.
-    with self.assertRaises(TypeCheckError):
-      expand_ints('t e s t'.split())
-
-    @check_type_hints
-    @with_output_types(typehints.List[typehints.Tuple[int, int]])
-    @with_input_types(it=typehints.List[int])
-    def expand_ints(it):
-      return [str(i) for i in it]
-
-    # Modified function now has invalid return type.
-    with self.assertRaises(TypeCheckError):
-      expand_ints(list(range(2)))
 
 
 class DecoratorHelpers(TypeHintTestCase):
@@ -1062,25 +797,60 @@ class DecoratorHelpers(TypeHintTestCase):
     self.assertTrue(is_consistent_with(str, Union[str, int]))
     self.assertFalse(is_consistent_with(Union[str, int], str))
 
-  def test_positional_arg_hints(self):
-    self.assertEqual(typehints.Any, _positional_arg_hints('x', {}))
-    self.assertEqual(int, _positional_arg_hints('x', {'x': int}))
-    self.assertEqual(typehints.Tuple[int, typehints.Any],
-                     _positional_arg_hints(['x', 'y'], {'x': int}))
-
   def test_getcallargs_forhints(self):
     def func(a, b_c, *d):
       b, c = b_c # pylint: disable=unused-variable
       return None
     self.assertEqual(
         {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...]},
-        getcallargs_forhints(func, *[Any, Any]))
-    self.assertEqual(
-        {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...]},
-        getcallargs_forhints(func, *[Any, Any, Any, int]))
+        getcallargs_forhints(False, func, *[Any, Any]))
+    if sys.version_info >= (3,):
+      self.assertEqual(
+          {'a': Any, 'b_c': Any, 'd': Tuple[Union[int, str], ...]},
+          getcallargs_forhints(False, func, *[Any, Any, str, int]))
+    else:
+      self.assertEqual(
+          {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...]},
+          getcallargs_forhints(False, func, *[Any, Any, Any, int]))
     self.assertEqual(
         {'a': int, 'b_c': Tuple[str, Any], 'd': Tuple[Any, ...]},
-        getcallargs_forhints(func, *[int, Tuple[str, Any]]))
+        getcallargs_forhints(False, func, *[int, Tuple[str, Any]]))
+
+  def test_getcallargs_forhints_using_var_hints(self):
+    def func(a, b_c, *d):
+      return a, b_c, d
+
+    self.assertEqual(
+        {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...]},
+        getcallargs_forhints(True, func, *[Any, Any]))
+    if sys.version_info >= (3,):
+      self.assertEqual(
+          {'a': Any, 'b_c': Any, 'd': Tuple[str, ...]},
+          getcallargs_forhints(True, func, *[Any, Any, Tuple[str, ...]]))
+    else:
+      self.assertEqual(
+          {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...]},
+          getcallargs_forhints(True, func, *[Any, Any, Any, int]))
+    self.assertEqual(
+        {'a': int, 'b_c': Tuple[str, Any], 'd': Tuple[Any, ...]},
+        getcallargs_forhints(True, func, *[int, Tuple[str, Any]]))
+
+  @unittest.skipIf(sys.version_info < (3,),
+                   'kwargs not supported in Py2 version of this function')
+  def test_getcallargs_forhints_varkw(self):
+    def func(a, b_c, *d, **e):
+      return a, b_c, d, e
+
+    self.assertEqual(
+        {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...],
+         'e': Dict[str, Union[str, int]]},
+        getcallargs_forhints(False, func, *[Any, Any],
+                             **{'kw1': str, 'kw2': int}))
+    self.assertEqual(
+        {'a': Any, 'b_c': Any, 'd': Tuple[Any, ...],
+         'e': Dict[str, Union[str, int]]},
+        getcallargs_forhints(True, func, *[Any, Any],
+                             e=Dict[str, Union[int, str]]))
 
   def test_getcallargs_forhints_builtins(self):
     if sys.version_info.major < 3:
@@ -1088,31 +858,31 @@ class DecoratorHelpers(TypeHintTestCase):
           {'_': str,
            '__unknown__varargs': Tuple[Any, ...],
            '__unknown__keywords': typehints.Dict[Any, Any]},
-          getcallargs_forhints(str.upper, str))
+          getcallargs_forhints(False, str.upper, str))
       self.assertEqual(
           {'_': str,
            '__unknown__varargs': Tuple[Any, ...],
            '__unknown__keywords': typehints.Dict[Any, Any]},
-          getcallargs_forhints(str.strip, str, str))
+          getcallargs_forhints(False, str.strip, str, str))
       self.assertEqual(
           {'_': str,
            '__unknown__varargs': Tuple[Any, ...],
            '__unknown__keywords': typehints.Dict[Any, Any]},
-          getcallargs_forhints(str.join, str, list))
+          getcallargs_forhints(False, str.join, str, list))
     elif sys.version_info.minor < 7:
       # Signatures for builtins are not supported in 3.5 and 3.6.
-      self.assertEqual({}, getcallargs_forhints(str.upper, str))
-      self.assertEqual({}, getcallargs_forhints(str.strip, str, str))
-      self.assertEqual({}, getcallargs_forhints(str.join, str, list))
+      self.assertEqual({}, getcallargs_forhints(False, str.upper, str))
+      self.assertEqual({}, getcallargs_forhints(False, str.strip, str, str))
+      self.assertEqual({}, getcallargs_forhints(False, str.join, str, list))
     else:
       self.assertEqual(
           {'self': str},
-          getcallargs_forhints(str.upper, str))
+          getcallargs_forhints(False, str.upper, str))
       # str.strip has an optional second argument.
       self.assertEqual({'self': str, 'chars': Any},
-                       getcallargs_forhints(str.strip, str))
+                       getcallargs_forhints(False, str.strip, str))
       self.assertEqual({'self': str, 'iterable': list},
-                       getcallargs_forhints(str.join, str, list))
+                       getcallargs_forhints(False, str.join, str, list))
 
 
 class TestCoerceToKvType(TypeHintTestCase):

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -894,6 +894,7 @@ class TakesDecoratorTestCase(TypeHintTestCase):
 
     self.assertEqual(3, add(1, 2))
 
+
 class InputDecoratorTestCase(TypeHintTestCase):
   def test_valid_hint(self):
     @with_input_types(int, int)
@@ -1213,6 +1214,7 @@ class TestGetYieldedType(unittest.TestCase):
   def test_not_iterable(self):
     with self.assertRaisesRegexp(ValueError, r'not iterable'):
       typehints.get_yielded_type(int)
+
 
 class TestCoerceToKvType(TypeHintTestCase):
   def test_coercion_success(self):

--- a/sdks/python/apache_beam/typehints/typehints_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typehints_test_py3.py
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the type-hint objects and decorators with Python 3 syntax not
+supported by 2.7."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import unittest
+
+from apache_beam.transforms.core import DoFn
+from apache_beam.typehints import KV
+
+
+class TestParDoAnnotations(unittest.TestCase):
+  def test_with_side_input(self):
+    class MyDoFn(DoFn):
+      def process(self, element: float, side_input: str) -> KV[str, float]:
+        pass
+    th = MyDoFn().get_type_hints()
+    self.assertEqual(th.input_types, ([float, str], {}))
+    self.assertEqual(th.output_types, ([KV[str, float]], {}))
+
+  def test_pep484_annotations(self):
+    class MyDoFn(DoFn):
+      def process(self, element: int) -> str:
+        pass
+
+    print(MyDoFn().get_type_hints())
+    th = MyDoFn().get_type_hints()
+    self.assertEqual(th.input_types, ([int], {}))
+    self.assertEqual(th.output_types, ([str], {}))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/typehints/typehints_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typehints_test_py3.py
@@ -25,26 +25,28 @@ import unittest
 
 from apache_beam.transforms.core import DoFn
 from apache_beam.typehints import KV
+from apache_beam.typehints import Iterable
 
 
 class TestParDoAnnotations(unittest.TestCase):
   def test_with_side_input(self):
     class MyDoFn(DoFn):
-      def process(self, element: float, side_input: str) -> KV[str, float]:
+      def process(self, element: float, side_input: str) -> \
+          Iterable[KV[str, float]]:
         pass
     th = MyDoFn().get_type_hints()
-    self.assertEqual(th.input_types, ([float, str], {}))
-    self.assertEqual(th.output_types, ([KV[str, float]], {}))
+    self.assertEqual(th.input_types, ((float, str), {}))
+    self.assertEqual(th.output_types, ((KV[str, float],), {}))
 
   def test_pep484_annotations(self):
     class MyDoFn(DoFn):
-      def process(self, element: int) -> str:
+      def process(self, element: int) -> Iterable[str]:
         pass
 
     print(MyDoFn().get_type_hints())
     th = MyDoFn().get_type_hints()
-    self.assertEqual(th.input_types, ([int], {}))
-    self.assertEqual(th.output_types, ([str], {}))
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((str,), {}))
 
 
 if __name__ == '__main__':

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -107,6 +107,7 @@ REQUIRED_PACKAGES = [
     'crcmod>=1.7,<2.0',
     'dill>=0.2.9,<0.4.0',
     'fastavro>=0.21.4,<0.22',
+    'funcsigs>=1.0.2,<2; python_version < "3.0"',
     'future>=0.16.0,<1.0.0',
     'futures>=3.2.0,<4.0.0; python_version < "3.0"',
     'grpcio>=1.12.1,<2',


### PR DESCRIPTION
Implements IOTypeHints.from_callable() to get type hints where
annotations are available.

Some under the hood changes to how arguments are obtained and applied. See commits for more details.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
