### PR TITLE
[BEAM-8176] Fix BigQuery Java test jobs

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_BigQueryIO_Java.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_BigQueryIO_Java.groovy
@@ -16,100 +16,98 @@
  * limitations under the License.
  */
 
-import CommonJobProperties as commonJobProperties
-import LoadTestsBuilder as loadTestsBuilder
+
+import CommonJobProperties as common
 import PhraseTriggeringPostCommitBuilder
 
 def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
-def bqioStreamTest = [
-        title          : 'BigQueryIO Streaming Performance Test Java 10 GB',
-        test           : 'org.apache.beam.sdk.bigqueryioperftests.BigQueryIOIT',
-        runner         : CommonTestProperties.Runner.DATAFLOW,
-        pipelineOptions: [
-                jobName               : 'performance-tests-bqio-java-stream-10gb' + now,
-                project               : 'apache-beam-testing',
-                tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
-                tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
-                writeMethod           : 'STREAMING_INSERTS',
-                publishToBigQuery     : true,
-                testBigQueryDataset   : 'beam_performance',
-                testBigQueryTable     : 'bqio_write_10GB_java',
-                metricsBigQueryDataset: 'beam_performance',
-                metricsBigQueryTable  : 'bqio_10GB_results_java_stream',
-                sourceOptions         : '\'{' +
-                        '"num_records": 10485760,' +
-                        '"key_size": 1,' +
-                        '"value_size": 1024}\'',
-                numWorkers            : 5,
-                autoscalingAlgorithm  : 'NONE',  // Disable autoscale the worker pool.
+def jobConfigs = [
+        [
+                title        : 'BigQueryIO Streaming Performance Test Java 10 GB',
+                triggerPhrase: 'Run BigQueryIO Streaming Performance Test Java',
+                name      : 'beam_BiqQueryIO_Streaming_Performance_Test_Java',
+                itClass      : 'org.apache.beam.sdk.bigqueryioperftests.BigQueryIOIT',
+                properties: [
+                        project               : 'apache-beam-testing',
+                        tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                        tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
+                        writeMethod           : 'STREAMING_INSERTS',
+                        testBigQueryDataset   : 'beam_performance',
+                        testBigQueryTable     : 'bqio_write_10GB_java',
+                        metricsBigQueryDataset: 'beam_performance',
+                        metricsBigQueryTable  : 'bqio_10GB_results_java_stream',
+                        sourceOptions         : """
+                                            {
+                                              "numRecords": "10485760",
+                                              "keySizeBytes": "1",
+                                              "valueSizeBytes": "1024"
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                        runner                : 'DataflowRunner',
+                        maxNumWorkers         : '5',
+                        numWorkers            : '5',
+                        autoscalingAlgorithm  : 'NONE',
+                ]
+        ],
+        [
+                title        : 'BigQueryIO Batch Performance Test Java 10 GB',
+                triggerPhrase: 'Run BigQueryIO Batch Performance Test Java',
+                name      : 'beam_BiqQueryIO_Batch_Performance_Test_Java',
+                itClass      : 'org.apache.beam.sdk.bigqueryioperftests.BigQueryIOIT',
+                properties: [
+                        project               : 'apache-beam-testing',
+                        tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                        tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
+                        writeMethod           : 'FILE_LOADS',
+                        testBigQueryDataset   : 'beam_performance',
+                        testBigQueryTable     : 'bqio_write_10GB_java',
+                        metricsBigQueryDataset: 'beam_performance',
+                        metricsBigQueryTable  : 'bqio_10GB_results_java_batch',
+                        sourceOptions         : """
+                                            {
+                                              "numRecords": "10485760",
+                                              "keySizeBytes": "1",
+                                              "valueSizeBytes": "1024"
+                                            }
+                                      """.trim().replaceAll("\\s", ""),
+                        runner                : "DataflowRunner",
+                        maxNumWorkers         : '5',
+                        numWorkers            : '5',
+                        autoscalingAlgorithm  : 'NONE',
+                ]
         ]
 ]
 
-def bqioBatchTest = [
-        title          : 'BigQueryIO Batch Performance Test Java 10 GB',
-        test           : 'org.apache.beam.sdk.bigqueryioperftests.BigQueryIOIT',
-        runner         : CommonTestProperties.Runner.DATAFLOW,
-        pipelineOptions: [
-                jobName               : 'performance-tests-bqio-java-stream-10gb' + now,
-                project               : 'apache-beam-testing',
-                tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
-                tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
-                writeMethod           : 'FILE_LOADS',
-                publishToBigQuery     : true,
-                testBigQueryDataset   : 'beam_performance',
-                testBigQueryTable     : 'bqio_write_10GB_java',
-                metricsBigQueryDataset: 'beam_performance',
-                metricsBigQueryTable  : 'bqio_10GB_results_java_batch',
-                sourceOptions         : '\'{' +
-                        '"num_records": 10485760,' +
-                        '"key_size": 1,' +
-                        '"value_size": 1024}\'',
-                numWorkers            : 5,
-                autoscalingAlgorithm  : 'NONE',  // Disable autoscale the worker pool.
-        ]
-]
+jobConfigs.forEach { jobConfig -> createPostCommitJob(jobConfig)}
 
-def executeJob = { scope, testConfig ->
-    job(testConfig.title) {
-        commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
-        def testTask = ':sdks:java:io:bigquery-io-perf-tests:integrationTest'
+private void createPostCommitJob(jobConfig) {
+    job(jobConfig.name) {
+        description(jobConfig.description)
+        common.setTopLevelMainJobProperties(delegate)
+        common.enablePhraseTriggeringFromPullRequest(delegate, jobConfig.title, jobConfig.triggerPhrase)
+        common.setAutoJob(delegate, 'H */6 * * *')
+        publishers {
+            archiveJunit('**/build/test-results/**/*.xml')
+        }
+        
         steps {
             gradle {
-                rootBuildScriptDir(commonJobProperties.checkoutDir)
-                commonJobProperties.setGradleSwitches(delegate)
+                rootBuildScriptDir(common.checkoutDir)
+                common.setGradleSwitches(delegate)
                 switches("--info")
-                switches("-DintegrationTestPipelineOptions=\'${commonJobProperties.joinPipelineOptions(testConfig.pipelineOptions)}\'")
-                switches("-DintegrationTestRunner=\'${testConfig.runner}\'")
-                tasks("${testTask} --tests ${testConfig.test}")
+                switches("-DintegrationTestPipelineOptions=\'${parsePipelineOptions(jobConfig.properties)}\'")
+                switches("-DintegrationTestRunner=dataflow")
+                tasks(":sdks:java:io:bigquery-io-perf-tests:integrationTest --tests ${jobConfig.itClass}")
             }
         }
-
     }
 }
 
-PhraseTriggeringPostCommitBuilder.postCommitJob(
-        'beam_BiqQueryIO_Batch_Performance_Test_Java',
-        'Run BigQueryIO Batch Performance Test Java',
-        'BigQueryIO Batch Performance Test Java',
-        this
-) {
-    executeJob(delegate, bqioBatchTest)
-}
-
-CronJobBuilder.cronJob('beam_BiqQueryIO_Batch_Performance_Test_Java', 'H 15 * * *', this) {
-    executeJob(delegate, bqioBatchTest)
-}
-
-PhraseTriggeringPostCommitBuilder.postCommitJob(
-        'beam_BiqQueryIO_Stream_Performance_Test_Java',
-        'Run BigQueryIO Streaming Performance Test Java',
-        'BigQueryIO Streaming Performance Test Java',
-        this
-) {
-    executeJob(delegate, bqioStreamTest)
-}
-
-CronJobBuilder.cronJob('beam_BiqQueryIO_Stream_Performance_Test_Java', 'H 15 * * *', this) {
-    executeJob(delegate, bqioStreamTest)
+static String parsePipelineOptions(Map pipelineOptions) {
+    List<String> pipelineArgList = []
+    pipelineOptions.each({
+        key, value -> pipelineArgList.add("\"--$key=${value.replaceAll("\"", "\\\\\\\\\"")}\"")
+    })
+    return "[" + pipelineArgList.join(',') + "]"
 }


### PR DESCRIPTION
The Jenkins job configuration required fixing
Due to problems with Jenkins job creation config, the job didn't contain the most important part - the Gradle task.

This PR fixes this error - Gradle task is included. I also refactored the code to be clearer
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
