### PR TITLE
[BEAM-8183] restructure Flink portable jars to support multiple pipel…

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/PortablePipelineJarUtils.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/PortablePipelineJarUtils.java
@@ -17,10 +17,15 @@
  */
 package org.apache.beam.runners.fnexecution.jobsubmission;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator.Feature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Pipeline;
 import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.Message.Builder;
 import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.Struct;
@@ -41,30 +46,40 @@ import org.slf4j.LoggerFactory;
  *       </ul>
  *   <li>BEAM-PIPELINE/
  *       <ul>
- *         <li>pipeline.json
- *         <li>pipeline-options.json
- *       </ul>
- *   <li>BEAM-ARTIFACT-STAGING/
- *       <ul>
- *         <li>artifact-manifest.json
- *         <li>artifacts/
+ *         <li>pipeline-manifest.json
+ *         <li>[1st pipeline (default)]
  *             <ul>
- *               <li>...artifact files...
+ *               <li>pipeline.json
+ *               <li>pipeline-options.json
+ *               <li>artifact-manifest.json
+ *               <li>artifacts/
+ *                   <ul>
+ *                     <li>...artifact files...
+ *                   </ul>
  *             </ul>
- *       </ul>
+ *         <li>[nth pipeline]
+ *             <ul>
+ *               Same as above
+ *         </ul>
+ *   </ul>
  *   <li>...Java classes...
  * </ul>
  */
 public abstract class PortablePipelineJarUtils {
-  private static final String ARTIFACT_STAGING_FOLDER_PATH = "BEAM-ARTIFACT-STAGING";
-  static final String ARTIFACT_FOLDER_PATH = ARTIFACT_STAGING_FOLDER_PATH + "/artifacts";
-  private static final String PIPELINE_FOLDER_PATH = "BEAM-PIPELINE";
-  public static final String ARTIFACT_MANIFEST_PATH =
-      ARTIFACT_STAGING_FOLDER_PATH + "/artifact-manifest.json";
-  static final String PIPELINE_PATH = PIPELINE_FOLDER_PATH + "/pipeline.json";
-  static final String PIPELINE_OPTIONS_PATH = PIPELINE_FOLDER_PATH + "/pipeline-options.json";
+  private static final String ARTIFACT_FOLDER = "artifacts";
+  private static final String PIPELINE_FOLDER = "BEAM-PIPELINE";
+  private static final String ARTIFACT_MANIFEST = "artifact-manifest.json";
+  private static final String PIPELINE = "pipeline.json";
+  private static final String PIPELINE_OPTIONS = "pipeline-options.json";
+  private static final String PIPELINE_MANIFEST = PIPELINE_FOLDER + "/pipeline-manifest.json";
 
-  private static final Logger LOG = LoggerFactory.getLogger(PortablePipelineJarCreator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(PortablePipelineJarUtils.class);
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper(new JsonFactory().configure(Feature.AUTO_CLOSE_TARGET, false));
+
+  private static class PipelineManifest {
+    public String defaultJobName;
+  }
 
   private static InputStream getResourceFromClassPath(String resourcePath) throws IOException {
     InputStream inputStream =
@@ -84,15 +99,47 @@ public abstract class PortablePipelineJarUtils {
     }
   }
 
-  public static Pipeline getPipelineFromClasspath() throws IOException {
+  public static Pipeline getPipelineFromClasspath(String jobName) throws IOException {
     Pipeline.Builder builder = Pipeline.newBuilder();
-    parseJsonResource(PIPELINE_PATH, builder);
+    parseJsonResource(getPipelineUri(jobName), builder);
     return builder.build();
   }
 
-  public static Struct getPipelineOptionsFromClasspath() throws IOException {
+  public static Struct getPipelineOptionsFromClasspath(String jobName) throws IOException {
     Struct.Builder builder = Struct.newBuilder();
-    parseJsonResource(PIPELINE_OPTIONS_PATH, builder);
+    parseJsonResource(getPipelineOptionsUri(jobName), builder);
     return builder.build();
+  }
+
+  public static String getArtifactManifestUri(String jobName) {
+    return PIPELINE_FOLDER + "/" + jobName + "/" + ARTIFACT_MANIFEST;
+  }
+
+  static String getPipelineUri(String jobName) {
+    return PIPELINE_FOLDER + "/" + jobName + "/" + PIPELINE;
+  }
+
+  static String getPipelineOptionsUri(String jobName) {
+    return PIPELINE_FOLDER + "/" + jobName + "/" + PIPELINE_OPTIONS;
+  }
+
+  static String getArtifactUri(String jobName, String artifactId) {
+    return PIPELINE_FOLDER + "/" + jobName + "/" + ARTIFACT_FOLDER + "/" + artifactId;
+  }
+
+  public static String getDefaultJobName() throws IOException {
+    try (InputStream inputStream = getResourceFromClassPath(PIPELINE_MANIFEST)) {
+      PipelineManifest pipelineManifest =
+          OBJECT_MAPPER.readValue(inputStream, PipelineManifest.class);
+      return pipelineManifest.defaultJobName;
+    }
+  }
+
+  public static void writeDefaultJobName(JarOutputStream outputStream, String jobName)
+      throws IOException {
+    outputStream.putNextEntry(new JarEntry(PIPELINE_MANIFEST));
+    PipelineManifest pipelineManifest = new PipelineManifest();
+    pipelineManifest.defaultJobName = jobName;
+    OBJECT_MAPPER.writeValue(outputStream, pipelineManifest);
   }
 }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/jobsubmission/PortablePipelineJarCreatorTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/jobsubmission/PortablePipelineJarCreatorTest.java
@@ -111,7 +111,7 @@ public class PortablePipelineJarCreatorTest implements Serializable {
         .thenReturn(GetManifestResponse.newBuilder().setManifest(manifest).build());
 
     ProxyManifest proxyManifest =
-        jarCreator.copyStagedArtifacts("retrievalToken", retrievalServiceStub);
+        jarCreator.copyStagedArtifacts("retrievalToken", retrievalServiceStub, "job");
 
     assertEquals(manifest, proxyManifest.getManifest());
     List<String> outputArtifactNames =
@@ -131,7 +131,7 @@ public class PortablePipelineJarCreatorTest implements Serializable {
     when(retrievalServiceStub.getManifest(any()))
         .thenReturn(GetManifestResponse.newBuilder().setManifest(manifest).build());
 
-    jarCreator.copyStagedArtifacts("retrievalToken", retrievalServiceStub);
+    jarCreator.copyStagedArtifacts("retrievalToken", retrievalServiceStub, "job");
 
     verify(outputStream, times(2)).putNextEntry(any());
   }
@@ -144,7 +144,7 @@ public class PortablePipelineJarCreatorTest implements Serializable {
 
   @Test
   public void testCreateManifest_withMainMethod() {
-    Manifest manifest = jarCreator.createManifest(FakePipelineRunnner.class);
+    Manifest manifest = jarCreator.createManifest(FakePipelineRunnner.class, "job");
     assertEquals(
         FakePipelineRunnner.class.getName(),
         manifest.getMainAttributes().getValue(Name.MAIN_CLASS));
@@ -154,7 +154,7 @@ public class PortablePipelineJarCreatorTest implements Serializable {
 
   @Test
   public void testCreateManifest_withoutMainMethod() {
-    Manifest manifest = jarCreator.createManifest(EmptyPipelineRunner.class);
+    Manifest manifest = jarCreator.createManifest(EmptyPipelineRunner.class, "job");
     assertNull(manifest.getMainAttributes().getValue(Name.MAIN_CLASS));
   }
 
@@ -166,7 +166,7 @@ public class PortablePipelineJarCreatorTest implements Serializable {
 
   @Test
   public void testCreateManifest_withInvalidMainMethod() {
-    Manifest manifest = jarCreator.createManifest(EvilPipelineRunner.class);
+    Manifest manifest = jarCreator.createManifest(EvilPipelineRunner.class, "job");
     assertNull(manifest.getMainAttributes().getValue(Name.MAIN_CLASS));
   }
 }


### PR DESCRIPTION
…ines

R: @angoenka @tweise 

This is basically just a restructuring of the Flink portable jars to enable them to include and toggle between different pipelines. Specifically, this PR changes only the _structure_ and _execution_ of portable jars. This PR does not change the existing behavior and *does not implement a way to actually create portable jars with multiple pipelines*, although it would be fairly straightforward to roll such a jar oneself from existing single-pipeline jars.

Each pipeline lives in the jar under a subdirectory of `BEAM-PIPELINE`, and different subdirectories can be chosen using the new `--base-job-name` flag at runtime.

I included this in the Javadoc, but here it is formatted:
<p>Jar layout:
<ul>
  <li>META-INF/
      <ul>
        <li>MANIFEST.MF
      </ul>
  <li>BEAM-PIPELINE/
      <ul>
        <li>[1st pipeline (default)]
            <ul>
              <li>pipeline.json
              <li>pipeline-options.json
              <li>artifact-manifest.json
              <li>artifacts/
                  <ul>
                    <li>...artifact files...
                  </ul>
            </ul>
        <li>[nth pipeline]
            <ul>
              Same as above
        </ul>
  </ul>
  <li>...Java classes...
</ul>

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
