### PR TITLE
Restore portable schema changes, with simple LogicalType support

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -647,29 +647,21 @@ message StandardCoders {
 
 // Experimental: A representation of a Beam Schema.
 message Schema {
-  enum TypeName {
-    BYTE = 0;
-    INT16 = 1;
-    INT32 = 2;
-    INT64 = 3;
-    DECIMAL = 4;
+  enum AtomicType {
+    UNSPECIFIED = 0;
+    BYTE = 1;
+    INT16 = 2;
+    INT32 = 3;
+    INT64 = 4;
     FLOAT = 5;
     DOUBLE = 6;
     STRING = 7;
-    DATETIME = 8;
-    BOOLEAN = 9;
-    BYTES = 10;
-    ARRAY = 11;
-    MAP = 13;
-    ROW = 14;
-    LOGICAL_TYPE = 15;
+    BOOLEAN = 8;
+    BYTES = 9;
   }
 
-  message LogicalType {
-    string id = 1;
-    string args = 2;
-    FieldType base_type = 3;
-    bytes serialized_class = 4;
+  message ArrayType {
+    FieldType element_type = 1;
   }
 
   message MapType {
@@ -677,13 +669,23 @@ message Schema {
     FieldType value_type = 2;
   }
 
+  message RowType {
+    Schema schema = 1;
+  }
+
+  message LogicalType {
+    string urn = 1;
+    string args = 2;
+    FieldType representation = 3;
+  }
+
   message FieldType {
-    TypeName type_name = 1;
-    bool nullable = 2;
+    bool nullable = 1;
     oneof type_info {
-      FieldType collection_element_type = 3;
+      AtomicType atomic_type = 2;
+      ArrayType array_type = 3;
       MapType map_type = 4;
-      Schema row_schema = 5;
+      RowType row_type = 5;
       LogicalType logical_type = 6;
     }
   }

--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -645,63 +645,6 @@ message StandardCoders {
   }
 }
 
-// Experimental: A representation of a Beam Schema.
-message Schema {
-  enum AtomicType {
-    UNSPECIFIED = 0;
-    BYTE = 1;
-    INT16 = 2;
-    INT32 = 3;
-    INT64 = 4;
-    FLOAT = 5;
-    DOUBLE = 6;
-    STRING = 7;
-    BOOLEAN = 8;
-    BYTES = 9;
-  }
-
-  message ArrayType {
-    FieldType element_type = 1;
-  }
-
-  message MapType {
-    FieldType key_type = 1;
-    FieldType value_type = 2;
-  }
-
-  message RowType {
-    Schema schema = 1;
-  }
-
-  message LogicalType {
-    string urn = 1;
-    string args = 2;
-    FieldType representation = 3;
-  }
-
-  message FieldType {
-    bool nullable = 1;
-    oneof type_info {
-      AtomicType atomic_type = 2;
-      ArrayType array_type = 3;
-      MapType map_type = 4;
-      RowType row_type = 5;
-      LogicalType logical_type = 6;
-    }
-  }
-
-  message Field {
-    string name = 1;
-    string description = 2;
-    FieldType type = 3;
-    int32 id = 4;
-    int32 encoding_position = 5;
-  }
-
-  repeated Field fields = 1;
-  string id = 2;
-}
-
 // A windowing strategy describes the window function, triggering, allowed
 // lateness, and accumulation mode for a PCollection.
 //

--- a/model/pipeline/src/main/proto/schema.proto
+++ b/model/pipeline/src/main/proto/schema.proto
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ** Experimental **
+// Protocol Buffers describing Beam Schemas, a portable representation for
+// complex types.
+
+syntax = "proto3";
+
+package org.apache.beam.model.pipeline.v1;
+
+option go_package = "pipeline_v1";
+option java_package = "org.apache.beam.model.pipeline.v1";
+option java_outer_classname = "SchemaApi";
+
+message Schema {
+  repeated Field fields = 1;
+  string id = 2;
+}
+
+message Field {
+  string name = 1;
+  string description = 2;
+  FieldType type = 3;
+  int32 id = 4;
+  int32 encoding_position = 5;
+}
+
+message FieldType {
+  bool nullable = 1;
+  oneof type_info {
+    AtomicType atomic_type = 2;
+    ArrayType array_type = 3;
+    MapType map_type = 4;
+    RowType row_type = 5;
+    LogicalType logical_type = 6;
+  }
+}
+
+enum AtomicType {
+  UNSPECIFIED = 0;
+  BYTE = 1;
+  INT16 = 2;
+  INT32 = 3;
+  INT64 = 4;
+  FLOAT = 5;
+  DOUBLE = 6;
+  STRING = 7;
+  BOOLEAN = 8;
+  BYTES = 9;
+}
+
+message ArrayType {
+  FieldType element_type = 1;
+}
+
+message MapType {
+  FieldType key_type = 1;
+  FieldType value_type = 2;
+}
+
+message RowType {
+  Schema schema = 1;
+}
+
+message LogicalType {
+  string urn = 1;
+  string args = 2;
+  FieldType representation = 3;
+}

--- a/model/pipeline/src/main/proto/schema.proto
+++ b/model/pipeline/src/main/proto/schema.proto
@@ -80,6 +80,6 @@ message RowType {
 
 message LogicalType {
   string urn = 1;
-  string args = 2;
+  bytes payload = 2;
   FieldType representation = 3;
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SchemaTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SchemaTranslation.java
@@ -25,32 +25,28 @@ import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
-import org.apache.beam.sdk.util.SerializableUtils;
-import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.BiMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableBiMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 
 /** Utility methods for translating schemas. */
 public class SchemaTranslation {
-  private static final BiMap<TypeName, RunnerApi.Schema.TypeName> TYPE_NAME_MAPPING =
-      ImmutableBiMap.<TypeName, RunnerApi.Schema.TypeName>builder()
-          .put(TypeName.BYTE, RunnerApi.Schema.TypeName.BYTE)
-          .put(TypeName.INT16, RunnerApi.Schema.TypeName.INT16)
-          .put(TypeName.INT32, RunnerApi.Schema.TypeName.INT32)
-          .put(TypeName.INT64, RunnerApi.Schema.TypeName.INT64)
-          .put(TypeName.DECIMAL, RunnerApi.Schema.TypeName.DECIMAL)
-          .put(TypeName.FLOAT, RunnerApi.Schema.TypeName.FLOAT)
-          .put(TypeName.DOUBLE, RunnerApi.Schema.TypeName.DOUBLE)
-          .put(TypeName.STRING, RunnerApi.Schema.TypeName.STRING)
-          .put(TypeName.DATETIME, RunnerApi.Schema.TypeName.DATETIME)
-          .put(TypeName.BOOLEAN, RunnerApi.Schema.TypeName.BOOLEAN)
-          .put(TypeName.BYTES, RunnerApi.Schema.TypeName.BYTES)
-          .put(TypeName.ARRAY, RunnerApi.Schema.TypeName.ARRAY)
-          .put(TypeName.MAP, RunnerApi.Schema.TypeName.MAP)
-          .put(TypeName.ROW, RunnerApi.Schema.TypeName.ROW)
-          .put(TypeName.LOGICAL_TYPE, RunnerApi.Schema.TypeName.LOGICAL_TYPE)
+
+  private static final BiMap<TypeName, RunnerApi.Schema.AtomicType> ATOMIC_TYPE_MAPPING =
+      ImmutableBiMap.<TypeName, RunnerApi.Schema.AtomicType>builder()
+          .put(TypeName.BYTE, RunnerApi.Schema.AtomicType.BYTE)
+          .put(TypeName.INT16, RunnerApi.Schema.AtomicType.INT16)
+          .put(TypeName.INT32, RunnerApi.Schema.AtomicType.INT32)
+          .put(TypeName.INT64, RunnerApi.Schema.AtomicType.INT64)
+          .put(TypeName.FLOAT, RunnerApi.Schema.AtomicType.FLOAT)
+          .put(TypeName.DOUBLE, RunnerApi.Schema.AtomicType.DOUBLE)
+          .put(TypeName.STRING, RunnerApi.Schema.AtomicType.STRING)
+          .put(TypeName.BOOLEAN, RunnerApi.Schema.AtomicType.BOOLEAN)
+          .put(TypeName.BYTES, RunnerApi.Schema.AtomicType.BYTES)
           .build();
+
+  private static final String URN_BEAM_LOGICAL_DATETIME = "beam:fieldtype:datetime";
+  private static final String URN_BEAM_LOGICAL_DECIMAL = "beam:fieldtype:decimal";
 
   public static RunnerApi.Schema toProto(Schema schema) {
     String uuid = schema.getUUID() != null ? schema.getUUID().toString() : "";
@@ -77,16 +73,17 @@ public class SchemaTranslation {
   }
 
   private static RunnerApi.Schema.FieldType toProto(FieldType fieldType) {
-    RunnerApi.Schema.FieldType.Builder builder =
-        RunnerApi.Schema.FieldType.newBuilder()
-            .setTypeName(TYPE_NAME_MAPPING.get(fieldType.getTypeName()));
+    RunnerApi.Schema.FieldType.Builder builder = RunnerApi.Schema.FieldType.newBuilder();
     switch (fieldType.getTypeName()) {
       case ROW:
-        builder.setRowSchema(toProto(fieldType.getRowSchema()));
+        builder.setRowType(
+            RunnerApi.Schema.RowType.newBuilder().setSchema(toProto(fieldType.getRowSchema())));
         break;
 
       case ARRAY:
-        builder.setCollectionElementType(toProto(fieldType.getCollectionElementType()));
+        builder.setArrayType(
+            RunnerApi.Schema.ArrayType.newBuilder()
+                .setElementType(toProto(fieldType.getCollectionElementType())));
         break;
 
       case MAP:
@@ -101,15 +98,29 @@ public class SchemaTranslation {
         LogicalType logicalType = fieldType.getLogicalType();
         builder.setLogicalType(
             RunnerApi.Schema.LogicalType.newBuilder()
-                .setId(logicalType.getIdentifier())
+                .setUrn(logicalType.getIdentifier())
                 .setArgs(logicalType.getArgument())
-                .setBaseType(toProto(logicalType.getBaseType()))
-                .setSerializedClass(
-                    ByteString.copyFrom(SerializableUtils.serializeToByteArray(logicalType)))
+                .setRepresentation(toProto(logicalType.getBaseType()))
                 .build());
         break;
-
+        // Special-case for DATETIME and DECIMAL which are logical types in portable representation,
+        // but not yet in Java. (BEAM-7554)
+      case DATETIME:
+        builder.setLogicalType(
+            RunnerApi.Schema.LogicalType.newBuilder()
+                .setUrn(URN_BEAM_LOGICAL_DATETIME)
+                .setRepresentation(toProto(FieldType.INT64))
+                .build());
+        break;
+      case DECIMAL:
+        builder.setLogicalType(
+            RunnerApi.Schema.LogicalType.newBuilder()
+                .setUrn(URN_BEAM_LOGICAL_DECIMAL)
+                .setRepresentation(toProto(FieldType.BYTES))
+                .build());
+        break;
       default:
+        builder.setAtomicType(ATOMIC_TYPE_MAPPING.get(fieldType.getTypeName()));
         break;
     }
     builder.setNullable(fieldType.getNullable());
@@ -139,32 +150,43 @@ public class SchemaTranslation {
   }
 
   private static FieldType fieldTypeFromProto(RunnerApi.Schema.FieldType protoFieldType) {
-    TypeName typeName = TYPE_NAME_MAPPING.inverse().get(protoFieldType.getTypeName());
     FieldType fieldType;
-    switch (typeName) {
-      case ROW:
-        fieldType = FieldType.row(fromProto(protoFieldType.getRowSchema()));
+    switch (protoFieldType.getTypeInfoCase()) {
+      case ATOMIC_TYPE:
+        TypeName typeName = ATOMIC_TYPE_MAPPING.inverse().get(protoFieldType.getAtomicType());
+        fieldType = FieldType.of(typeName);
         break;
-      case ARRAY:
-        fieldType = FieldType.array(fieldTypeFromProto(protoFieldType.getCollectionElementType()));
+      case ROW_TYPE:
+        fieldType = FieldType.row(fromProto(protoFieldType.getRowType().getSchema()));
         break;
-      case MAP:
+      case ARRAY_TYPE:
+        fieldType =
+            FieldType.array(fieldTypeFromProto(protoFieldType.getArrayType().getElementType()));
+        break;
+      case MAP_TYPE:
         fieldType =
             FieldType.map(
                 fieldTypeFromProto(protoFieldType.getMapType().getKeyType()),
                 fieldTypeFromProto(protoFieldType.getMapType().getValueType()));
         break;
       case LOGICAL_TYPE:
-        LogicalType logicalType =
-            (LogicalType)
-                SerializableUtils.deserializeFromByteArray(
-                    protoFieldType.getLogicalType().getSerializedClass().toByteArray(),
-                    "logicalType");
-        fieldType = FieldType.logicalType(logicalType);
+        // Special-case for DATETIME and DECIMAL which are logical types in portable representation,
+        // but not yet in Java. (BEAM-7554)
+        String urn = protoFieldType.getLogicalType().getUrn();
+        if (urn.equals(URN_BEAM_LOGICAL_DATETIME)) {
+          fieldType = FieldType.DATETIME;
+        } else if (urn.equals(URN_BEAM_LOGICAL_DECIMAL)) {
+          fieldType = FieldType.DECIMAL;
+        } else {
+          // TODO: Look up logical type class by URN.
+          throw new IllegalArgumentException("Decoding logical types is not yet supported.");
+        }
         break;
       default:
-        fieldType = FieldType.of(typeName);
+        throw new IllegalArgumentException(
+            "Unexpected type_info: " + protoFieldType.getTypeInfoCase());
     }
+
     if (protoFieldType.getNullable()) {
       fieldType = fieldType.withNullable(true);
     }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
@@ -20,7 +20,7 @@ package org.apache.beam.runners.core.construction;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -80,7 +80,7 @@ public class SchemaTranslationTest {
 
     @Test
     public void toAndFromProto() throws Exception {
-      RunnerApi.Schema schemaProto = SchemaTranslation.toProto(schema);
+      SchemaApi.Schema schemaProto = SchemaTranslation.toProto(schema);
 
       Schema decodedSchema = SchemaTranslation.fromProto(schemaProto);
       assertThat(decodedSchema, equalTo(schema));

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.construction;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Tests for {@link SchemaTranslation}. */
+public class SchemaTranslationTest {
+
+  /** Tests round-trip proto encodings for {@link Schema}. */
+  @RunWith(Parameterized.class)
+  public static class ToFromProtoTest {
+    @Parameters(name = "{index}: {0}")
+    public static Iterable<Schema> data() {
+      return ImmutableList.<Schema>builder()
+          .add(Schema.of(Field.of("string", FieldType.STRING)))
+          .add(
+              Schema.of(
+                  Field.of("boolean", FieldType.BOOLEAN),
+                  Field.of("byte", FieldType.BYTE),
+                  Field.of("int16", FieldType.INT16),
+                  Field.of("int32", FieldType.INT32),
+                  Field.of("int64", FieldType.INT64)))
+          .add(
+              Schema.of(
+                  Field.of(
+                      "row",
+                      FieldType.row(
+                          Schema.of(
+                              Field.of("foo", FieldType.STRING),
+                              Field.of("bar", FieldType.DOUBLE),
+                              Field.of("baz", FieldType.BOOLEAN))))))
+          .add(
+              Schema.of(
+                  Field.of(
+                      "array(array(int64)))",
+                      FieldType.array(FieldType.array(FieldType.INT64.withNullable(true))))))
+          .add(
+              Schema.of(
+                  Field.of("nullable", FieldType.STRING.withNullable(true)),
+                  Field.of("non_nullable", FieldType.STRING.withNullable(false))))
+          .add(
+              Schema.of(
+                  Field.of("decimal", FieldType.DECIMAL), Field.of("datetime", FieldType.DATETIME)))
+          // Test for when Logical types are supported
+          // .add(Schema.of(Field.of("logical",
+          // FieldType.logicalType(LogicalTypes.FixedBytes.of(24)))))
+          .build();
+    }
+
+    @Parameter(0)
+    public Schema schema;
+
+    @Test
+    public void toAndFromProto() throws Exception {
+      RunnerApi.Schema schemaProto = SchemaTranslation.toProto(schema);
+
+      Schema decodedSchema = SchemaTranslation.fromProto(schemaProto);
+      assertThat(decodedSchema, equalTo(schema));
+    }
+  }
+}

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
@@ -80,7 +80,7 @@ public class SchemaTranslationTest {
 
     @Test
     public void toAndFromProto() throws Exception {
-      SchemaApi.Schema schemaProto = SchemaTranslation.toProto(schema);
+      SchemaApi.Schema schemaProto = SchemaTranslation.schemaToProto(schema);
 
       Schema decodedSchema = SchemaTranslation.fromProto(schemaProto);
       assertThat(decodedSchema, equalTo(schema));

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import org.apache.beam.model.pipeline.v1.SchemaApi;
+import org.apache.beam.sdk.schemas.LogicalTypes;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -69,9 +70,8 @@ public class SchemaTranslationTest {
           .add(
               Schema.of(
                   Field.of("decimal", FieldType.DECIMAL), Field.of("datetime", FieldType.DATETIME)))
-          // Test for when Logical types are supported
-          // .add(Schema.of(Field.of("logical",
-          // FieldType.logicalType(LogicalTypes.FixedBytes.of(24)))))
+          .add(
+              Schema.of(Field.of("logical", FieldType.logicalType(LogicalTypes.FixedBytes.of(24)))))
           .build();
     }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
@@ -18,7 +18,7 @@
 package org.apache.beam.runners.dataflow.util;
 
 import java.io.IOException;
-import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.runners.core.construction.SchemaTranslation;
 import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.sdk.schemas.Schema;
@@ -72,8 +72,8 @@ public class SchemaCoderCloudObjectTranslator implements CloudObjectTranslator<S
                   StringUtils.jsonStringToByteArray(
                       Structs.getString(cloudObject, FROM_ROW_FUNCTION)),
                   "fromRowFunction");
-      RunnerApi.Schema protoSchema =
-          RunnerApi.Schema.parseFrom(
+      SchemaApi.Schema protoSchema =
+          SchemaApi.Schema.parseFrom(
               StringUtils.jsonStringToByteArray(Structs.getString(cloudObject, SCHEMA)));
       Schema schema = SchemaTranslation.fromProto(protoSchema);
       return SchemaCoder.of(schema, toRowFunction, fromRowFunction);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
@@ -52,7 +52,7 @@ public class SchemaCoderCloudObjectTranslator implements CloudObjectTranslator<S
         base,
         SCHEMA,
         StringUtils.byteArrayToJsonString(
-            SchemaTranslation.toProto(target.getSchema()).toByteArray()));
+            SchemaTranslation.schemaToProto(target.getSchema()).toByteArray()));
     return base;
   }
 


### PR DESCRIPTION
Un-reverts changes to the portable schema representation, with a couple of changes (https://github.com/apache/beam/commit/22f38527799f0863d74ee3d1e92011be2fd72c28):
- Changes the LogicalType string args to a byte payload
- Supports encoding arbitrary Java SDK LogicalTypes with the `beam:fieldtype:javasdk` URN. Long-term I would like to move types to a registry and discourage this URN ([BEAM-7855](https://issues.apache.org/jira/browse/BEAM-7855)), but for now it replicates the current implementation.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
