### PR TITLE
[BEAM-7969] Fix doublecount on GRPC PCollections in streaming jobs.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/MeanByteCountMonitoringInfoToCounterUpdateTransformer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/MeanByteCountMonitoringInfoToCounterUpdateTransformer.java
@@ -43,7 +43,7 @@ public class MeanByteCountMonitoringInfoToCounterUpdateTransformer
   private final Map<String, NameContext> pcollectionIdToNameContext;
 
   // TODO(BEAM-6945): utilize value from metrics.proto once it gets in.
-  private static final String SUPPORTED_URN = "beam:metric:sampled_byte_size:v1";
+  private static final String SUPPORTED_URN = MonitoringInfoConstants.Urns.SAMPLED_BYTE_SIZE;
 
   /**
    * @param specValidator SpecMonitoringInfoValidator to utilize for default validation.
@@ -74,7 +74,6 @@ public class MeanByteCountMonitoringInfoToCounterUpdateTransformer
       throw new RuntimeException(String.format("Received unexpected counter urn: %s", urn));
     }
 
-    // TODO(migryz): extract and utilize pcollection label from beam_fn_api.proto
     if (!pcollectionIdToNameContext.containsKey(
         monitoringInfo.getLabelsMap().get(MonitoringInfoConstants.Labels.PCOLLECTION))) {
       return Optional.of(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/RegisterAndProcessBundleOperation.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/RegisterAndProcessBundleOperation.java
@@ -173,11 +173,11 @@ public class RegisterAndProcessBundleOperation extends Operation {
     }
 
     grpcReadTransformReadWritePCollectionNames =
-        extractGrpcPCollectionNames(
+        extractCrossBoundaryGrpcPCollectionNames(
             registerRequest.getProcessBundleDescriptor(0).getTransformsMap().entrySet());
   }
 
-  private Set<String> extractGrpcPCollectionNames(
+  private Set<String> extractCrossBoundaryGrpcPCollectionNames(
       final Set<Entry<String, PTransform>> ptransforms) {
     Set<String> result = new HashSet<>();
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/RegisterAndProcessBundleOperation.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/RegisterAndProcessBundleOperation.java
@@ -21,9 +21,12 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,9 +48,11 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest.RequestCase;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateResponse;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.runners.core.SideInputReader;
 import org.apache.beam.runners.core.StateNamespaces;
 import org.apache.beam.runners.core.StateTags;
+import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
 import org.apache.beam.runners.dataflow.worker.ByteStringCoder;
 import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.DataflowStepContext;
 import org.apache.beam.runners.dataflow.worker.DataflowOperationContext;
@@ -61,6 +66,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.fn.IdGenerator;
 import org.apache.beam.sdk.fn.data.RemoteGrpcPortRead;
+import org.apache.beam.sdk.fn.data.RemoteGrpcPortWrite;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.transforms.Materializations;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -110,6 +116,8 @@ public class RegisterAndProcessBundleOperation extends Operation {
 
   private @Nullable String grpcReadTransformId = null;
   private String grpcReadTransformOutputName = null;
+  private String grpcReadTransformOutputPCollectionName = null;
+  private final Set<String> grpcReadTransformReadWritePCollectionNames;
 
   public RegisterAndProcessBundleOperation(
       IdGenerator idGenerator,
@@ -145,6 +153,7 @@ public class RegisterAndProcessBundleOperation extends Operation {
       LOG.debug(
           "Process bundle descriptor {}", toDot(registerRequest.getProcessBundleDescriptor(0)));
     }
+
     for (Map.Entry<String, RunnerApi.PTransform> pTransform :
         registerRequest.getProcessBundleDescriptor(0).getTransformsMap().entrySet()) {
       if (pTransform.getValue().getSpec().getUrn().equals(RemoteGrpcPortRead.URN)) {
@@ -152,13 +161,45 @@ public class RegisterAndProcessBundleOperation extends Operation {
           // TODO: Handle the case of more than one input.
           grpcReadTransformId = null;
           grpcReadTransformOutputName = null;
+          grpcReadTransformOutputPCollectionName = null;
           break;
         }
         grpcReadTransformId = pTransform.getKey();
         grpcReadTransformOutputName =
             Iterables.getOnlyElement(pTransform.getValue().getOutputsMap().keySet());
+        grpcReadTransformOutputPCollectionName =
+            pTransform.getValue().getOutputsMap().get(grpcReadTransformOutputName);
       }
     }
+
+    grpcReadTransformReadWritePCollectionNames =
+        extractGrpcPCollectionNames(
+            registerRequest.getProcessBundleDescriptor(0).getTransformsMap().entrySet());
+  }
+
+  private Set<String> extractGrpcPCollectionNames(
+      final Set<Entry<String, PTransform>> ptransforms) {
+    Set<String> result = new HashSet<>();
+
+    // GRPC Read/Write expected to only have one Output/Input respectively.
+    for (Map.Entry<String, RunnerApi.PTransform> pTransform : ptransforms) {
+      if (pTransform.getValue().getSpec().getUrn().equals(RemoteGrpcPortRead.URN)) {
+        String grpcReadTransformOutputName =
+            Iterables.getOnlyElement(pTransform.getValue().getOutputsMap().keySet());
+        String pcollectionName =
+            pTransform.getValue().getOutputsMap().get(grpcReadTransformOutputName);
+        result.add(pcollectionName);
+      }
+
+      if (pTransform.getValue().getSpec().getUrn().equals(RemoteGrpcPortWrite.URN)) {
+        String grpcTransformInputName =
+            Iterables.getOnlyElement(pTransform.getValue().getInputsMap().keySet());
+        String pcollectionName = pTransform.getValue().getInputsMap().get(grpcTransformInputName);
+        result.add(pcollectionName);
+      }
+    }
+
+    return result;
   }
 
   /** Generates a dot description of the process bundle descriptor. */
@@ -373,6 +414,49 @@ public class RegisterAndProcessBundleOperation extends Operation {
       // At the very least, we don't know that this has failed yet.
       return false;
     }
+  }
+
+  /*
+   * Returns a subset of monitoring infos that refer to grpc IO.
+   */
+  public List<MonitoringInfo> findIOPCollectionMonitoringInfos(
+      Iterable<MonitoringInfo> monitoringInfos) {
+    List<MonitoringInfo> result = new ArrayList<MonitoringInfo>();
+    if (grpcReadTransformReadWritePCollectionNames.isEmpty()) {
+      return result;
+    }
+
+    for (MonitoringInfo mi : monitoringInfos) {
+      if (mi.getUrn().equals(MonitoringInfoConstants.Urns.ELEMENT_COUNT)) {
+        String pcollection =
+            mi.getLabelsOrDefault(MonitoringInfoConstants.Labels.PCOLLECTION, null);
+        if ((pcollection != null)
+            && (grpcReadTransformReadWritePCollectionNames.contains(pcollection))) {
+          result.add(mi);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  long getInputElementsConsumed(final Iterable<MonitoringInfo> monitoringInfos) {
+    if (grpcReadTransformId == null) {
+      return 0;
+    }
+
+    for (MonitoringInfo mi : monitoringInfos) {
+      if (mi.getUrn().equals(MonitoringInfoConstants.Urns.ELEMENT_COUNT)) {
+        String pcollection =
+            mi.getLabelsOrDefault(MonitoringInfoConstants.Labels.PCOLLECTION, null);
+        if ((pcollection != null)
+            && (!pcollection.equals(grpcReadTransformOutputPCollectionName))) {
+          return mi.getMetric().getCounterData().getInt64Value();
+        }
+      }
+    }
+
+    return 0;
   }
 
   /** Returns the number of input elements consumed by the gRPC read, if known, otherwise 0. */

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_exercise_streaming_metrics_pipeline_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_exercise_streaming_metrics_pipeline_test.py
@@ -126,6 +126,21 @@ class ExerciseStreamingMetricsPipelineTest(unittest.TestCase):
       ('apache_beam.runners.dataflow.'
        'dataflow_exercise_streaming_metrics_pipeline.StreamingUserMetricsDoFn')
     matchers = [
+        # System metrics
+        MetricResultMatcher(
+            name='ElementCount',
+            labels={"output_user_name": "generate_metrics-out0",
+                    "original_name": "generate_metrics-out0-ElementCount"},
+            attempted=len(MESSAGES_TO_PUBLISH),
+            committed=len(MESSAGES_TO_PUBLISH),
+        ),
+        MetricResultMatcher(
+            name='ElementCount',
+            labels={"output_user_name": "ReadFromPubSub/Read-out0",
+                    "original_name": "ReadFromPubSub/Read-out0-ElementCount"},
+            attempted=len(MESSAGES_TO_PUBLISH),
+            committed=len(MESSAGES_TO_PUBLISH),
+        ),
         # User Counter Metrics.
         MetricResultMatcher(
             name='double_msg_counter_name',


### PR DESCRIPTION
For PTransform IOs that cross SDK Harness border we create two PCollections: one lives outside SDK harness, one inside. As a result counters for these PCollections are counted inside Java DF worker as well as in SDK Harness. This causes us to double count them in Streaming jobs. This worked fine in Batch jobs since DFE will do deduplication work for us.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
