### PR TITLE
[BEAM-8015] Get logs from Docker containers

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerCommand.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerCommand.java
@@ -121,6 +121,20 @@ class DockerCommand {
   }
 
   /**
+   * Returns logs for the container specified by {@code containerId}.
+   *
+   * @throws IOException if an IOException occurs or if the given container id does not exist
+   */
+  public String getContainerLogs(String containerId)
+      throws IOException, TimeoutException, InterruptedException {
+    checkArgument(containerId != null);
+    checkArgument(
+        CONTAINER_ID_PATTERN.matcher(containerId).matches(),
+        "Container ID must be a 64-character hexadecimal string");
+    return runShortCommand(Arrays.asList(dockerExecutable, "logs", containerId), true, "\n");
+  }
+
+  /**
    * Kills a docker container by container id.
    *
    * @throws IOException if an IOException occurs or if the given container id does not exist
@@ -134,10 +148,41 @@ class DockerCommand {
     runShortCommand(Arrays.asList(dockerExecutable, "kill", containerId));
   }
 
-  /** Run the given command invocation and return stdout as a String. */
+  /**
+   * Removes docker container with container id.
+   *
+   * @throws IOException if an IOException occurs, or if the given container id either does not
+   *     exist or is still running
+   */
+  public void removeContainer(String containerId)
+      throws IOException, TimeoutException, InterruptedException {
+    checkArgument(containerId != null);
+    checkArgument(
+        CONTAINER_ID_PATTERN.matcher(containerId).matches(),
+        "Container ID must be a 64-character hexadecimal string");
+    runShortCommand(Arrays.asList(dockerExecutable, "rm", containerId));
+  }
+
   private String runShortCommand(List<String> invocation)
       throws IOException, TimeoutException, InterruptedException {
+    return runShortCommand(invocation, false, "");
+  }
+
+  /**
+   * Runs a command, blocks until {@link DockerCommand#commandTimeout} has elapsed, then returns the
+   * command's output.
+   *
+   * @param invocation command and arguments to be run
+   * @param redirectErrorStream if true, include the process's stderr in the return value
+   * @param delimiter used for separating output lines
+   * @return stdout of the command, including stderr if {@code redirectErrorStream} is true
+   * @throws TimeoutException if command has not finished by {@link DockerCommand#commandTimeout}
+   */
+  private String runShortCommand(
+      List<String> invocation, boolean redirectErrorStream, CharSequence delimiter)
+      throws IOException, TimeoutException, InterruptedException {
     ProcessBuilder pb = new ProcessBuilder(invocation);
+    pb.redirectErrorStream(redirectErrorStream);
     Process process = pb.start();
     // TODO: Consider supplying executor service here.
     CompletableFuture<String> resultString =
@@ -147,17 +192,26 @@ class DockerCommand {
               BufferedReader reader =
                   new BufferedReader(
                       new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
-              return reader.lines().collect(Collectors.joining());
+              return reader.lines().collect(Collectors.joining(delimiter));
             });
-    // NOTE: We only consume the error string in the case of an error.
-    CompletableFuture<String> errorFuture =
-        CompletableFuture.supplyAsync(
-            () -> {
-              BufferedReader reader =
-                  new BufferedReader(
-                      new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8));
-              return reader.lines().collect(Collectors.joining());
-            });
+    CompletableFuture<String> errorFuture;
+    String errorStringName;
+    if (redirectErrorStream) {
+      // The standard output and standard error are combined into one stream.
+      errorStringName = "stdout and stderr";
+      errorFuture = resultString;
+    } else {
+      // The error stream is separate, and we only consume it in the case of an error.
+      errorStringName = "stderr";
+      errorFuture =
+          CompletableFuture.supplyAsync(
+              () -> {
+                BufferedReader reader =
+                    new BufferedReader(
+                        new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8));
+                return reader.lines().collect(Collectors.joining(delimiter));
+              });
+    }
     // TODO: Retry on interrupt?
     boolean processDone = process.waitFor(commandTimeout.toMillis(), TimeUnit.MILLISECONDS);
     if (!processDone) {
@@ -173,12 +227,16 @@ class DockerCommand {
       try {
         errorString = errorFuture.get(commandTimeout.toMillis(), TimeUnit.MILLISECONDS);
       } catch (Exception stderrEx) {
-        errorString = String.format("Error capturing stderr: %s", stderrEx.getMessage());
+        errorString =
+            String.format("Error capturing %s: %s", errorStringName, stderrEx.getMessage());
       }
       throw new IOException(
           String.format(
-              "Received exit code %d for command '%s'. stderr: %s",
-              exitCode, invocation.stream().collect(Collectors.joining(" ")), errorString));
+              "Received exit code %d for command '%s'. %s: %s",
+              exitCode,
+              invocation.stream().collect(Collectors.joining(" ")),
+              errorStringName,
+              errorString));
     }
     try {
       // TODO: Consider a stricter timeout.


### PR DESCRIPTION
- Log Docker output both when the container fails to start up, and when it is closed normally.
- In order to get logs for stopped (failed) containers, don't use the `rm` option for `docker run`, which deletes containers before we can inspect what happened to them. Instead, call `docker rm` ourselves to clean up the container only after we log its logs. (Behavior for `--retain_docker_container` stays the same.)
- Remove a bit of dead code in Docker container startup.

Apologies for complicating the test setup -- I wanted to parameterize to make sure we're covering all the cases.

R: @angoenka @mxm 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
