### PR TITLE
[BEAM-7981] Fix double iterable stripping

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -582,7 +582,10 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   def default_type_hints(self):
     fn_type_hints = typehints.decorators.IOTypeHints.from_callable(self.process)
     if fn_type_hints is not None:
-      return fn_type_hints.strip_iterable()
+      try:
+        return fn_type_hints.strip_iterable()
+      except ValueError as e:
+        raise ValueError('Return value not iterable: %s: %s' % (self, e))
 
   # TODO(sourabhbajaj): Do we want to remove the responsibility of these from
   # the DoFn or maybe the runner
@@ -678,7 +681,7 @@ class CallableWrapperDoFn(DoFn):
     try:
       type_hints = type_hints.strip_iterable()
     except ValueError as e:
-      # TODO(BEAM-7981): Raise exception here if using stricter type checking.
+      # TODO(BEAM-8466): Raise exception here if using stricter type checking.
       logging.warning('%s: %s', self.display_data()['fn'].value, e)
     return type_hints
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -678,6 +678,7 @@ class CallableWrapperDoFn(DoFn):
     try:
       type_hints = type_hints.strip_iterable()
     except ValueError as e:
+      # TODO(BEAM-7981): Raise exception here if using stricter type checking.
       logging.warning('%s: %s', self.display_data()['fn'].value, e)
     return type_hints
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -582,11 +582,7 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   def default_type_hints(self):
     fn_type_hints = typehints.decorators.IOTypeHints.from_callable(self.process)
     if fn_type_hints is not None:
-      try:
-        fn_type_hints.strip_iterable()
-      except ValueError as e:
-        logging.warning('%s: %s', self.default_label(), e)
-    return fn_type_hints
+      return fn_type_hints.strip_iterable()
 
   # TODO(sourabhbajaj): Do we want to remove the responsibility of these from
   # the DoFn or maybe the runner
@@ -677,14 +673,10 @@ class CallableWrapperDoFn(DoFn):
   def default_type_hints(self):
     fn_type_hints = typehints.decorators.IOTypeHints.from_callable(self._fn)
     type_hints = get_type_hints(self._fn).with_defaults(fn_type_hints)
-    # Do not modify self._fn's type hints object. This method may be called more
-    # than once (such as once for input and once for output type checks) and
-    # strip_iterable modifies the object.
-    type_hints = type_hints.copy()
     # The fn's output type should be iterable. Strip off the outer
     # container type due to the 'flatten' portion of FlatMap/ParDo.
     try:
-      type_hints.strip_iterable()
+      type_hints = type_hints.strip_iterable()
     except ValueError as e:
       logging.warning('%s: %s', self.display_data()['fn'].value, e)
     return type_hints

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -585,7 +585,7 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
       try:
         fn_type_hints.strip_iterable()
       except ValueError as e:
-        raise ValueError('Return value not iterable: %s: %s' % (self, e))
+        logging.warning('%s: %s', self.default_label(), e)
     return fn_type_hints
 
   # TODO(sourabhbajaj): Do we want to remove the responsibility of these from
@@ -686,7 +686,7 @@ class CallableWrapperDoFn(DoFn):
     try:
       type_hints.strip_iterable()
     except ValueError as e:
-      raise ValueError('Return value not iterable: %s: %s' % (self._fn, e))
+      logging.warning('%s: %s', self.display_data()['fn'].value, e)
     return type_hints
 
   def infer_output_type(self, input_type):
@@ -1094,8 +1094,8 @@ class ParDo(PTransformWithSideInputs):
   Args:
     pcoll (~apache_beam.pvalue.PCollection):
       a :class:`~apache_beam.pvalue.PCollection` to be processed.
-    fn (DoFn): a :class:`DoFn` object to be applied to each element
-      of **pcoll** argument.
+    fn (`typing.Union[DoFn, typing.Callable]`): a :class:`DoFn` object to be
+      applied to each element of **pcoll** argument, or a Callable.
     *args: positional arguments passed to the :class:`DoFn` object.
     **kwargs:  keyword arguments passed to the :class:`DoFn` object.
 

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -294,16 +294,22 @@ class IOTypeHints(object):
     """Removes outer Iterable (or equivalent) from output type.
 
     Only affects instances with simple output types, otherwise is a no-op.
+    Does not modify self.
 
     Example: Generator[Tuple(int, int)] becomes Tuple(int, int)
+
+    Returns:
+      A possible copy of this instance with a possibly different output type.
 
     Raises:
       ValueError if output type is simple and not iterable.
     """
     if not self.has_simple_output_type():
-      return
+      return self
     yielded_type = typehints.get_yielded_type(self.output_types[0][0])
-    self.output_types = ((yielded_type,), {})
+    res = self.copy()
+    res.output_types = ((yielded_type,), {})
+    return res
 
   def copy(self):
     return IOTypeHints(self.input_types, self.output_types)

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -161,8 +161,9 @@ class AnnotationsTest(unittest.TestCase):
       def process(self, element: int) -> str:
         return str(element)
 
-    with self.assertRaisesRegex(ValueError, r'Return value not iterable'):
+    with self.assertLogs() as cm:
       _ = beam.ParDo(MyDoFn()).get_type_hints()
+    self.assertRegex(''.join(cm.output), r'MyDoFn.* not iterable')
 
   def test_pardo_wrapper(self):
     def do_fn(element: int) -> typehints.Iterable[str]:
@@ -186,8 +187,9 @@ class AnnotationsTest(unittest.TestCase):
     def do_fn(element: int) -> str:
       return str(element)
 
-    with self.assertRaisesRegex(ValueError, r'Return value not iterable'):
+    with self.assertLogs() as cm:
       _ = beam.ParDo(do_fn).get_type_hints()
+    self.assertRegex(''.join(cm.output), r'do_fn.* not iterable')
 
   def test_flat_map_wrapper(self):
     def map_fn(element: int) -> typehints.Iterable[int]:

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -107,9 +107,6 @@ class MainInputTest(unittest.TestCase):
 
     with self.assertRaisesRegex(ValueError, r'str.*is not iterable'):
       _ = [1, 2, 3] | beam.ParDo(MyDoFn())
-    # with self.assertLogs() as cm:
-    #   [1, 2, 3] | beam.ParDo(MyDoFn())
-    # self.assertRegexpMatches(''.join(cm.output), r'str.*is not iterable')
 
   def test_typed_callable_not_iterable(self):
     def do_fn(element: int) -> int:
@@ -165,9 +162,8 @@ class AnnotationsTest(unittest.TestCase):
       def process(self, element: int) -> str:
         return str(element)
 
-    with self.assertLogs() as cm:
+    with self.assertRaisesRegex(ValueError, r'str.*is not iterable'):
       _ = beam.ParDo(MyDoFn()).get_type_hints()
-    self.assertRegex(''.join(cm.output), r'MyDoFn.* not iterable')
 
   def test_pardo_wrapper(self):
     def do_fn(element: int) -> typehints.Iterable[str]:

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -112,8 +112,8 @@ class MainInputTest(unittest.TestCase):
     def do_fn(element: int) -> int:
       return [element]  # Return a list to not fail the pipeline.
     with self.assertLogs() as cm:
-      [1, 2, 3] | beam.ParDo(do_fn)
-    self.assertRegexpMatches(''.join(cm.output), r'int.*is not iterable')
+      _ = [1, 2, 3] | beam.ParDo(do_fn)
+    self.assertRegex(''.join(cm.output), r'int.*is not iterable')
 
   def test_typed_dofn_kwonly(self):
     class MyDoFn(beam.DoFn):

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -107,12 +107,16 @@ class MainInputTest(unittest.TestCase):
 
     with self.assertRaisesRegex(ValueError, r'str.*is not iterable'):
       _ = [1, 2, 3] | beam.ParDo(MyDoFn())
+    # with self.assertLogs() as cm:
+    #   [1, 2, 3] | beam.ParDo(MyDoFn())
+    # self.assertRegexpMatches(''.join(cm.output), r'str.*is not iterable')
 
   def test_typed_callable_not_iterable(self):
-    def do_fn(element: typehints.Tuple[int, int]) -> int:
-      return element[0]
-    with self.assertRaisesRegex(ValueError, r'int.*is not iterable'):
-      _ = [1, 2, 3] | beam.ParDo(do_fn)
+    def do_fn(element: int) -> int:
+      return [element]  # Return a list to not fail the pipeline.
+    with self.assertLogs() as cm:
+      [1, 2, 3] | beam.ParDo(do_fn)
+    self.assertRegexpMatches(''.join(cm.output), r'int.*is not iterable')
 
   def test_typed_dofn_kwonly(self):
     class MyDoFn(beam.DoFn):

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1171,7 +1171,8 @@ def is_consistent_with(sub, base):
 def get_yielded_type(type_hint):
   """Obtains the type of elements yielded by an iterable.
 
-  Note that "iterable" here means: can be iterated over in a for loop.
+  Note that "iterable" here means: can be iterated over in a for loop, excluding
+  strings.
 
   Args:
     type_hint: (TypeConstraint) The iterable in question. Must be normalize()-d.


### PR DESCRIPTION
... in CallableWrapperDoFn

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
