### PR TITLE
[BEAM-8010] Remove translation of bounded reads from portable Flink Runner

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ReadTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ReadTranslation.java
@@ -129,8 +129,7 @@ public class ReadTranslation {
         .build();
   }
 
-  public static UnboundedSource<?, ?> unboundedSourceFromProto(ReadPayload payload)
-      throws InvalidProtocolBufferException {
+  public static UnboundedSource<?, ?> unboundedSourceFromProto(ReadPayload payload) {
     checkArgument(payload.getIsBounded().equals(IsBounded.Enum.UNBOUNDED));
     return (UnboundedSource<?, ?>)
         SerializableUtils.deserializeFromByteArray(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -45,7 +45,6 @@ import org.apache.beam.runners.core.construction.ReadTranslation;
 import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.RunnerPCollectionView;
 import org.apache.beam.runners.core.construction.TestStreamTranslation;
-import org.apache.beam.runners.core.construction.UnboundedReadFromBoundedSource;
 import org.apache.beam.runners.core.construction.WindowingStrategyTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.PipelineNode;
@@ -89,6 +88,7 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.ValueWithRecordId;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.BiMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.HashMultiset;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
@@ -213,8 +213,8 @@ public class FlinkStreamingPortablePipelineTranslator
     // TODO Legacy transforms which need to be removed
     // Consider removing now that timers are supported
     translatorMap.put(STREAMING_IMPULSE_TRANSFORM_URN, this::translateStreamingImpulse);
-    // Remove once Reads can be wrapped in SDFs
-    translatorMap.put(PTransformTranslation.READ_TRANSFORM_URN, this::translateRead);
+    // Remove once unbounded Reads can be wrapped in SDFs
+    translatorMap.put(PTransformTranslation.READ_TRANSFORM_URN, this::translateUnboundedRead);
 
     // For testing only
     translatorMap.put(PTransformTranslation.TEST_STREAM_TRANSFORM_URN, this::translateTestStream);
@@ -444,7 +444,7 @@ public class FlinkStreamingPortablePipelineTranslator
   }
 
   @SuppressWarnings("unchecked")
-  private <T> void translateRead(
+  private <T> void translateUnboundedRead(
       String id, RunnerApi.Pipeline pipeline, StreamingTranslationContext context) {
     RunnerApi.PTransform transform = pipeline.getComponents().getTransformsOrThrow(id);
     String outputCollectionId = Iterables.getOnlyElement(transform.getOutputsMap().values());
@@ -456,15 +456,12 @@ public class FlinkStreamingPortablePipelineTranslator
       throw new RuntimeException("Failed to parse ReadPayload from transform", e);
     }
 
-    final ReadSourceTranslator<T> readTranslator;
-    if (payload.getIsBounded() == RunnerApi.IsBounded.Enum.BOUNDED) {
-      readTranslator = new ReadBoundedTranslator<>();
-    } else {
-      readTranslator = new ReadUnboundedTranslator<>();
-    }
+    Preconditions.checkState(
+        payload.getIsBounded() != RunnerApi.IsBounded.Enum.BOUNDED,
+        "Bounded reads should run inside an environment instead of being translated by the Runner.");
 
     DataStream<WindowedValue<T>> source =
-        readTranslator.translateRead(
+        translateUnboundedSource(
             transform.getUniqueName(),
             outputCollectionId,
             payload,
@@ -475,123 +472,61 @@ public class FlinkStreamingPortablePipelineTranslator
     context.addDataStream(outputCollectionId, source);
   }
 
-  interface ReadSourceTranslator<T> {
-    DataStream<WindowedValue<T>> translateRead(
-        String transformName,
-        String outputCollectionId,
-        RunnerApi.ReadPayload payload,
-        RunnerApi.Pipeline pipeline,
-        PipelineOptions pipelineOptions,
-        StreamExecutionEnvironment env);
-  }
+  private static <T> DataStream<WindowedValue<T>> translateUnboundedSource(
+      String transformName,
+      String outputCollectionId,
+      RunnerApi.ReadPayload payload,
+      RunnerApi.Pipeline pipeline,
+      PipelineOptions pipelineOptions,
+      StreamExecutionEnvironment env) {
 
-  private static class ReadBoundedTranslator<T> implements ReadSourceTranslator<T> {
+    final DataStream<WindowedValue<T>> source;
+    final DataStream<WindowedValue<ValueWithRecordId<T>>> nonDedupSource;
+    Coder<WindowedValue<T>> windowCoder =
+        instantiateCoder(outputCollectionId, pipeline.getComponents());
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public DataStream<WindowedValue<T>> translateRead(
-        String transformName,
-        String outputCollectionId,
-        RunnerApi.ReadPayload payload,
-        RunnerApi.Pipeline pipeline,
-        PipelineOptions pipelineOptions,
-        StreamExecutionEnvironment env) {
-      Coder<WindowedValue<T>> windowCoder =
-          instantiateCoder(outputCollectionId, pipeline.getComponents());
-      TypeInformation<WindowedValue<T>> outputTypeInfo = new CoderTypeInformation<>(windowCoder);
+    TypeInformation<WindowedValue<T>> outputTypeInfo = new CoderTypeInformation<>(windowCoder);
 
-      UnboundedReadFromBoundedSource.BoundedToUnboundedSourceAdapter<?> convertedSource;
-      try {
-        convertedSource =
-            new UnboundedReadFromBoundedSource.BoundedToUnboundedSourceAdapter<>(
-                ReadTranslation.boundedSourceFromProto(payload));
-      } catch (IOException e) {
-        throw new RuntimeException("Failed to extract UnboundedSource from payload", e);
+    WindowingStrategy windowStrategy =
+        getWindowingStrategy(outputCollectionId, pipeline.getComponents());
+    TypeInformation<WindowedValue<ValueWithRecordId<T>>> withIdTypeInfo =
+        new CoderTypeInformation<>(
+            WindowedValue.getFullCoder(
+                ValueWithRecordId.ValueWithRecordIdCoder.of(
+                    ((WindowedValueCoder) windowCoder).getValueCoder()),
+                windowStrategy.getWindowFn().windowCoder()));
+
+    UnboundedSource unboundedSource = ReadTranslation.unboundedSourceFromProto(payload);
+
+    try {
+      int parallelism =
+          env.getMaxParallelism() > 0 ? env.getMaxParallelism() : env.getParallelism();
+      UnboundedSourceWrapper sourceWrapper =
+          new UnboundedSourceWrapper<>(
+              transformName, pipelineOptions, unboundedSource, parallelism);
+      nonDedupSource =
+          env.addSource(sourceWrapper)
+              .name(transformName)
+              .uid(transformName)
+              .returns(withIdTypeInfo);
+
+      if (unboundedSource.requiresDeduping()) {
+        source =
+            nonDedupSource
+                .keyBy(new FlinkStreamingTransformTranslators.ValueWithRecordIdKeySelector<>())
+                .transform("deduping", outputTypeInfo, new DedupingOperator<>())
+                .uid(format("%s/__deduplicated__", transformName));
+      } else {
+        source =
+            nonDedupSource
+                .flatMap(new FlinkStreamingTransformTranslators.StripIdsMap<>())
+                .returns(outputTypeInfo);
       }
-
-      try {
-        int parallelism =
-            env.getMaxParallelism() > 0 ? env.getMaxParallelism() : env.getParallelism();
-        FlinkStreamingTransformTranslators.UnboundedSourceWrapperNoValueWithRecordId sourceWrapper =
-            new FlinkStreamingTransformTranslators.UnboundedSourceWrapperNoValueWithRecordId<>(
-                new UnboundedSourceWrapper<>(
-                    transformName, pipelineOptions, convertedSource, parallelism));
-        return env.addSource(sourceWrapper)
-            .name(transformName)
-            .uid(transformName)
-            .returns(outputTypeInfo);
-      } catch (Exception e) {
-        throw new RuntimeException("Error while translating BoundedSource: " + convertedSource, e);
-      }
+    } catch (Exception e) {
+      throw new RuntimeException("Error while translating UnboundedSource: " + unboundedSource, e);
     }
-  }
 
-  private static class ReadUnboundedTranslator<T> implements ReadSourceTranslator<T> {
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public DataStream<WindowedValue<T>> translateRead(
-        String transformName,
-        String outputCollectionId,
-        RunnerApi.ReadPayload payload,
-        RunnerApi.Pipeline pipeline,
-        PipelineOptions pipelineOptions,
-        StreamExecutionEnvironment env) {
-
-      final DataStream<WindowedValue<T>> source;
-      final DataStream<WindowedValue<ValueWithRecordId<T>>> nonDedupSource;
-      Coder<WindowedValue<T>> windowCoder =
-          instantiateCoder(outputCollectionId, pipeline.getComponents());
-
-      TypeInformation<WindowedValue<T>> outputTypeInfo = new CoderTypeInformation<>(windowCoder);
-
-      WindowingStrategy windowStrategy =
-          getWindowingStrategy(outputCollectionId, pipeline.getComponents());
-      TypeInformation<WindowedValue<ValueWithRecordId<T>>> withIdTypeInfo =
-          new CoderTypeInformation<>(
-              WindowedValue.getFullCoder(
-                  ValueWithRecordId.ValueWithRecordIdCoder.of(
-                      ((WindowedValueCoder) windowCoder).getValueCoder()),
-                  windowStrategy.getWindowFn().windowCoder()));
-
-      UnboundedSource unboundedSource;
-      try {
-        unboundedSource = ReadTranslation.unboundedSourceFromProto(payload);
-      } catch (IOException e) {
-        throw new RuntimeException("Failed to extract UnboundedSource from payload", e);
-      }
-
-      try {
-        int parallelism =
-            env.getMaxParallelism() > 0 ? env.getMaxParallelism() : env.getParallelism();
-        UnboundedSourceWrapper sourceWrapper =
-            new UnboundedSourceWrapper<>(
-                transformName, pipelineOptions, unboundedSource, parallelism);
-        nonDedupSource =
-            env.addSource(sourceWrapper)
-                .name(transformName)
-                .uid(transformName)
-                .returns(withIdTypeInfo);
-
-        if (unboundedSource.requiresDeduping()) {
-          source =
-              nonDedupSource
-                  .keyBy(new FlinkStreamingTransformTranslators.ValueWithRecordIdKeySelector<>())
-                  .transform("deduping", outputTypeInfo, new DedupingOperator<>())
-                  .uid(format("%s/__deduplicated__", transformName));
-        } else {
-          source =
-              nonDedupSource
-                  .flatMap(new FlinkStreamingTransformTranslators.StripIdsMap<>())
-                  .returns(outputTypeInfo);
-        }
-      } catch (Exception e) {
-        throw new RuntimeException(
-            "Error while translating UnboundedSource: " + unboundedSource, e);
-      }
-
-      return source;
-    }
+    return source;
   }
 
   private void translateImpulse(


### PR DESCRIPTION
In the course of BEAM-6730 we added a way to Runner-translate bounded and
unbounded Reads in portable pipelines. However, bounded Reads are already
supported via Impulse + BoundedReadViaImpulse.

This can be fixed by removing the bounded read translators from portable
pipelines.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
