### PR TITLE
Fix typo in Cloud Pub/Sub topic path

### DIFF
--- a/sdks/python/apache_beam/examples/streaming_wordcount.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount.py
@@ -39,7 +39,7 @@ def run(argv=None):
   parser.add_argument(
       '--output_topic', required=True,
       help=('Output PubSub topic of the form '
-            '"projects/<PROJECT>/topic/<TOPIC>".'))
+            '"projects/<PROJECT>/topics/<TOPIC>".'))
   group = parser.add_mutually_exclusive_group(required=True)
   group.add_argument(
       '--input_topic',


### PR DESCRIPTION
Just a small typo in the topic path. 