### PR TITLE
[BEAM-8256] Set fixed number of workers for Java IOITs

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
@@ -28,7 +28,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'textioit_results',
-                        numberOfRecords: '1000000'
+                        numberOfRecords: '1000000',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
 
         ],
@@ -42,7 +44,9 @@ def jobs = [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'compressed_textioit_results',
                         numberOfRecords: '1000000',
-                        compressionType: 'GZIP'
+                        compressionType: 'GZIP',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -57,7 +61,9 @@ def jobs = [
                         reportGcsPerformanceMetrics: 'true',
                         gcsPerformanceMetrics      : 'true',
                         numberOfRecords            : '1000000',
-                        numberOfShards             : '1000'
+                        numberOfShards             : '1000',
+                        maxNumWorkers              : '5',
+                        numWorkers                 : '5'
                 ]
 
         ],
@@ -71,6 +77,8 @@ def jobs = [
                         numberOfRecords: '1000000',
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'avroioit_results',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -82,7 +90,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'tfrecordioit_results',
-                        numberOfRecords: '1000000'
+                        numberOfRecords: '1000000',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -95,7 +105,9 @@ def jobs = [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'xmlioit_results',
                         numberOfRecords: '100000000',
-                        charset        : 'UTF-8'
+                        charset        : 'UTF-8',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -107,7 +119,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'parquetioit_results',
-                        numberOfRecords: '100000000'
+                        numberOfRecords: '100000000',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -119,7 +133,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'textioit_hdfs_results',
-                        numberOfRecords: '1000000'
+                        numberOfRecords: '1000000',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
 
         ],
@@ -133,7 +149,9 @@ def jobs = [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'compressed_textioit_hdfs_results',
                         numberOfRecords: '1000000',
-                        compressionType: 'GZIP'
+                        compressionType: 'GZIP',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -148,7 +166,9 @@ def jobs = [
                         reportGcsPerformanceMetrics: 'true',
                         gcsPerformanceMetrics      : 'true',
                         numberOfRecords            : '1000000',
-                        numberOfShards             : '1000'
+                        numberOfShards             : '1000',
+                        maxNumWorkers              : '5',
+                        numWorkers                 : '5'
                 ]
 
         ],
@@ -161,7 +181,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'avroioit_hdfs_results',
-                        numberOfRecords: '1000000'
+                        numberOfRecords: '1000000',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -171,7 +193,9 @@ def jobs = [
                 githubTitle        : 'Java TFRecordIO Performance Test on HDFS',
                 githubTriggerPhrase: 'Run Java TFRecordIO Performance Test HDFS',
                 pipelineOptions    : [
-                        numberOfRecords: '1000000'
+                        numberOfRecords: '1000000',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -184,7 +208,9 @@ def jobs = [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'xmlioit_hdfs_results',
                         numberOfRecords: '100000',
-                        charset        : 'UTF-8'
+                        charset        : 'UTF-8',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ],
         [
@@ -196,7 +222,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset: 'beam_performance',
                         bigQueryTable  : 'parquetioit_hdfs_results',
-                        numberOfRecords: '1000000'
+                        numberOfRecords: '1000000',
+                        maxNumWorkers  : '5',
+                        numWorkers     : '5'
                 ]
         ]
 ]

--- a/.test-infra/jenkins/job_PerformanceTests_HadoopFormat.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_HadoopFormat.groovy
@@ -49,6 +49,8 @@ job(jobName) {
           postgresServerName  : "\$${postgresHostName}",
           postgresSsl         : false,
           postgresPort        : '5432',
+          maxNumWorkers: '5',
+          numWorkers: '5'
   ]
 
   steps {

--- a/.test-infra/jenkins/job_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_JDBC.groovy
@@ -49,7 +49,9 @@ job(jobName) {
           postgresDatabaseName: 'postgres',
           postgresServerName  : "\$${postgresHostName}",
           postgresSsl         : false,
-          postgresPort        : '5432'
+          postgresPort        : '5432',
+          maxNumWorkers: '5',
+          numWorkers: '5'
   ]
 
   steps {

--- a/.test-infra/jenkins/job_PerformanceTests_MongoDBIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_MongoDBIO_IT.groovy
@@ -45,7 +45,9 @@ job(jobName) {
           mongoDBDatabaseName: 'beam',
           mongoDBHostName: "\$${mongoHostName}",
           mongoDBPort: 27017,
-          runner: 'DataflowRunner'
+          runner: 'DataflowRunner',
+          maxNumWorkers: '5',
+          numWorkers: '5'
   ]
 
   steps {


### PR DESCRIPTION
Fixing number of workers and disabling autoscaling will make the performance tests more representative.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
