### PR TITLE
[BEAM-6855] Side inputs are not supported when using the state API

### DIFF
--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
@@ -17,48 +17,87 @@
  */
 package org.apache.beam.runners.core;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.beam.runners.core.TimerInternals.TimerData;
+import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.sdk.metrics.MetricsEnvironment;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
 import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.IdentitySideInputWindowFn;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 /** Tests for {@link SimplePushbackSideInputDoFnRunner}. */
 @RunWith(JUnit4.class)
 public class SimplePushbackSideInputDoFnRunnerTest {
+  @Mock StepContext mockStepContext;
   @Mock private ReadyCheckingSideInputReader reader;
   private TestDoFnRunner<Integer, Integer> underlying;
   private PCollectionView<Integer> singletonView;
+  private DoFnRunner<KV<String, Integer>, Integer> statefulRunner;
+
+  private static final long WINDOW_SIZE = 10;
+  private static final long ALLOWED_LATENESS = 1;
+
+  private static final IntervalWindow WINDOW_1 =
+          new IntervalWindow(new Instant(0), new Instant(10));
+
+  private static final IntervalWindow WINDOW_2 =
+          new IntervalWindow(new Instant(10), new Instant(20));
+
+  private static final WindowingStrategy<?, ?> WINDOWING_STRATEGY =
+          WindowingStrategy.of(FixedWindows.of(Duration.millis(WINDOW_SIZE)))
+                  .withAllowedLateness(Duration.millis(ALLOWED_LATENESS));
+
+  private InMemoryStateInternals<String> stateInternals;
+  private InMemoryTimerInternals timerInternals;
 
   @Rule public TestPipeline p = TestPipeline.create().enableAbandonedNodeEnforcement(false);
 
@@ -72,10 +111,30 @@ public class SimplePushbackSideInputDoFnRunnerTest {
             .apply(Sum.integersGlobally().asSingletonView());
 
     underlying = new TestDoFnRunner<>();
+
+    DoFn<KV<String, Integer>, Integer> fn = new MyDoFn();
+
+    MockitoAnnotations.initMocks(this);
+    when(mockStepContext.timerInternals()).thenReturn(timerInternals);
+
+    stateInternals = new InMemoryStateInternals<>("hello");
+    timerInternals = new InMemoryTimerInternals();
+
+    when(mockStepContext.stateInternals()).thenReturn((StateInternals) stateInternals);
+    when(mockStepContext.timerInternals()).thenReturn(timerInternals);
+
+    statefulRunner =
+            DoFnRunners.defaultStatefulDoFnRunner(
+                    fn,
+                    getDoFnRunner(fn),
+                    WINDOWING_STRATEGY,
+                    new StatefulDoFnRunner.TimeInternalsCleanupTimer(timerInternals, WINDOWING_STRATEGY),
+                    new StatefulDoFnRunner.StateInternalsStateCleaner<>(
+                            fn, stateInternals, (Coder) WINDOWING_STRATEGY.getWindowFn().windowCoder()));
   }
 
   private SimplePushbackSideInputDoFnRunner<Integer, Integer> createRunner(
-      ImmutableList<PCollectionView<?>> views) {
+          ImmutableList<PCollectionView<?>> views) {
     SimplePushbackSideInputDoFnRunner<Integer, Integer> runner =
         SimplePushbackSideInputDoFnRunner.create(underlying, views, reader);
     runner.startBundle();
@@ -276,4 +335,162 @@ public class SimplePushbackSideInputDoFnRunnerTest {
       finished = true;
     }
   }
+
+    private SimplePushbackSideInputDoFnRunner<KV<String, Integer>, Integer> createRunner(
+            DoFnRunner<KV<String, Integer>, Integer> doFnRunner,
+            ImmutableList<PCollectionView<?>> views) {
+        SimplePushbackSideInputDoFnRunner<KV<String, Integer>, Integer> runner =
+                SimplePushbackSideInputDoFnRunner.create(doFnRunner, views, reader);
+        runner.startBundle();
+        return runner;
+    }
+
+    @Test
+    @Category({ValidatesRunner.class})
+    public void testLateDroppingForStatefulDoFnRunner() throws Exception {
+        MetricsContainerImpl container = new MetricsContainerImpl("any");
+        MetricsEnvironment.setCurrentContainer(container);
+
+        timerInternals.advanceInputWatermark(new Instant(BoundedWindow.TIMESTAMP_MAX_VALUE));
+        timerInternals.advanceOutputWatermark(new Instant(BoundedWindow.TIMESTAMP_MAX_VALUE));
+
+        PushbackSideInputDoFnRunner runner = createRunner(statefulRunner,ImmutableList.of(singletonView));
+
+        runner.startBundle();
+
+        when(reader.isReady(Mockito.eq(singletonView), Mockito.any(BoundedWindow.class)))
+                .thenReturn(true);
+
+        WindowedValue<Integer> multiWindow =
+                WindowedValue.of(
+                        1,
+                        new Instant(0),
+                        ImmutableList.of(
+                                new IntervalWindow(new Instant(0), new Instant(0L + WINDOW_SIZE))),
+                        PaneInfo.ON_TIME_AND_ONLY_FIRING);
+
+        runner.processElementInReadyWindows(multiWindow);
+
+        long droppedValues =
+                container
+                        .getCounter(
+                                MetricName.named(
+                                        StatefulDoFnRunner.class, StatefulDoFnRunner.DROPPED_DUE_TO_LATENESS_COUNTER))
+                        .getCumulative();
+        assertEquals(1L, droppedValues);
+
+        runner.finishBundle();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class})
+    public void testGarbageCollectForStatefulDoFnRunner() throws Exception {
+        timerInternals.advanceInputWatermark(new Instant(1L));
+
+        MyDoFn fn = new MyDoFn();
+        StateTag<ValueState<Integer>> stateTag = StateTags.tagForSpec(fn.stateId, fn.intState);
+
+        PushbackSideInputDoFnRunner runner = createRunner(statefulRunner,ImmutableList.of(singletonView));
+
+        Instant elementTime = new Instant(1);
+
+        when(reader.isReady(Mockito.eq(singletonView), Mockito.any(BoundedWindow.class)))
+                .thenReturn(true);
+
+        // first element, key is hello, WINDOW_1
+        runner.processElementInReadyWindows(
+                WindowedValue.of(KV.of("hello", 1), elementTime, WINDOW_1, PaneInfo.NO_FIRING));
+
+        assertEquals(1, (int) stateInternals.state(windowNamespace(WINDOW_1), stateTag).read());
+
+        // second element, key is hello, WINDOW_2
+        runner.processElementInReadyWindows(
+                WindowedValue.of(
+                        KV.of("hello", 1), elementTime.plus(WINDOW_SIZE), WINDOW_2, PaneInfo.NO_FIRING));
+
+        runner.processElementInReadyWindows(
+                WindowedValue.of(
+                        KV.of("hello", 1), elementTime.plus(WINDOW_SIZE), WINDOW_2, PaneInfo.NO_FIRING));
+
+        assertEquals(2, (int) stateInternals.state(windowNamespace(WINDOW_2), stateTag).read());
+
+        // advance watermark past end of WINDOW_1 + allowed lateness
+        // the cleanup timer is set to window.maxTimestamp() + allowed lateness + 1
+        // to ensure that state is still available when a user timer for window.maxTimestamp() fires
+        advanceInputWatermark(
+                timerInternals,
+                WINDOW_1
+                        .maxTimestamp()
+                        .plus(ALLOWED_LATENESS)
+                        .plus(StatefulDoFnRunner.TimeInternalsCleanupTimer.GC_DELAY_MS)
+                        .plus(1), // so the watermark is past the GC horizon, not on it
+                runner);
+
+        assertTrue(
+                stateInternals.isEmptyForTesting(
+                        stateInternals.state(windowNamespace(WINDOW_1), stateTag)));
+
+        assertEquals(2, (int) stateInternals.state(windowNamespace(WINDOW_2), stateTag).read());
+
+        // advance watermark past end of WINDOW_2 + allowed lateness
+        advanceInputWatermark(
+                timerInternals,
+                WINDOW_2
+                        .maxTimestamp()
+                        .plus(ALLOWED_LATENESS)
+                        .plus(StatefulDoFnRunner.TimeInternalsCleanupTimer.GC_DELAY_MS)
+                        .plus(1), // so the watermark is past the GC horizon, not on it
+                runner);
+
+        assertTrue(
+                stateInternals.isEmptyForTesting(
+                        stateInternals.state(windowNamespace(WINDOW_2), stateTag)));
+    }
+
+    private static void advanceInputWatermark(
+            InMemoryTimerInternals timerInternals, Instant newInputWatermark, PushbackSideInputDoFnRunner<?, ?> toTrigger)
+            throws Exception {
+        timerInternals.advanceInputWatermark(newInputWatermark);
+        TimerInternals.TimerData timer;
+        while ((timer = timerInternals.removeNextEventTimer()) != null) {
+            StateNamespace namespace = timer.getNamespace();
+            checkArgument(namespace instanceof StateNamespaces.WindowNamespace);
+            BoundedWindow window = ((StateNamespaces.WindowNamespace) namespace).getWindow();
+            toTrigger.onTimer(timer.getTimerId(), window, timer.getTimestamp(), timer.getDomain());
+        }
+    }
+
+    private static StateNamespace windowNamespace(IntervalWindow window) {
+        return StateNamespaces.window((Coder) WINDOWING_STRATEGY.getWindowFn().windowCoder(), window);
+    }
+
+    private static class MyDoFn extends DoFn<KV<String, Integer>, Integer> {
+
+      public final String stateId = "foo";
+
+      @StateId(stateId)
+      public final StateSpec<ValueState<Integer>> intState = StateSpecs.value(VarIntCoder.of());
+
+      @ProcessElement
+      public void processElement(ProcessContext c, @StateId(stateId) ValueState<Integer> state) {
+        Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
+        state.write(currentValue + 1);
+      }
+    }
+
+    private DoFnRunner<KV<String, Integer>, Integer> getDoFnRunner(
+            DoFn<KV<String, Integer>, Integer> fn) {
+        return new SimpleDoFnRunner<>(
+                null,
+                fn,
+                NullSideInputReader.empty(),
+                null,
+                null,
+                Collections.emptyList(),
+                mockStepContext,
+                null,
+                Collections.emptyMap(),
+                WINDOWING_STRATEGY,
+                DoFnSchemaInformation.create());
+    }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
@@ -17,6 +17,20 @@
  */
 package org.apache.beam.runners.core;
 
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.apache.beam.runners.core.TimerInternals.TimerData;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.sdk.coders.Coder;
@@ -59,21 +73,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
 /** Tests for {@link SimplePushbackSideInputDoFnRunner}. */
 @RunWith(JUnit4.class)
 public class SimplePushbackSideInputDoFnRunnerTest {
@@ -87,14 +86,14 @@ public class SimplePushbackSideInputDoFnRunnerTest {
   private static final long ALLOWED_LATENESS = 1;
 
   private static final IntervalWindow WINDOW_1 =
-          new IntervalWindow(new Instant(0), new Instant(10));
+      new IntervalWindow(new Instant(0), new Instant(10));
 
   private static final IntervalWindow WINDOW_2 =
-          new IntervalWindow(new Instant(10), new Instant(20));
+      new IntervalWindow(new Instant(10), new Instant(20));
 
   private static final WindowingStrategy<?, ?> WINDOWING_STRATEGY =
-          WindowingStrategy.of(FixedWindows.of(Duration.millis(WINDOW_SIZE)))
-                  .withAllowedLateness(Duration.millis(ALLOWED_LATENESS));
+      WindowingStrategy.of(FixedWindows.of(Duration.millis(WINDOW_SIZE)))
+          .withAllowedLateness(Duration.millis(ALLOWED_LATENESS));
 
   private InMemoryStateInternals<String> stateInternals;
   private InMemoryTimerInternals timerInternals;
@@ -124,17 +123,17 @@ public class SimplePushbackSideInputDoFnRunnerTest {
     when(mockStepContext.timerInternals()).thenReturn(timerInternals);
 
     statefulRunner =
-            DoFnRunners.defaultStatefulDoFnRunner(
-                    fn,
-                    getDoFnRunner(fn),
-                    WINDOWING_STRATEGY,
-                    new StatefulDoFnRunner.TimeInternalsCleanupTimer(timerInternals, WINDOWING_STRATEGY),
-                    new StatefulDoFnRunner.StateInternalsStateCleaner<>(
-                            fn, stateInternals, (Coder) WINDOWING_STRATEGY.getWindowFn().windowCoder()));
+        DoFnRunners.defaultStatefulDoFnRunner(
+            fn,
+            getDoFnRunner(fn),
+            WINDOWING_STRATEGY,
+            new StatefulDoFnRunner.TimeInternalsCleanupTimer(timerInternals, WINDOWING_STRATEGY),
+            new StatefulDoFnRunner.StateInternalsStateCleaner<>(
+                fn, stateInternals, (Coder) WINDOWING_STRATEGY.getWindowFn().windowCoder()));
   }
 
   private SimplePushbackSideInputDoFnRunner<Integer, Integer> createRunner(
-          ImmutableList<PCollectionView<?>> views) {
+      ImmutableList<PCollectionView<?>> views) {
     SimplePushbackSideInputDoFnRunner<Integer, Integer> runner =
         SimplePushbackSideInputDoFnRunner.create(underlying, views, reader);
     runner.startBundle();
@@ -336,161 +335,164 @@ public class SimplePushbackSideInputDoFnRunnerTest {
     }
   }
 
-    private SimplePushbackSideInputDoFnRunner<KV<String, Integer>, Integer> createRunner(
-            DoFnRunner<KV<String, Integer>, Integer> doFnRunner,
-            ImmutableList<PCollectionView<?>> views) {
-        SimplePushbackSideInputDoFnRunner<KV<String, Integer>, Integer> runner =
-                SimplePushbackSideInputDoFnRunner.create(doFnRunner, views, reader);
-        runner.startBundle();
-        return runner;
+  private SimplePushbackSideInputDoFnRunner<KV<String, Integer>, Integer> createRunner(
+      DoFnRunner<KV<String, Integer>, Integer> doFnRunner,
+      ImmutableList<PCollectionView<?>> views) {
+    SimplePushbackSideInputDoFnRunner<KV<String, Integer>, Integer> runner =
+        SimplePushbackSideInputDoFnRunner.create(doFnRunner, views, reader);
+    runner.startBundle();
+    return runner;
+  }
+
+  @Test
+  @Category({ValidatesRunner.class})
+  public void testLateDroppingForStatefulDoFnRunner() throws Exception {
+    MetricsContainerImpl container = new MetricsContainerImpl("any");
+    MetricsEnvironment.setCurrentContainer(container);
+
+    timerInternals.advanceInputWatermark(new Instant(BoundedWindow.TIMESTAMP_MAX_VALUE));
+    timerInternals.advanceOutputWatermark(new Instant(BoundedWindow.TIMESTAMP_MAX_VALUE));
+
+    PushbackSideInputDoFnRunner runner =
+        createRunner(statefulRunner, ImmutableList.of(singletonView));
+
+    runner.startBundle();
+
+    when(reader.isReady(Mockito.eq(singletonView), Mockito.any(BoundedWindow.class)))
+        .thenReturn(true);
+
+    WindowedValue<Integer> multiWindow =
+        WindowedValue.of(
+            1,
+            new Instant(0),
+            ImmutableList.of(new IntervalWindow(new Instant(0), new Instant(0L + WINDOW_SIZE))),
+            PaneInfo.ON_TIME_AND_ONLY_FIRING);
+
+    runner.processElementInReadyWindows(multiWindow);
+
+    long droppedValues =
+        container
+            .getCounter(
+                MetricName.named(
+                    StatefulDoFnRunner.class, StatefulDoFnRunner.DROPPED_DUE_TO_LATENESS_COUNTER))
+            .getCumulative();
+    assertEquals(1L, droppedValues);
+
+    runner.finishBundle();
+  }
+
+  @Test
+  @Category({ValidatesRunner.class})
+  public void testGarbageCollectForStatefulDoFnRunner() throws Exception {
+    timerInternals.advanceInputWatermark(new Instant(1L));
+
+    MyDoFn fn = new MyDoFn();
+    StateTag<ValueState<Integer>> stateTag = StateTags.tagForSpec(fn.stateId, fn.intState);
+
+    PushbackSideInputDoFnRunner runner =
+        createRunner(statefulRunner, ImmutableList.of(singletonView));
+
+    Instant elementTime = new Instant(1);
+
+    when(reader.isReady(Mockito.eq(singletonView), Mockito.any(BoundedWindow.class)))
+        .thenReturn(true);
+
+    // first element, key is hello, WINDOW_1
+    runner.processElementInReadyWindows(
+        WindowedValue.of(KV.of("hello", 1), elementTime, WINDOW_1, PaneInfo.NO_FIRING));
+
+    assertEquals(1, (int) stateInternals.state(windowNamespace(WINDOW_1), stateTag).read());
+
+    // second element, key is hello, WINDOW_2
+    runner.processElementInReadyWindows(
+        WindowedValue.of(
+            KV.of("hello", 1), elementTime.plus(WINDOW_SIZE), WINDOW_2, PaneInfo.NO_FIRING));
+
+    runner.processElementInReadyWindows(
+        WindowedValue.of(
+            KV.of("hello", 1), elementTime.plus(WINDOW_SIZE), WINDOW_2, PaneInfo.NO_FIRING));
+
+    assertEquals(2, (int) stateInternals.state(windowNamespace(WINDOW_2), stateTag).read());
+
+    // advance watermark past end of WINDOW_1 + allowed lateness
+    // the cleanup timer is set to window.maxTimestamp() + allowed lateness + 1
+    // to ensure that state is still available when a user timer for window.maxTimestamp() fires
+    advanceInputWatermark(
+        timerInternals,
+        WINDOW_1
+            .maxTimestamp()
+            .plus(ALLOWED_LATENESS)
+            .plus(StatefulDoFnRunner.TimeInternalsCleanupTimer.GC_DELAY_MS)
+            .plus(1), // so the watermark is past the GC horizon, not on it
+        runner);
+
+    assertTrue(
+        stateInternals.isEmptyForTesting(
+            stateInternals.state(windowNamespace(WINDOW_1), stateTag)));
+
+    assertEquals(2, (int) stateInternals.state(windowNamespace(WINDOW_2), stateTag).read());
+
+    // advance watermark past end of WINDOW_2 + allowed lateness
+    advanceInputWatermark(
+        timerInternals,
+        WINDOW_2
+            .maxTimestamp()
+            .plus(ALLOWED_LATENESS)
+            .plus(StatefulDoFnRunner.TimeInternalsCleanupTimer.GC_DELAY_MS)
+            .plus(1), // so the watermark is past the GC horizon, not on it
+        runner);
+
+    assertTrue(
+        stateInternals.isEmptyForTesting(
+            stateInternals.state(windowNamespace(WINDOW_2), stateTag)));
+  }
+
+  private static void advanceInputWatermark(
+      InMemoryTimerInternals timerInternals,
+      Instant newInputWatermark,
+      PushbackSideInputDoFnRunner<?, ?> toTrigger)
+      throws Exception {
+    timerInternals.advanceInputWatermark(newInputWatermark);
+    TimerInternals.TimerData timer;
+    while ((timer = timerInternals.removeNextEventTimer()) != null) {
+      StateNamespace namespace = timer.getNamespace();
+      checkArgument(namespace instanceof StateNamespaces.WindowNamespace);
+      BoundedWindow window = ((StateNamespaces.WindowNamespace) namespace).getWindow();
+      toTrigger.onTimer(timer.getTimerId(), window, timer.getTimestamp(), timer.getDomain());
     }
+  }
 
-    @Test
-    @Category({ValidatesRunner.class})
-    public void testLateDroppingForStatefulDoFnRunner() throws Exception {
-        MetricsContainerImpl container = new MetricsContainerImpl("any");
-        MetricsEnvironment.setCurrentContainer(container);
+  private static StateNamespace windowNamespace(IntervalWindow window) {
+    return StateNamespaces.window((Coder) WINDOWING_STRATEGY.getWindowFn().windowCoder(), window);
+  }
 
-        timerInternals.advanceInputWatermark(new Instant(BoundedWindow.TIMESTAMP_MAX_VALUE));
-        timerInternals.advanceOutputWatermark(new Instant(BoundedWindow.TIMESTAMP_MAX_VALUE));
+  private static class MyDoFn extends DoFn<KV<String, Integer>, Integer> {
 
-        PushbackSideInputDoFnRunner runner = createRunner(statefulRunner,ImmutableList.of(singletonView));
+    public final String stateId = "foo";
 
-        runner.startBundle();
+    @StateId(stateId)
+    public final StateSpec<ValueState<Integer>> intState = StateSpecs.value(VarIntCoder.of());
 
-        when(reader.isReady(Mockito.eq(singletonView), Mockito.any(BoundedWindow.class)))
-                .thenReturn(true);
-
-        WindowedValue<Integer> multiWindow =
-                WindowedValue.of(
-                        1,
-                        new Instant(0),
-                        ImmutableList.of(
-                                new IntervalWindow(new Instant(0), new Instant(0L + WINDOW_SIZE))),
-                        PaneInfo.ON_TIME_AND_ONLY_FIRING);
-
-        runner.processElementInReadyWindows(multiWindow);
-
-        long droppedValues =
-                container
-                        .getCounter(
-                                MetricName.named(
-                                        StatefulDoFnRunner.class, StatefulDoFnRunner.DROPPED_DUE_TO_LATENESS_COUNTER))
-                        .getCumulative();
-        assertEquals(1L, droppedValues);
-
-        runner.finishBundle();
+    @ProcessElement
+    public void processElement(ProcessContext c, @StateId(stateId) ValueState<Integer> state) {
+      Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
+      state.write(currentValue + 1);
     }
+  }
 
-    @Test
-    @Category({ValidatesRunner.class})
-    public void testGarbageCollectForStatefulDoFnRunner() throws Exception {
-        timerInternals.advanceInputWatermark(new Instant(1L));
-
-        MyDoFn fn = new MyDoFn();
-        StateTag<ValueState<Integer>> stateTag = StateTags.tagForSpec(fn.stateId, fn.intState);
-
-        PushbackSideInputDoFnRunner runner = createRunner(statefulRunner,ImmutableList.of(singletonView));
-
-        Instant elementTime = new Instant(1);
-
-        when(reader.isReady(Mockito.eq(singletonView), Mockito.any(BoundedWindow.class)))
-                .thenReturn(true);
-
-        // first element, key is hello, WINDOW_1
-        runner.processElementInReadyWindows(
-                WindowedValue.of(KV.of("hello", 1), elementTime, WINDOW_1, PaneInfo.NO_FIRING));
-
-        assertEquals(1, (int) stateInternals.state(windowNamespace(WINDOW_1), stateTag).read());
-
-        // second element, key is hello, WINDOW_2
-        runner.processElementInReadyWindows(
-                WindowedValue.of(
-                        KV.of("hello", 1), elementTime.plus(WINDOW_SIZE), WINDOW_2, PaneInfo.NO_FIRING));
-
-        runner.processElementInReadyWindows(
-                WindowedValue.of(
-                        KV.of("hello", 1), elementTime.plus(WINDOW_SIZE), WINDOW_2, PaneInfo.NO_FIRING));
-
-        assertEquals(2, (int) stateInternals.state(windowNamespace(WINDOW_2), stateTag).read());
-
-        // advance watermark past end of WINDOW_1 + allowed lateness
-        // the cleanup timer is set to window.maxTimestamp() + allowed lateness + 1
-        // to ensure that state is still available when a user timer for window.maxTimestamp() fires
-        advanceInputWatermark(
-                timerInternals,
-                WINDOW_1
-                        .maxTimestamp()
-                        .plus(ALLOWED_LATENESS)
-                        .plus(StatefulDoFnRunner.TimeInternalsCleanupTimer.GC_DELAY_MS)
-                        .plus(1), // so the watermark is past the GC horizon, not on it
-                runner);
-
-        assertTrue(
-                stateInternals.isEmptyForTesting(
-                        stateInternals.state(windowNamespace(WINDOW_1), stateTag)));
-
-        assertEquals(2, (int) stateInternals.state(windowNamespace(WINDOW_2), stateTag).read());
-
-        // advance watermark past end of WINDOW_2 + allowed lateness
-        advanceInputWatermark(
-                timerInternals,
-                WINDOW_2
-                        .maxTimestamp()
-                        .plus(ALLOWED_LATENESS)
-                        .plus(StatefulDoFnRunner.TimeInternalsCleanupTimer.GC_DELAY_MS)
-                        .plus(1), // so the watermark is past the GC horizon, not on it
-                runner);
-
-        assertTrue(
-                stateInternals.isEmptyForTesting(
-                        stateInternals.state(windowNamespace(WINDOW_2), stateTag)));
-    }
-
-    private static void advanceInputWatermark(
-            InMemoryTimerInternals timerInternals, Instant newInputWatermark, PushbackSideInputDoFnRunner<?, ?> toTrigger)
-            throws Exception {
-        timerInternals.advanceInputWatermark(newInputWatermark);
-        TimerInternals.TimerData timer;
-        while ((timer = timerInternals.removeNextEventTimer()) != null) {
-            StateNamespace namespace = timer.getNamespace();
-            checkArgument(namespace instanceof StateNamespaces.WindowNamespace);
-            BoundedWindow window = ((StateNamespaces.WindowNamespace) namespace).getWindow();
-            toTrigger.onTimer(timer.getTimerId(), window, timer.getTimestamp(), timer.getDomain());
-        }
-    }
-
-    private static StateNamespace windowNamespace(IntervalWindow window) {
-        return StateNamespaces.window((Coder) WINDOWING_STRATEGY.getWindowFn().windowCoder(), window);
-    }
-
-    private static class MyDoFn extends DoFn<KV<String, Integer>, Integer> {
-
-      public final String stateId = "foo";
-
-      @StateId(stateId)
-      public final StateSpec<ValueState<Integer>> intState = StateSpecs.value(VarIntCoder.of());
-
-      @ProcessElement
-      public void processElement(ProcessContext c, @StateId(stateId) ValueState<Integer> state) {
-        Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
-        state.write(currentValue + 1);
-      }
-    }
-
-    private DoFnRunner<KV<String, Integer>, Integer> getDoFnRunner(
-            DoFn<KV<String, Integer>, Integer> fn) {
-        return new SimpleDoFnRunner<>(
-                null,
-                fn,
-                NullSideInputReader.empty(),
-                null,
-                null,
-                Collections.emptyList(),
-                mockStepContext,
-                null,
-                Collections.emptyMap(),
-                WINDOWING_STRATEGY,
-                DoFnSchemaInformation.create());
-    }
+  private DoFnRunner<KV<String, Integer>, Integer> getDoFnRunner(
+      DoFn<KV<String, Integer>, Integer> fn) {
+    return new SimpleDoFnRunner<>(
+        null,
+        fn,
+        NullSideInputReader.empty(),
+        null,
+        null,
+        Collections.emptyList(),
+        mockStepContext,
+        null,
+        Collections.emptyMap(),
+        WINDOWING_STRATEGY,
+        DoFnSchemaInformation.create());
+  }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
@@ -73,21 +73,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
 /** Tests for {@link SimplePushbackSideInputDoFnRunner}. */
 @RunWith(JUnit4.class)
 public class SimplePushbackSideInputDoFnRunnerTest {
@@ -148,7 +133,7 @@ public class SimplePushbackSideInputDoFnRunnerTest {
   }
 
   private SimplePushbackSideInputDoFnRunner<Integer, Integer> createRunner(
-          ImmutableList<PCollectionView<?>> views) {
+      ImmutableList<PCollectionView<?>> views) {
     SimplePushbackSideInputDoFnRunner<Integer, Integer> runner =
         SimplePushbackSideInputDoFnRunner.create(underlying, views, reader);
     runner.startBundle();
@@ -509,6 +494,6 @@ public class SimplePushbackSideInputDoFnRunnerTest {
         Collections.emptyMap(),
         WINDOWING_STRATEGY,
         DoFnSchemaInformation.create(),
-        Collections.emptyMap());
+  Collections.emptyMap());
   }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
@@ -494,6 +494,6 @@ public class SimplePushbackSideInputDoFnRunnerTest {
         Collections.emptyMap(),
         WINDOWING_STRATEGY,
         DoFnSchemaInformation.create(),
-  Collections.emptyMap());
+        Collections.emptyMap());
   }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
@@ -73,6 +73,21 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 /** Tests for {@link SimplePushbackSideInputDoFnRunner}. */
 @RunWith(JUnit4.class)
 public class SimplePushbackSideInputDoFnRunnerTest {
@@ -133,7 +148,7 @@ public class SimplePushbackSideInputDoFnRunnerTest {
   }
 
   private SimplePushbackSideInputDoFnRunner<Integer, Integer> createRunner(
-      ImmutableList<PCollectionView<?>> views) {
+          ImmutableList<PCollectionView<?>> views) {
     SimplePushbackSideInputDoFnRunner<Integer, Integer> runner =
         SimplePushbackSideInputDoFnRunner.create(underlying, views, reader);
     runner.startBundle();
@@ -493,6 +508,7 @@ public class SimplePushbackSideInputDoFnRunnerTest {
         null,
         Collections.emptyMap(),
         WINDOWING_STRATEGY,
-        DoFnSchemaInformation.create());
+        DoFnSchemaInformation.create(),
+        Collections.emptyMap());
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -2298,31 +2298,48 @@ public class ParDoTest implements Serializable {
     @Test
     @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesSideInputs.class})
     public void testStateSideInput() {
+
+      // SideInput tag id
+      final String sideInputTag1 = "tag1";
+
+      Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
+      pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
       final PCollectionView<Integer> sideInput =
           pipeline
               .apply("CreateSideInput1", Create.of(2))
               .apply("ViewSideInput1", View.asSingleton());
 
       TestSimpleStatefulDoFn fn = new TestSimpleStatefulDoFn(sideInput);
-      pipeline.apply(Create.of(KV.of(1, 2))).apply(ParDo.of(fn).withSideInputs(sideInput));
+      pipeline
+          .apply(Create.of(KV.of(1, 2)))
+          .apply(ParDo.of(fn).withSideInput(sideInputTag1, sideInput));
 
       pipeline.run();
     }
 
     private static class TestSimpleStatefulDoFn extends DoFn<KV<Integer, Integer>, Integer> {
 
+      // SideInput tag id
+      final String sideInputTag1 = "tag1";
       private final PCollectionView<Integer> view;
 
-      @StateId("foo")
-      private final StateSpec<ValueState<Integer>> spec = StateSpecs.value(VarIntCoder.of());
+      final String stateId = "foo";
+      Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
+
+      @StateId(stateId)
+      private final StateSpec<BagState<MyInteger>> bufferState = StateSpecs.bag();
 
       private TestSimpleStatefulDoFn(PCollectionView<Integer> view) {
         this.view = view;
       }
 
       @ProcessElement
-      public void processElem(ProcessContext c) {
-        // noop
+      public void processElem(
+          ProcessContext c,
+          @SideInput(sideInputTag1) Integer sideInputTag,
+          @StateId(stateId) BagState<MyInteger> state) {
+        state.add(new MyInteger(sideInputTag));
+        c.output(sideInputTag);
       }
 
       @Override


### PR DESCRIPTION
Added test cases for `StatefulDoFnRunner` implementation for `DoFnRunner` in `SimplePushbackSideInputDoFnRunner`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
