### PR TITLE
Revert "[Go SDK] Off By One error on splitting"

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -272,8 +272,8 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 				ProcessBundleSplit: &fnpb.ProcessBundleSplitResponse{
 					ChannelSplits: []*fnpb.ProcessBundleSplitResponse_ChannelSplit{
 						&fnpb.ProcessBundleSplitResponse_ChannelSplit{
-							LastPrimaryElement:   int32(split),
-							FirstResidualElement: int32(split + 1),
+							LastPrimaryElement:   int32(split - 1),
+							FirstResidualElement: int32(split),
 						},
 					},
 				},


### PR DESCRIPTION
Reverts apache/beam#9528 after further discussion with @ananvay and @robertwb 