### PR TITLE
[Beam-6858] Validate that side-input parameters match the type of the PCollectionView

### DIFF
--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslationTest.java
@@ -19,8 +19,6 @@ package org.apache.beam.runners.core.construction;
 
 import static org.junit.Assert.assertThat;
 
-import java.io.Serializable;
-import java.util.function.Supplier;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.runners.AppliedPTransform;
@@ -32,7 +30,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
-import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.PCollectionViews.TypeDescriptorSupplier;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.hamcrest.Matchers;
@@ -54,7 +52,7 @@ public class CreatePCollectionViewTranslationTest {
         CreatePCollectionView.of(
             PCollectionViews.singletonView(
                 testPCollection,
-                (Supplier<TypeDescriptor<String>> & Serializable) () -> TypeDescriptors.strings(),
+                (TypeDescriptorSupplier<String>) () -> TypeDescriptors.strings(),
                 testPCollection.getWindowingStrategy(),
                 false,
                 null,
@@ -62,7 +60,7 @@ public class CreatePCollectionViewTranslationTest {
         CreatePCollectionView.of(
             PCollectionViews.listView(
                 testPCollection,
-                (Supplier<TypeDescriptor<String>> & Serializable) () -> TypeDescriptors.strings(),
+                (TypeDescriptorSupplier<String>) () -> TypeDescriptors.strings(),
                 testPCollection.getWindowingStrategy())));
   }
 

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslationTest.java
@@ -19,6 +19,8 @@ package org.apache.beam.runners.core.construction;
 
 import static org.junit.Assert.assertThat;
 
+import java.io.Serializable;
+import java.util.function.Supplier;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.runners.AppliedPTransform;
@@ -30,6 +32,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.hamcrest.Matchers;
@@ -51,7 +54,7 @@ public class CreatePCollectionViewTranslationTest {
         CreatePCollectionView.of(
             PCollectionViews.singletonView(
                 testPCollection,
-                () -> TypeDescriptors.strings(),
+                (Supplier<TypeDescriptor<String>> & Serializable) () -> TypeDescriptors.strings(),
                 testPCollection.getWindowingStrategy(),
                 false,
                 null,
@@ -59,7 +62,7 @@ public class CreatePCollectionViewTranslationTest {
         CreatePCollectionView.of(
             PCollectionViews.listView(
                 testPCollection,
-                () -> TypeDescriptors.strings(),
+                (Supplier<TypeDescriptor<String>> & Serializable) () -> TypeDescriptors.strings(),
                 testPCollection.getWindowingStrategy())));
   }
 

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslationTest.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -50,12 +51,16 @@ public class CreatePCollectionViewTranslationTest {
         CreatePCollectionView.of(
             PCollectionViews.singletonView(
                 testPCollection,
+                () -> TypeDescriptors.strings(),
                 testPCollection.getWindowingStrategy(),
                 false,
                 null,
                 StringUtf8Coder.of())),
         CreatePCollectionView.of(
-            PCollectionViews.listView(testPCollection, testPCollection.getWindowingStrategy())));
+            PCollectionViews.listView(
+                testPCollection,
+                () -> TypeDescriptors.strings(),
+                testPCollection.getWindowingStrategy())));
   }
 
   @Parameter(0)

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PCollectionViewTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PCollectionViewTranslationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import org.apache.beam.sdk.transforms.Materialization;
 import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -60,6 +61,11 @@ public class PCollectionViewTranslationTest {
     @Override
     public Object apply(Object o) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TypeDescriptor<Object> getTypeDescriptor() {
+      return new TypeDescriptor<Object>() {};
     }
 
     @Override

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -66,9 +66,11 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.PCollectionViews.IterableViewFn;
 import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
@@ -405,7 +407,8 @@ public class PTransformMatchersTest implements Serializable {
     PCollectionView<Iterable<Integer>> view = input.apply(View.asIterable());
 
     // Purposely create a subclass to get a different class then what was expected.
-    ViewFn<?, ?> viewFn = new PCollectionViews.IterableViewFn() {};
+    IterableViewFn<Integer> viewFn =
+        new PCollectionViews.IterableViewFn<Integer>(() -> TypeDescriptors.integers()) {};
     CreatePCollectionView<?, ?> createView = CreatePCollectionView.of(view);
 
     PTransformMatcher matcher = PTransformMatchers.createViewWithViewFn(viewFn.getClass());

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 import java.io.IOException;
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,7 +37,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.function.Supplier;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.SystemReduceFn;
 import org.apache.beam.runners.core.construction.NativeTransforms;
@@ -811,9 +809,9 @@ public class FlinkStreamingPortablePipelineTranslator
     ViewFn<Iterable<WindowedValue<?>>, ?> viewFn =
         (ViewFn)
             new PCollectionViews.MultimapViewFn<>(
-                (Supplier<TypeDescriptor<Iterable<WindowedValue<Void>>>> & Serializable)
+                (PCollectionViews.TypeDescriptorSupplier<Iterable<WindowedValue<Void>>>)
                     () -> TypeDescriptors.iterables(new TypeDescriptor<WindowedValue<Void>>() {}),
-                (Supplier<TypeDescriptor<Void>> & Serializable) TypeDescriptors::voids);
+                (PCollectionViews.TypeDescriptorSupplier<Void>) TypeDescriptors::voids);
 
     for (RunnerApi.ExecutableStagePayload.SideInputId sideInputId :
         stagePayload.getSideInputsList()) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,6 +38,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.SystemReduceFn;
 import org.apache.beam.runners.core.construction.NativeTransforms;
@@ -85,6 +87,8 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
 import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.sdk.values.ValueWithRecordId;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.InvalidProtocolBufferException;
@@ -805,7 +809,11 @@ public class FlinkStreamingPortablePipelineTranslator
         new LinkedHashMap<>();
     // for PCollectionView compatibility, not used to transform materialization
     ViewFn<Iterable<WindowedValue<?>>, ?> viewFn =
-        (ViewFn) new PCollectionViews.MultimapViewFn<Iterable<WindowedValue<Void>>, Void>();
+        (ViewFn)
+            new PCollectionViews.MultimapViewFn<>(
+                (Supplier<TypeDescriptor<Iterable<WindowedValue<Void>>>> & Serializable)
+                    () -> TypeDescriptors.iterables(new TypeDescriptor<WindowedValue<Void>>() {}),
+                (Supplier<TypeDescriptor<Void>> & Serializable) TypeDescriptors::voids);
 
     for (RunnerApi.ExecutableStagePayload.SideInputId sideInputId :
         stagePayload.getSideInputsList()) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowPortabilityPCollectionView.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowPortabilityPCollectionView.java
@@ -38,6 +38,7 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.WindowingStrategy;
 
 /**
@@ -104,6 +105,11 @@ public class DataflowPortabilityPCollectionView<K, V, W extends BoundedWindow>
     @Override
     public MultimapView<K, V> apply(MultimapView<K, V> o) {
       return o;
+    }
+
+    @Override
+    public TypeDescriptor<MultimapView<K, V>> getTypeDescriptor() {
+      throw new UnsupportedOperationException();
     }
   };
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
@@ -22,7 +22,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -66,6 +64,7 @@ import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.PCollectionViews.TypeDescriptorSupplier;
 import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
@@ -1311,7 +1310,7 @@ public class Combine {
       PCollectionView<OutputT> view =
           PCollectionViews.singletonView(
               materializationInput,
-              (Supplier<TypeDescriptor<OutputT>> & Serializable)
+              (TypeDescriptorSupplier<OutputT>)
                   () -> outputCoder != null ? outputCoder.getEncodedTypeDescriptor() : null,
               input.getWindowingStrategy(),
               insertDefault,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
@@ -17,8 +17,10 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.annotations.Internal;
@@ -32,6 +34,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * Transforms for creating {@link PCollectionView PCollectionViews} from {@link PCollection
@@ -233,9 +236,12 @@ public class View {
 
       PCollection<KV<Void, T>> materializationInput =
           input.apply(new VoidKeyToMultimapMaterialization<>());
+      Coder<T> inputCoder = input.getCoder();
       PCollectionView<List<T>> view =
           PCollectionViews.listView(
-              materializationInput, materializationInput.getWindowingStrategy());
+              materializationInput,
+              (Supplier<TypeDescriptor<T>> & Serializable) inputCoder::getEncodedTypeDescriptor,
+              materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
     }
@@ -263,9 +269,12 @@ public class View {
 
       PCollection<KV<Void, T>> materializationInput =
           input.apply(new VoidKeyToMultimapMaterialization<>());
+      Coder<T> inputCoder = input.getCoder();
       PCollectionView<Iterable<T>> view =
           PCollectionViews.iterableView(
-              materializationInput, materializationInput.getWindowingStrategy());
+              materializationInput,
+              (Supplier<TypeDescriptor<T>> & Serializable) inputCoder::getEncodedTypeDescriptor,
+              materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
     }
@@ -402,11 +411,17 @@ public class View {
         throw new IllegalStateException("Unable to create a side-input view from input", e);
       }
 
+      KvCoder<K, V> kvCoder = (KvCoder<K, V>) input.getCoder();
+      Coder<K> keyCoder = kvCoder.getKeyCoder();
+      Coder<V> valueCoder = kvCoder.getValueCoder();
       PCollection<KV<Void, KV<K, V>>> materializationInput =
           input.apply(new VoidKeyToMultimapMaterialization<>());
       PCollectionView<Map<K, Iterable<V>>> view =
           PCollectionViews.multimapView(
-              materializationInput, materializationInput.getWindowingStrategy());
+              materializationInput,
+              (Supplier<TypeDescriptor<K>> & Serializable) keyCoder::getEncodedTypeDescriptor,
+              (Supplier<TypeDescriptor<V>> & Serializable) valueCoder::getEncodedTypeDescriptor,
+              materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
     }
@@ -438,11 +453,18 @@ public class View {
         throw new IllegalStateException("Unable to create a side-input view from input", e);
       }
 
+      KvCoder<K, V> kvCoder = (KvCoder<K, V>) input.getCoder();
+      Coder<K> keyCoder = kvCoder.getKeyCoder();
+      Coder<V> valueCoder = kvCoder.getValueCoder();
+
       PCollection<KV<Void, KV<K, V>>> materializationInput =
           input.apply(new VoidKeyToMultimapMaterialization<>());
       PCollectionView<Map<K, V>> view =
           PCollectionViews.mapView(
-              materializationInput, materializationInput.getWindowingStrategy());
+              materializationInput,
+              (Supplier<TypeDescriptor<K>> & Serializable) keyCoder::getEncodedTypeDescriptor,
+              (Supplier<TypeDescriptor<V>> & Serializable) valueCoder::getEncodedTypeDescriptor,
+              materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
@@ -17,10 +17,8 @@
  */
 package org.apache.beam.sdk.transforms;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.annotations.Internal;
@@ -34,7 +32,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
-import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.PCollectionViews.TypeDescriptorSupplier;
 
 /**
  * Transforms for creating {@link PCollectionView PCollectionViews} from {@link PCollection
@@ -240,7 +238,7 @@ public class View {
       PCollectionView<List<T>> view =
           PCollectionViews.listView(
               materializationInput,
-              (Supplier<TypeDescriptor<T>> & Serializable) inputCoder::getEncodedTypeDescriptor,
+              (TypeDescriptorSupplier<T>) inputCoder::getEncodedTypeDescriptor,
               materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
@@ -273,7 +271,7 @@ public class View {
       PCollectionView<Iterable<T>> view =
           PCollectionViews.iterableView(
               materializationInput,
-              (Supplier<TypeDescriptor<T>> & Serializable) inputCoder::getEncodedTypeDescriptor,
+              (TypeDescriptorSupplier<T>) inputCoder::getEncodedTypeDescriptor,
               materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
@@ -419,8 +417,8 @@ public class View {
       PCollectionView<Map<K, Iterable<V>>> view =
           PCollectionViews.multimapView(
               materializationInput,
-              (Supplier<TypeDescriptor<K>> & Serializable) keyCoder::getEncodedTypeDescriptor,
-              (Supplier<TypeDescriptor<V>> & Serializable) valueCoder::getEncodedTypeDescriptor,
+              (TypeDescriptorSupplier<K>) keyCoder::getEncodedTypeDescriptor,
+              (TypeDescriptorSupplier<V>) valueCoder::getEncodedTypeDescriptor,
               materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
@@ -462,8 +460,8 @@ public class View {
       PCollectionView<Map<K, V>> view =
           PCollectionViews.mapView(
               materializationInput,
-              (Supplier<TypeDescriptor<K>> & Serializable) keyCoder::getEncodedTypeDescriptor,
-              (Supplier<TypeDescriptor<V>> & Serializable) valueCoder::getEncodedTypeDescriptor,
+              (TypeDescriptorSupplier<K>) keyCoder::getEncodedTypeDescriptor,
+              (TypeDescriptorSupplier<V>) valueCoder::getEncodedTypeDescriptor,
               materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ViewFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ViewFn.java
@@ -47,5 +47,6 @@ public abstract class ViewFn<PrimitiveViewT, ViewT> implements Serializable {
   /** A function to adapt a primitive view type to a desired view type. */
   public abstract ViewT apply(PrimitiveViewT primitiveViewT);
 
+  /** Return the {@link TypeDescriptor} describing the output of this fn. */
   public abstract TypeDescriptor<ViewT> getTypeDescriptor();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ViewFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ViewFn.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * <b><i>For internal use only; no backwards-compatibility guarantees.</i></b>
@@ -45,4 +46,6 @@ public abstract class ViewFn<PrimitiveViewT, ViewT> implements Serializable {
 
   /** A function to adapt a primitive view type to a desired view type. */
   public abstract ViewT apply(PrimitiveViewT primitiveViewT);
+
+  public abstract TypeDescriptor<ViewT> getTypeDescriptor();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -40,6 +40,7 @@ import org.apache.beam.sdk.transforms.DoFn.TimerId;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.OutputReceiverParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionTrackerParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SchemaElementParameter;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SideInputParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.StateParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.TimerParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.WindowParameter;
@@ -757,6 +758,14 @@ public abstract class DoFnSignature {
       return extraParameters().stream()
           .filter(Predicates.instanceOf(SchemaElementParameter.class)::apply)
           .map(SchemaElementParameter.class::cast)
+          .collect(Collectors.toList());
+    }
+
+    @Nullable
+    public List<SideInputParameter> getSideInputParameters() {
+      return extraParameters().stream()
+          .filter(Predicates.instanceOf(SideInputParameter.class)::apply)
+          .map(SideInputParameter.class::cast)
           .collect(Collectors.toList());
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -62,13 +63,14 @@ public class PCollectionViews {
    */
   public static <T, W extends BoundedWindow> PCollectionView<T> singletonView(
       PCollection<KV<Void, T>> pCollection,
+      Supplier<TypeDescriptor<T>> typeDescriptorSupplier,
       WindowingStrategy<?, W> windowingStrategy,
       boolean hasDefault,
       @Nullable T defaultValue,
       Coder<T> defaultValueCoder) {
     return new SimplePCollectionView<>(
         pCollection,
-        new SingletonViewFn<>(hasDefault, defaultValue, defaultValueCoder),
+        new SingletonViewFn<T>(hasDefault, defaultValue, defaultValueCoder, typeDescriptorSupplier),
         windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
         windowingStrategy);
   }
@@ -78,10 +80,12 @@ public class PCollectionViews {
    * the provided {@link WindowingStrategy}.
    */
   public static <T, W extends BoundedWindow> PCollectionView<Iterable<T>> iterableView(
-      PCollection<KV<Void, T>> pCollection, WindowingStrategy<?, W> windowingStrategy) {
+      PCollection<KV<Void, T>> pCollection,
+      Supplier<TypeDescriptor<T>> typeDescriptorSupplier,
+      WindowingStrategy<?, W> windowingStrategy) {
     return new SimplePCollectionView<>(
         pCollection,
-        new IterableViewFn<T>(),
+        new IterableViewFn<T>(typeDescriptorSupplier),
         windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
         windowingStrategy);
   }
@@ -91,10 +95,12 @@ public class PCollectionViews {
    * provided {@link WindowingStrategy}.
    */
   public static <T, W extends BoundedWindow> PCollectionView<List<T>> listView(
-      PCollection<KV<Void, T>> pCollection, WindowingStrategy<?, W> windowingStrategy) {
+      PCollection<KV<Void, T>> pCollection,
+      Supplier<TypeDescriptor<T>> typeDescriptorSupplier,
+      WindowingStrategy<?, W> windowingStrategy) {
     return new SimplePCollectionView<>(
         pCollection,
-        new ListViewFn<T>(),
+        new ListViewFn<>(typeDescriptorSupplier),
         windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
         windowingStrategy);
   }
@@ -103,10 +109,13 @@ public class PCollectionViews {
    * provided {@link WindowingStrategy}.
    */
   public static <K, V, W extends BoundedWindow> PCollectionView<Map<K, V>> mapView(
-      PCollection<KV<Void, KV<K, V>>> pCollection, WindowingStrategy<?, W> windowingStrategy) {
+      PCollection<KV<Void, KV<K, V>>> pCollection,
+      Supplier<TypeDescriptor<K>> keyTypeDescriptorSupplier,
+      Supplier<TypeDescriptor<V>> valueTypeDescriptorSupplier,
+      WindowingStrategy<?, W> windowingStrategy) {
     return new SimplePCollectionView<>(
         pCollection,
-        new MapViewFn<K, V>(),
+        new MapViewFn<>(keyTypeDescriptorSupplier, valueTypeDescriptorSupplier),
         windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
         windowingStrategy);
   }
@@ -116,10 +125,13 @@ public class PCollectionViews {
    * using the provided {@link WindowingStrategy}.
    */
   public static <K, V, W extends BoundedWindow> PCollectionView<Map<K, Iterable<V>>> multimapView(
-      PCollection<KV<Void, KV<K, V>>> pCollection, WindowingStrategy<?, W> windowingStrategy) {
+      PCollection<KV<Void, KV<K, V>>> pCollection,
+      Supplier<TypeDescriptor<K>> keyTypeDescriptorSupplier,
+      Supplier<TypeDescriptor<V>> valueTypeDescriptorSupplier,
+      WindowingStrategy<?, W> windowingStrategy) {
     return new SimplePCollectionView<>(
         pCollection,
-        new MultimapViewFn<K, V>(),
+        new MultimapViewFn<>(keyTypeDescriptorSupplier, valueTypeDescriptorSupplier),
         windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
         windowingStrategy);
   }
@@ -149,11 +161,17 @@ public class PCollectionViews {
     @Nullable private transient T defaultValue;
     @Nullable private Coder<T> valueCoder;
     private boolean hasDefault;
+    private Supplier<TypeDescriptor<T>> typeDescriptorSupplier;
 
-    private SingletonViewFn(boolean hasDefault, T defaultValue, Coder<T> valueCoder) {
+    private SingletonViewFn(
+        boolean hasDefault,
+        T defaultValue,
+        Coder<T> valueCoder,
+        Supplier<TypeDescriptor<T>> typeDescriptorSupplier) {
       this.hasDefault = hasDefault;
       this.defaultValue = defaultValue;
       this.valueCoder = valueCoder;
+      this.typeDescriptorSupplier = typeDescriptorSupplier;
       if (hasDefault) {
         try {
           this.encodedDefaultValue = CoderUtils.encodeToByteArray(valueCoder, defaultValue);
@@ -212,6 +230,11 @@ public class PCollectionViews {
             "PCollection with more than one element accessed as a singleton view.");
       }
     }
+
+    @Override
+    public TypeDescriptor<T> getTypeDescriptor() {
+      return typeDescriptorSupplier.get();
+    }
   }
 
   /**
@@ -223,6 +246,11 @@ public class PCollectionViews {
    */
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class IterableViewFn<T> extends ViewFn<MultimapView<Void, T>, Iterable<T>> {
+    private Supplier<TypeDescriptor<T>> typeDescriptorSupplier;
+
+    public IterableViewFn(Supplier<TypeDescriptor<T>> typeDescriptorSupplier) {
+      this.typeDescriptorSupplier = typeDescriptorSupplier;
+    }
 
     @Override
     public Materialization<MultimapView<Void, T>> getMaterialization() {
@@ -232,6 +260,11 @@ public class PCollectionViews {
     @Override
     public Iterable<T> apply(MultimapView<Void, T> primitiveViewT) {
       return Iterables.unmodifiableIterable(primitiveViewT.get(null));
+    }
+
+    @Override
+    public TypeDescriptor<Iterable<T>> getTypeDescriptor() {
+      return TypeDescriptors.iterables(typeDescriptorSupplier.get());
     }
   }
 
@@ -244,6 +277,12 @@ public class PCollectionViews {
    */
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class ListViewFn<T> extends ViewFn<MultimapView<Void, T>, List<T>> {
+    private Supplier<TypeDescriptor<T>> typeDescriptorSupplier;
+
+    public ListViewFn(Supplier<TypeDescriptor<T>> typeDescriptorSupplier) {
+      this.typeDescriptorSupplier = typeDescriptorSupplier;
+    }
+
     @Override
     public Materialization<MultimapView<Void, T>> getMaterialization() {
       return Materializations.multimap();
@@ -256,6 +295,11 @@ public class PCollectionViews {
         list.add(t);
       }
       return Collections.unmodifiableList(list);
+    }
+
+    @Override
+    public TypeDescriptor<List<T>> getTypeDescriptor() {
+      return TypeDescriptors.lists(typeDescriptorSupplier.get());
     }
 
     @Override
@@ -280,6 +324,16 @@ public class PCollectionViews {
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class MultimapViewFn<K, V>
       extends ViewFn<MultimapView<Void, KV<K, V>>, Map<K, Iterable<V>>> {
+    private Supplier<TypeDescriptor<K>> keyTypeDescriptorSupplier;
+    private Supplier<TypeDescriptor<V>> valueTypeDescriptorSupplier;
+
+    public MultimapViewFn(
+        Supplier<TypeDescriptor<K>> keyTypeDescriptorSupplier,
+        Supplier<TypeDescriptor<V>> valueTypeDescriptorSupplier) {
+      this.keyTypeDescriptorSupplier = keyTypeDescriptorSupplier;
+      this.valueTypeDescriptorSupplier = valueTypeDescriptorSupplier;
+    }
+
     @Override
     public Materialization<MultimapView<Void, KV<K, V>>> getMaterialization() {
       return Materializations.multimap();
@@ -298,6 +352,13 @@ public class PCollectionViews {
       Map<K, Iterable<V>> resultMap = (Map) multimap.asMap();
       return Collections.unmodifiableMap(resultMap);
     }
+
+    @Override
+    public TypeDescriptor<Map<K, Iterable<V>>> getTypeDescriptor() {
+      return TypeDescriptors.maps(
+          keyTypeDescriptorSupplier.get(),
+          TypeDescriptors.iterables(valueTypeDescriptorSupplier.get()));
+    }
   }
 
   /**
@@ -309,6 +370,15 @@ public class PCollectionViews {
    */
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class MapViewFn<K, V> extends ViewFn<MultimapView<Void, KV<K, V>>, Map<K, V>> {
+    private Supplier<TypeDescriptor<K>> keyTypeDescriptorSupplier;
+    private Supplier<TypeDescriptor<V>> valueTypeDescriptorSupplier;
+
+    public MapViewFn(
+        Supplier<TypeDescriptor<K>> keyTypeDescriptorSupplier,
+        Supplier<TypeDescriptor<V>> valueTypeDescriptorSupplier) {
+      this.keyTypeDescriptorSupplier = keyTypeDescriptorSupplier;
+      this.valueTypeDescriptorSupplier = valueTypeDescriptorSupplier;
+    }
 
     @Override
     public Materialization<MultimapView<Void, KV<K, V>>> getMaterialization() {
@@ -327,6 +397,12 @@ public class PCollectionViews {
         map.put(elem.getKey(), elem.getValue());
       }
       return Collections.unmodifiableMap(map);
+    }
+
+    @Override
+    public TypeDescriptor<Map<K, V>> getTypeDescriptor() {
+      return TypeDescriptors.maps(
+          keyTypeDescriptorSupplier.get(), valueTypeDescriptorSupplier.get());
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -738,6 +738,76 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
+    @Category({NeedsRunner.class, UsesSideInputs.class})
+    public void testSideInputAnnotationFailedValidationMissing() {
+      // SideInput tag id
+      final String sideInputTag1 = "tag1";
+
+      DoFn<Integer, List<Integer>> fn =
+          new DoFn<Integer, List<Integer>>() {
+            @ProcessElement
+            public void processElement(@SideInput(sideInputTag1) String tag1) {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      PCollection<List<Integer>> output =
+          pipeline.apply("Create main input", Create.of(2)).apply(ParDo.of(fn));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesSideInputs.class})
+    public void testSideInputAnnotationFailedValidationSingletonType() {
+
+      final PCollectionView<Integer> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(2))
+              .apply("ViewSideInput1", View.asSingleton());
+
+      // SideInput tag id
+      final String sideInputTag1 = "tag1";
+
+      DoFn<Integer, List<Integer>> fn =
+          new DoFn<Integer, List<Integer>>() {
+            @ProcessElement
+            public void processElement(@SideInput(sideInputTag1) String tag1) {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      PCollection<List<Integer>> output =
+          pipeline
+              .apply("Create main input", Create.of(2))
+              .apply(ParDo.of(fn).withSideInput(sideInputTag1, sideInput1));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesSideInputs.class})
+    public void testSideInputAnnotationFailedValidationListType() {
+
+      final PCollectionView<List<Integer>> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(2, 1, 0))
+              .apply("ViewSideInput1", View.asList());
+
+      // SideInput tag id
+      final String sideInputTag1 = "tag1";
+
+      DoFn<Integer, List<Integer>> fn =
+          new DoFn<Integer, List<Integer>>() {
+            @ProcessElement
+            public void processElement(@SideInput(sideInputTag1) List<String> tag1) {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      PCollection<List<Integer>> output =
+          pipeline
+              .apply("Create main input", Create.of(2))
+              .apply(ParDo.of(fn).withSideInput(sideInputTag1, sideInput1));
+      pipeline.run();
+    }
+
+    @Test
     @Category({ValidatesRunner.class, UsesSideInputs.class})
     public void testSideInputAnnotation() {
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -808,6 +808,84 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
+    @Category({NeedsRunner.class, UsesSideInputs.class})
+    public void testSideInputAnnotationFailedValidationIterableType() {
+
+      final PCollectionView<Iterable<Integer>> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(2, 1, 0))
+              .apply("ViewSideInput1", View.asIterable());
+
+      // SideInput tag id
+      final String sideInputTag1 = "tag1";
+
+      DoFn<Integer, List<Integer>> fn =
+          new DoFn<Integer, List<Integer>>() {
+            @ProcessElement
+            public void processElement(@SideInput(sideInputTag1) List<String> tag1) {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      PCollection<List<Integer>> output =
+          pipeline
+              .apply("Create main input", Create.of(2))
+              .apply(ParDo.of(fn).withSideInput(sideInputTag1, sideInput1));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesSideInputs.class})
+    public void testSideInputAnnotationFailedValidationMapType() {
+
+      final PCollectionView<Map<Integer, Integer>> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(KV.of(1, 2), KV.of(2, 3), KV.of(3, 4)))
+              .apply("ViewSideInput1", View.asMap());
+
+      // SideInput tag id
+      final String sideInputTag1 = "tag1";
+
+      DoFn<Integer, List<Integer>> fn =
+          new DoFn<Integer, List<Integer>>() {
+            @ProcessElement
+            public void processElement(@SideInput(sideInputTag1) Map<String, String> tag1) {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      PCollection<List<Integer>> output =
+          pipeline
+              .apply("Create main input", Create.of(2))
+              .apply(ParDo.of(fn).withSideInput(sideInputTag1, sideInput1));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesSideInputs.class})
+    public void testSideInputAnnotationFailedValidationMultiMapType() {
+
+      final PCollectionView<Map<Integer, Iterable<Integer>>> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(KV.of(1, 2), KV.of(1, 3), KV.of(3, 4)))
+              .apply("ViewSideInput1", View.asMultimap());
+
+      // SideInput tag id
+      final String sideInputTag1 = "tag1";
+
+      DoFn<Integer, List<Integer>> fn =
+          new DoFn<Integer, List<Integer>>() {
+            @ProcessElement
+            public void processElement(@SideInput(sideInputTag1) Map<Integer, Integer> tag1) {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      PCollection<List<Integer>> output =
+          pipeline
+              .apply("Create main input", Create.of(2))
+              .apply(ParDo.of(fn).withSideInput(sideInputTag1, sideInput1));
+      pipeline.run();
+    }
+
+    @Test
     @Category({ValidatesRunner.class, UsesSideInputs.class})
     public void testSideInputAnnotation() {
 
@@ -844,53 +922,98 @@ public class ParDoTest implements Serializable {
     @Category({ValidatesRunner.class, UsesSideInputs.class})
     public void testSideInputAnnotationWithMultipleSideInputs() {
 
+      final List<Integer> side1Data = ImmutableList.of(2, 0);
       final PCollectionView<List<Integer>> sideInput1 =
           pipeline
-              .apply("CreateSideInput1", Create.of(2, 0))
+              .apply("CreateSideInput1", Create.of(side1Data))
               .apply("ViewSideInput1", View.asList());
 
+      final Integer side2Data = 5;
       final PCollectionView<Integer> sideInput2 =
           pipeline
-              .apply("CreateSideInput2", Create.of(5))
+              .apply("CreateSideInput2", Create.of(side2Data))
               .apply("ViewSideInput2", View.asSingleton());
 
-      final PCollectionView<List<Integer>> sideInput3 =
+      final List<Integer> side3Data = ImmutableList.of(1, 3);
+      final PCollectionView<Iterable<Integer>> sideInput3 =
           pipeline
-              .apply("CreateSideInput3", Create.of(1, 3))
-              .apply("ViewSideInput3", View.asList());
+              .apply("CreateSideInput3", Create.of(side3Data))
+              .apply("ViewSideInput3", View.asIterable());
+
+      final List<KV<Integer, Integer>> side4Data =
+          ImmutableList.of(KV.of(1, 2), KV.of(2, 3), KV.of(3, 4));
+      final PCollectionView<Map<Integer, Integer>> sideInput4 =
+          pipeline
+              .apply("CreateSideInput4", Create.of(side4Data))
+              .apply("ViewSideInput4", View.asMap());
+
+      final List<KV<Integer, Integer>> side5Data =
+          ImmutableList.of(KV.of(1, 2), KV.of(1, 3), KV.of(3, 4));
+      final PCollectionView<Map<Integer, Iterable<Integer>>> sideInput5 =
+          pipeline
+              .apply("CreateSideInput5", Create.of(side5Data))
+              .apply("ViewSideInput5", View.asMultimap());
 
       // SideInput tag id
       final String sideInputTag1 = "tag1";
       final String sideInputTag2 = "tag2";
       final String sideInputTag3 = "tag3";
+      final String sideInputTag4 = "tag4";
+      final String sideInputTag5 = "tag5";
 
-      DoFn<Integer, List<Integer>> fn =
-          new DoFn<Integer, List<Integer>>() {
+      final TupleTag<Integer> outputTag1 = new TupleTag<>();
+      final TupleTag<Integer> outputTag2 = new TupleTag<>();
+      final TupleTag<Integer> outputTag3 = new TupleTag<>();
+      final TupleTag<KV<Integer, Integer>> outputTag4 = new TupleTag<>();
+      final TupleTag<KV<Integer, Integer>> outputTag5 = new TupleTag<>();
+
+      DoFn<Integer, Integer> fn =
+          new DoFn<Integer, Integer>() {
             @ProcessElement
             public void processElement(
-                OutputReceiver<List<Integer>> r,
-                @SideInput(sideInputTag1) List<Integer> tag1,
-                @SideInput(sideInputTag2) Integer tag2,
-                @SideInput(sideInputTag3) List<Integer> tag3) {
-
-              List<Integer> sideSorted = Lists.newArrayList(tag1);
-              sideSorted.add(tag2);
-              sideSorted.addAll(tag3);
-              Collections.sort(sideSorted);
-              r.output(sideSorted);
+                MultiOutputReceiver r,
+                @SideInput(sideInputTag1) List<Integer> side1,
+                @SideInput(sideInputTag2) Integer side2,
+                @SideInput(sideInputTag3) Iterable<Integer> side3,
+                @SideInput(sideInputTag4) Map<Integer, Integer> side4,
+                @SideInput(sideInputTag5) Map<Integer, Iterable<Integer>> side5) {
+              side1.forEach(i -> r.get(outputTag1).output(i));
+              r.get(outputTag2).output(side2);
+              side3.forEach(i -> r.get(outputTag3).output(i));
+              side4.forEach((k, v) -> r.get(outputTag4).output(KV.of(k, v)));
+              side5.forEach((k, v) -> v.forEach(v2 -> r.get(outputTag5).output(KV.of(k, v2))));
             }
           };
 
-      PCollection<List<Integer>> output =
+      PCollectionTuple output =
           pipeline
               .apply("Create main input", Create.of(2))
               .apply(
                   ParDo.of(fn)
                       .withSideInput(sideInputTag1, sideInput1)
                       .withSideInput(sideInputTag2, sideInput2)
-                      .withSideInput(sideInputTag3, sideInput3));
+                      .withSideInput(sideInputTag3, sideInput3)
+                      .withSideInput(sideInputTag4, sideInput4)
+                      .withSideInput(sideInputTag5, sideInput5)
+                      .withOutputTags(
+                          outputTag1,
+                          TupleTagList.of(outputTag2)
+                              .and(outputTag3)
+                              .and(outputTag4)
+                              .and(outputTag5)));
 
-      PAssert.that(output).containsInAnyOrder(Lists.newArrayList(0, 1, 2, 3, 5));
+      output.get(outputTag1).setCoder(VarIntCoder.of());
+      output.get(outputTag2).setCoder(VarIntCoder.of());
+      output.get(outputTag3).setCoder(VarIntCoder.of());
+      output.get(outputTag4).setCoder(KvCoder.of(VarIntCoder.of(), VarIntCoder.of()));
+      output.get(outputTag5).setCoder(KvCoder.of(VarIntCoder.of(), VarIntCoder.of()));
+
+      PAssert.that(output.get(outputTag1)).containsInAnyOrder(side1Data);
+      PAssert.that(output.get(outputTag2)).containsInAnyOrder(side2Data);
+      PAssert.that(output.get(outputTag3)).containsInAnyOrder(side3Data);
+      PAssert.that(output.get(outputTag4)).containsInAnyOrder(side4Data);
+      PAssert.that(output.get(outputTag5)).containsInAnyOrder(side5Data);
+
       pipeline.run();
     }
 


### PR DESCRIPTION
Validate that the type of a processElement side-input parameter matches that of the PCollectionView.

Note: Suppliers are used because often the TypeDescriptor is not Serializable, and so cannot be captured in the PCollectionView.