### PR TITLE
[BEAM-7980] External environment with containerized worker pool

### DIFF
--- a/model/fn-execution/src/main/proto/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/beam_fn_api.proto
@@ -804,7 +804,7 @@ service BeamFnLogging {
           stream LogControl) {}
 }
 
-message NotifyRunnerAvailableRequest {
+message StartWorkerRequest {
   string worker_id = 1;
   org.apache.beam.model.pipeline.v1.ApiServiceDescriptor control_endpoint = 2;
   org.apache.beam.model.pipeline.v1.ApiServiceDescriptor logging_endpoint = 3;
@@ -813,11 +813,21 @@ message NotifyRunnerAvailableRequest {
   map<string, string> params = 10;
 }
 
-message NotifyRunnerAvailableResponse {
+message StartWorkerResponse {
+  string error = 1;
+}
+
+message StopWorkerRequest {
+  string worker_id = 1;
+}
+
+message StopWorkerResponse {
   string error = 1;
 }
 
 service BeamFnExternalWorkerPool {
-  rpc NotifyRunnerAvailable(NotifyRunnerAvailableRequest)
-      returns (NotifyRunnerAvailableResponse) {}
+  // Start the SDK worker with the given ID.
+  rpc StartWorker (StartWorkerRequest) returns (StartWorkerResponse) {}
+  // Stop the SDK worker.
+  rpc StopWorker (StopWorkerRequest) returns (StopWorkerResponse) {}
 }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
@@ -206,7 +206,7 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
    * hostname has historically changed between versions, so this is subject to breakages and will
    * likely only support the latest version at any time.
    */
-  private static class DockerOnMac {
+  static class DockerOnMac {
     // TODO: This host name seems to change with every other Docker release. Do we attempt to keep
     // up
     // or attempt to document the supported Docker version(s)?
@@ -220,7 +220,7 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
     private static final int MAC_PORT_END = 8200;
     private static final AtomicInteger MAC_PORT = new AtomicInteger(MAC_PORT_START);
 
-    private static ServerFactory getServerFactory() {
+    static ServerFactory getServerFactory() {
       ServerFactory.UrlFactory dockerUrlFactory =
           (host, port) -> HostAndPort.fromParts(DOCKER_FOR_MAC_HOST, port).toString();
       if (RUNNING_INSIDE_DOCKER_ON_MAC) {

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/ExternalWorkerService.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/ExternalWorkerService.java
@@ -18,8 +18,8 @@
 package org.apache.beam.runners.reference;
 
 import org.apache.beam.fn.harness.FnHarness;
-import org.apache.beam.model.fnexecution.v1.BeamFnApi.NotifyRunnerAvailableRequest;
-import org.apache.beam.model.fnexecution.v1.BeamFnApi.NotifyRunnerAvailableResponse;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.StartWorkerRequest;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.StartWorkerResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnExternalWorkerPoolGrpc.BeamFnExternalWorkerPoolImplBase;
 import org.apache.beam.runners.fnexecution.FnService;
 import org.apache.beam.runners.fnexecution.GrpcFnServer;
@@ -44,9 +44,8 @@ public class ExternalWorkerService extends BeamFnExternalWorkerPoolImplBase impl
   }
 
   @Override
-  public void notifyRunnerAvailable(
-      NotifyRunnerAvailableRequest request,
-      StreamObserver<NotifyRunnerAvailableResponse> responseObserver) {
+  public void startWorker(
+      StartWorkerRequest request, StreamObserver<StartWorkerResponse> responseObserver) {
     LOG.info(
         "Starting worker {} pointing at {}.",
         request.getWorkerId(),
@@ -70,7 +69,7 @@ public class ExternalWorkerService extends BeamFnExternalWorkerPoolImplBase impl
     th.setDaemon(true);
     th.start();
 
-    responseObserver.onNext(NotifyRunnerAvailableResponse.newBuilder().build());
+    responseObserver.onNext(StartWorkerResponse.newBuilder().build());
     responseObserver.onCompleted();
   }
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -1264,8 +1264,8 @@ class ExternalWorkerHandler(GrpcWorkerHandler):
     stub = beam_fn_api_pb2_grpc.BeamFnExternalWorkerPoolStub(
         GRPCChannelFactory.insecure_channel(
             self._external_payload.endpoint.url))
-    response = stub.NotifyRunnerAvailable(
-        beam_fn_api_pb2.NotifyRunnerAvailableRequest(
+    response = stub.StartWorker(
+        beam_fn_api_pb2.StartWorkerRequest(
             worker_id=self.worker_id,
             control_endpoint=endpoints_pb2.ApiServiceDescriptor(
                 url=self.control_address),

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -44,6 +44,7 @@ from apache_beam.runners.portability import fn_api_runner_test
 from apache_beam.runners.portability import portable_runner
 from apache_beam.runners.portability.local_job_service import LocalJobServicer
 from apache_beam.runners.portability.portable_runner import PortableRunner
+from apache_beam.runners.worker import worker_pool_main
 from apache_beam.runners.worker.channel_factory import GRPCChannelFactory
 
 
@@ -199,7 +200,7 @@ class PortableRunnerTestWithExternalEnv(PortableRunnerTest):
   @classmethod
   def setUpClass(cls):
     cls._worker_address, cls._worker_server = (
-        portable_runner.BeamFnExternalWorkerPoolServicer.start())
+        worker_pool_main.BeamFnExternalWorkerPoolServicer.start())
 
   @classmethod
   def tearDownClass(cls):

--- a/sdks/python/apache_beam/runners/worker/worker_pool_main.py
+++ b/sdks/python/apache_beam/runners/worker/worker_pool_main.py
@@ -1,0 +1,177 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Worker pool entry point.
+
+The worker pool exposes an RPC service that is used with EXTERNAL
+environment to start and stop the SDK workers.
+
+The worker pool uses child processes for parallelism; threads are
+subject to the GIL and not sufficient.
+
+This entry point is used by the Python SDK container in worker pool mode.
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import atexit
+import logging
+import subprocess
+import sys
+import threading
+import time
+from concurrent import futures
+
+import grpc
+
+from apache_beam.portability.api import beam_fn_api_pb2
+from apache_beam.portability.api import beam_fn_api_pb2_grpc
+from apache_beam.runners.worker import sdk_worker
+
+
+class BeamFnExternalWorkerPoolServicer(
+    beam_fn_api_pb2_grpc.BeamFnExternalWorkerPoolServicer):
+
+  def __init__(self, worker_threads, use_process=False,
+               container_executable=None):
+    self._worker_threads = worker_threads
+    self._use_process = use_process
+    self._container_executable = container_executable
+    self._worker_processes = {}
+
+  @classmethod
+  def start(cls, worker_threads=1, use_process=False, port=0,
+            container_executable=None):
+    worker_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    worker_address = 'localhost:%s' % worker_server.add_insecure_port(
+        '[::]:%s' % port)
+    beam_fn_api_pb2_grpc.add_BeamFnExternalWorkerPoolServicer_to_server(
+        cls(worker_threads,
+            use_process=use_process,
+            container_executable=container_executable),
+        worker_server)
+    worker_server.start()
+
+    # Register to kill the subprocesses on exit.
+    def kill_worker_processes():
+      for worker_process in cls._worker_processes.values():
+        worker_process.kill()
+    atexit.register(kill_worker_processes)
+
+    return worker_address, worker_server
+
+  def StartWorker(self, start_worker_request, unused_context):
+    try:
+      if self._use_process:
+        command = ['python', '-c',
+                   'from apache_beam.runners.worker.sdk_worker '
+                   'import SdkHarness; '
+                   'SdkHarness("%s",worker_count=%d,worker_id="%s").run()' % (
+                       start_worker_request.control_endpoint.url,
+                       self._worker_threads,
+                       start_worker_request.worker_id)]
+        if self._container_executable:
+          # command as per container spec
+          # the executable is responsible to handle concurrency
+          # for artifact retrieval and other side effects
+          command = [self._container_executable,
+                     '--id=%s' % start_worker_request.worker_id,
+                     '--logging_endpoint=%s'
+                     % start_worker_request.logging_endpoint.url,
+                     '--artifact_endpoint=%s'
+                     % start_worker_request.artifact_endpoint.url,
+                     '--provision_endpoint=%s'
+                     % start_worker_request.provision_endpoint.url,
+                     '--control_endpoint=%s'
+                     % start_worker_request.control_endpoint.url,
+                    ]
+
+        logging.warn("Starting worker with command %s" % command)
+        worker_process = subprocess.Popen(command, stdout=subprocess.PIPE,
+                                          close_fds=True)
+        self._worker_processes[start_worker_request.worker_id] = worker_process
+      else:
+        worker = sdk_worker.SdkHarness(
+            start_worker_request.control_endpoint.url,
+            worker_count=self._worker_threads,
+            worker_id=start_worker_request.worker_id)
+        worker_thread = threading.Thread(
+            name='run_worker_%s' % start_worker_request.worker_id,
+            target=worker.run)
+        worker_thread.daemon = True
+        worker_thread.start()
+
+      return beam_fn_api_pb2.StartWorkerResponse()
+    except Exception as exn:
+      return beam_fn_api_pb2.StartWorkerResponse(error=str(exn))
+
+  def StopWorker(self, stop_worker_request, unused_context):
+    # applicable for process mode to ensure process cleanup
+    # thread based workers terminate automatically
+    worker_process = self._worker_processes.pop(stop_worker_request.worker_id)
+    if worker_process:
+      def kill_worker_process():
+        try:
+          worker_process.kill()
+        except OSError:
+          # ignore already terminated process
+          return
+      logging.info("Stopping worker %s" % stop_worker_request.worker_id)
+      # communicate is necessary to avoid zombie process
+      # time box communicate (it has no timeout parameter in Py2)
+      threading.Timer(1, kill_worker_process).start()
+      worker_process.communicate()
+    return beam_fn_api_pb2.StopWorkerResponse()
+
+
+def main(argv=None):
+  """Entry point for worker pool service for external environments."""
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--threads_per_worker',
+                      type=int,
+                      default=argparse.SUPPRESS,
+                      dest='worker_threads',
+                      help='Number of threads per SDK worker.')
+  parser.add_argument('--container_executable',
+                      type=str,
+                      default=None,
+                      help='Executable that implements the Beam SDK '
+                           'container contract.')
+  parser.add_argument('--service_port',
+                      type=int,
+                      required=True,
+                      dest='port',
+                      help='Bind port for the worker pool service.')
+
+  args, _ = parser.parse_known_args(argv)
+
+  address, server = (BeamFnExternalWorkerPoolServicer.start(use_process=True,
+                                                            **vars(args)))
+  logging.getLogger().setLevel(logging.INFO)
+  logging.info('Started worker pool servicer at port: %s with executable: %s',
+               address, args.container_executable)
+  try:
+    while True:
+      time.sleep(60 * 60 * 24)
+  except KeyboardInterrupt:
+    server.stop(0)
+
+
+if __name__ == '__main__':
+  main(sys.argv)

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -40,6 +40,7 @@ var (
 
 	// Contract: https://s.apache.org/beam-fn-api-container-contract.
 
+	workerPool        = flag.Bool("worker_pool", false, "Run as worker pool (optional).")
 	id                = flag.String("id", "", "Local identifier (required).")
 	loggingEndpoint   = flag.String("logging_endpoint", "", "Logging endpoint (required).")
 	artifactEndpoint  = flag.String("artifact_endpoint", "", "Artifact endpoint (required).")
@@ -59,6 +60,18 @@ const (
 
 func main() {
 	flag.Parse()
+
+	if *workerPool == true {
+		args := []string{
+			"-m",
+			"apache_beam.runners.worker.worker_pool_main",
+			"--service_port=50000",
+			"--container_executable=/opt/apache/beam/boot",
+		}
+		log.Printf("Starting Python SDK worker pool: python %v", strings.Join(args, " "))
+		log.Fatalf("Python SDK worker pool exited: %v", execx.Execute("python", args...))
+	}
+
 	if *id == "" {
 		log.Fatal("No id provided.")
 	}


### PR DESCRIPTION
Add option to use the Python SDK Docker image for execution as worker pool, launching individual workers through boot.go as per container spec.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
