### PR TITLE
[Go SDK] Fix Off by One error splitting DataSource

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -39,8 +39,8 @@ type DataSource struct {
 
 	source   DataManager
 	state    StateReader
-	count    int64
-	splitPos int64
+	index    int64
+	splitIdx int64
 	start    time.Time
 
 	mu sync.Mutex
@@ -62,8 +62,8 @@ func (n *DataSource) StartBundle(ctx context.Context, id string, data DataContex
 	n.source = data.Data
 	n.state = data.State
 	n.start = time.Now()
-	n.count = 0
-	n.splitPos = math.MaxInt64
+	n.index = -1
+	n.splitIdx = math.MaxInt64
 	n.mu.Unlock()
 	return n.Out.StartBundle(ctx, id, data)
 }
@@ -94,7 +94,7 @@ func (n *DataSource) Process(ctx context.Context) error {
 	}
 
 	for {
-		if n.IncrementCountAndCheckSplit(ctx) {
+		if n.incrementIndexAndCheckSplit() {
 			return nil
 		}
 		ws, t, err := DecodeWindowedValueHeader(wc, r)
@@ -201,16 +201,14 @@ func readStreamToBuffer(cv ElementDecoder, r io.ReadCloser, size int64, buf []Fu
 	return buf, nil
 }
 
-// FinishBundle resets the source and metric counters.
+// FinishBundle resets the source.
 func (n *DataSource) FinishBundle(ctx context.Context) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	log.Infof(ctx, "DataSource: %d elements in %d ns", n.count, time.Now().Sub(n.start))
+	log.Infof(ctx, "DataSource: %d elements in %d ns", n.index, time.Now().Sub(n.start))
 	n.source = nil
-	err := n.Out.FinishBundle(ctx)
-	n.count = 0
-	n.splitPos = math.MaxInt64
-	return err
+	n.splitIdx = 0 // Ensure errors are returned for split requests if this plan is re-used.
+	return n.Out.FinishBundle(ctx)
 }
 
 // Down resets the source.
@@ -223,15 +221,15 @@ func (n *DataSource) String() string {
 	return fmt.Sprintf("DataSource[%v, %v] Coder:%v Out:%v", n.SID, n.Name, n.Coder, n.Out.ID())
 }
 
-// IncrementCountAndCheckSplit increments DataSource.count by one and checks if
+// incrementIndexAndCheckSplit increments DataSource.index by one and checks if
 // the caller should abort further element processing, and finish the bundle.
-// Returns true if the new value of count is greater than or equal to the split
-// point, and false otherwise.
-func (n *DataSource) IncrementCountAndCheckSplit(ctx context.Context) bool {
+// Returns true if the new value of index is greater than or equal to the split
+// index, and false otherwise.
+func (n *DataSource) incrementIndexAndCheckSplit() bool {
 	b := false
 	n.mu.Lock()
-	n.count++
-	if n.count >= n.splitPos {
+	n.index++
+	if n.index >= n.splitIdx {
 		b = true
 	}
 	n.mu.Unlock()
@@ -250,13 +248,19 @@ func (n *DataSource) Progress() ProgressReportSnapshot {
 		return ProgressReportSnapshot{}
 	}
 	n.mu.Lock()
-	c := n.count
+	// The count is the number of "completely processed elements"
+	// which matches the index of the currently processing element.
+	c := n.index
 	n.mu.Unlock()
-	return ProgressReportSnapshot{n.SID.PtransformID, n.Name, c}
+	// Do not sent negative progress reports, index is initialized to 0.
+	if c < 0 {
+		c = 0
+	}
+	return ProgressReportSnapshot{ID: n.SID.PtransformID, Name: n.Name, Count: c}
 }
 
-// Split takes a sorted set of potential split points, selects and actuates
-// split on an appropriate split point, and returns the selected split point
+// Split takes a sorted set of potential split index, selects and actuates
+// split on an appropriate split index, and returns the selected split index
 // if successful. Returns an error when unable to split.
 func (n *DataSource) Split(splits []int64, frac float32) (int64, error) {
 	if splits == nil {
@@ -266,19 +270,19 @@ func (n *DataSource) Split(splits []int64, frac float32) (int64, error) {
 		return 0, fmt.Errorf("failed to split at requested splits: {%v}, DataSource not initialized", splits)
 	}
 	n.mu.Lock()
-	c := n.count
+	c := n.index
 	// Find the smallest split index that we haven't yet processed, and set
-	// the promised split position to this value.
+	// the promised split index to this value.
 	for _, s := range splits {
-		if s > 0 && s >= c && s < n.splitPos  {
-			n.splitPos = s
-			fs := n.splitPos
+		if s > 0 && s >= c && s < n.splitIdx {
+			n.splitIdx = s
+			fs := n.splitIdx
 			n.mu.Unlock()
 			return fs, nil
 		}
 	}
 	n.mu.Unlock()
-	// If we can't find a suitable split point from the requested choices,
+	// If we can't find a suitable split index from the requested choices,
 	// return an error.
 	return 0, fmt.Errorf("failed to split at requested splits: {%v}, DataSource at index: %v", splits, c)
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -259,7 +259,7 @@ func (n *DataSource) Progress() ProgressReportSnapshot {
 	return ProgressReportSnapshot{ID: n.SID.PtransformID, Name: n.Name, Count: c}
 }
 
-// Split takes a sorted set of potential split index, selects and actuates
+// Split takes a sorted set of potential split indices, selects and actuates
 // split on an appropriate split index, and returns the selected split index
 // if successful. Returns an error when unable to split.
 func (n *DataSource) Split(splits []int64, frac float32) (int64, error) {

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
@@ -17,6 +17,7 @@ package exec
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 
@@ -46,6 +47,7 @@ func TestDataSource_PerElement(t *testing.T) {
 				pw.Close()
 			},
 		},
+		// TODO: Test progress.
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -64,13 +66,7 @@ func TestDataSource_PerElement(t *testing.T) {
 				Data: &TestDataManager{R: pr},
 			})
 
-			expected := makeValues(test.expected...)
-			if got, want := len(out.Elements), len(expected); got != want {
-				t.Fatalf("lengths don't match: got %v, want %v", got, want)
-			}
-			if !equalList(out.Elements, expected) {
-				t.Errorf("DataSource => %#v, want %#v", extractValues(out.Elements...), extractValues(expected...))
-			}
+			validateSource(t, out, source, makeValues(test.expected...))
 		})
 	}
 }
@@ -158,7 +154,6 @@ func TestDataSource_Iterators(t *testing.T) {
 				dmw.Close()
 			},
 		},
-		// TODO: Test splitting.
 		// TODO: Test progress.
 	}
 	for _, test := range tests {
@@ -211,6 +206,147 @@ func TestDataSource_Iterators(t *testing.T) {
 	}
 }
 
+func TestDataSource_Split(t *testing.T) {
+	elements := []interface{}{int64(1), int64(2), int64(3), int64(4), int64(5)}
+	initSourceTest := func(name string) (*DataSource, *CaptureNode, io.ReadCloser) {
+		out := &CaptureNode{UID: 1}
+		c := coder.NewW(coder.NewVarInt(), coder.NewGlobalWindow())
+		source := &DataSource{
+			UID:   2,
+			SID:   StreamID{PtransformID: "myPTransform"},
+			Name:  name,
+			Coder: c,
+			Out:   out,
+		}
+		pr, pw := io.Pipe()
+
+		go func(c *coder.Coder, pw io.WriteCloser, elements []interface{}) {
+			wc := MakeWindowEncoder(c.Window)
+			ec := MakeElementEncoder(coder.SkipW(c))
+			for _, v := range elements {
+				EncodeWindowedValueHeader(wc, window.SingleGlobalWindow, mtime.ZeroTimestamp, pw)
+				ec.Encode(&FullValue{Elm: v}, pw)
+			}
+			pw.Close()
+		}(c, pw, elements)
+		return source, out, pr
+	}
+
+	tests := []struct {
+		name     string
+		expected []interface{}
+		splitIdx int64
+	}{
+		{splitIdx: 1},
+		{splitIdx: 2},
+		{splitIdx: 3},
+		{splitIdx: 4},
+		{splitIdx: 5},
+		{
+			name:     "wellBeyondRange",
+			expected: elements,
+			splitIdx: 1000,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		if len(test.name) == 0 {
+			test.name = fmt.Sprintf("atIndex%d", test.splitIdx)
+		}
+		if test.expected == nil {
+			test.expected = elements[:test.splitIdx]
+		}
+		t.Run(test.name, func(t *testing.T) {
+			source, out, pr := initSourceTest(test.name)
+			p, err := NewPlan("a", []Unit{out, source})
+			if err != nil {
+				t.Fatalf("failed to construct plan: %v", err)
+			}
+			dc := DataContext{Data: &TestDataManager{R: pr}}
+			ctx := context.Background()
+
+			// StartBundle resets the source, so no splits can be actuated before then,
+			// which means we need to actuate the plan manually, and insert the split request
+			// after StartBundle.
+			for i, root := range p.units {
+				if err := root.Up(ctx); err != nil {
+					t.Fatalf("error in root[%d].Up: %v", i, err)
+				}
+			}
+			p.status = Active
+
+			runOnRoots(ctx, t, p, "StartBundle", func(root Root, ctx context.Context) error { return root.StartBundle(ctx, "1", dc) })
+
+			// SDK never splits on 0, so check that every test.
+			if splitIdx, err := p.Split(SplitPoints{Splits: []int64{0, test.splitIdx}}); err != nil {
+				t.Fatalf("error in Split: %v", err)
+			} else if got, want := splitIdx, test.splitIdx; got != want {
+				t.Fatalf("error in Split: got splitIdx = %v, want %v ", got, want)
+			}
+			runOnRoots(ctx, t, p, "Process", Root.Process)
+			runOnRoots(ctx, t, p, "FinishBundle", Root.FinishBundle)
+
+			validateSource(t, out, source, makeValues(test.expected...))
+		})
+	}
+
+	// Test expects splitting errors, but for processing to be successful.
+	t.Run("errors", func(t *testing.T) {
+		source, out, pr := initSourceTest("noSplitsUntilStarted")
+		p, err := NewPlan("a", []Unit{out, source})
+		if err != nil {
+			t.Fatalf("failed to construct plan: %v", err)
+		}
+		dc := DataContext{Data: &TestDataManager{R: pr}}
+		ctx := context.Background()
+
+		if _, err := p.Split(SplitPoints{Splits: []int64{0, 3}, Frac: -1}); err == nil {
+			t.Fatal("plan uninitialized, expected error when splitting, got nil")
+		}
+		for i, root := range p.units {
+			if err := root.Up(ctx); err != nil {
+				t.Fatalf("error in root[%d].Up: %v", i, err)
+			}
+		}
+		p.status = Active
+		if _, err := p.Split(SplitPoints{Splits: []int64{0, 3}, Frac: -1}); err == nil {
+			t.Fatal("plan not started, expected error when splitting, got nil")
+		}
+		runOnRoots(ctx, t, p, "StartBundle", func(root Root, ctx context.Context) error { return root.StartBundle(ctx, "1", dc) })
+		if _, err := p.Split(SplitPoints{Splits: []int64{0}, Frac: -1}); err == nil {
+			t.Fatal("plan started, expected error when splitting, got nil")
+		}
+		runOnRoots(ctx, t, p, "Process", Root.Process)
+		if _, err := p.Split(SplitPoints{Splits: []int64{0}, Frac: -1}); err == nil {
+			t.Fatal("plan in progress, expected error when unable to get a desired split, got nil")
+		}
+		runOnRoots(ctx, t, p, "FinishBundle", Root.FinishBundle)
+		if _, err := p.Split(SplitPoints{Splits: []int64{0}, Frac: -1}); err == nil {
+			t.Fatal("plan finished, expected error when splitting, got nil")
+		}
+		validateSource(t, out, source, makeValues(elements...))
+	})
+
+	t.Run("sanity_errors", func(t *testing.T) {
+		var source *DataSource
+		if _, err := source.Split([]int64{0}, -1); err == nil {
+			t.Fatal("expected error splitting nil *DataSource")
+		}
+		if _, err := source.Split(nil, -1); err == nil {
+			t.Fatal("expected error splitting nil desired splits")
+		}
+	})
+}
+
+func runOnRoots(ctx context.Context, t *testing.T, p *Plan, name string, mthd func(Root, context.Context) error) {
+	t.Helper()
+	for i, root := range p.roots {
+		if err := mthd(root, ctx); err != nil {
+			t.Fatalf("error in root[%d].%s: %v", i, name, err)
+		}
+	}
+}
+
 type TestDataManager struct {
 	R io.ReadCloser
 }
@@ -244,5 +380,18 @@ func constructAndExecutePlanWithContext(t *testing.T, us []Unit, dc DataContext)
 	}
 	if err := p.Down(context.Background()); err != nil {
 		t.Fatalf("down failed: %v", err)
+	}
+}
+
+func validateSource(t *testing.T, out *CaptureNode, source *DataSource, expected []FullValue) {
+	t.Helper()
+	if got, want := len(out.Elements), len(expected); got != want {
+		t.Fatalf("lengths don't match: got %v, want %v", got, want)
+	}
+	if got, want := source.Progress().Count, int64(len(expected)); got != want {
+		t.Fatalf("progress count didn't match: got %v, want %v", got, want)
+	}
+	if !equalList(out.Elements, expected) {
+		t.Errorf("DataSource => %#v, want %#v", extractValues(out.Elements...), extractValues(expected...))
 	}
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/plan.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan.go
@@ -199,12 +199,14 @@ func (p *Plan) Metrics() *fnpb.Metrics {
 
 // SplitPoints captures the split requested by the Runner.
 type SplitPoints struct {
+	// Splits is a list of desired split indices.
 	Splits []int64
 	Frac   float32
 }
 
-// Split takes a set of potential split points, selects and actuates split on an
-// appropriate split point, and returns the selected split point if successful.
+// Split takes a set of potential split indexes, and if successful returns
+// the split index of the first element of the residual, on which processing
+// will be halted.
 // Returns an error when unable to split.
 func (p *Plan) Split(s SplitPoints) (int64, error) {
 	if p.source != nil {


### PR DESCRIPTION
Fix subtle Off By One error when splitting from a DataSource, likely caused by using an ambiguous count, rather than an index. This change renames the ambiguous variable and improves the comments around splitting to clarify that the returned split is the first element of the residual (and not the last element of the primary). 
The fix is starting the bundle's index from -1 to mark a "before processing has begun", and then incrementing normally from there, so that the first received element has a 0 index.

Also resolves the follow on ambiguity of the OutputElementCount when providing bundle progress. This value is the number of "completely processed elements", which tracks the index. eg. When processing index 0 (the first element), 0 elements have been completely processed. When processing index 5, 5 elements have been completely processed, and so on.
After a bundle is complete, in both the split and unsplit cases, an additional increment occurs, making the index accurately reflect the count at the end of a bundle. In the case of splitting, the increment func is how the bundle processing exits, while for unsplit cases, it's the ordinary EOF of the data which indicates no further elements exist.

Adds a battery of tests around splitting to help avoid this in the future, though there are no tests validating "during" processing at this time since those are inherently race condition inducing, and would require a better harness to check that.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
