### PR TITLE
[BEAM-8281] Resize IOITs datasets

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
@@ -28,11 +28,12 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'textioit_results',
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '25000000',
+                        expectedHash        : 'f8453256ccf861e8a312c125dfe0e436',
+                        datasetSize         : '1062290000',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
                 ]
-
         ],
         [
                 name               : 'beam_PerformanceTests_Compressed_TextIOIT',
@@ -43,7 +44,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'compressed_textioit_results',
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '450000000',
+                        expectedHash        : '8a3de973354abc6fba621c6797cc0f06',
+                        datasetSize         : '1097840000',
                         compressionType     : 'GZIP',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
@@ -60,7 +63,9 @@ def jobs = [
                         bigQueryTable              : 'many_files_textioit_results',
                         reportGcsPerformanceMetrics: 'true',
                         gcsPerformanceMetrics      : 'true',
-                        numberOfRecords            : '1000000',
+                        numberOfRecords            : '25000000',
+                        expectedHash               : 'f8453256ccf861e8a312c125dfe0e436',
+                        datasetSize                : '1062290000',
                         numberOfShards             : '1000',
                         numWorkers                 : '5',
                         autoscalingAlgorithm       : 'NONE'
@@ -74,7 +79,9 @@ def jobs = [
                 githubTitle        : 'Java AvroIO Performance Test',
                 githubTriggerPhrase: 'Run Java AvroIO Performance Test',
                 pipelineOptions    : [
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '225000000',
+                        expectedHash        : '2f9f5ca33ea464b25109c0297eb6aecb',
+                        datasetSize         : '1089730000',
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'avroioit_results',
                         numWorkers          : '5',
@@ -90,7 +97,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'tfrecordioit_results',
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '18000000',
+                        expectedHash        : '543104423f8b6eb097acb9f111c19fe4',
+                        datasetSize         : '1019380000',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
                 ]
@@ -104,7 +113,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'xmlioit_results',
-                        numberOfRecords     : '100000000',
+                        numberOfRecords     : '12000000',
+                        expectedHash        : 'b3b717e7df8f4878301b20f314512fb3',
+                        datasetSize         : '1076590000',
                         charset             : 'UTF-8',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
@@ -119,7 +130,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'parquetioit_results',
-                        numberOfRecords     : '100000000',
+                        numberOfRecords     : '225000000',
+                        expectedHash        : '2f9f5ca33ea464b25109c0297eb6aecb',
+                        datasetSize         : '1087370000',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
                 ]
@@ -133,7 +146,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'textioit_hdfs_results',
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '25000000',
+                        expectedHash        : 'f8453256ccf861e8a312c125dfe0e436',
+                        datasetSize         : '1062290000',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
                 ]
@@ -148,7 +163,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'compressed_textioit_hdfs_results',
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '450000000',
+                        expectedHash        : '8a3de973354abc6fba621c6797cc0f06',
+                        datasetSize         : '1097840000',
                         compressionType     : 'GZIP',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
@@ -165,7 +182,9 @@ def jobs = [
                         bigQueryTable              : 'many_files_textioit_hdfs_results',
                         reportGcsPerformanceMetrics: 'true',
                         gcsPerformanceMetrics      : 'true',
-                        numberOfRecords            : '1000000',
+                        numberOfRecords            : '25000000',
+                        expectedHash               : 'f8453256ccf861e8a312c125dfe0e436',
+                        datasetSize                : '1062290000',
                         numberOfShards             : '1000',
                         numWorkers                 : '5',
                         autoscalingAlgorithm       : 'NONE'
@@ -181,7 +200,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'avroioit_hdfs_results',
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '225000000',
+                        expectedHash        : '2f9f5ca33ea464b25109c0297eb6aecb',
+                        datasetSize         : '1089730000',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
                 ]
@@ -193,7 +214,9 @@ def jobs = [
                 githubTitle        : 'Java TFRecordIO Performance Test on HDFS',
                 githubTriggerPhrase: 'Run Java TFRecordIO Performance Test HDFS',
                 pipelineOptions    : [
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '18000000',
+                        expectedHash        : '543104423f8b6eb097acb9f111c19fe4',
+                        datasetSize         : '1019380000',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
                 ]
@@ -207,7 +230,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'xmlioit_hdfs_results',
-                        numberOfRecords     : '100000',
+                        numberOfRecords     : '12000000',
+                        expectedHash        : 'b3b717e7df8f4878301b20f314512fb3',
+                        datasetSize         : '1076590000',
                         charset             : 'UTF-8',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
@@ -222,7 +247,9 @@ def jobs = [
                 pipelineOptions    : [
                         bigQueryDataset     : 'beam_performance',
                         bigQueryTable       : 'parquetioit_hdfs_results',
-                        numberOfRecords     : '1000000',
+                        numberOfRecords     : '225000000',
+                        expectedHash        : '2f9f5ca33ea464b25109c0297eb6aecb',
+                        datasetSize         : '1087370000',
                         numWorkers          : '5',
                         autoscalingAlgorithm: 'NONE'
                 ]

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/avro/AvroIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/avro/AvroIOIT.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.io.avro;
 
 import static org.apache.beam.sdk.io.FileIO.ReadMatches.DirectoryTreatment;
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.appendTimestampSuffix;
-import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.getExpectedHashForLineCount;
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.readFileBasedIOITPipelineOptions;
 
 import com.google.cloud.Timestamp;
@@ -66,6 +65,8 @@ import org.junit.runners.JUnit4;
  *  ./gradlew integrationTest -p sdks/java/io/file-based-io-tests
  *  -DintegrationTestPipelineOptions='[
  *  "--numberOfRecords=100000",
+ *  "--datasetSize=12345",
+ *  "--expectedHash=99f23ab",
  *  "--filenamePrefix=output_file_path"
  *  ]'
  *  --tests org.apache.beam.sdk.io.avro.AvroIOIT
@@ -91,10 +92,12 @@ public class AvroIOIT {
                   + "}");
 
   private static String filenamePrefix;
-  private static Integer numberOfTextLines;
   private static String bigQueryDataset;
   private static String bigQueryTable;
   private static final String AVRO_NAMESPACE = AvroIOIT.class.getName();
+  private static Integer numberOfTextLines;
+  private static Integer datasetSize;
+  private static String expectedHash;
 
   @Rule public TestPipeline pipeline = TestPipeline.create();
 
@@ -102,10 +105,12 @@ public class AvroIOIT {
   public static void setup() {
     FileBasedIOTestPipelineOptions options = readFileBasedIOITPipelineOptions();
 
-    numberOfTextLines = options.getNumberOfRecords();
     filenamePrefix = appendTimestampSuffix(options.getFilenamePrefix());
     bigQueryDataset = options.getBigQueryDataset();
     bigQueryTable = options.getBigQueryTable();
+    datasetSize = options.getDatasetSize();
+    expectedHash = options.getExpectedHash();
+    numberOfTextLines = options.getNumberOfRecords();
   }
 
   @Test
@@ -141,7 +146,6 @@ public class AvroIOIT {
             .apply("Collect end time", ParDo.of(new TimeMonitor<>(AVRO_NAMESPACE, "endPoint")))
             .apply("Parse Avro records to Strings", ParDo.of(new ParseAvroRecordsFn()))
             .apply("Calculate hashcode", Combine.globally(new HashingFn()));
-    String expectedHash = getExpectedHashForLineCount(numberOfTextLines);
     PAssert.thatSingleton(consolidatedHashcode).isEqualTo(expectedHash);
 
     testFilenames.apply(
@@ -191,7 +195,10 @@ public class AvroIOIT {
           double runTime = (readEnd - writeStart) / 1e3;
           return NamedTestResult.create(uuid, timestamp, "run_time", runTime);
         });
-
+    if (datasetSize != null) {
+      suppliers.add(
+          (reader) -> NamedTestResult.create(uuid, timestamp, "dataset_size", datasetSize));
+    }
     return suppliers;
   }
 

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/common/FileBasedIOITHelper.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/common/FileBasedIOITHelper.java
@@ -17,19 +17,15 @@
  */
 package org.apache.beam.sdk.io.common;
 
-import static org.apache.beam.sdk.io.common.IOITHelper.getHashForRecordCount;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 
 /** Contains helper methods for file based IO Integration tests. */
@@ -43,17 +39,6 @@ public class FileBasedIOITHelper {
 
   public static String appendTimestampSuffix(String text) {
     return String.format("%s_%s", text, new Date().getTime());
-  }
-
-  public static String getExpectedHashForLineCount(int lineCount) {
-    Map<Integer, String> expectedHashes =
-        ImmutableMap.of(
-            1000, "8604c70b43405ef9803cb49b77235ea2",
-            100_000, "4c8bb3b99dcc59459b20fefba400d446",
-            1_000_000, "9796db06e7a7960f974d5a91164afff1",
-            100_000_000, "6ce05f456e2fdc846ded2abd0ec1de95");
-
-    return getHashForRecordCount(lineCount, expectedHashes);
   }
 
   /** Constructs text lines in files used for testing. */

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/common/FileBasedIOTestPipelineOptions.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/common/FileBasedIOTestPipelineOptions.java
@@ -48,4 +48,16 @@ public interface FileBasedIOTestPipelineOptions extends IOTestPipelineOptions {
   boolean getReportGcsPerformanceMetrics();
 
   void setReportGcsPerformanceMetrics(boolean performanceMetrics);
+
+  @Validation.Required
+  @Description(
+      "Precomputed hashcode to assert IO test pipeline content identity after writing and reading back the dataset")
+  String getExpectedHash();
+
+  void setExpectedHash(String hash);
+
+  @Description("Size of data saved on the target filesystem (bytes)")
+  Integer getDatasetSize();
+
+  void setDatasetSize(Integer size);
 }


### PR DESCRIPTION
This PR introduces a new way of configuring file-based IOITs. It also adds a known dataset size to reported metrics (the size was measured by the author and is calibrated to be around 1GB) in order to measure also throughput of the IOs (throughput will be calculated on the dashboards)



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
