### PR TITLE
[BEAM-8100] Exception handling for AsJsons and ParseJsons

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FlatMapElementsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FlatMapElementsTest.java
@@ -21,8 +21,8 @@ import static org.apache.beam.sdk.transforms.Contextful.fn;
 import static org.apache.beam.sdk.transforms.Requirements.requiresSideInputs;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.apache.beam.sdk.values.TypeDescriptors.integers;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 import java.io.Serializable;
 import java.util.Collections;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MapElementsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MapElementsTest.java
@@ -21,12 +21,12 @@ import static org.apache.beam.sdk.transforms.Contextful.fn;
 import static org.apache.beam.sdk.transforms.Requirements.requiresSideInputs;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.apache.beam.sdk.values.TypeDescriptors.integers;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -46,7 +46,6 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -538,8 +537,6 @@ public class MapElementsTest implements Serializable {
 
     PAssert.that(result.output()).containsInAnyOrder(1);
 
-    Map<String, String> expectedFailureInfo =
-        ImmutableMap.of("className", "java.lang.ArithmeticException");
     PAssert.thatSingleton(result.failures())
         .satisfies(
             kv -> {

--- a/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/AsJsons.java
+++ b/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/AsJsons.java
@@ -17,13 +17,27 @@
  */
 package org.apache.beam.sdk.extensions.jackson;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.transforms.Contextful;
+import org.apache.beam.sdk.transforms.InferableFunction;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ProcessFunction;
+import org.apache.beam.sdk.transforms.Requirements;
 import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.WithFailures;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Optional;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 
 /**
  * {@link PTransform} for serializing objects to JSON {@link String Strings}. Transforms a {@code
@@ -41,12 +55,12 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
    * into a {@link PCollection} of JSON {@link String Strings} representing those objects using a
    * Jackson {@link ObjectMapper}.
    */
-  public static <OutputT> AsJsons<OutputT> of(Class<? extends OutputT> outputClass) {
-    return new AsJsons<>(outputClass);
+  public static <InputT> AsJsons<InputT> of(Class<? extends InputT> inputClass) {
+    return new AsJsons<>(inputClass);
   }
 
-  private AsJsons(Class<? extends InputT> outputClass) {
-    this.inputClass = outputClass;
+  private AsJsons(Class<? extends InputT> inputClass) {
+    this.inputClass = inputClass;
   }
 
   /** Use custom Jackson {@link ObjectMapper} instead of the default one. */
@@ -54,6 +68,83 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
     AsJsons<InputT> newTransform = new AsJsons<>(inputClass);
     newTransform.customMapper = mapper;
     return newTransform;
+  }
+
+  /**
+   * Returns a new {@link AsJsonsWithFailures} transform that catches exceptions raised while
+   * writing JSON elements, with the given type descriptor used for the failure collection but the
+   * exception handler yet to be specified using {@link
+   * AsJsonsWithFailures#exceptionsVia(ProcessFunction)}.
+   *
+   * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
+   * WithFailures.Result}.
+   */
+  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  public <NewFailureT> AsJsonsWithFailures<NewFailureT> exceptionsInto(
+      TypeDescriptor<NewFailureT> failureTypeDescriptor) {
+    return new AsJsonsWithFailures<>(null, failureTypeDescriptor);
+  }
+
+  /**
+   * Returns a new {@link AsJsonsWithFailures} transform that catches exceptions raised while
+   * writing JSON elements, passing the raised exception instance and the input element being
+   * processed through the given {@code exceptionHandler} and emitting the result to a failure
+   * collection.
+   *
+   * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
+   * WithFailures.Result}.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * WithFailures.Result<PCollection<String>, KV<MyPojo, Map<String, String>>> result =
+   *     pojos.apply(
+   *         AsJsons.of(MyPojo.class)
+   *             .exceptionsVia(new WithFailures.ExceptionAsMapHandler<MyPojo>() {}));
+   *
+   * PCollection<String> output = result.output(); // valid json elements
+   * PCollection<KV<MyPojo, Map<String, String>>> failures = result.failures();
+   * }</pre>
+   */
+  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  public <FailureT> AsJsonsWithFailures<FailureT> exceptionsVia(
+      InferableFunction<WithFailures.ExceptionElement<InputT>, FailureT> exceptionHandler) {
+    return new AsJsonsWithFailures<>(exceptionHandler, exceptionHandler.getOutputTypeDescriptor());
+  }
+
+  /**
+   * Returns a new {@link AsJsonsWithFailures} transform that catches exceptions raised while
+   * writing JSON elements, passing the raised exception instance and the input element being
+   * processed through the default exception handler {@link DefaultExceptionAsMapHandler} and
+   * emitting the result to a failure collection.
+   *
+   * <p>See {@link DefaultExceptionAsMapHandler} for more details about default handler behavior.
+   *
+   * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
+   * WithFailures.Result}.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * WithFailures.Result<PCollection<String>, KV<MyPojo, Map<String, String>>> result =
+   *     pojos.apply(
+   *         AsJsons.of(MyPojo.class)
+   *             .exceptionsVia());
+   *
+   * PCollection<String> output = result.output(); // valid json elements
+   * PCollection<KV<MyPojo, Map<String, String>>> failures = result.failures();
+   * }</pre>
+   */
+  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  public AsJsonsWithFailures<KV<InputT, Map<String, String>>> exceptionsVia() {
+    DefaultExceptionAsMapHandler<InputT> exceptionHandler =
+        new DefaultExceptionAsMapHandler<InputT>() {};
+    return new AsJsonsWithFailures<>(exceptionHandler, exceptionHandler.getOutputTypeDescriptor());
+  }
+
+  private String writeValue(InputT input) throws JsonProcessingException {
+    ObjectMapper mapper = Optional.ofNullable(customMapper).orElse(DEFAULT_MAPPER);
+    return mapper.writeValueAsString(input);
   }
 
   @Override
@@ -64,13 +155,101 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
               @Override
               public String apply(InputT input) {
                 try {
-                  ObjectMapper mapper = Optional.fromNullable(customMapper).or(DEFAULT_MAPPER);
-                  return mapper.writeValueAsString(input);
+                  return writeValue(input);
                 } catch (IOException e) {
                   throw new RuntimeException(
                       "Failed to serialize " + inputClass.getName() + " value: " + input, e);
                 }
               }
             }));
+  }
+
+  /** A {@code PTransform} that adds exception handling to {@link AsJsons}. */
+  public class AsJsonsWithFailures<FailureT>
+      extends PTransform<PCollection<InputT>, WithFailures.Result<PCollection<String>, FailureT>> {
+
+    @Nullable
+    private InferableFunction<WithFailures.ExceptionElement<InputT>, FailureT> exceptionHandler;
+
+    @Nullable private final transient TypeDescriptor<FailureT> failureType;
+
+    AsJsonsWithFailures(
+        InferableFunction<WithFailures.ExceptionElement<InputT>, FailureT> exceptionHandler,
+        TypeDescriptor<FailureT> failureType) {
+      this.exceptionHandler = exceptionHandler;
+      this.failureType = failureType;
+    }
+
+    /**
+     * Returns a new {@link AsJsonsWithFailures} transform that catches exceptions raised while
+     * writing JSON elements, passing the raised exception instance and the input element being
+     * processed through the given {@code exceptionHandler} and emitting the result to a failure
+     * collection. It is supposed to be used along with {@link
+     * AsJsons#exceptionsInto(TypeDescriptor)} and get lambda function as exception handler.
+     *
+     * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
+     * WithFailures.Result}.
+     *
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * WithFailures.Result<PCollection<String>, KV<MyPojo, Map<String, String>>> result =
+     *     pojos.apply(
+     *         AsJsons.of(MyPojo.class)
+     *             .exceptionsInto(
+     *                 TypeDescriptors.kvs(
+     *                     TypeDescriptor.of(MyPojo.class), TypeDescriptors.strings()))
+     *             .exceptionsVia(
+     *                 f -> KV.of(f.element(), f.exception().getClass().getCanonicalName())));
+     *
+     * PCollection<String> output = result.output(); // valid json elements
+     * PCollection<KV<MyPojo, Map<String, String>>> failures = result.failures();
+     * }</pre>
+     */
+    public AsJsonsWithFailures<FailureT> exceptionsVia(
+        ProcessFunction<WithFailures.ExceptionElement<InputT>, FailureT> exceptionHandler) {
+      return new AsJsonsWithFailures<>(
+          new InferableFunction<WithFailures.ExceptionElement<InputT>, FailureT>(
+              exceptionHandler) {},
+          failureType);
+    }
+
+    @Override
+    public WithFailures.Result<PCollection<String>, FailureT> expand(PCollection<InputT> input) {
+      return input.apply(
+          MapElements.into(TypeDescriptors.strings())
+              .via(
+                  Contextful.fn(
+                      (Contextful.Fn<InputT, String>) (input1, c) -> writeValue(input1),
+                      Requirements.empty()))
+              .exceptionsInto(failureType)
+              .exceptionsVia(exceptionHandler));
+    }
+  }
+
+  /**
+   * A default handler that extracts information from an exception to a {@code Map<String, String>}
+   * and returns a {@link KV} where the key is the input element that failed processing, and the
+   * value is the map of exception attributes. It handles only {@code JsonProcessingException},
+   * other type of exceptions will be rethrown as {@code RuntimeException}.
+   *
+   * <p>The keys populated in the map are "className", "message", and "stackTrace" of the exception.
+   */
+  private static class DefaultExceptionAsMapHandler<InputT>
+      extends SimpleFunction<
+          WithFailures.ExceptionElement<InputT>, KV<InputT, Map<String, String>>> {
+    @Override
+    public KV<InputT, Map<String, String>> apply(WithFailures.ExceptionElement<InputT> f)
+        throws RuntimeException {
+      if (!(f.exception() instanceof JsonProcessingException)) {
+        throw new RuntimeException(f.exception());
+      }
+      return KV.of(
+          f.element(),
+          ImmutableMap.of(
+              "className", f.exception().getClass().getName(),
+              "message", f.exception().getMessage(),
+              "stackTrace", Arrays.toString(f.exception().getStackTrace())));
+    }
   }
 }

--- a/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/ParseJsons.java
+++ b/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/ParseJsons.java
@@ -19,11 +19,23 @@ package org.apache.beam.sdk.extensions.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.transforms.Contextful;
+import org.apache.beam.sdk.transforms.InferableFunction;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ProcessFunction;
+import org.apache.beam.sdk.transforms.Requirements;
 import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.WithFailures;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Optional;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 
 /**
  * {@link PTransform} for parsing JSON {@link String Strings}. Parse {@link PCollection} of {@link
@@ -55,6 +67,84 @@ public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollec
     return newTransform;
   }
 
+  /**
+   * Returns a new {@link ParseJsonsWithFailures} transform that catches exceptions raised while
+   * parsing elements, with the given type descriptor used for the failure collection but the
+   * exception handler yet to be specified using {@link
+   * ParseJsonsWithFailures#exceptionsVia(ProcessFunction)}.
+   *
+   * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
+   * WithFailures.Result}.
+   */
+  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  public <NewFailureT> ParseJsonsWithFailures<NewFailureT> exceptionsInto(
+      TypeDescriptor<NewFailureT> failureTypeDescriptor) {
+    return new ParseJsonsWithFailures<>(null, failureTypeDescriptor);
+  }
+
+  /**
+   * Returns a new {@link ParseJsonsWithFailures} transform that catches exceptions raised while
+   * parsing elements, passing the raised exception instance and the input element being processed
+   * through the given {@code exceptionHandler} and emitting the result to a failure collection.
+   *
+   * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
+   * WithFailures.Result}.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * WithFailures.Result<PCollection<MyPojo>, KV<String, Map<String, String>>> result =
+   *     json.apply(
+   *         ParseJsons.of(MyPojo.class)
+   *             .exceptionsVia(new WithFailures.ExceptionAsMapHandler<String>() {}));
+   *
+   * PCollection<MyPojo> output = result.output(); // valid POJOs
+   * PCollection<KV<String, Map<String, String>>> failures = result.failures();
+   * }</pre>
+   */
+  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  public <FailureT> ParseJsonsWithFailures<FailureT> exceptionsVia(
+      InferableFunction<WithFailures.ExceptionElement<String>, FailureT> exceptionHandler) {
+    return new ParseJsonsWithFailures<>(
+        exceptionHandler, exceptionHandler.getOutputTypeDescriptor());
+  }
+
+  /**
+   * Returns a new {@link ParseJsonsWithFailures} transform that catches exceptions raised while
+   * parsing elements, passing the raised exception instance and the input element being processed
+   * through the default exception handler {@link DefaultExceptionAsMapHandler} and emitting the
+   * result to a failure collection.
+   *
+   * <p>See {@link DefaultExceptionAsMapHandler} for more details about default handler behavior.
+   *
+   * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
+   * WithFailures.Result}.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * WithFailures.Result<PCollection<MyPojo>, KV<String, Map<String, String>>> result =
+   *     json.apply(
+   *         ParseJsons.of(MyPojo.class)
+   *             .exceptionsVia());
+   *
+   * PCollection<MyPojo> output = result.output(); // valid POJOs
+   * PCollection<KV<String, Map<String, String>>> failures = result.failures();
+   * }</pre>
+   */
+  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  public ParseJsonsWithFailures<KV<String, Map<String, String>>> exceptionsVia() {
+    DefaultExceptionAsMapHandler<String> exceptionHandler =
+        new DefaultExceptionAsMapHandler<String>() {};
+    return new ParseJsonsWithFailures<>(
+        exceptionHandler, exceptionHandler.getOutputTypeDescriptor());
+  }
+
+  private OutputT readValue(String input) throws IOException {
+    ObjectMapper mapper = Optional.ofNullable(customMapper).orElse(DEFAULT_MAPPER);
+    return mapper.readValue(input, outputClass);
+  }
+
   @Override
   public PCollection<OutputT> expand(PCollection<String> input) {
     return input.apply(
@@ -63,8 +153,7 @@ public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollec
               @Override
               public OutputT apply(String input) {
                 try {
-                  ObjectMapper mapper = Optional.fromNullable(customMapper).or(DEFAULT_MAPPER);
-                  return mapper.readValue(input, outputClass);
+                  return readValue(input);
                 } catch (IOException e) {
                   throw new RuntimeException(
                       "Failed to parse a " + outputClass.getName() + " from JSON value: " + input,
@@ -72,5 +161,92 @@ public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollec
                 }
               }
             }));
+  }
+
+  /** A {@code PTransform} that adds exception handling to {@link ParseJsons}. */
+  public class ParseJsonsWithFailures<FailureT>
+      extends PTransform<PCollection<String>, WithFailures.Result<PCollection<OutputT>, FailureT>> {
+    @Nullable
+    private InferableFunction<WithFailures.ExceptionElement<String>, FailureT> exceptionHandler;
+
+    @Nullable private final transient TypeDescriptor<FailureT> failureType;
+
+    ParseJsonsWithFailures(
+        InferableFunction<WithFailures.ExceptionElement<String>, FailureT> exceptionHandler,
+        TypeDescriptor<FailureT> failureType) {
+      this.exceptionHandler = exceptionHandler;
+      this.failureType = failureType;
+    }
+
+    /**
+     * Returns a new {@link ParseJsonsWithFailures} transform that catches exceptions raised while
+     * parsing elements, passing the raised exception instance and the input element being processed
+     * through the given {@code exceptionHandler} and emitting the result to a failure collection.
+     * It is supposed to be used along with {@link ParseJsons#exceptionsInto(TypeDescriptor)} and
+     * get lambda function as exception handler.
+     *
+     * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
+     * WithFailures.Result}.
+     *
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * WithFailures.Result<PCollection<MyPojo>, KV<String, Map<String, String>>> result =
+     *     json.apply(
+     *         ParseJsons.of(MyPojo.class)
+     *             .exceptionsInto(
+     *                 TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.strings()))
+     *             .exceptionsVia(
+     *                 f -> KV.of(f.element(), f.exception().getClass().getCanonicalName())));
+     *
+     * PCollection<MyPojo> output = result.output(); // valid POJOs
+     * PCollection<KV<String, Map<String, String>>> failures = result.failures();
+     * }</pre>
+     */
+    public ParseJsonsWithFailures<FailureT> exceptionsVia(
+        ProcessFunction<WithFailures.ExceptionElement<String>, FailureT> exceptionHandler) {
+      return new ParseJsonsWithFailures<>(
+          new InferableFunction<WithFailures.ExceptionElement<String>, FailureT>(
+              exceptionHandler) {},
+          failureType);
+    }
+
+    @Override
+    public WithFailures.Result<PCollection<OutputT>, FailureT> expand(PCollection<String> input) {
+      return input.apply(
+          MapElements.into(new TypeDescriptor<OutputT>() {})
+              .via(
+                  Contextful.fn(
+                      (Contextful.Fn<String, OutputT>) (input1, c) -> readValue(input1),
+                      Requirements.empty()))
+              .exceptionsInto(failureType)
+              .exceptionsVia(exceptionHandler));
+    }
+  }
+
+  /**
+   * A default handler that extracts information from an exception to a {@code Map<String, String>}
+   * and returns a {@link KV} where the key is the input element that failed processing, and the
+   * value is the map of exception attributes. It handles only {@code IOException}, other type of
+   * exceptions will be rethrown as {@code RuntimeException}.
+   *
+   * <p>The keys populated in the map are "className", "message", and "stackTrace" of the exception.
+   */
+  private static class DefaultExceptionAsMapHandler<OutputT>
+      extends SimpleFunction<
+          WithFailures.ExceptionElement<OutputT>, KV<OutputT, Map<String, String>>> {
+    @Override
+    public KV<OutputT, Map<String, String>> apply(WithFailures.ExceptionElement<OutputT> f)
+        throws RuntimeException {
+      if (!(f.exception() instanceof IOException)) {
+        throw new RuntimeException(f.exception());
+      }
+      return KV.of(
+          f.element(),
+          ImmutableMap.of(
+              "className", f.exception().getClass().getName(),
+              "message", f.exception().getMessage(),
+              "stackTrace", Arrays.toString(f.exception().getStackTrace())));
+    }
   }
 }

--- a/sdks/java/extensions/jackson/src/test/java/org/apache/beam/sdk/extensions/jackson/JacksonTransformsTest.java
+++ b/sdks/java/extensions/jackson/src/test/java/org/apache/beam/sdk/extensions/jackson/JacksonTransformsTest.java
@@ -17,25 +17,38 @@
  */
 package org.apache.beam.sdk.extensions.jackson;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.MapCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.WithFailures;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.junit.Rule;
 import org.junit.Test;
 
 /** Test Jackson transforms {@link ParseJsons} and {@link AsJsons}. */
-public class JacksonTransformsTest {
+public class JacksonTransformsTest implements Serializable {
   private static final List<String> VALID_JSONS =
       Arrays.asList("{\"myString\":\"abc\",\"myInt\":3}", "{\"myString\":\"def\",\"myInt\":4}");
 
@@ -50,6 +63,9 @@ public class JacksonTransformsTest {
 
   private static final List<MyPojo> POJOS =
       Arrays.asList(new MyPojo("abc", 3), new MyPojo("def", 4));
+
+  private static final List<MyInvalidPojo> INVALID_POJOS =
+      Arrays.asList(new MyInvalidPojo("aaa", 5), new MyInvalidPojo("bbb", 6));
 
   private static final List<MyEmptyBean> EMPTY_BEANS =
       Arrays.asList(new MyEmptyBean("abc", 3), new MyEmptyBean("def", 4));
@@ -78,6 +94,83 @@ public class JacksonTransformsTest {
             .setCoder(SerializableCoder.of(MyPojo.class));
 
     PAssert.that(output).containsInAnyOrder(POJOS);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testParsingInvalidJsonsWithFailuresDefaultHandler() {
+    WithFailures.Result<PCollection<MyPojo>, KV<String, Map<String, String>>> result =
+        pipeline
+            .apply(Create.of(Iterables.concat(VALID_JSONS, INVALID_JSONS)))
+            .apply(ParseJsons.of(MyPojo.class).exceptionsVia());
+
+    result.output().setCoder(SerializableCoder.of(MyPojo.class));
+
+    PAssert.that(result.output()).containsInAnyOrder(POJOS);
+    assertParsingWithErrorMapHandler(result);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testParsingInvalidJsonsWithFailuresAsMap() {
+    WithFailures.Result<PCollection<MyPojo>, KV<String, Map<String, String>>> result =
+        pipeline
+            .apply(Create.of(Iterables.concat(VALID_JSONS, INVALID_JSONS)))
+            .apply(
+                ParseJsons.of(MyPojo.class)
+                    .exceptionsVia(new WithFailures.ExceptionAsMapHandler<String>() {}));
+
+    result.output().setCoder(SerializableCoder.of(MyPojo.class));
+
+    PAssert.that(result.output()).containsInAnyOrder(POJOS);
+    assertParsingWithErrorMapHandler(result);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testParsingInvalidJsonsWithFailuresSimpleFunction() {
+    WithFailures.Result<PCollection<MyPojo>, KV<String, String>> result =
+        pipeline
+            .apply(Create.of(Iterables.concat(VALID_JSONS, INVALID_JSONS)))
+            .apply(
+                ParseJsons.of(MyPojo.class)
+                    .exceptionsVia(
+                        new SimpleFunction<
+                            WithFailures.ExceptionElement<String>, KV<String, String>>() {
+                          @Override
+                          public KV<String, String> apply(
+                              WithFailures.ExceptionElement<String> failure) {
+                            return KV.of(
+                                failure.element(),
+                                failure.exception().getClass().getCanonicalName());
+                          }
+                        }));
+    result.output().setCoder(SerializableCoder.of(MyPojo.class));
+
+    PAssert.that(result.output()).containsInAnyOrder(POJOS);
+    assertParsingWithErrorFunctionHandler(result);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testParsingInvalidJsonsWithFailuresLambda() {
+    WithFailures.Result<PCollection<MyPojo>, KV<String, String>> result =
+        pipeline
+            .apply(Create.of(Iterables.concat(VALID_JSONS, INVALID_JSONS)))
+            .apply(
+                ParseJsons.of(MyPojo.class)
+                    .exceptionsInto(
+                        TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.strings()))
+                    .exceptionsVia(
+                        f -> KV.of(f.element(), f.exception().getClass().getCanonicalName())));
+    result.output().setCoder(SerializableCoder.of(MyPojo.class));
+
+    PAssert.that(result.output()).containsInAnyOrder(POJOS);
+    assertParsingWithErrorFunctionHandler(result);
 
     pipeline.run();
   }
@@ -146,6 +239,99 @@ public class JacksonTransformsTest {
             .setCoder(StringUtf8Coder.of());
 
     PAssert.that(output).containsInAnyOrder(EMPTY_JSONS);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testWritingInvalidJsonsWithFailuresDefaultHandler() {
+    WithFailures.Result<PCollection<String>, KV<MyPojo, Map<String, String>>> result =
+        pipeline
+            .apply(
+                Create.of(Iterables.concat(POJOS, INVALID_POJOS))
+                    .withCoder(SerializableCoder.of(MyPojo.class)))
+            .apply(AsJsons.of(MyPojo.class).exceptionsVia());
+
+    result.output().setCoder(StringUtf8Coder.of());
+
+    result
+        .failures()
+        .setCoder(
+            KvCoder.of(
+                SerializableCoder.of(MyPojo.class),
+                MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())));
+
+    PAssert.that(result.output()).containsInAnyOrder(VALID_JSONS);
+    assertWritingWithErrorMapHandler(result);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testWritingInvalidJsonsWithFailuresAsMap() {
+    WithFailures.Result<PCollection<String>, KV<MyPojo, Map<String, String>>> result =
+        pipeline
+            .apply(
+                Create.of(Iterables.concat(POJOS, INVALID_POJOS))
+                    .withCoder(SerializableCoder.of(MyPojo.class)))
+            .apply(
+                AsJsons.of(MyPojo.class)
+                    .exceptionsVia(new WithFailures.ExceptionAsMapHandler<MyPojo>() {}));
+
+    result.output().setCoder(StringUtf8Coder.of());
+
+    PAssert.that(result.output()).containsInAnyOrder(VALID_JSONS);
+    assertWritingWithErrorMapHandler(result);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testWritingInvalidJsonsWithFailuresSimpleFunction() {
+    WithFailures.Result<PCollection<String>, KV<MyPojo, String>> result =
+        pipeline
+            .apply(
+                Create.of(Iterables.concat(POJOS, INVALID_POJOS))
+                    .withCoder(SerializableCoder.of(MyPojo.class)))
+            .apply(
+                AsJsons.of(MyPojo.class)
+                    .exceptionsVia(
+                        new SimpleFunction<
+                            WithFailures.ExceptionElement<MyPojo>, KV<MyPojo, String>>() {
+                          @Override
+                          public KV<MyPojo, String> apply(
+                              WithFailures.ExceptionElement<MyPojo> failure) {
+                            return KV.of(
+                                failure.element(),
+                                failure.exception().getClass().getCanonicalName());
+                          }
+                        }));
+    result.output().setCoder(StringUtf8Coder.of());
+
+    PAssert.that(result.output()).containsInAnyOrder(VALID_JSONS);
+    assertWritingWithErrorFunctionHandler(result);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testWritingInvalidJsonsWithFailuresLambda() {
+    WithFailures.Result<PCollection<String>, KV<MyPojo, String>> result =
+        pipeline
+            .apply(
+                Create.of(Iterables.concat(POJOS, INVALID_POJOS))
+                    .withCoder(SerializableCoder.of(MyPojo.class)))
+            .apply(
+                AsJsons.of(MyPojo.class)
+                    .exceptionsInto(
+                        TypeDescriptors.kvs(
+                            TypeDescriptor.of(MyPojo.class), TypeDescriptors.strings()))
+                    .exceptionsVia(
+                        f -> KV.of(f.element(), f.exception().getClass().getCanonicalName())));
+    result.output().setCoder(StringUtf8Coder.of());
+
+    PAssert.that(result.output()).containsInAnyOrder(VALID_JSONS);
+    assertWritingWithErrorFunctionHandler(result);
 
     pipeline.run();
   }
@@ -237,5 +423,85 @@ public class JacksonTransformsTest {
       result = 31 * result + myInt;
       return result;
     }
+  }
+
+  /** Pojo for tests. */
+  @SuppressWarnings({"WeakerAccess", "unused"})
+  public static class MyInvalidPojo extends MyPojo {
+    public MyInvalidPojo(String myString, int myInt) {
+      super(myString, myInt);
+    }
+
+    @Override
+    public String getMyString() {
+      throw new RuntimeException("Unknown error!");
+    }
+  }
+
+  private void assertParsingWithErrorMapHandler(
+      WithFailures.Result<PCollection<MyPojo>, KV<String, Map<String, String>>> result) {
+    PAssert.that(result.failures())
+        .satisfies(
+            kv -> {
+              for (KV<String, Map<String, String>> entry : kv) {
+                if (entry.getKey().equals(INVALID_JSONS.get(0))) {
+                  assertEquals(
+                      "com.fasterxml.jackson.core.JsonParseException",
+                      entry.getValue().get("className"));
+                } else if (entry.getKey().equals(INVALID_JSONS.get(1))) {
+                  assertEquals(
+                      "com.fasterxml.jackson.core.io.JsonEOFException",
+                      entry.getValue().get("className"));
+                } else if (entry.getKey().equals(INVALID_JSONS.get(2))) {
+                  assertEquals(
+                      "com.fasterxml.jackson.databind.exc.MismatchedInputException",
+                      entry.getValue().get("className"));
+                } else {
+                  throw new AssertionError(
+                      "Unexpected key is found in failures result: \"" + entry.getKey() + "\"");
+                }
+                assertThat(entry.getValue().entrySet(), hasSize(3));
+                assertThat(entry.getValue(), hasKey("stackTrace"));
+                assertThat(entry.getValue(), hasKey("message"));
+              }
+
+              return null;
+            });
+  }
+
+  private void assertParsingWithErrorFunctionHandler(
+      WithFailures.Result<PCollection<MyPojo>, KV<String, String>> result) {
+    PAssert.that(result.failures())
+        .containsInAnyOrder(
+            KV.of(INVALID_JSONS.get(0), "com.fasterxml.jackson.core.JsonParseException"),
+            KV.of(INVALID_JSONS.get(1), "com.fasterxml.jackson.core.io.JsonEOFException"),
+            KV.of(
+                INVALID_JSONS.get(2),
+                "com.fasterxml.jackson.databind.exc.MismatchedInputException"));
+  }
+
+  private void assertWritingWithErrorMapHandler(
+      WithFailures.Result<PCollection<String>, KV<MyPojo, Map<String, String>>> result) {
+    PAssert.that(result.failures())
+        .satisfies(
+            kv -> {
+              for (KV<MyPojo, Map<String, String>> entry : kv) {
+                assertThat(entry.getValue().entrySet(), hasSize(3));
+                assertThat(entry.getValue(), hasKey("stackTrace"));
+                assertThat(entry.getValue(), hasKey("message"));
+                assertEquals(
+                    "com.fasterxml.jackson.databind.JsonMappingException",
+                    entry.getValue().get("className"));
+              }
+              return null;
+            });
+  }
+
+  private void assertWritingWithErrorFunctionHandler(
+      WithFailures.Result<PCollection<String>, KV<MyPojo, String>> result) {
+    PAssert.that(result.failures())
+        .containsInAnyOrder(
+            KV.of(INVALID_POJOS.get(0), "com.fasterxml.jackson.databind.JsonMappingException"),
+            KV.of(INVALID_POJOS.get(1), "com.fasterxml.jackson.databind.JsonMappingException"));
   }
 }


### PR DESCRIPTION
This PR is based on work done in #7736 and it adds a possibility to handle exceptions for `AsJsons` and `ParseJsons` transforms.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
