### PR TITLE
Use common metric matchers for fnapi and legacy python dataflow metric integration tests

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_exercise_metrics_pipeline.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_exercise_metrics_pipeline.py
@@ -34,7 +34,7 @@ METRIC_NAMESPACE = ('apache_beam.runners.dataflow.'
                     'dataflow_exercise_metrics_pipeline.UserMetricsDoFn')
 
 
-def common_metric_matchers():
+def metric_matchers():
   """MetricResult matchers common to all tests."""
   # TODO(ajamato): Matcher for the 'metrics' step's ElementCount.
   # TODO(ajamato): Matcher for the 'metrics' step's MeanByteCount.
@@ -66,6 +66,42 @@ def common_metric_matchers():
           step='metrics',
           attempted=greater_than(0),
           committed=greater_than(0)
+      ),
+      MetricResultMatcher(
+        name='distribution_values',
+        namespace=METRIC_NAMESPACE,
+        step='metrics',
+        attempted=DistributionMatcher(
+          sum_value=sum(INPUT),
+          count_value=len(INPUT),
+          min_value=min(INPUT),
+          max_value=max(INPUT)
+        ),
+        committed=DistributionMatcher(
+          sum_value=sum(INPUT),
+          count_value=len(INPUT),
+          min_value=min(INPUT),
+          max_value=max(INPUT)
+        ),
+      ),
+      # Element count and MeanByteCount for a User ParDo.
+      MetricResultMatcher(
+        name='ElementCount',
+        labels={
+          'output_user_name': 'metrics-out0',
+          'original_name': 'metrics-out0-ElementCount'
+        },
+        attempted=greater_than(0),
+        committed=greater_than(0)
+      ),
+      MetricResultMatcher(
+        name='MeanByteCount',
+        labels={
+          'output_user_name': 'metrics-out0',
+          'original_name': 'metrics-out0-MeanByteCount'
+        },
+        attempted=greater_than(0),
+        committed=greater_than(0)
       )
   ]
 
@@ -98,59 +134,6 @@ def common_metric_matchers():
             committed=greater_than(0)
         ),
     ])
-  return matchers
-
-
-def fn_api_metric_matchers():
-  """MetricResult matchers with adjusted step names for the FN API DF test."""
-  matchers = common_metric_matchers()
-  return matchers
-
-
-def legacy_metric_matchers():
-  """MetricResult matchers with adjusted step names for the legacy DF test."""
-  # TODO(ajamato): Move these to the common_metric_matchers once implemented
-  # in the FN API.
-  matchers = common_metric_matchers()
-  matchers.extend([
-      # User distribution metric, legacy DF only.
-      MetricResultMatcher(
-          name='distribution_values',
-          namespace=METRIC_NAMESPACE,
-          step='metrics',
-          attempted=DistributionMatcher(
-              sum_value=sum(INPUT),
-              count_value=len(INPUT),
-              min_value=min(INPUT),
-              max_value=max(INPUT)
-          ),
-          committed=DistributionMatcher(
-              sum_value=sum(INPUT),
-              count_value=len(INPUT),
-              min_value=min(INPUT),
-              max_value=max(INPUT)
-          ),
-      ),
-      # Element count and MeanByteCount for a User ParDo.
-      MetricResultMatcher(
-          name='ElementCount',
-          labels={
-              'output_user_name': 'metrics-out0',
-              'original_name': 'metrics-out0-ElementCount'
-          },
-          attempted=greater_than(0),
-          committed=greater_than(0)
-      ),
-      MetricResultMatcher(
-          name='MeanByteCount',
-          labels={
-              'output_user_name': 'metrics-out0',
-              'original_name': 'metrics-out0-MeanByteCount'
-          },
-          attempted=greater_than(0),
-          committed=greater_than(0)
-      ),
-  ])
   return matchers
 
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_exercise_metrics_pipeline.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_exercise_metrics_pipeline.py
@@ -68,40 +68,40 @@ def metric_matchers():
           committed=greater_than(0)
       ),
       MetricResultMatcher(
-        name='distribution_values',
-        namespace=METRIC_NAMESPACE,
-        step='metrics',
-        attempted=DistributionMatcher(
-          sum_value=sum(INPUT),
-          count_value=len(INPUT),
-          min_value=min(INPUT),
-          max_value=max(INPUT)
-        ),
-        committed=DistributionMatcher(
-          sum_value=sum(INPUT),
-          count_value=len(INPUT),
-          min_value=min(INPUT),
-          max_value=max(INPUT)
-        ),
+          name='distribution_values',
+          namespace=METRIC_NAMESPACE,
+          step='metrics',
+          attempted=DistributionMatcher(
+              sum_value=sum(INPUT),
+              count_value=len(INPUT),
+              min_value=min(INPUT),
+              max_value=max(INPUT)
+          ),
+          committed=DistributionMatcher(
+              sum_value=sum(INPUT),
+              count_value=len(INPUT),
+              min_value=min(INPUT),
+              max_value=max(INPUT)
+          ),
       ),
       # Element count and MeanByteCount for a User ParDo.
       MetricResultMatcher(
-        name='ElementCount',
-        labels={
-          'output_user_name': 'metrics-out0',
-          'original_name': 'metrics-out0-ElementCount'
-        },
-        attempted=greater_than(0),
-        committed=greater_than(0)
+          name='ElementCount',
+          labels={
+              'output_user_name': 'metrics-out0',
+              'original_name': 'metrics-out0-ElementCount'
+          },
+          attempted=greater_than(0),
+          committed=greater_than(0)
       ),
       MetricResultMatcher(
-        name='MeanByteCount',
-        labels={
-          'output_user_name': 'metrics-out0',
-          'original_name': 'metrics-out0-MeanByteCount'
-        },
-        attempted=greater_than(0),
-        committed=greater_than(0)
+          name='MeanByteCount',
+          labels={
+              'output_user_name': 'metrics-out0',
+              'original_name': 'metrics-out0-MeanByteCount'
+          },
+          attempted=greater_than(0),
+          committed=greater_than(0)
       )
   ]
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_exercise_metrics_pipeline_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_exercise_metrics_pipeline_test.py
@@ -52,7 +52,7 @@ class ExerciseMetricsPipelineTest(unittest.TestCase):
     result = self.run_pipeline()
     errors = metric_result_matchers.verify_all(
         result.metrics().all_metrics(),
-        dataflow_exercise_metrics_pipeline.legacy_metric_matchers())
+        dataflow_exercise_metrics_pipeline.metric_matchers())
     self.assertFalse(errors, str(errors))
 
   @attr('IT', 'ValidatesContainer')
@@ -60,7 +60,7 @@ class ExerciseMetricsPipelineTest(unittest.TestCase):
     result = self.run_pipeline(experiment='beam_fn_api')
     errors = metric_result_matchers.verify_all(
         result.metrics().all_metrics(),
-        dataflow_exercise_metrics_pipeline.fn_api_metric_matchers())
+        dataflow_exercise_metrics_pipeline.metric_matchers())
     self.assertFalse(errors, str(errors))
 
 


### PR DESCRIPTION
Move user distribution value and element count, mean byte count to common metrics so it is tested in fnapi integration tests.


Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
