### PR TITLE
[BEAM-5822] Remove non vendored byte-buddy dependency from sdks/java/core

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -375,7 +375,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // non-declared dependency, since these can break users (as in BEAM-6558)
     //
     // Though this is Java-specific, it is required to be applied to the root
-    // project due to implemeentation-details of the plugin. It can be enabled/disabled
+    // project due to implementation-details of the plugin. It can be enabled/disabled
     // via JavaNatureConfiguration per project. It is disabled by default until we can
     // make all of our deps good.
     project.apply plugin: "ca.cutterslade.analyze"
@@ -462,7 +462,6 @@ class BeamModulePlugin implements Plugin<Project> {
         bigdataoss_util                             : "com.google.cloud.bigdataoss:util:$google_cloud_bigdataoss_version",
         bigtable_client_core                        : "com.google.cloud.bigtable:bigtable-client-core:1.8.0",
         bigtable_protos                             : "com.google.api.grpc:grpc-google-cloud-bigtable-v2:$generated_grpc_beta_version",
-        byte_buddy                                  : "net.bytebuddy:byte-buddy:1.9.3",
         cassandra_driver_core                       : "com.datastax.cassandra:cassandra-driver-core:$cassandra_driver_version",
         cassandra_driver_mapping                    : "com.datastax.cassandra:cassandra-driver-mapping:$cassandra_driver_version",
         commons_codec                               : "commons-codec:commons-codec:1.10",
@@ -832,7 +831,6 @@ class BeamModulePlugin implements Plugin<Project> {
       project.apply plugin: "net.ltgt.apt-eclipse"
 
       // Enables a plugin which can apply code formatting to source.
-      // TODO(https://issues.apache.org/jira/browse/BEAM-4394): Should this plugin be enabled for all projects?
       project.apply plugin: "com.diffplug.gradle.spotless"
       // scan CVE
       project.apply plugin: "net.ossindex.audit"

--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -114,6 +114,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="message" value="You should not use TestNG classes in Beam."/>
     </module>
 
+    <!-- Forbid Non-vendored byte-buddy imports. -->
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="ForbidByteBuddy"/>
+      <property name="format" value="(\snet\.bytebuddy)"/>
+      <property name="severity" value="error"/>
+      <property name="message" value="You are using raw byte-buddy, please use vendored byte-buddy classes."/>
+    </module>
+
     <module name="UnusedImports">
       <property name="severity" value="error"/>
       <property name="processJavadoc" value="true"/>

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -64,7 +64,6 @@ dependencies {
   shadow library.java.vendored_guava_26_0_jre
   compile library.java.antlr_runtime
   compile library.java.protobuf_java
-  compile library.java.byte_buddy
   compile library.java.commons_compress
   compile library.java.commons_lang3
   shadow library.java.jackson_core


### PR DESCRIPTION
Just fixing some minor things forgotten after #9272

It also enforces that no Beam module uses the unvendored byte-buddy
dependency in the future.

R: @lukecwik 
CC: @vectorijk @kennknowles 
