### PR TITLE
[BEAM-8269] Convert Py3 type hints to Beam types

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -596,7 +596,7 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
       **kwargs: other keyword arguments.
 
     Returns:
-      An Iterable of output elements.
+      An Iterable of output elements or None.
     """
     raise NotImplementedError
 

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -95,6 +95,7 @@ from builtins import zip
 
 from apache_beam.typehints import native_type_compatibility
 from apache_beam.typehints import typehints
+from apache_beam.typehints.native_type_compatibility import convert_to_beam_type
 from apache_beam.typehints.typehints import CompositeTypeHintError
 from apache_beam.typehints.typehints import SimpleTypeHintError
 from apache_beam.typehints.typehints import check_constraint
@@ -254,16 +255,16 @@ class IOTypeHints(object):
           input_args.append(typehints.Any)
       else:
         if param.kind in [param.KEYWORD_ONLY, param.VAR_KEYWORD]:
-          input_kwargs[param.name] = param.annotation
+          input_kwargs[param.name] = convert_to_beam_type(param.annotation)
         else:
           assert param.kind in [param.POSITIONAL_ONLY,
                                 param.POSITIONAL_OR_KEYWORD,
                                 param.VAR_POSITIONAL], \
               'Unsupported Parameter kind: %s' % param.kind
-          input_args.append(param.annotation)
+          input_args.append(convert_to_beam_type(param.annotation))
     output_args = []
     if signature.return_annotation != signature.empty:
-      output_args.append(signature.return_annotation)
+      output_args.append(convert_to_beam_type(signature.return_annotation))
     else:
       output_args.append(typehints.Any)
 

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -101,12 +101,12 @@ class IOTypeHintsTest(unittest.TestCase):
     self._test_strip_iterable(typehints.Tuple[str, ...], str)
     self._test_strip_iterable(typehints.KV[str, int],
                               typehints.Union[str, int])
-    self._test_strip_iterable(typehints.Dict[str, int], str)
     self._test_strip_iterable(typehints.Set[str], str)
 
     self._test_strip_iterable_fail(typehints.Union[str, int])
     self._test_strip_iterable_fail(typehints.Optional[str])
     self._test_strip_iterable_fail(typehints.WindowedValue[str])
+    self._test_strip_iterable_fail(typehints.Dict[str, int])
 
 
 class WithTypeHintsTest(unittest.TestCase):

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -26,6 +26,7 @@ from apache_beam.typehints import Any
 from apache_beam.typehints import List
 from apache_beam.typehints import WithTypeHints
 from apache_beam.typehints import decorators
+from apache_beam.typehints import typehints
 
 decorators._enable_from_callable = True
 
@@ -71,6 +72,41 @@ class IOTypeHintsTest(unittest.TestCase):
                        ((str, decorators._ANY_VAR_POSITIONAL),
                         {'__unknown__keywords': decorators._ANY_VAR_KEYWORD}))
     self.assertEqual(th.output_types, ((Any,), {}))
+
+  def test_strip_iterable_not_simple_output_noop(self):
+    th = decorators.IOTypeHints(output_types=((int, str), {}))
+    th.strip_iterable()
+    self.assertEqual(((int, str), {}), th.output_types)
+
+  def _test_strip_iterable(self, before, expected_after):
+    after = decorators.IOTypeHints(
+        output_types=((before,), {})).strip_iterable()
+    self.assertEqual(((expected_after, ), {}), after.output_types)
+
+  def _test_strip_iterable_fail(self, before):
+    with self.assertRaisesRegex(ValueError, r'not iterable'):
+      self._test_strip_iterable(before, None)
+
+  def test_strip_iterable(self):
+    # TODO(BEAM-8492): Uncomment once #9895 is merged.
+    # self._test_strip_iterable(None, None)
+    self._test_strip_iterable(typehints.Any, typehints.Any)
+    self._test_strip_iterable(typehints.Iterable[str], str)
+    self._test_strip_iterable(typehints.List[str], str)
+    self._test_strip_iterable(typehints.Iterator[str], str)
+    self._test_strip_iterable(typehints.Generator[str], str)
+    self._test_strip_iterable(typehints.Tuple[str], str)
+    self._test_strip_iterable(typehints.Tuple[str, int],
+                              typehints.Union[str, int])
+    self._test_strip_iterable(typehints.Tuple[str, ...], str)
+    self._test_strip_iterable(typehints.KV[str, int],
+                              typehints.Union[str, int])
+    self._test_strip_iterable(typehints.Dict[str, int], str)
+    self._test_strip_iterable(typehints.Set[str], str)
+
+    self._test_strip_iterable_fail(typehints.Union[str, int])
+    self._test_strip_iterable_fail(typehints.Optional[str])
+    self._test_strip_iterable_fail(typehints.WindowedValue[str])
 
 
 class WithTypeHintsTest(unittest.TestCase):

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -47,7 +47,10 @@ def _get_compatible_args(typ):
   # __union_params__ argument respectively.
   if (3, 0, 0) <= sys.version_info[0:3] < (3, 5, 3):
     if getattr(typ, '__tuple_params__', None) is not None:
-      return typ.__tuple_params__
+      if typ.__tuple_use_ellipsis__:
+        return typ.__tuple_params__ + (Ellipsis,)
+      else:
+        return typ.__tuple_params__
     elif getattr(typ, '__union_params__', None) is not None:
       return typ.__union_params__
   return None

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -20,12 +20,15 @@
 from __future__ import absolute_import
 
 import collections
+import logging
 import sys
 import typing
 from builtins import next
 from builtins import range
 
 from apache_beam.typehints import typehints
+
+_LOGGER = logging.getLogger(__name__)
 
 # Describes an entry in the type map in convert_to_beam_type.
 # match is a function that takes a user type and returns whether the conversion
@@ -251,8 +254,9 @@ def convert_to_beam_type(typ):
   # Find the first matching entry.
   matched_entry = next((entry for entry in type_map if entry.match(typ)), None)
   if not matched_entry:
-    # No match: return original type.
-    return typ
+    # Please add missing type support if you see this message.
+    _LOGGER.info('Using Any for unsupported type: %s', typ)
+    return typehints.Any
 
   if matched_entry.arity == -1:
     arity = _len_arg(typ)

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1174,7 +1174,7 @@ def get_yielded_type(type_hint):
   """Obtains the type of elements yielded by an iterable.
 
   Note that "iterable" here means: can be iterated over in a for loop, excluding
-  strings.
+  strings and dicts.
 
   Args:
     type_hint: (TypeConstraint) The iterable in question. Must be normalize()-d.
@@ -1196,8 +1196,6 @@ def get_yielded_type(type_hint):
       return type_hint.inner_type
   if is_consistent_with(type_hint, Iterable[Any]):
     return type_hint.inner_type
-  if is_consistent_with(type_hint, Dict[Any, Any]):
-    return type_hint.key_type
   raise ValueError('%s is not iterable' % type_hint)
 
 

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1190,9 +1190,14 @@ def get_yielded_type(type_hint):
   if is_consistent_with(type_hint, Iterator[Any]):
     return type_hint.yielded_type
   if is_consistent_with(type_hint, Tuple[Any, ...]):
-    return Union[type_hint.tuple_types]
+    if isinstance(type_hint, TupleConstraint):
+      return Union[type_hint.tuple_types]
+    else:  # TupleSequenceConstraint
+      return type_hint.inner_type
   if is_consistent_with(type_hint, Iterable[Any]):
     return type_hint.inner_type
+  if is_consistent_with(type_hint, Dict[Any, Any]):
+    return type_hint.key_type
   raise ValueError('%s is not iterable' % type_hint)
 
 


### PR DESCRIPTION
Also adds test coverage for strip_iterable and fixes a couple of cases
in get_yielded_type.

And other fixes (see commit comments).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
