### PR TITLE
[BEAM-7926] Visualize PCollection

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
@@ -259,7 +259,7 @@ class PCollectionVisualization(object):
         # Makes such data structured.
         normalized_list.append({normalized_column: el})
       else:
-        normalized_list.append(_pv_jsons_load(_pv_jsons_dump(el)))
+        normalized_list.append(jsons.load(jsons.dump(el)))
     # Creates a dataframe that str() 1-d iterable elements after
     # normalization so that facets_overview can treat such data as categorical.
     return json_normalize(normalized_list).applymap(

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
@@ -117,7 +117,7 @@ def visualize(pcoll, dynamic_plotting_interval=None):
     # We don't want to do dynamic plotting if there is no notebook frontend.
     return None
 
-  if ie.current_env().is_in_notebook and dynamic_plotting_interval:
+  if dynamic_plotting_interval:
     # Disables the verbose logging from timeloop.
     logging.getLogger('timeloop').disabled = True
     tl = Timeloop()
@@ -183,7 +183,7 @@ class PCollectionVisualization(object):
     This function is used when the ipython kernel is not connected to a
     notebook frontend such as when running ipython in terminal or in unit tests.
     """
-    # Double check if the dependency is ready in case someone mistakenly use
+    # Double check if the dependency is ready in case someone mistakenly uses
     # the function.
     if _pcoll_visualization_ready:
       data = self._to_dataframe()

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
@@ -1,0 +1,282 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Module visualizes PCollection data.
+
+For internal use only; no backwards-compatibility guarantees.
+Only works with Python 3.5+.
+"""
+from __future__ import absolute_import
+
+import base64
+import logging
+from datetime import timedelta
+
+from pandas.io.json import json_normalize
+
+from apache_beam import pvalue
+from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive import pipeline_instrument as instr
+
+# jsons doesn't support < Python 3.5. Work around with json for legacy tests.
+# TODO(BEAM-8288): clean up once Py2 is deprecated from Beam.
+try:
+  import jsons
+  _pv_jsons_load = jsons.load
+  _pv_jsons_dump = jsons.dump
+except ImportError:
+  import json
+  _pv_jsons_load = json.load
+  _pv_jsons_dump = json.dump
+
+try:
+  from facets_overview.generic_feature_statistics_generator import GenericFeatureStatisticsGenerator
+  _facets_gfsg_ready = True
+except ImportError:
+  _facets_gfsg_ready = False
+
+try:
+  from IPython.core.display import HTML
+  from IPython.core.display import Javascript
+  from IPython.core.display import display
+  from IPython.core.display import display_javascript
+  from IPython.core.display import update_display
+  _ipython_ready = True
+except ImportError:
+  _ipython_ready = False
+
+try:
+  from timeloop import Timeloop
+  _tl_ready = True
+except ImportError:
+  _tl_ready = False
+
+# 1-d types that need additional normalization to be compatible with DataFrame.
+_one_dimension_types = (int, float, str, bool, list, tuple)
+
+_DIVE_SCRIPT_TEMPLATE = """
+            document.querySelector("#{display_id}").data = {jsonstr};"""
+_DIVE_HTML_TEMPLATE = """
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"></script>
+            <link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html">
+            <facets-dive sprite-image-width="{sprite_size}" sprite-image-height="{sprite_size}" id="{display_id}" height="600"></facets-dive>
+            <script>
+              document.querySelector("#{display_id}").data = {jsonstr};
+            </script>"""
+_OVERVIEW_SCRIPT_TEMPLATE = """
+              document.querySelector("#{display_id}").protoInput = "{protostr}";
+              """
+_OVERVIEW_HTML_TEMPLATE = """
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"></script>
+            <link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html">
+            <facets-overview id="{display_id}"></facets-overview>
+            <script>
+              document.querySelector("#{display_id}").protoInput = "{protostr}";
+            </script>"""
+_DATAFRAME_PAGINATION_TEMPLATE = """
+            <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script> 
+            <script src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script> 
+            <link rel="stylesheet" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
+            {dataframe_html}
+            <script>
+              $("#{table_id}").DataTable();
+            </script>"""
+
+
+def visualize(pcoll, dynamic_plotting_interval=None):
+  """Visualizes the data of a given PCollection. Optionally enables dynamic
+  plotting with interval in seconds if the PCollection is being produced by a
+  running pipeline or the pipeline is streaming indefinitely. The function
+  always returns immediately and is asynchronous when dynamic plotting is on.
+
+  If dynamic plotting enabled, the visualization is updated continuously until
+  the pipeline producing the PCollection is in an end state. The visualization
+  would be anchored to the notebook cell output area. The function
+  asynchronously returns a handle to the visualization job immediately. The user
+  could manually do::
+
+    # In one notebook cell, enable dynamic plotting every 1 second:
+    handle = visualize(pcoll, dynamic_plotting_interval=1)
+    # Visualization anchored to the cell's output area.
+    # In a different cell:
+    handle.stop()
+    # Will stop the dynamic plotting of the above visualization manually.
+    # Otherwise, dynamic plotting ends when pipeline is not running anymore.
+
+  If dynamic_plotting is not enabled (by default), None is returned.
+  """
+  if not _ipython_ready:
+    return None
+  pv = PCollectionVisualization(pcoll)
+  pv.display_facets()
+
+  if dynamic_plotting_interval and _tl_ready:
+    # Disables the verbose logging from timeloop.
+    logging.getLogger('timeloop').disabled = True
+    tl = Timeloop()
+
+    def dynamic_plotting(pcoll, pv, tl):
+      @tl.job(interval=timedelta(seconds=dynamic_plotting_interval))
+      def continuous_update_display():  # pylint: disable=unused-variable
+        # Always creates a new PCollVisualization instance when the
+        # PCollection materialization is being updated and dynamic
+        # plotting is in-process.
+        updated_pv = PCollectionVisualization(pcoll)
+        updated_pv.display_facets(updating_pv=pv)
+        if ie.current_env().is_terminated(pcoll.pipeline):
+          try:
+            tl.stop()
+          except RuntimeError:
+            # The job can only be stopped once. Ignore excessive stops.
+            pass
+
+      tl.start()
+      return tl
+
+    return dynamic_plotting(pcoll, pv, tl)
+  return None
+
+
+class PCollectionVisualization(object):
+  """A visualization of a PCollection.
+
+  The class relies on creating a PipelineInstrument w/o actual instrument to
+  access current interactive environment for materialized PCollection data at
+  the moment of self instantiation through cache.
+  """
+
+  def __init__(self, pcoll):
+    assert isinstance(pcoll, pvalue.PCollection), (
+        'pcoll should be apache_beam.pvalue.PCollection')
+    self._pcoll = pcoll
+    # This allows us to access cache key and other meta data about the pipeline
+    # whether it's the pipeline defined in user code or a copy of that pipeline.
+    # Thus, this module doesn't need any other user input but the PCollection
+    # variable to be visualized. It then automatically figures out the pipeline
+    # definition, materialized data and the pipeline result for the execution
+    # even if the user never assigned or waited the result explicitly.
+    # With only the constructor of PipelineInstrument, any interactivity related
+    # pre-process or instrument is not triggered for performance concerns.
+    self._pin = instr.PipelineInstrument(pcoll.pipeline)
+    self._cache_key = self._pin.cache_key(self._pcoll)
+    self._dive_display_id = 'facets_dive_{}_{}'.format(self._cache_key,
+                                                       id(self))
+    self._overview_display_id = 'facets_overview_{}_{}'.format(self._cache_key,
+                                                               id(self))
+    self._df_display_id = 'df_{}_{}'.format(self._cache_key, id(self))
+
+  def display_facets(self, updating_pv=None):
+    """Displays the visualization through IPython.
+
+    Args:
+      updating_pv: A PCollectionVisualization object. When provided, the
+        display_id of each visualization part will inherit from the initial
+        display of updating_pv and only update that visualization web element
+        instead of creating new ones.
+
+    The visualization has 3 parts: facets-dive, facets-overview and paginated
+    data table. Each part is assigned an auto-generated unique display id
+    (the uniqueness is guaranteed throughout the lifespan of the PCollection
+    variable).
+    """
+    # Ensures that dive, overview and table render the same data because the
+    # materialized PCollection data might being updated continuously.
+    data = self._to_dataframe()
+    if updating_pv:
+      self._display_dive(data, updating_pv._dive_display_id)
+      self._display_overview(data, updating_pv._overview_display_id)
+      self._display_dataframe(data, updating_pv._df_display_id)
+    else:
+      self._display_dive(data)
+      self._display_overview(data)
+      self._display_dataframe(data)
+
+  def _display_dive(self, data, update=None):
+    sprite_size = 32 if len(data.index) > 50000 else 64
+    jsonstr = data.to_json(orient='records')
+    if update:
+      script = _DIVE_SCRIPT_TEMPLATE.format(display_id=update,
+                                            jsonstr=jsonstr)
+      display_javascript(Javascript(script))
+    else:
+      html = _DIVE_HTML_TEMPLATE.format(display_id=self._dive_display_id,
+                                        jsonstr=jsonstr,
+                                        sprite_size=sprite_size)
+      display(HTML(html))
+
+  def _display_overview(self, data, update=None):
+    if _facets_gfsg_ready:
+      gfsg = GenericFeatureStatisticsGenerator()
+      proto = gfsg.ProtoFromDataFrames(
+          [{'name': 'data', 'table': data}])
+      protostr = base64.b64encode(proto.SerializeToString()).decode('utf-8')
+    else:  # GenericFeatureStatisticsGenerator is not supported.
+      protostr = ''
+    if update:
+      script = _OVERVIEW_SCRIPT_TEMPLATE.format(
+          display_id=update,
+          protostr=protostr)
+      display_javascript(Javascript(script))
+    else:
+      html = _OVERVIEW_HTML_TEMPLATE.format(
+          display_id=self._overview_display_id,
+          protostr=protostr)
+      display(HTML(html))
+
+  def _display_dataframe(self, data, update=None):
+    if update:
+      table_id = 'table_{}'.format(update)
+      html = _DATAFRAME_PAGINATION_TEMPLATE.format(
+          dataframe_html=data.to_html(notebook=True,
+                                      table_id=table_id),
+          table_id=table_id)
+      update_display(HTML(html), display_id=update)
+    else:
+      table_id = 'table_{}'.format(self._df_display_id)
+      html = _DATAFRAME_PAGINATION_TEMPLATE.format(
+          dataframe_html=data.to_html(notebook=True,
+                                      table_id=table_id),
+          table_id=table_id)
+      display(HTML(html), display_id=self._df_display_id)
+
+  def _to_element_list(self):
+    pcoll_list = []
+    if ie.current_env().cache_manager().exists('full', self._cache_key):
+      pcoll_list, _ = ie.current_env().cache_manager().read('full',
+                                                            self._cache_key)
+    return pcoll_list
+
+  def _to_dataframe(self):
+    normalized_list = []
+    # Column name for _one_dimension_types if presents.
+    normalized_column = str(self._pcoll)
+    # Normalization needs to be done for each element because they might be of
+    # different types. The check is only done on the root level, pandas json
+    # normalization I/O would take care of the nested levels.
+    for el in self._to_element_list():
+      if self._is_one_dimension_type(el):
+        # Makes such data structured.
+        normalized_list.append({normalized_column: el})
+      else:
+        normalized_list.append(_pv_jsons_load(_pv_jsons_dump(el)))
+    # Creates a dataframe that str() 1-d iterable elements after
+    # normalization so that facets_overview can treat such data as categorical.
+    return json_normalize(normalized_list).applymap(
+        lambda x: str(x) if type(x) in (list, tuple) else x)
+
+  def _is_one_dimension_type(self, val):
+    return type(val) in _one_dimension_types

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
@@ -27,7 +27,8 @@ from apache_beam.runners import runner
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive.display import pcoll_visualization as pv
 
-# Work around nose tests using Python2 without unittest.mock module.
+# TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
+# unittest.mock module.
 try:
   from unittest.mock import patch
 except ImportError:

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
@@ -1,0 +1,164 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for apache_beam.runners.interactive.display.pcoll_visualization."""
+from __future__ import absolute_import
+
+import sys
+import time
+import unittest
+
+import apache_beam as beam
+from apache_beam.runners import runner
+from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive.display import pcoll_visualization as pv
+
+# Work around nose tests using Python2 without unittest.mock module.
+try:
+  from unittest.mock import patch
+except ImportError:
+  from mock import patch
+
+try:
+  import IPython  # pylint: disable=unused-import
+  import jsons  # pylint: disable=unused-import
+  import timeloop
+  from facets_overview.generic_feature_statistics_generator import GenericFeatureStatisticsGenerator  # pylint: disable=unused-import
+  _interactive_installed = True
+except ImportError:
+  _interactive_installed = False
+
+
+@unittest.skipIf(not _interactive_installed,
+                 '[interactive] dependency is not installed.')
+class PCollectionVisualizationTest(unittest.TestCase):
+
+  def setUp(self):
+    self._p = beam.Pipeline()
+    # pylint: disable=range-builtin-not-iterating
+    self._pcoll = self._p | 'Create' >> beam.Create(range(1000))
+
+  @unittest.skipIf(sys.version_info < (3, 5, 3),
+                   'PCollectionVisualization is supported on Python 3.5.3+.')
+  def test_raise_error_for_non_pcoll_input(self):
+    class Foo(object):
+      pass
+
+    with self.assertRaises(AssertionError) as ctx:
+      pv.PCollectionVisualization(Foo())
+      self.assertTrue('pcoll should be apache_beam.pvalue.PCollection' in
+                      ctx.exception)
+
+  @unittest.skipIf(sys.version_info < (3, 5, 3),
+                   'PCollectionVisualization is supported on Python 3.5.3+.')
+  def test_pcoll_visualization_generate_unique_display_id(self):
+    pv_1 = pv.PCollectionVisualization(self._pcoll)
+    pv_2 = pv.PCollectionVisualization(self._pcoll)
+    self.assertNotEqual(pv_1._dive_display_id, pv_2._dive_display_id)
+    self.assertNotEqual(pv_1._overview_display_id, pv_2._overview_display_id)
+    self.assertNotEqual(pv_1._df_display_id, pv_2._df_display_id)
+
+  @unittest.skipIf(sys.version_info < (3, 5, 3),
+                   'PCollectionVisualization is supported on Python 3.5.3+.')
+  @patch('apache_beam.runners.interactive.display.pcoll_visualization'
+         '.PCollectionVisualization._to_element_list', lambda x: [1, 2, 3])
+  def test_one_shot_visualization_not_return_handle(self):
+    self.assertIsNone(pv.visualize(self._pcoll))
+
+  def _mock_to_element_list(self):
+    yield [1, 2, 3]
+    yield [1, 2, 3, 4]
+    yield [1, 2, 3, 4, 5]
+    yield [1, 2, 3, 4, 5, 6]
+    yield [1, 2, 3, 4, 5, 6, 7]
+    yield [1, 2, 3, 4, 5, 6, 7, 8]
+
+  @unittest.skipIf(sys.version_info < (3, 5, 3),
+                   'PCollectionVisualization is supported on Python 3.5.3+.')
+  @patch('apache_beam.runners.interactive.display.pcoll_visualization'
+         '.PCollectionVisualization._to_element_list', _mock_to_element_list)
+  def test_dynamic_plotting_return_handle(self):
+    h = pv.visualize(self._pcoll, dynamic_plotting_interval=1)
+    self.assertIsInstance(h, timeloop.Timeloop)
+    h.stop()
+
+  @unittest.skipIf(sys.version_info < (3, 5, 3),
+                   'PCollectionVisualization is supported on Python 3.5.3+.')
+  @patch('apache_beam.runners.interactive.display.pcoll_visualization'
+         '.PCollectionVisualization._to_element_list', _mock_to_element_list)
+  @patch('apache_beam.runners.interactive.display.pcoll_visualization'
+         '.PCollectionVisualization.display_facets')
+  def test_dynamic_plotting_update_same_display(self,
+                                                mocked_display_facets):
+    fake_pipeline_result = runner.PipelineResult(runner.PipelineState.RUNNING)
+    ie.current_env().set_pipeline_result(self._p, fake_pipeline_result)
+    # Starts async dynamic plotting that never ends in this test.
+    h = pv.visualize(self._pcoll, dynamic_plotting_interval=0.001)
+    # Blocking so the above async task can execute at least 3 iterations.
+    timeout = time.time() + 1
+    while len(mocked_display_facets.call_args_list) < 3:
+      if time.time() > timeout:
+        break
+    # The first iteration doesn't provide updating_pv to display_facets.
+    _, first_kwargs = mocked_display_facets.call_args_list[0]
+    self.assertEqual(first_kwargs, {})
+    # The following iterations use the same updating_pv to display_facets and so
+    # on.
+    _, second_kwargs = mocked_display_facets.call_args_list[1]
+    updating_pv = second_kwargs['updating_pv']
+    for call in mocked_display_facets.call_args_list[2:]:
+      _, kwargs = call
+      self.assertIs(kwargs['updating_pv'], updating_pv)
+    h.stop()
+
+  # The code being tested supports 3.5.3+. This specific test has assertion
+  # feature that was introduced in 3.6.
+  @unittest.skipIf(sys.version_info < (3, 6),
+                   'The test requires Python 3.6+.')
+  @patch('apache_beam.runners.interactive.display.pcoll_visualization'
+         '.PCollectionVisualization._to_element_list', _mock_to_element_list)
+  @patch('apache_beam.runners.interactive.display.pcoll_visualization'
+         '.PCollectionVisualization.display_facets')
+  @patch('timeloop.Timeloop.stop')
+  def test_auto_stop_dynamic_plotting_when_job_is_terminated(
+      self,
+      mocked_timeloop,
+      mocked_display_facets):
+    fake_pipeline_result = runner.PipelineResult(runner.PipelineState.RUNNING)
+    ie.current_env().set_pipeline_result(self._p, fake_pipeline_result)
+    # Starts non-stopping async dynamic plotting until the job is terminated.
+    pv.visualize(self._pcoll, dynamic_plotting_interval=0.001)
+    # Blocking so the above async task can execute at least 3 iterations.
+    timeout = time.time() + 1
+    while len(mocked_display_facets.call_args_list) < 3:
+      if time.time() > timeout:
+        break
+    mocked_timeloop.assert_not_called()
+    fake_pipeline_result = runner.PipelineResult(runner.PipelineState.DONE)
+    ie.current_env().set_pipeline_result(self._p, fake_pipeline_result)
+    # Blocking so the above async task can execute at least another 3
+    # iterations.
+    timeout = time.time() + 1
+    while len(mocked_display_facets.call_args_list) < 6:
+      if time.time() > timeout:
+        break
+    # "assert_called" is new in Python 3.6.
+    mocked_timeloop.assert_called()
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
@@ -35,17 +35,12 @@ except ImportError:
   from mock import patch
 
 try:
-  import IPython  # pylint: disable=unused-import
-  import jsons  # pylint: disable=unused-import
   import timeloop
-  from facets_overview.generic_feature_statistics_generator import GenericFeatureStatisticsGenerator  # pylint: disable=unused-import
-
-  _interactive_installed = True
 except ImportError:
-  _interactive_installed = False
+  pass
 
 
-@unittest.skipIf(not _interactive_installed,
+@unittest.skipIf(not ie.current_env().is_interactive_ready,
                  '[interactive] dependency is not installed.')
 class PCollectionVisualizationTest(unittest.TestCase):
 

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -107,8 +107,8 @@ class InteractiveEnvironment(object):
     if not self._is_in_ipython:
       logging.warning('You cannot use Interactive Beam features when you are '
                       'not in an interactive environment such as a Jupyter '
-                      'notebook.')
-    if not self._is_in_notebook:
+                      'notebook or ipython terminal.')
+    if self._is_in_ipython and not self._is_in_notebook:
       logging.warning('You have limited Interactive Beam features since your '
                       'ipython kernel is not connected any notebook frontend.')
 

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -25,6 +25,11 @@ application code or notebook.
 from __future__ import absolute_import
 
 import importlib
+import logging
+import sys
+
+import apache_beam as beam
+from apache_beam.runners import runner
 
 _interactive_beam_env = None
 
@@ -61,8 +66,37 @@ class InteractiveEnvironment(object):
     self._watching_set = set()
     # Holds variables list of (Dict[str, object]).
     self._watching_dict_list = []
+    # Holds results of pipeline runs as Dict[Pipeline, PipelineResult].
+    # Each key is a pipeline instance defined by the end user. The
+    # InteractiveRunner is responsible for populating this dictionary
+    # implicitly.
+    self._pipeline_results = {}
     # Always watch __main__ module.
     self.watch('__main__')
+    # Do a warning level logging if current python version is below 3.5.3.
+    if sys.version_info < (3, 5, 3):
+      logging.warning('Interactive Beam requires Python 3.5.3+.')
+    # Check if [interactive] dependencies are installed.
+    try:
+      import IPython  # pylint: disable=unused-import
+      import jsons  # pylint: disable=unused-import
+      import timeloop  # pylint: disable=unused-import
+      from facets_overview.generic_feature_statistics_generator import GenericFeatureStatisticsGenerator  # pylint: disable=unused-import
+    except ImportError:
+      logging.warning('Dependencies required for Interactive Beam PCollection '
+                      'visualization are not available, please use: `pip '
+                      'install apache-beam[interactive]` to install necessary '
+                      'dependencies to enable all data visualization features.')
+
+    # Check if the runtime is within an interactive environment, i.e., ipython.
+    try:
+      from IPython import get_ipython  # pylint: disable=import-error
+      if not get_ipython():
+        logging.warning('You cannot use Interactive Beam features when you are '
+                        'not in an interactive environment such as a Jupyter '
+                        'notebook.')
+    except ImportError:
+      pass
 
   def watch(self, watchable):
     """Watches a watchable.
@@ -105,3 +139,28 @@ class InteractiveEnvironment(object):
   def cache_manager(self):
     """Gets the cache manager held by current Interactive Environment."""
     return self._cache_manager
+
+  def set_pipeline_result(self, pipeline, result):
+    """Sets the pipeline run result. Adds one if absent. Otherwise, replace."""
+    assert issubclass(type(pipeline), beam.Pipeline), (
+        'pipeline must be an instance of apache_beam.Pipeline or its subclass')
+    assert issubclass(type(result), runner.PipelineResult), (
+        'result must be an instance of '
+        'apache_beam.runners.runner.PipelineResult or its subclass')
+    self._pipeline_results[pipeline] = result
+
+  def evict_pipeline_result(self, pipeline):
+    """Evicts the tracking of given pipeline run. Noop if absent."""
+    return self._pipeline_results.pop(pipeline, None)
+
+  def pipeline_result(self, pipeline):
+    """Gets the pipeline run result. None if absent."""
+    return self._pipeline_results.get(pipeline, None)
+
+  def is_terminated(self, pipeline):
+    """Queries if the most recent job (by executing the given pipeline) state
+    is in a terminal state. True if absent."""
+    result = self.pipeline_result(pipeline)
+    if result:
+      return runner.PipelineState.is_terminal(result.state)
+    return True

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -94,17 +94,23 @@ class InteractiveEnvironment(object):
                       'dependencies to enable all data visualization features.')
 
     self._is_in_ipython = False
+    self._is_in_notebook = False
     # Check if the runtime is within an interactive environment, i.e., ipython.
     try:
       from IPython import get_ipython  # pylint: disable=import-error
       if get_ipython():
         self._is_in_ipython = True
-      else:
-        logging.warning('You cannot use Interactive Beam features when you are '
-                        'not in an interactive environment such as a Jupyter '
-                        'notebook.')
+        if 'IPKernelApp' in get_ipython().config:
+          self._is_in_notebook = True
     except ImportError:
       pass
+    if not self._is_in_ipython:
+      logging.warning('You cannot use Interactive Beam features when you are '
+                      'not in an interactive environment such as a Jupyter '
+                      'notebook.')
+    if not self._is_in_notebook:
+      logging.warning('You have limited Interactive Beam features since your '
+                      'ipython kernel is not connected any notebook frontend.')
 
   @property
   def is_py_version_ready(self):
@@ -120,6 +126,15 @@ class InteractiveEnvironment(object):
   def is_in_ipython(self):
     """If the runtime is within an IPython kernel."""
     return self._is_in_ipython
+
+  @property
+  def is_in_notebook(self):
+    """If the kernel is connected to a notebook frontend.
+
+    If not, it could be that the user is using kernel in a terminal or a unit
+    test.
+    """
+    return self._is_in_notebook
 
   def watch(self, watchable):
     """Watches a watchable.

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -75,28 +75,51 @@ class InteractiveEnvironment(object):
     self.watch('__main__')
     # Do a warning level logging if current python version is below 3.5.3.
     if sys.version_info < (3, 5, 3):
+      self._is_py_version_ready = False
       logging.warning('Interactive Beam requires Python 3.5.3+.')
+    else:
+      self._is_py_version_ready = True
     # Check if [interactive] dependencies are installed.
     try:
       import IPython  # pylint: disable=unused-import
       import jsons  # pylint: disable=unused-import
       import timeloop  # pylint: disable=unused-import
       from facets_overview.generic_feature_statistics_generator import GenericFeatureStatisticsGenerator  # pylint: disable=unused-import
+      self._is_interactive_ready = True
     except ImportError:
+      self._is_interactive_ready = False
       logging.warning('Dependencies required for Interactive Beam PCollection '
                       'visualization are not available, please use: `pip '
                       'install apache-beam[interactive]` to install necessary '
                       'dependencies to enable all data visualization features.')
 
+    self._is_in_ipython = False
     # Check if the runtime is within an interactive environment, i.e., ipython.
     try:
       from IPython import get_ipython  # pylint: disable=import-error
-      if not get_ipython():
+      if get_ipython():
+        self._is_in_ipython = True
+      else:
         logging.warning('You cannot use Interactive Beam features when you are '
                         'not in an interactive environment such as a Jupyter '
                         'notebook.')
     except ImportError:
       pass
+
+  @property
+  def is_py_version_ready(self):
+    """If Python version is above the minimum requirement."""
+    return self._is_py_version_ready
+
+  @property
+  def is_interactive_ready(self):
+    """If the [interactive] dependencies are installed."""
+    return self._is_interactive_ready
+
+  @property
+  def is_in_ipython(self):
+    """If the runtime is within an IPython kernel."""
+    return self._is_in_ipython
 
   def watch(self, watchable):
     """Watches a watchable.

--- a/sdks/python/apache_beam/runners/runner.py
+++ b/sdks/python/apache_beam/runners/runner.py
@@ -35,6 +35,7 @@ _ALL_KNOWN_RUNNERS = (
     'apache_beam.runners.direct.direct_runner.BundleBasedDirectRunner',
     'apache_beam.runners.direct.direct_runner.DirectRunner',
     'apache_beam.runners.direct.direct_runner.SwitchingDirectRunner',
+    'apache_beam.runners.interactive.interactive_runner.InteractiveRunner',
     'apache_beam.runners.portability.flink_runner.FlinkRunner',
     'apache_beam.runners.portability.portable_runner.PortableRunner',
     'apache_beam.runners.test.TestDirectRunner',
@@ -84,6 +85,10 @@ def create_runner(runner_name):
         raise ImportError(
             'Google Cloud Dataflow runner not available, '
             'please install apache_beam[gcp]')
+      elif 'interactive' in runner_name.lower():
+        raise ImportError(
+            'Interactive runner not available, '
+            'please install apache_beam[interactive]')
       else:
         raise
   else:

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -155,8 +155,6 @@ GCP_REQUIREMENTS = [
     'cachetools>=3.1.0,<4',
     'google-apitools>=0.5.28,<0.5.29',
     # [BEAM-4543] googledatastore is not supported in Python 3.
-    'proto-google-cloud-datastore-v1>=0.90.0,<=0.90.4; python_version < "3.0"',
-    # [BEAM-4543] googledatastore is not supported in Python 3.
     'googledatastore>=7.0.1,<7.1; python_version < "3.0"',
     'google-cloud-datastore>=1.7.1,<1.8.0',
     'google-cloud-pubsub>=0.39.0,<1.1.0',
@@ -164,8 +162,17 @@ GCP_REQUIREMENTS = [
     'google-cloud-bigquery>=1.6.0,<1.18.0',
     'google-cloud-core>=0.28.1,<2',
     'google-cloud-bigtable>=0.31.1,<1.1.0',
+    # [BEAM-4543] googledatastore is not supported in Python 3.
+    'proto-google-cloud-datastore-v1>=0.90.0,<=0.90.4; python_version < "3.0"',
 ]
 
+INTERACTIVE_BEAM = [
+    'facets-overview>=1.0.0,<2',
+    'ipython>=5.8.0,<6',
+    # jsons is supported by Python 3.5.3+.
+    'jsons>=1.0.0,<2; python_version >= "3.5.3"',
+    'timeloop>=1.0.2,<2',
+]
 
 # We must generate protos after setup_requires are installed.
 def generate_protos_first(original_cmd):
@@ -224,6 +231,7 @@ setuptools.setup(
         'docs': ['Sphinx>=1.5.2,<2.0'],
         'test': REQUIRED_TEST_PACKAGES,
         'gcp': GCP_REQUIREMENTS,
+        'interactive': INTERACTIVE_BEAM,
     },
     zip_safe=False,
     # PyPI package information.

--- a/sdks/python/test-suites/tox/py36/build.gradle
+++ b/sdks/python/test-suites/tox/py36/build.gradle
@@ -35,9 +35,6 @@ test.dependsOn testPy36Gcp
 toxTask "testPy36Cython", "py36-cython"
 test.dependsOn testPy36Cython
 
-toxTask "testPy36Interactive", "py36-interactive"
-test.dependsOn testPy36Interactive
-
 // Ensure that testPy36Cython runs exclusively to other tests. This line is not
 // actually required, since gradle doesn't do parallel execution within a
 // project.
@@ -47,5 +44,4 @@ task preCommitPy36() {
     dependsOn "testPython36"
     dependsOn "testPy36Gcp"
     dependsOn "testPy36Cython"
-    dependsOn "testPy36Interactive"
 }

--- a/sdks/python/test-suites/tox/py36/build.gradle
+++ b/sdks/python/test-suites/tox/py36/build.gradle
@@ -34,6 +34,10 @@ test.dependsOn testPy36Gcp
 
 toxTask "testPy36Cython", "py36-cython"
 test.dependsOn testPy36Cython
+
+toxTask "testPy36Interactive", "py36-interactive"
+test.dependsOn testPy36Interactive
+
 // Ensure that testPy36Cython runs exclusively to other tests. This line is not
 // actually required, since gradle doesn't do parallel execution within a
 // project.
@@ -43,4 +47,5 @@ task preCommitPy36() {
     dependsOn "testPython36"
     dependsOn "testPy36Gcp"
     dependsOn "testPy36Cython"
+    dependsOn "testPy36Interactive"
 }

--- a/sdks/python/test-suites/tox/py37/build.gradle
+++ b/sdks/python/test-suites/tox/py37/build.gradle
@@ -40,6 +40,10 @@ test.dependsOn testPy37Gcp
 
 toxTask "testPy37Cython", "py37-cython"
 test.dependsOn testPy37Cython
+
+toxTask "testPy37Interactive", "py37-interactive"
+test.dependsOn testPy37Interactive
+
 // Ensure that testPy37Cython runs exclusively to other tests. This line is not
 // actually required, since gradle doesn't do parallel execution within a
 // project.
@@ -49,4 +53,5 @@ task preCommitPy37() {
     dependsOn "testPython37"
     dependsOn "testPy37Gcp"
     dependsOn "testPy37Cython"
+    dependsOn "testPy37Interactive"
 }

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -210,11 +210,15 @@ commands =
   coverage xml
 
 [testenv:py36-interactive]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
 extras = test,interactive
 commands =
-  python setup.py nosetests --where 'apache_beam/runners/interactive' {posargs}
+  python setup.py nosetests --ignore-files '.*py3[7-9]\.py$' {posargs}
 
 [testenv:py37-interactive]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
 extras = test,interactive
 commands =
-  python setup.py nosetests --where 'apache_beam/runners/interactive' {posargs}
+  python setup.py nosetests --ignore-files '.*py3[8-9]\.py$' {posargs}

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -209,13 +209,6 @@ commands =
   # Generate report in xml format
   coverage xml
 
-[testenv:py36-interactive]
-setenv =
-  RUN_SKIPPED_PY3_TESTS=0
-extras = test,interactive
-commands =
-  python setup.py nosetests --ignore-files '.*py3[7-9]\.py$' {posargs}
-
 [testenv:py37-interactive]
 setenv =
   RUN_SKIPPED_PY3_TESTS=0

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -189,7 +189,7 @@ commands =
   time {toxinidir}/scripts/run_pylint.sh
 
 [testenv:docs]
-extras = test,gcp,docs
+extras = test,gcp,docs,interactive
 deps =
   Sphinx==1.6.5
   sphinx_rtd_theme==0.2.4
@@ -208,3 +208,13 @@ commands =
   coverage report --skip-covered
   # Generate report in xml format
   coverage xml
+
+[testenv:py36-interactive]
+extras = test,interactive
+commands =
+  python setup.py nosetests --where 'apache_beam/runners/interactive' {posargs}
+
+[testenv:py37-interactive]
+extras = test,interactive
+commands =
+  python setup.py nosetests --where 'apache_beam/runners/interactive' {posargs}


### PR DESCRIPTION
1. Added pcoll_visualization module to visualize materialized
PCollection data.
2. A visualization mainly consists of 3 parts: facets-dive,
facets-overview and data-table.
3. The visualization is always non-blocking w/ 2 modes: one-shot and
dynamic plotting.
4. One-shot visualization renders the visualization as HTML statically.
5. Dynamical plotting polls materialized data, initializes a
visualization and then updates the visualization continuously.
6. It's the pipeline state, i.e., whether the PCollection
materialization is being updated that decides if the visualization is
dynamic plotting or one-shot. It's not the boundedness of PCollection
that decides the visualization mode. However, when engineering for
Interactive Beam, it's alright to always use the dynamic plotting
mode as long as the InteractiveRunner(s) manages jobs and tracks the
pipeline(job) results correctly. Failing to terminate a visualization
job might cause resource leak.
7. The materialized PCollection data goes through the following process
flow: cache -> element list -> normalization -> dataframe ->
HTMLs/scripts.
8. A visualization is always self-contained. Meaning it controls when
the visualization starts and ends by itself. Once visualized, the
visualization is anchored within the notebook cell's output area. Code
in other cells can affect the visualization in the cell but will not
change the existing visualization's position in the notebook. Multiple
visualize(pcoll) calls will render multiple independent distinct
visualization instances/jobs. Each visualization runs in its own thread
outside of the notebook main thread.
9. Unittest added focusing on the above visualization logic other than
the visualization UI (those should belong to Facets, pandas and jQuery,
we'll trust them work as intended). Integration tests can be added
later.
10. Each visualization job regularly queries interactive environment for
running pipeline(job) results implicitly to determine the default
visualization end condition. It's based on the limitation that within
current interactive environment, at a time, at most one job is in
non-terminated state for an end user defined pipeline instance (in
whatever state). The end user could also use the handle returned by
visualize() to stop() the visualization job manually.
11. Added INTERACTIVE_BEAM extras_require and tests_require in setup.
They are only needed for data visualization in notebook. `jsons` is for
easy serialization of any object and `timeloop` is for self-contained
periodic async tasks. They both use MIT licenses. `facets-overview` is
for overview part of facets. It uses apache 2.0 license. `ipython` is the
kernel used by jupyter, included for non-jupyter environment though it
always comes with jupyter. It uses BSD license. The lower version limit
set is the highest version listed by flink.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
