### PR TITLE
[BEAM-7760] Added pipeline_instrument module

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -1,0 +1,470 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Module to instrument interactivity to the given pipeline.
+
+For internal use only; no backwards-compatibility guarantees.
+This module accesses current interactive environment and analyzes given pipeline
+to transform original pipeline into a one-shot pipeline with interactivity.
+"""
+from __future__ import absolute_import
+
+import logging
+
+import apache_beam as beam
+from apache_beam.pipeline import PipelineVisitor
+from apache_beam.runners.interactive import cache_manager as cache
+from apache_beam.runners.interactive import interactive_environment as ie
+
+READ_CACHE = "_ReadCache_"
+WRITE_CACHE = "_WriteCache_"
+
+
+class PipelineInstrument(object):
+  """A pipeline instrument for pipeline to be executed by interactive runner.
+
+  This module should never depend on underlying runner that interactive runner
+  delegates. It instruments the original instance of pipeline directly by
+  appending or replacing transforms with help of cache. It provides
+  interfaces to recover states of original pipeline. It's the interactive
+  runner's responsibility to coordinate supported underlying runners to run
+  the pipeline instrumented and recover the original pipeline states if needed.
+  """
+
+  def __init__(self, pipeline, options=None):
+    self._pipeline = pipeline
+    # The cache manager should be initiated outside of this module and outside
+    # of run_pipeline() from interactive runner so that its lifespan could cover
+    # multiple runs in the interactive environment. Owned by
+    # interactive_environment module. Not owned by this module.
+    # TODO(BEAM-7760): change the scope of cache to be owned by runner or
+    # pipeline result instances because a pipeline is not 1:1 correlated to a
+    # running job. Only complete and read-only cache is valid across multiple
+    # jobs. Other cache instances should have their own scopes. Some design
+    # change should support only runner.run(pipeline) pattern rather than
+    # pipeline.run([runner]) and a runner can only run at most one pipeline at a
+    # time. Otherwise, result returned by run() is the only 1:1 anchor.
+    self._cache_manager = ie.current_env().cache_manager()
+
+    # Invoke a round trip through the runner API. This makes sure the Pipeline
+    # proto is stable. The snapshot of pipeline will not be mutated within this
+    # module and can be used to recover original pipeline if needed.
+    self._pipeline_snap = beam.pipeline.Pipeline.from_runner_api(
+        pipeline.to_runner_api(use_fake_coders=True),
+        pipeline.runner,
+        options)
+    # Snapshot of original pipeline information.
+    (self._original_pipeline_proto,
+     self._original_context) = self._pipeline_snap.to_runner_api(
+         return_context=True, use_fake_coders=True)
+
+    # All compute-once-against-original-pipeline fields.
+    self._has_unbounded_source = has_unbounded_source(self._pipeline_snap)
+    # TODO(BEAM-7760): once cache scope changed, this is not needed to manage
+    # relationships across pipelines, runners, and jobs.
+    self._pcolls_to_pcoll_id = pcolls_to_pcoll_id(self._pipeline_snap,
+                                                  self._original_context)
+
+    # A mapping from PCollection id to python id() value in user defined
+    # pipeline instance.
+    (self._pcoll_version_map,
+     self._cacheables) = cacheables(self.pcolls_to_pcoll_id())
+
+    # A dict from cache key to PCollection that is read from cache.
+    # If exists, caller should reuse the PCollection read. If not, caller
+    # should create new transform and track the PCollection read from cache.
+    # (Dict[str, AppliedPTransform]).
+    self._cached_pcoll_read = {}
+
+  def instrumented_pipeline_proto(self):
+    """Always returns a new instance of portable instrumented proto."""
+    return self._pipeline.to_runner_api(use_fake_coders=True)
+
+  def has_unbounded_source(self):
+    """Checks if a given pipeline has any source that is unbounded.
+
+    The function directly checks the source transform definition instead
+    of pvalues in the pipeline. Thus manually setting is_bounded field of
+    a PCollection or switching streaming mode will not affect this
+    function's result. The result is always deterministic when the source
+    code of a pipeline is defined.
+    """
+    return self._has_unbounded_source
+
+  def cacheables(self):
+    """Finds cacheable PCollections from the pipeline.
+
+    The function only treats the result as cacheables since there is no
+    guarantee whether the cache desired PCollection has been cached or
+    not. A PCollection desires caching when it's bound to a user defined
+    variable in source code. Otherwise, the PCollection is not reusale
+    nor introspectable which nullifying the need of cache.
+    """
+    return self._cacheables
+
+  def pcolls_to_pcoll_id(self):
+    """Returns a dict mapping str(PCollection)s to IDs."""
+    return self._pcolls_to_pcoll_id
+
+  def original_pipeline_proto(self):
+    """Returns the portable proto representation of the pipeline before
+    instrumentation."""
+    return self._original_pipeline_proto
+
+  def original_pipeline(self):
+    """Returns a snapshot of the pipeline before instrumentation."""
+    return self._pipeline_snap
+
+  def instrument(self):
+    """Instruments original pipeline with cache.
+
+    For cacheable output PCollection, if cache for the key doesn't exist, do
+    _write_cache(); for cacheable input PCollection, if cache for the key
+    exists, do _read_cache(). No instrument in any other situation.
+
+    Modifies:
+      self._pipeline
+    """
+    self._preprocess()
+    cacheable_inputs = set()
+
+    class InstrumentVisitor(PipelineVisitor):
+      """Visitor utilizes cache to instrument the pipeline."""
+
+      def __init__(self, pin):
+        self._pin = pin
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        cacheable_inputs.update(self._pin._cacheable_inputs(transform_node))
+
+    v = InstrumentVisitor(self)
+    self._pipeline.visit(v)
+    # Create ReadCache transforms.
+    for cacheable_input in cacheable_inputs:
+      self._read_cache(cacheable_input)
+    # Replace/wire inputs w/ cached PCollections from ReadCache transforms.
+    self._replace_with_cached_inputs()
+    # Write cache for all cacheables.
+    for _, cacheable in self.cacheables().items():
+      self._write_cache(cacheable['pcoll'])
+    # TODO(BEAM-7760): prune sub graphs that doesn't need to be executed.
+
+  def _preprocess(self):
+    """Pre-processes the pipeline.
+
+    Since the pipeline instance in the class might not be the same instance
+    defined in the user code, the pre-process will figure out the relationship
+    of cacheable PCollections between these 2 instances by replacing 'pcoll'
+    fields in the cacheable dictionary with ones from the running instance.
+    """
+
+    class PreprocessVisitor(PipelineVisitor):
+
+      def __init__(self, pin):
+        self._pin = pin
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        for in_pcoll in transform_node.inputs:
+          self._process(in_pcoll)
+        for out_pcoll in transform_node.outputs.values():
+          self._process(out_pcoll)
+
+      def _process(self, pcoll):
+        pcoll_id = self._pin.pcolls_to_pcoll_id().get(str(pcoll), '')
+        if pcoll_id in self._pin._pcoll_version_map:
+          cacheable_key = self._pin._cacheable_key(pcoll)
+          if (cacheable_key in self._pin.cacheables() and
+              self._pin.cacheables()[cacheable_key]['pcoll'] != pcoll):
+            self._pin.cacheables()[cacheable_key]['pcoll'] = pcoll
+
+    v = PreprocessVisitor(self)
+    self._pipeline.visit(v)
+
+  def _write_cache(self, pcoll):
+    """Caches a cacheable PCollection.
+
+    For the given PCollection, by appending sub transform part that materialize
+    the PCollection through sink into cache implementation. The cache write is
+    not immediate. It happens when the runner runs the transformed pipeline
+    and thus not usable for this run as intended. It's the caller's
+    responsibility to make sure the PCollection is indeed cacheable. Otherwise,
+    cache resources might be wasted. If a cache with corresponding key exists,
+    noop since a cache write is only needed when the last cache is invalidated.
+    And if a cache is invalidated, the PCollection's new key is guaranteed to
+    not exist in current cache.
+
+    Modifies:
+      self._pipeline
+    """
+    if pcoll.pipeline is not self._pipeline:
+      return
+    key = self.cache_key(pcoll)
+    if not self._cache_manager.exists('full', key):
+      logging.debug('%s write cache: %s', pcoll.producer, key)
+      _ = pcoll | '{}{}'.format(WRITE_CACHE, key) >> cache.WriteCache(
+          self._cache_manager, key)
+
+  def _read_cache(self, pcoll):
+    """Reads a cached pvalue.
+
+    A noop will cause the pipeline to execute the transform as
+    it is and cache nothing from this transform for next run.
+
+    Modifies:
+      self._pipeline
+    """
+    if pcoll.pipeline is not self._pipeline:
+      return
+    key = self.cache_key(pcoll)
+    if self._cache_manager.exists('full', key):
+      if key not in self._cached_pcoll_read:
+        logging.debug('read cache: %s', key)
+        # Mutates the pipeline with cache read transform attached
+        # to root of the pipeline.
+        pcoll_from_cache = (
+            self._pipeline
+            | '{}{}'.format(READ_CACHE, key) >> cache.ReadCache(
+                self._cache_manager, key))
+        self._cached_pcoll_read[key] = pcoll_from_cache
+    # else: NOOP when cache doesn't exist.
+
+  def _replace_with_cached_inputs(self):
+    """Replace PCollection inputs in the pipeline with cache if possible.
+
+    For any input PCollection, find out whether there is valid cache. If so,
+    replace the input of the AppliedPTransform with output of the
+    AppliedPtransform that sources pvalue from the cache. If there is no valid
+    cache, noop.
+    """
+
+    class ReadCacheWireVisitor(PipelineVisitor):
+      """Visitor wires cache read as inputs to replace corresponding original
+      input PCollections in pipeline.
+      """
+
+      def __init__(self, pin):
+        """Initializes with a PipelineInstrument."""
+        self._pin = pin
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        if transform_node.inputs:
+          input_list = list(transform_node.inputs)
+          for i in range(len(input_list)):
+            key = self._pin.cache_key(input_list[i])
+            if key in self._pin._cached_pcoll_read:
+              input_list[i] = self._pin._cached_pcoll_read[key]
+          transform_node.inputs = tuple(input_list)
+
+    v = ReadCacheWireVisitor(self)
+    self._pipeline.visit(v)
+
+  def _cacheable_inputs(self, transform):
+    inputs = set()
+    for in_pcoll in transform.inputs:
+      if self._cacheable_key(in_pcoll) in self.cacheables():
+        inputs.add(in_pcoll)
+    return inputs
+
+  def _cacheable_key(self, pcoll):
+    """Gets the key a cacheable PCollection is tracked within the instrument."""
+    return cacheable_key(pcoll, self.pcolls_to_pcoll_id(),
+                         self._pcoll_version_map)
+
+  def cache_key(self, pcoll):
+    """Gets the identifier of a cacheable PCollection in cache.
+
+    If the pcoll is not a cacheable, return ''.
+    The key is what the pcoll would use as identifier if it's materialized in
+    cache. It doesn't mean that there would definitely be such cache already.
+    Also, the pcoll can come from the original user defined pipeline object or
+    an equivalent pcoll from a transformed copy of the original pipeline.
+    """
+    cacheable = self.cacheables().get(self._cacheable_key(pcoll), None)
+    if cacheable:
+      return '_'.join((cacheable['var'],
+                       cacheable['version'],
+                       cacheable['pcoll_id'],
+                       cacheable['producer_version']))
+    return ''
+
+  def _debug_appliedptransform(self, transform_node):
+    """Debugs AppliedPTransform at debug level logging.
+
+    Logs structure of an AppliedPTransform instance. Used for testing,
+    debugging and dev purpose.
+    """
+    logging.debug('parent is: %s', transform_node.parent)
+    logging.debug('full label of transform_node: %s',
+                  transform_node.full_label)
+    logging.debug('inputs: ')
+    for inp in transform_node.inputs:
+      logging.debug('  %s', inp)
+    logging.debug('parts: ')
+    for part in transform_node.parts:
+      logging.debug('  %s', part)
+    logging.debug('outputs: ')
+    for output in transform_node.outputs:
+      logging.debug('  %s', output)
+
+  def _debug_pipeline_graph(self):
+    """Debugs the pipeline at debug level logging.
+
+    The pipeline within the class is being instrumented and mutates. This
+    function logs structure of the pipeline exactly when invoked and can be
+    invoked multiple times at different instrumenting stages for testing,
+    debugging and dev purposes.
+    """
+
+    class DebugVisitor(PipelineVisitor):
+      def __init__(self, pin):
+        self._pin = pin
+
+      def enter_composite(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        self._pin._debug_appliedptransform(transform_node)
+
+    v = DebugVisitor(self)
+    self._pipeline.visit(v)
+
+
+def pin(pipeline, options=None):
+  """Creates PipelineInstrument for a pipeline and its options with cache."""
+  pi = PipelineInstrument(pipeline, options)
+  pi.instrument()  # Instruments the pipeline only once.
+  return pi
+
+
+def cacheables(pcolls_to_pcoll_id):
+  """Finds cache desired PCollections from the instrumented pipeline.
+
+  The function only treats the result as cacheables since whether the cache
+  desired PCollection has been cached depends on whether the pipeline has been
+  executed in current interactive environment. A PCollection desires caching
+  when it's bound to a user defined variable in source code. Otherwise, the
+  PCollection is not reusable nor introspectable which nullifies the need of
+  cache. There might be multiple pipelines defined and watched, this will
+  return for PCollections from the ones with pcolls_to_pcoll_id analyzed. The
+  check is not strict because pcoll_id is not unique across multiple pipelines.
+  Additional check needs to be done during instrument.
+  """
+  pcoll_version_map = {}
+  cacheables = {}
+  for watching in ie.current_env().watching():
+    for key, val in watching:
+      # TODO(BEAM-8288): cleanup the attribute check when py2 is not supported.
+      if hasattr(val, '__class__') and isinstance(val, beam.pvalue.PCollection):
+        cacheable = {}
+        cacheable['pcoll_id'] = pcolls_to_pcoll_id.get(str(val), None)
+        # It's highly possible that PCollection str is not unique across
+        # multiple pipelines, further check during instrument is needed.
+        if not cacheable['pcoll_id']:
+          continue
+        cacheable['var'] = key
+        cacheable['version'] = str(id(val))
+        cacheable['pcoll'] = val
+        cacheable['producer_version'] = str(id(val.producer))
+        cacheables[cacheable_key(val, pcolls_to_pcoll_id)] = cacheable
+        pcoll_version_map[cacheable['pcoll_id']] = cacheable['version']
+  return pcoll_version_map, cacheables
+
+
+def cacheable_key(pcoll, pcolls_to_pcoll_id, pcoll_version_map=None):
+  pcoll_version = str(id(pcoll))
+  pcoll_id = pcolls_to_pcoll_id.get(str(pcoll), '')
+  if pcoll_version_map:
+    original_pipeline_pcoll_version = pcoll_version_map.get(pcoll_id, None)
+    if original_pipeline_pcoll_version:
+      pcoll_version = original_pipeline_pcoll_version
+  return '_'.join((pcoll_version, pcoll_id))
+
+
+def has_unbounded_source(pipeline):
+  """Checks if a given pipeline has any source that is unbounded."""
+
+  class CheckUnboundednessVisitor(PipelineVisitor):
+    """Vsitor checks if there is any unbouned read source in the Pipeline.
+
+    Visitor visits all nodes and check is_bounded() for all sources of read
+    PTransform. As long as there is at least 1 source introduces unbounded
+    data, returns True. We don't check the is_bounded field from proto based
+    PCollection since they may not be correctly set with to_runner_api.
+    """
+
+    def __init__(self):
+      self.has_unbounded_source = False
+
+    def enter_composite_transform(self, transform_node):
+      self.visit_transform(transform_node)
+
+    def visit_transform(self, transform_node):
+      if (not self.has_unbounded_source and
+          isinstance(transform_node, beam.pipeline.AppliedPTransform) and
+          isinstance(transform_node.transform, beam.io.iobase.Read) and
+          not transform_node.transform.source.is_bounded()):
+        self.has_unbounded_source = True
+
+  v = CheckUnboundednessVisitor()
+  pipeline.visit(v)
+  return v.has_unbounded_source
+
+
+def pcolls_to_pcoll_id(pipeline, original_context):
+  """Returns a dict mapping PCollections string to PCollection IDs.
+
+  Using a PipelineVisitor to iterate over every node in the pipeline,
+  records the mapping from PCollections to PCollections IDs. This mapping
+  will be used to query cached PCollections.
+
+  Returns:
+    (dict from str to str) a dict mapping str(pcoll) to pcoll_id.
+  """
+
+  class PCollVisitor(PipelineVisitor):
+    """"A visitor that records input and output values to be replaced.
+
+    Input and output values that should be updated are recorded in maps
+    input_replacements and output_replacements respectively.
+
+    We cannot update input and output values while visiting since that
+    results in validation errors.
+    """
+
+    def __init__(self):
+      self.pcolls_to_pcoll_id = {}
+
+    def enter_composite_transform(self, transform_node):
+      self.visit_transform(transform_node)
+
+    def visit_transform(self, transform_node):
+      for pcoll in transform_node.outputs.values():
+        self.pcolls_to_pcoll_id[str(pcoll)] = (
+            original_context.pcollections.get_id(pcoll))
+
+  v = PCollVisitor()
+  pipeline.visit(v)
+  return v.pcolls_to_pcoll_id

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -150,7 +150,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     ib.watch(locals())
 
     pin = instr.pin(p)
-    self.assertEqual(pin.cacheables(), {
+    self.assertEqual(pin.cacheables, {
         pin._cacheable_key(init_pcoll): {
             'var': 'init_pcoll',
             'version': str(id(init_pcoll)),

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -1,0 +1,283 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for apache_beam.runners.interactive.pipeline_instrument."""
+from __future__ import absolute_import
+
+import tempfile
+import time
+import unittest
+
+import apache_beam as beam
+from apache_beam import coders
+from apache_beam.io import filesystems
+from apache_beam.pipeline import PipelineVisitor
+from apache_beam.runners.interactive import cache_manager as cache
+from apache_beam.runners.interactive import interactive_beam as ib
+from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive import pipeline_instrument as instr
+from apache_beam.runners.interactive import interactive_runner
+
+# Work around nose tests using Python2 without unittest.mock module.
+try:
+  from unittest.mock import MagicMock
+except ImportError:
+  from mock import MagicMock
+
+
+class PipelineInstrumentTest(unittest.TestCase):
+
+  def setUp(self):
+    ie.new_env(cache_manager=cache.FileBasedCacheManager())
+
+  def assertPipelineEqual(self, actual_pipeline, expected_pipeline):
+    actual_pipeline_proto = actual_pipeline.to_runner_api(use_fake_coders=True)
+    expected_pipeline_proto = expected_pipeline.to_runner_api(
+        use_fake_coders=True)
+    components1 = actual_pipeline_proto.components
+    components2 = expected_pipeline_proto.components
+    self.assertEqual(len(components1.transforms), len(components2.transforms))
+    self.assertEqual(len(components1.pcollections),
+                     len(components2.pcollections))
+
+    # GreatEqual instead of Equal because the pipeline_proto_to_execute could
+    # include more windowing_stratagies and coders than necessary.
+    self.assertGreaterEqual(len(components1.windowing_strategies),
+                            len(components2.windowing_strategies))
+    self.assertGreaterEqual(len(components1.coders), len(components2.coders))
+    self.assertTransformEqual(actual_pipeline_proto,
+                              actual_pipeline_proto.root_transform_ids[0],
+                              expected_pipeline_proto,
+                              expected_pipeline_proto.root_transform_ids[0])
+
+  def assertTransformEqual(self, actual_pipeline_proto, actual_transform_id,
+                           expected_pipeline_proto, expected_transform_id):
+    transform_proto1 = actual_pipeline_proto.components.transforms[
+        actual_transform_id]
+    transform_proto2 = expected_pipeline_proto.components.transforms[
+        expected_transform_id]
+    self.assertEqual(transform_proto1.spec.urn, transform_proto2.spec.urn)
+    # Skipping payload checking because PTransforms of the same functionality
+    # could generate different payloads.
+    self.assertEqual(len(transform_proto1.subtransforms),
+                     len(transform_proto2.subtransforms))
+    self.assertSetEqual(set(transform_proto1.inputs),
+                        set(transform_proto2.inputs))
+    self.assertSetEqual(set(transform_proto1.outputs),
+                        set(transform_proto2.outputs))
+
+  def test_pcolls_to_pcoll_id(self):
+    p = beam.Pipeline(interactive_runner.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    init_pcoll = p | 'Init Create' >> beam.Create(range(10))
+    _, ctx = p.to_runner_api(use_fake_coders=True, return_context=True)
+    self.assertEqual(instr.pcolls_to_pcoll_id(p, ctx), {
+        str(init_pcoll): 'ref_PCollection_PCollection_1'})
+
+  def test_cacheable_key_without_version_map(self):
+    p = beam.Pipeline(interactive_runner.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    init_pcoll = p | 'Init Create' >> beam.Create(range(10))
+    _, ctx = p.to_runner_api(use_fake_coders=True, return_context=True)
+    self.assertEqual(
+        instr.cacheable_key(init_pcoll, instr.pcolls_to_pcoll_id(p, ctx)),
+        str(id(init_pcoll)) + '_ref_PCollection_PCollection_1')
+
+  def test_cacheable_key_with_version_map(self):
+    p = beam.Pipeline(interactive_runner.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    init_pcoll = p | 'Init Create' >> beam.Create(range(10))
+
+    # It's normal that when executing, the pipeline object is a different
+    # but equivalent instance from what user has built. The pipeline instrument
+    # should be able to identify if the original instance has changed in an
+    # interactive env while mutating the other instance for execution. The
+    # version map can be used to figure out what the PCollection instances are
+    # in the original instance and if the evaluation has changed since last
+    # execution.
+    p2 = beam.Pipeline(interactive_runner.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    init_pcoll_2 = p2 | 'Init Create' >> beam.Create(range(10))
+    _, ctx = p2.to_runner_api(use_fake_coders=True, return_context=True)
+
+    # The cacheable_key should use id(init_pcoll) as prefix even when
+    # init_pcoll_2 is supplied as long as the version map is given.
+    self.assertEqual(
+        instr.cacheable_key(init_pcoll_2, instr.pcolls_to_pcoll_id(p2, ctx), {
+            'ref_PCollection_PCollection_1': str(id(init_pcoll))}),
+        str(id(init_pcoll)) + '_ref_PCollection_PCollection_1')
+
+  def test_cache_key(self):
+    p = beam.Pipeline(interactive_runner.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    init_pcoll = p | 'Init Create' >> beam.Create(range(10))
+    squares = init_pcoll | 'Square' >> beam.Map(lambda x: x * x)
+    cubes = init_pcoll | 'Cube' >> beam.Map(lambda x: x ** 3)
+    # Watch the local variables, i.e., the Beam pipeline defined.
+    ib.watch(locals())
+
+    pin = instr.pin(p)
+    self.assertEqual(pin.cache_key(init_pcoll), 'init_pcoll_' + str(
+        id(init_pcoll)) + '_ref_PCollection_PCollection_1_' + str(id(
+            init_pcoll.producer)))
+    self.assertEqual(pin.cache_key(squares), 'squares_' + str(
+        id(squares)) + '_ref_PCollection_PCollection_2_' + str(id(
+            squares.producer)))
+    self.assertEqual(pin.cache_key(cubes), 'cubes_' + str(
+        id(cubes)) + '_ref_PCollection_PCollection_3_' + str(id(
+            cubes.producer)))
+
+  def test_cacheables(self):
+    p = beam.Pipeline(interactive_runner.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    init_pcoll = p | 'Init Create' >> beam.Create(range(10))
+    squares = init_pcoll | 'Square' >> beam.Map(lambda x: x * x)
+    cubes = init_pcoll | 'Cube' >> beam.Map(lambda x: x ** 3)
+    ib.watch(locals())
+
+    pin = instr.pin(p)
+    self.assertEqual(pin.cacheables(), {
+        pin._cacheable_key(init_pcoll): {
+            'var': 'init_pcoll',
+            'version': str(id(init_pcoll)),
+            'pcoll_id': 'ref_PCollection_PCollection_1',
+            'producer_version': str(id(init_pcoll.producer)),
+            'pcoll': init_pcoll
+        },
+        pin._cacheable_key(squares): {
+            'var': 'squares',
+            'version': str(id(squares)),
+            'pcoll_id': 'ref_PCollection_PCollection_2',
+            'producer_version': str(id(squares.producer)),
+            'pcoll': squares
+        },
+        pin._cacheable_key(cubes): {
+            'var': 'cubes',
+            'version': str(id(cubes)),
+            'pcoll_id': 'ref_PCollection_PCollection_3',
+            'producer_version': str(id(cubes.producer)),
+            'pcoll': cubes
+        }
+    })
+
+  def test_has_unbounded_source(self):
+    p = beam.Pipeline(interactive_runner.InteractiveRunner())
+    _ = p | 'ReadUnboundedSource' >> beam.io.ReadFromPubSub(
+        subscription='projects/fake-project/subscriptions/fake_sub')
+    self.assertTrue(instr.has_unbounded_source(p))
+
+  def test_not_has_unbounded_source(self):
+    p = beam.Pipeline(interactive_runner.InteractiveRunner())
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+      f.write(b'test')
+    _ = p | 'ReadBoundedSource' >> beam.io.ReadFromText(f.name)
+    self.assertFalse(instr.has_unbounded_source(p))
+
+  def _example_pipeline(self, watch=True):
+    p = beam.Pipeline(interactive_runner.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    init_pcoll = p | 'Init Create' >> beam.Create(range(10))
+    second_pcoll = init_pcoll | 'Second' >> beam.Map(lambda x: x * x)
+    if watch:
+      ib.watch(locals())
+    return (p, init_pcoll, second_pcoll)
+
+  def _mock_write_cache(self, pcoll, cache_key):
+    """Cache the PCollection where cache.WriteCache would write to."""
+    cache_path = filesystems.FileSystems.join(
+        ie.current_env().cache_manager()._cache_dir, 'full')
+    if not filesystems.FileSystems.exists(cache_path):
+      filesystems.FileSystems.mkdirs(cache_path)
+
+    # Pause for 0.1 sec, because the Jenkins test runs so fast that the file
+    # writes happen at the same timestamp.
+    time.sleep(0.1)
+
+    cache_file = cache_key + '-1-of-2'
+    labels = ['full', cache_key]
+
+    # Usually, the pcoder will be inferred from `pcoll.element_type`
+    pcoder = coders.registry.get_coder(object)
+    ie.current_env().cache_manager().save_pcoder(pcoder, *labels)
+    sink = ie.current_env().cache_manager().sink(*labels)
+
+    with open(ie.current_env().cache_manager()._path('full', cache_file),
+              'wb') as f:
+      sink.write_record(f, pcoll)
+
+  def test_instrument_example_pipeline_to_write_cache(self):
+    # Original instance defined by user code has all variables handlers.
+    p_origin, init_pcoll, second_pcoll = self._example_pipeline()
+    # Copied instance when execution has no user defined variables.
+    p_copy, _, _ = self._example_pipeline(False)
+    # Instrument the copied pipeline.
+    pin = instr.pin(p_copy)
+    # Manually instrument original pipeline with expected pipeline transforms.
+    init_pcoll_cache_key = pin.cache_key(init_pcoll)
+    _ = init_pcoll | (
+        ('_WriteCache_' + init_pcoll_cache_key) >> cache.WriteCache(
+            ie.current_env().cache_manager(), init_pcoll_cache_key))
+    second_pcoll_cache_key = pin.cache_key(second_pcoll)
+    _ = second_pcoll | (
+        ('_WriteCache_' + second_pcoll_cache_key) >> cache.WriteCache(
+            ie.current_env().cache_manager(), second_pcoll_cache_key))
+    # The 2 pipelines should be the same now.
+    self.assertPipelineEqual(p_copy, p_origin)
+
+  def test_instrument_example_pipeline_to_read_cache(self):
+    p_origin, init_pcoll, second_pcoll = self._example_pipeline()
+    p_copy, _, _ = self._example_pipeline(False)
+
+    # Mock as if cacheable PCollections are cached.
+    init_pcoll_cache_key = 'init_pcoll_' + str(
+        id(init_pcoll)) + '_ref_PCollection_PCollection_1_' + str(id(
+            init_pcoll.producer))
+    self._mock_write_cache(init_pcoll, init_pcoll_cache_key)
+    second_pcoll_cache_key = 'second_pcoll_' + str(
+        id(second_pcoll)) + '_ref_PCollection_PCollection_2_' + str(id(
+            second_pcoll.producer))
+    self._mock_write_cache(second_pcoll, second_pcoll_cache_key)
+    ie.current_env().cache_manager().exists = MagicMock(return_value=True)
+    instr.pin(p_copy)
+
+    cached_init_pcoll = p_origin | (
+        '_ReadCache_' + init_pcoll_cache_key) >> cache.ReadCache(
+            ie.current_env().cache_manager(), init_pcoll_cache_key)
+
+    # second_pcoll is never used as input and there is no need to read cache.
+
+    class TestReadCacheWireVisitor(PipelineVisitor):
+      """Replace init_pcoll with cached_init_pcoll for all occuring inputs."""
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        if transform_node.inputs:
+          input_list = list(transform_node.inputs)
+          for i in range(len(input_list)):
+            if input_list[i] == init_pcoll:
+              input_list[i] = cached_init_pcoll
+          transform_node.inputs = tuple(input_list)
+
+    v = TestReadCacheWireVisitor()
+    p_origin.visit(v)
+    self.assertPipelineEqual(p_origin, p_copy)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
1. Added the pipeline_instrument module to automatically instrument a
given Interactive Beam pipeline by mutating it with additional cache
based PTransforms if available so that, within an interactive
environment, each pipeline run could have effect against the future
runs to provide an interactive experience when executing Beam
pipelines.
2. The pipeline_instrument module will replace pipeline_analyzer module
when the integration with a re-written of display module interfaces is
done since the interactivity instrument (i.e., parameters passed and
used) has changed. Most of the display logic won't change.
3. An optional pruning logic is marked as TODO so that when executing
an instrumented pipeline, any sub graph doesn't generate new states
should not be re-executed if implemented.
4. Tests included.
5. The philosophy is to keep the pipeline instance defined by user code
intact and mutate directly on a copied pipeline instance; to always
convert the instrumented pipeline to a portable pipeline and pass it
to runner for execution; to maintain the mapping relationship from
original user defined pipeline to instrumented copied pipeline instances
and jobs executed by runners.
6. Additional complexity occurs when there are multiple pipeline
instances defined in user code, multiple runners instantiated, and
multiple jobs running from those pipeline instances by the runner
instances. Currently, the only guarantee is that a pipeline result
bounded to a job must be the return of a run by a runner and originate
from a pipeline instance. Some design change proposals are marked as TODO
around the cache scoping to solve the context problem in interactive
environment: when and what to instrument when the additional complexity
occurs.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
