### PR TITLE
[WIP] Add TemporaryPubsubResouce objects which automatically collect create topics, subscriptions, and snapshots

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/caching/pubsub_utils.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pubsub_utils.py
@@ -1,0 +1,216 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+import uuid
+import warnings
+from datetime import datetime
+
+try:
+  from weakref import finalize
+except ImportError:
+  from backports.weakref import finalize
+
+try:
+  from google.api_core import exceptions as gexc
+  from google.cloud import pubsub
+except ImportError:
+  gexc = None
+  pubsub = None
+
+__all__ = [
+    "TemporaryPubsubTopic", "TemporaryPubsubSubscription",
+    "TemporaryPubsubSnapshot"
+]
+
+
+def generate_unique_name(prefix):
+  unique_name = "{}-{}-{}".format(prefix,
+                                  datetime.now().strftime("%Y-%m-%d-%H%M%S"),
+                                  uuid.uuid4().hex[:8])
+  return unique_name
+
+
+class TemporaryPubsubTopic(object):
+  """Create a temporary PubSub topic.
+
+  When the resulting object goes out of scope, the underlying topic is
+  deleted. The result can also be used as a context manager, in which case
+  the topic is deleted once the context is closed.
+
+  Attributes:
+    name (str): The name of the temporary topic.
+  """
+
+  def __init__(self, project, prefix="temp"):
+    self.pub_client = pubsub.PublisherClient()
+    self.project = project
+
+    num_tires = 5
+    for _ in range(num_tires):
+      try:
+        self.topic = self.pub_client.create_topic(
+            self.pub_client.topic_path(self.project,
+                                       generate_unique_name(prefix)))
+        break
+      except gexc.AlreadyExists:
+        pass
+    else:
+      raise ValueError(
+          "Could not create a unique topic after {} tries.".format(num_tires))
+
+    self._finalizer = finalize(
+        self,
+        self._cleanup,
+        self.pub_client,
+        self.topic.name,
+        warn_message="Implicitly cleaning up {!r}".format(self))
+
+  @property
+  def name(self):
+    return self.topic.name
+
+  @classmethod
+  def _cleanup(cls, pub_client, name, warn_message):
+    pub_client.delete_topic(name)
+    warnings.warn(warn_message, ResourceWarning)
+
+  def cleanup(self):
+    if self._finalizer.detach():
+      self.pub_client.delete_topic(self.topic.name)
+
+  def __enter__(self):
+    return self.name
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    self.cleanup()
+
+
+class TemporaryPubsubSubscription(object):
+  """Create a temporary PubSub subscription.
+
+  When the resulting object goes out of scope, the underlying subscription is
+  deleted. The result can also be used as a context manager, in which case
+  the subscription is deleted once the context is closed.
+
+  Attributes:
+    name (str): The name of the temporary subscription.
+  """
+
+  def __init__(self, project, topic_path, prefix="temp"):
+    self.sub_client = pubsub.SubscriberClient()
+    self.project = project
+    self.topic_path = topic_path
+
+    num_tires = 5
+    for _ in range(num_tires):
+      try:
+        self.subscription = self.sub_client.create_subscription(
+            self.sub_client.subscription_path(self.project,
+                                              generate_unique_name(prefix)),
+            self.topic_path)
+        break
+      except gexc.AlreadyExists:
+        pass
+    else:
+      raise ValueError(
+          "Could not create a unique subscription after {} tries.".format(
+              num_tires))
+
+    self._finalizer = finalize(
+        self,
+        self._cleanup,
+        self.sub_client,
+        self.subscription.name,
+        warn_message="Implicitly cleaning up {!r}".format(self))
+
+  @property
+  def name(self):
+    return self.subscription.name
+
+  @classmethod
+  def _cleanup(cls, sub_client, name, warn_message):
+    sub_client.delete_subscription(name)
+    warnings.warn(warn_message, ResourceWarning)
+
+  def cleanup(self):
+    if self._finalizer.detach():
+      self.sub_client.delete_subscription(self.subscription.name)
+
+  def __enter__(self):
+    return self.name
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    self.cleanup()
+
+
+class TemporaryPubsubSnapshot(object):
+  """Create a temporary PubSub snapshot.
+
+  When the resulting object goes out of scope, the underlying snapshot is
+  deleted. The result can also be used as a context manager, in which case
+  the snapshot is deleted once the context is closed.
+
+  Attributes:
+    name (str): The name of the temporary snapshot.
+  """
+
+  def __init__(self, project, subscription_path, prefix="temp"):
+    self.sub_client = pubsub.SubscriberClient()
+    self.project = project
+    self.subscription_path = subscription_path
+
+    num_tires = 5
+    for _ in range(num_tires):
+      try:
+        self.snapshot = self.sub_client.create_snapshot(
+            self.sub_client.snapshot_path(self.project,
+                                          generate_unique_name(prefix)),
+            self.subscription_path)
+        break
+      except gexc.AlreadyExists:
+        pass
+    else:
+      raise ValueError(
+          "Could not create a unique snapshot after {} tries.".format(
+              num_tires))
+
+    self._finalizer = finalize(
+        self,
+        self._cleanup,
+        self.sub_client,
+        self.snapshot.name,
+        warn_message="Implicitly cleaning up {!r}".format(self))
+
+  @property
+  def name(self):
+    return self.snapshot.name
+
+  @classmethod
+  def _cleanup(cls, sub_client, name, warn_message):
+    sub_client.delete_snapshot(name)
+    warnings.warn(warn_message, ResourceWarning)
+
+  def cleanup(self):
+    if self._finalizer.detach():
+      self.sub_client.delete_snapshot(self.snapshot.name)
+
+  def __enter__(self):
+    return self.name
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    self.cleanup()

--- a/sdks/python/apache_beam/runners/interactive/caching/pubsub_utils_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/pubsub_utils_test.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+
+
+class TemporaryPubsubResourceTest(object):
+
+  def test_create(self, mock_pubsub):
+    pass
+
+  def test_create_existing(self,):
+    with self.assertRaisesRegexp(ValueError, "Could not create"):
+      pass
+
+  def test_explicit_cleanup(self):
+    pass
+
+  def test_implicit_cleanup(self):
+    pass
+
+  def test_garbage_collect(self):
+    pass
+
+  def test_context_manager(self):
+    pass


### PR DESCRIPTION


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
