### PR TITLE
[BEAM-8156] Add convert_to_typing_type

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -138,6 +138,8 @@ def _match_is_union(user_type):
   return False
 
 
+# Mapping from typing.TypeVar/typehints.TypeVariable ids to an object of the
+# other type. Bidirectional mapping preserves typing.TypeVar instances.
 _type_var_cache = {}
 
 
@@ -161,10 +163,12 @@ def convert_to_beam_type(typ):
     # A global cache should be OK as the number of distinct type variables
     # is generally small.
     if id(typ) not in _type_var_cache:
-      _type_var_cache[id(typ)] = typehints.TypeVariable(typ.__name__)
+      new_type_variable = typehints.TypeVariable(typ.__name__)
+      _type_var_cache[id(typ)] = new_type_variable
+      _type_var_cache[id(new_type_variable)] = typ
     return _type_var_cache[id(typ)]
   elif getattr(typ, '__module__', None) != 'typing':
-    # Only tranlsate types from the typing module.
+    # Only translate types from the typing module.
     return typ
 
   type_map = [
@@ -198,6 +202,10 @@ def convert_to_beam_type(typ):
           arity=-1,
           beam_type=typehints.Tuple),
       _TypeMapEntry(match=_match_is_union, arity=-1, beam_type=typehints.Union),
+      _TypeMapEntry(
+          match=_match_issubclass(typing.Iterator),
+          arity=1,
+          beam_type=typehints.Iterator),
   ]
 
   # Find the first matching entry.
@@ -239,3 +247,73 @@ def convert_to_beam_types(args):
     return {k: convert_to_beam_type(v) for k, v in args.items()}
   else:
     return [convert_to_beam_type(v) for v in args]
+
+
+def convert_to_typing_type(typ):
+  """Converts a given Beam type to a typing type.
+
+  This is the reverse of convert_to_beam_type.
+
+  Args:
+    typ: If a typehints.TypeConstraint, the type to convert. Otherwise, typ
+      will be unchanged.
+
+  Returns:
+    Converted version of typ, or unchanged.
+
+  Raises:
+    ~exceptions.ValueError: The type was malformed or could not be converted.
+  """
+  if isinstance(typ, typehints.TypeVariable):
+    # This is a special case, as it's not parameterized by types.
+    # Also, identity must be preserved through conversion (i.e. the same
+    # TypeVariable instance must get converted into the same TypeVar instance).
+    # A global cache should be OK as the number of distinct type variables
+    # is generally small.
+    if id(typ) not in _type_var_cache:
+      new_type_variable = typing.TypeVar(typ.name)
+      _type_var_cache[id(typ)] = new_type_variable
+      _type_var_cache[id(new_type_variable)] = typ
+    return _type_var_cache[id(typ)]
+  elif not getattr(typ, '__module__', None).endswith('typehints'):
+    # Only translate types from the typehints module.
+    return typ
+
+  if isinstance(typ, typehints.AnyTypeConstraint):
+    return typing.Any
+  if isinstance(typ, typehints.DictConstraint):
+    return typing.Dict[convert_to_typing_type(typ.key_type),
+                       convert_to_typing_type(typ.value_type)]
+  if isinstance(typ, typehints.ListConstraint):
+    return typing.List[convert_to_typing_type(typ.inner_type)]
+  if isinstance(typ, typehints.IterableTypeConstraint):
+    return typing.Iterable[convert_to_typing_type(typ.inner_type)]
+  if isinstance(typ, typehints.UnionConstraint):
+    return typing.Union[tuple(convert_to_typing_types(typ.union_types))]
+  if isinstance(typ, typehints.SetTypeConstraint):
+    return typing.Set[convert_to_typing_type(typ.inner_type)]
+  if isinstance(typ, typehints.TupleConstraint):
+    return typing.Tuple[tuple(convert_to_typing_types(typ.tuple_types))]
+  if isinstance(typ, typehints.TupleSequenceConstraint):
+    return typing.Tuple[convert_to_typing_type(typ.inner_type), ...]
+  if isinstance(typ, typehints.IteratorTypeConstraint):
+    return typing.Iterator[convert_to_typing_type(typ.yielded_type)]
+
+  raise ValueError('Failed to convert Beam type: %s' % typ)
+
+
+def convert_to_typing_types(args):
+  """Convert the given list or dictionary of args to typing types.
+
+  Args:
+    args: Either an iterable of types, or a dictionary where the values are
+    types.
+
+  Returns:
+    If given an iterable, a list of converted types. If given a dictionary,
+    a dictionary with the same keys, and values which have been converted.
+  """
+  if isinstance(args, dict):
+    return {k: convert_to_typing_type(v) for k, v in args.items()}
+  else:
+    return [convert_to_typing_type(v) for v in args]

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -203,6 +203,10 @@ def convert_to_beam_type(typ):
           beam_type=typehints.Tuple),
       _TypeMapEntry(match=_match_is_union, arity=-1, beam_type=typehints.Union),
       _TypeMapEntry(
+          match=_match_issubclass(typing.Generator),
+          arity=3,
+          beam_type=typehints.Generator),
+      _TypeMapEntry(
           match=_match_issubclass(typing.Iterator),
           arity=1,
           beam_type=typehints.Iterator),

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -97,9 +97,9 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
       converted_typing_type = convert_to_typing_type(converted_beam_type)
       self.assertEqual(converted_typing_type, typing_type, description)
 
-  def test_generator_not_converted(self):
+  def test_generator_converted_to_iterator(self):
     self.assertEqual(
-        typing.Generator[int, None, None],
+        typehints.Iterator[int],
         convert_to_beam_type(typing.Generator[int, None, None]))
 
   def test_convert_nested_to_beam_type(self):

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -19,11 +19,15 @@
 
 from __future__ import absolute_import
 
+import sys
 import typing
 import unittest
 
-from apache_beam.typehints import native_type_compatibility
 from apache_beam.typehints import typehints
+from apache_beam.typehints.native_type_compatibility import convert_to_beam_type
+from apache_beam.typehints.native_type_compatibility import convert_to_beam_types
+from apache_beam.typehints.native_type_compatibility import convert_to_typing_type
+from apache_beam.typehints.native_type_compatibility import convert_to_typing_types
 
 _TestNamedTuple = typing.NamedTuple('_TestNamedTuple',
                                     [('age', int), ('name', bytes)])
@@ -62,8 +66,9 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
          typehints.Tuple[bytes, typehints.List[typehints.Tuple[
              bytes, typehints.Union[int, bytes, float]]]]),
         # TODO(BEAM-7713): This case seems to fail on Py3.5.2 but not 3.5.4.
-        # ('arbitrary-length tuple', typing.Tuple[int, ...],
-        #  typehints.Tuple[int, ...]),
+        ('arbitrary-length tuple', typing.Tuple[int, ...],
+         typehints.Tuple[int, ...])
+        if sys.version_info >= (3, 5, 4) else None,
         ('flat alias', _TestFlatAlias, typehints.Tuple[bytes, float]),
         ('nested alias', _TestNestedAlias,
          typehints.List[typehints.Tuple[bytes, float]]),
@@ -76,16 +81,26 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
          typing.Tuple[typing.TypeVar('K'), typing.TypeVar('V')],
          typehints.Tuple[typehints.TypeVariable('K'),
                          typehints.TypeVariable('V')]),
+        ('iterator', typing.Iterator[typing.Any],
+         typehints.Iterator[typehints.Any]),
     ]
 
     for test_case in test_cases:
+      if test_case is None:
+        continue
       # Unlike typing types, Beam types are guaranteed to compare equal.
       description = test_case[0]
       typing_type = test_case[1]
-      beam_type = test_case[2]
-      self.assertEqual(
-          native_type_compatibility.convert_to_beam_type(typing_type),
-          beam_type, description)
+      expected_beam_type = test_case[2]
+      converted_beam_type = convert_to_beam_type(typing_type)
+      self.assertEqual(converted_beam_type, expected_beam_type, description)
+      converted_typing_type = convert_to_typing_type(converted_beam_type)
+      self.assertEqual(converted_typing_type, typing_type, description)
+
+  def test_generator_not_converted(self):
+    self.assertEqual(
+        typing.Generator[int, None, None],
+        convert_to_beam_type(typing.Generator[int, None, None]))
 
   def test_convert_nested_to_beam_type(self):
     self.assertEqual(
@@ -102,9 +117,10 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
     beam_types = [bytes, typehints.List[bytes],
                   typehints.List[typehints.Tuple[bytes, int]],
                   typehints.Union[int, typehints.List[int]]]
-    self.assertEqual(
-        native_type_compatibility.convert_to_beam_types(typing_types),
-        beam_types)
+    converted_beam_types = convert_to_beam_types(typing_types)
+    self.assertEqual(converted_beam_types, beam_types)
+    converted_typing_types = convert_to_typing_types(converted_beam_types)
+    self.assertEqual(converted_typing_types, typing_types)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -67,6 +67,7 @@ from __future__ import absolute_import
 
 import collections
 import copy
+import logging
 import sys
 import types
 from builtins import next
@@ -1075,7 +1076,22 @@ class WindowedTypeConstraint(with_metaclass(GetitemConstructor,
 
 
 class GeneratorHint(IteratorHint):
-  pass
+  """A Generator type hint.
+
+  Subscriptor is in the form [yield_type, send_type, return_type], however
+  only yield_type is supported. The 2 others are expected to be None.
+  """
+
+  def __getitem__(self, type_params):
+    if isinstance(type_params, tuple) and len(type_params) == 3:
+      yield_type, send_type, return_type = type_params
+      if send_type is not None:
+        logging.warning('Ignoring send_type hint: %s' % send_type)
+      if send_type is not None:
+        logging.warning('Ignoring return_type hint: %s' % return_type)
+    else:
+      yield_type = type_params
+    return self.IteratorTypeConstraint(yield_type)
 
 
 # Create the actual instances for all defined type-hints above.

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -986,6 +986,13 @@ class IteratorHint(CompositeTypeHint):
     def __repr__(self):
       return 'Iterator[%s]' % _unified_repr(self.yielded_type)
 
+    def __eq__(self, other):
+      return (type(self) == type(other)
+              and self.yielded_type == other.yielded_type)
+
+    def __hash__(self):
+      return hash(self.yielded_type)
+
     def _inner_types(self):
       yield self.yielded_type
 
@@ -1120,9 +1127,9 @@ _KNOWN_PRIMITIVE_TYPES.update({
 
 
 def is_consistent_with(sub, base):
-  """Returns whether the type a is consistent with b.
+  """Checks whether sub a is consistent with base.
 
-  This is accordig to the terminology of PEP 483/484.  This relationship is
+  This is according to the terminology of PEP 483/484.  This relationship is
   neither symmetric nor transitive, but a good mnemonic to keep in mind is that
   is_consistent_with(a, b) is roughly equivalent to the issubclass(a, b)
   relation, but also handles the special Any type as well as type

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -755,6 +755,11 @@ class GeneratorHintTestCase(TypeHintTestCase):
     self.assertCompatible(typehints.Iterator[int], typehints.Iterator[int])
     self.assertNotCompatible(typehints.Iterator[str], typehints.Iterator[float])
 
+  def test_conversion(self):
+    self.assertCompatible(typehints.Iterator[int], typehints.Generator[int])
+    self.assertCompatible(typehints.Iterator[int],
+                          typehints.Generator[int, None, None])
+
   def test_generator_return_hint_invalid_yield_type(self):
     @check_type_hints
     @with_output_types(typehints.Iterator[int])


### PR DESCRIPTION
First step in being able to compartmentalize Beam typing types to
certain functions, and not expose them externally.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
