### PR TITLE
[BEAM-3713] Add pytest for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ sdks/python/README.md
 sdks/python/apache_beam/portability/api/*pb2*.*
 sdks/python/apache_beam/portability/api/*.yaml
 sdks/python/nosetests*.xml
+sdks/python/pytest*.xml
 sdks/python/postcommit_requirements.txt
 
 # Ignore IntelliJ files.

--- a/.test-infra/jenkins/PrecommitJobBuilder.groovy
+++ b/.test-infra/jenkins/PrecommitJobBuilder.groovy
@@ -38,6 +38,9 @@ class PrecommitJobBuilder {
   /** If defined, set of path expressions used to trigger the job on commit. */
   List<String> triggerPathPatterns = []
 
+  /** Whether to trigger on new PR commits. Useful to set to false when testing new jobs. */
+  boolean commitTriggering = true
+
   /**
    * Define a set of pre-commit jobs.
    *
@@ -45,7 +48,9 @@ class PrecommitJobBuilder {
    */
   void build(Closure additionalCustomization = {}) {
     defineCronJob additionalCustomization
-    defineCommitJob additionalCustomization
+    if (commitTriggering) {
+      defineCommitJob additionalCustomization
+    }
     definePhraseJob additionalCustomization
   }
 

--- a/.test-infra/jenkins/job_PreCommit_Python.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Python.groovy
@@ -35,3 +35,18 @@ builder.build {
     archiveJunit('**/nosetests*.xml')
   }
 }
+
+// Temporary job for testing pytest-based testing.
+// TODO(BEAM-3713): Remove this job once nose tests are replaced.
+PrecommitJobBuilder builder = new PrecommitJobBuilder(
+    scope: this,
+    nameBase: 'Python_pytest',
+    gradleTask: ':pythonPreCommitPytest',
+    commitTriggering: false,
+)
+builder.build {
+  // Publish all test results to Jenkins.
+  publishers {
+    archiveJunit('**/pytest*.xml')
+  }
+}

--- a/.test-infra/jenkins/job_PreCommit_Python.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Python.groovy
@@ -38,13 +38,13 @@ builder.build {
 
 // Temporary job for testing pytest-based testing.
 // TODO(BEAM-3713): Remove this job once nose tests are replaced.
-PrecommitJobBuilder builder = new PrecommitJobBuilder(
+PrecommitJobBuilder builderPytest = new PrecommitJobBuilder(
     scope: this,
     nameBase: 'Python_pytest',
     gradleTask: ':pythonPreCommitPytest',
     commitTriggering: false,
 )
-builder.build {
+builderPytest.build {
   // Publish all test results to Jenkins.
   publishers {
     archiveJunit('**/pytest*.xml')

--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,14 @@ task pythonPreCommit() {
   // have caught. Note that the same tests will still run in postcommit.
 }
 
+// TODO(BEAM-3713): Temporary task for testing pytest.
+task pythonPreCommitPytest() {
+  dependsOn ":sdks:python:test-suites:tox:py2:preCommitPy2Pytest"
+  dependsOn ":sdks:python:test-suites:tox:py35:preCommitPy35Pytest"
+  dependsOn ":sdks:python:test-suites:tox:py36:preCommitPy36Pytest"
+  dependsOn ":sdks:python:test-suites:tox:py37:preCommitPy37Pytest"
+}
+
 task pythonLintPreCommit() {
   dependsOn ":sdks:python:test-suites:tox:py2:lint"
   dependsOn ":sdks:python:test-suites:tox:py37:lint"

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -24,6 +24,8 @@ import sys
 import unittest
 from builtins import range
 
+import pytest
+
 from apache_beam.coders import proto2_coder_test_messages_pb2 as test_message
 from apache_beam.coders import coders
 from apache_beam.internal import pickler
@@ -47,6 +49,9 @@ class CustomCoder(coders.Coder):
     return int(encoded) - 1
 
 
+# These tests need to all be run in the same process due to the asserts
+# in tearDownClass.
+@pytest.mark.no_xdist
 class CodersTest(unittest.TestCase):
 
   # These class methods ensure that we test each defined coder in both

--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
@@ -24,6 +24,7 @@ import sys
 import unittest
 
 import mock
+import pytest
 from hamcrest import assert_that as hc_assert_that
 
 from apache_beam.io.gcp import bigquery_tools
@@ -114,6 +115,7 @@ class BigqueryTableMatcherTest(unittest.TestCase):
     self.assertEqual(bq_verifier.MAX_RETRIES + 1, mock_query.call_count)
 
 
+@pytest.mark.no_xdist  # xdist somehow makes the test do real requests.
 @unittest.skipIf(bigquery is None, 'Bigquery dependencies are not installed.')
 @mock.patch.object(
     bq_verifier.BigqueryFullResultStreamingMatcher,

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -231,8 +231,8 @@ class DataflowRunnerTest(unittest.TestCase):
                                 r'source is not currently available'):
       p.run()
 
-  @pytest.mark.skipif(sys.version_info >= (3, 7),
-                      reason='TODO(BEAM-8095): Segfaults in Python 3.7')
+  # TODO(BEAM-8095): Segfaults in Python 3.7 with xdist.
+  @pytest.mark.no_xdist
   def test_remote_runner_display_data(self):
     remote_runner = DataflowRunner()
     p = Pipeline(remote_runner,

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -29,6 +29,7 @@ from datetime import datetime
 # patches unittest.TestCase to be python3 compatible
 import future.tests.base  # pylint: disable=unused-import
 import mock
+import pytest
 
 import apache_beam as beam
 import apache_beam.transforms as ptransform
@@ -230,6 +231,8 @@ class DataflowRunnerTest(unittest.TestCase):
                                 r'source is not currently available'):
       p.run()
 
+  @pytest.mark.skipif(sys.version_info >= (3, 7),
+                      reason='TODO(BEAM-8095): Segfaults in Python 3.7')
   def test_remote_runner_display_data(self):
     remote_runner = DataflowRunner()
     p = Pipeline(remote_runner,

--- a/sdks/python/apache_beam/runners/portability/stager_test.py
+++ b/sdks/python/apache_beam/runners/portability/stager_test.py
@@ -26,6 +26,7 @@ import tempfile
 import unittest
 
 import mock
+import pytest
 
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.options.pipeline_options import DebugOptions
@@ -160,6 +161,8 @@ class StagerTest(unittest.TestCase):
                      self.stager.stage_job_resources(
                          options, staging_location=staging_dir)[1])
 
+  # xdist adds unpicklable modules to the main session.
+  @pytest.mark.no_xdist
   def test_with_main_session(self):
     staging_dir = self.make_temp_dir()
     options = PipelineOptions()

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -700,8 +700,8 @@ class PTransformWithSideInputs(PTransform):
     # Ensure fn and side inputs are picklable for remote execution.
     try:
       self.fn = pickler.loads(pickler.dumps(self.fn))
-    except RuntimeError:
-      raise RuntimeError('Unable to pickle fn %s' % self.fn)
+    except RuntimeError as e:
+      raise RuntimeError('Unable to pickle fn %s: %s' % (self.fn, e))
 
     self.args = pickler.loads(pickler.dumps(self.args))
     self.kwargs = pickler.loads(pickler.dumps(self.kwargs))

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -54,9 +54,6 @@ def context(element, timestamp):
   return WindowFn.AssignContext(timestamp, element)
 
 
-sort_values = Map(lambda k_vs: (k_vs[0], sorted(k_vs[1])))
-
-
 class ReifyWindowsFn(core.DoFn):
   def process(self, element, window=core.DoFn.WindowParam):
     key, values = element
@@ -186,6 +183,7 @@ class WindowTest(unittest.TestCase):
   def test_sessions(self):
     with TestPipeline() as p:
       pcoll = self.timestamped_key_values(p, 'key', 1, 2, 3, 20, 35, 27)
+      sort_values = Map(lambda k_vs: (k_vs[0], sorted(k_vs[1])))
       result = (pcoll
                 | 'w' >> WindowInto(Sessions(10))
                 | GroupByKey()

--- a/sdks/python/conftest.py
+++ b/sdks/python/conftest.py
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Pytest configuration and custom hooks."""
+
+from __future__ import absolute_import
+
+import sys
+
+# See pytest.ini for main collection rules.
+collect_ignore_glob = []
+if sys.version_info < (3,):
+  collect_ignore_glob.append('*_py3.py')
+for minor in [5, 6, 7, 8, 9]:
+  if sys.version_info < (3, minor):
+    collect_ignore_glob.append('*_py3%d.py' % minor)

--- a/sdks/python/conftest.py
+++ b/sdks/python/conftest.py
@@ -20,10 +20,13 @@ from __future__ import absolute_import
 
 import sys
 
+MAX_SUPPORTED_PYTHON_VERSION = (3, 8)
+
 # See pytest.ini for main collection rules.
 collect_ignore_glob = []
 if sys.version_info < (3,):
-  collect_ignore_glob.append('*_py3.py')
-for minor in [5, 6, 7, 8, 9]:
-  if sys.version_info < (3, minor):
+  collect_ignore_glob.append('*_py3*.py')
+else:
+  for minor in range(sys.version_info.minor + 1,
+                     MAX_SUPPORTED_PYTHON_VERSION[1] + 1):
     collect_ignore_glob.append('*_py3%d.py' % minor)

--- a/sdks/python/pytest.ini
+++ b/sdks/python/pytest.ini
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[pytest]
+junit_family = xunit2
+
+# Disable class-name-based test discovery.
+python_classes =
+# Disable function-name-based test discovery.
+python_functions =
+# Discover tests using filenames.
+# See conftest.py for extra collection rules.
+python_files = test_*.py *_test.py *_test_py3*.py
+
+markers =
+    # Tests using this marker conflict with the xdist plugin in some way, such
+    # as enabling save_main_session.
+    no_xdist: run without pytest-xdist plugin

--- a/sdks/python/scripts/run_pytest.sh
+++ b/sdks/python/scripts/run_pytest.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# Utility script for tox.ini for running unit tests.
+#
+# Runs tests in parallel, except those not compatible with xdist. Combines
+# exit statuses of runs, special-casing 5, which says that no tests were
+# selected.
+#
+# $1 - suite base name
+# $2 - additional arguments to pass to pytest
+
+envname=${1?First argument required: suite base name}
+posargs=$2
+
+# Run with pytest-xdist and without.
+python setup.py pytest --addopts="-o junit_suite_name=${envname} \
+  --junitxml=pytest_${envname}.xml -m 'not no_xdist' -n 6 --pyargs ${posargs}"
+status1=$?
+python setup.py pytest --addopts="-o junit_suite_name=${envname}_no_xdist \
+  --junitxml=pytest_${envname}_no_xdist.xml -m 'no_xdist' --pyargs ${posargs}"
+status2=$?
+
+# Exit with error if no tests were run (status code 5).
+if [[ $status1 == 5 && $status2 == 5 ]]; then
+  exit $status1
+fi
+
+# Exit with error if one of the statuses has an error that's not 5.
+if [[ $status1 && $status1 != 5 ]]; then
+  exit $status1
+fi
+if [[ $status2 && $status2 != 5 ]]; then
+  exit $status2
+fi

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -149,6 +149,8 @@ REQUIRED_TEST_PACKAGES = [
     'pyyaml>=3.12,<6.0.0',
     'requests_mock>=1.7,<2.0',
     'tenacity>=5.0.2,<6.0',
+    'pytest>=4.4.0,<5.0',
+    'pytest-xdist>=1.29.0,<2',
     ]
 
 GCP_REQUIREMENTS = [
@@ -219,6 +221,7 @@ setuptools.setup(
     install_requires=REQUIRED_PACKAGES,
     python_requires=python_requires,
     test_suite='nose.collector',
+    setup_requires=['pytest_runner'],
     tests_require=REQUIRED_TEST_PACKAGES,
     extras_require={
         'docs': ['Sphinx>=1.5.2,<2.0'],

--- a/sdks/python/test-suites/tox/py2/build.gradle
+++ b/sdks/python/test-suites/tox/py2/build.gradle
@@ -45,6 +45,14 @@ test.dependsOn testPy2Cython
 // project.
 testPy2Cython.mustRunAfter testPython2, testPy2Gcp
 
+// TODO(BEAM-3713): Temporary pytest tasks that should eventually replace
+//  nose-based test tasks.
+toxTask "testPy2GcpPytest", "py27-gcp-pytest"
+toxTask "testPython2Pytest", "py27-pytest"
+toxTask "testPy2CythonPytest", "py27-cython-pytest"
+// Ensure that cython tests run exclusively to other tests.
+testPy2CythonPytest.mustRunAfter testPython2Pytest, testPy2GcpPytest
+
 toxTask "docs", "docs"
 assemble.dependsOn docs
 
@@ -55,4 +63,12 @@ task preCommitPy2() {
   dependsOn "testPy2Cython"
   dependsOn "testPython2"
   dependsOn "testPy2Gcp"
+}
+
+task preCommitPy2Pytest {
+  dependsOn "docs"
+  dependsOn "testPy2CythonPytest"
+  dependsOn "testPython2Pytest"
+  dependsOn "testPy2GcpPytest"
+  dependsOn "lint"
 }

--- a/sdks/python/test-suites/tox/py35/build.gradle
+++ b/sdks/python/test-suites/tox/py35/build.gradle
@@ -39,8 +39,23 @@ test.dependsOn testPy35Cython
 // project.
 testPy35Cython.mustRunAfter testPython35, testPy35Gcp
 
+// TODO(BEAM-3713): Temporary pytest tasks that should eventually replace
+//  nose-based test tasks.
+toxTask "testPy35GcpPytest", "py35-gcp-pytest"
+toxTask "testPython35Pytest", "py35-pytest"
+toxTask "testPy35CythonPytest", "py35-cython-pytest"
+// Ensure that cython tests run exclusively to other tests.
+testPy35CythonPytest.mustRunAfter testPython35Pytest, testPy35GcpPytest
+
 task preCommitPy35() {
     dependsOn "testPython35"
     dependsOn "testPy35Gcp"
     dependsOn "testPy35Cython"
+}
+
+task preCommitPy35Pytest {
+  dependsOn "testPython35Pytest"
+  dependsOn "testPy35GcpPytest"
+  dependsOn "testPy35CythonPytest"
+  dependsOn "lint"
 }

--- a/sdks/python/test-suites/tox/py36/build.gradle
+++ b/sdks/python/test-suites/tox/py36/build.gradle
@@ -39,8 +39,22 @@ test.dependsOn testPy36Cython
 // project.
 testPy36Cython.mustRunAfter testPython36, testPy36Gcp
 
+// TODO(BEAM-3713): Temporary pytest tasks that should eventually replace
+//  nose-based test tasks.
+toxTask "testPy36GcpPytest", "py36-gcp-pytest"
+toxTask "testPython36Pytest", "py36-pytest"
+toxTask "testPy36CythonPytest", "py36-cython-pytest"
+// Ensure that cython tests run exclusively to other tests.
+testPy36CythonPytest.mustRunAfter testPython36Pytest, testPy36GcpPytest
+
 task preCommitPy36() {
     dependsOn "testPython36"
     dependsOn "testPy36Gcp"
     dependsOn "testPy36Cython"
+}
+
+task preCommitPy36Pytest {
+  dependsOn "testPython36Pytest"
+  dependsOn "testPy36GcpPytest"
+  dependsOn "testPy36CythonPytest"
 }

--- a/sdks/python/test-suites/tox/py37/build.gradle
+++ b/sdks/python/test-suites/tox/py37/build.gradle
@@ -45,8 +45,22 @@ test.dependsOn testPy37Cython
 // project.
 testPy37Cython.mustRunAfter testPython37, testPy37Gcp
 
+// TODO(BEAM-3713): Temporary pytest tasks that should eventually replace
+//  nose-based test tasks.
+toxTask "testPy37GcpPytest", "py37-gcp-pytest"
+toxTask "testPython37Pytest", "py37-pytest"
+toxTask "testPy37CythonPytest", "py37-cython-pytest"
+// Ensure that cython tests run exclusively to other tests.
+testPy37CythonPytest.mustRunAfter testPython37Pytest, testPy37GcpPytest
+
 task preCommitPy37() {
     dependsOn "testPython37"
     dependsOn "testPy37Gcp"
     dependsOn "testPy37Cython"
+}
+
+task preCommitPy37Pytest {
+  dependsOn "testPython37Pytest"
+  dependsOn "testPy37GcpPytest"
+  dependsOn "testPy37CythonPytest"
 }

--- a/sdks/python/test_config.py
+++ b/sdks/python/test_config.py
@@ -20,6 +20,7 @@
 This module contains nose plugin hooks that configures Beam tests which
 includes ValidatesRunner test and E2E integration test.
 
+TODO(BEAM-3713): Remove this module once nose is removed.
 """
 
 from __future__ import absolute_import

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -57,12 +57,24 @@ commands =
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests --ignore-files '.*py3\d?\.py$' {posargs}
 
+[testenv:py27-pytest]
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+
 [testenv:py35]
 setenv =
   RUN_SKIPPED_PY3_TESTS=0
 commands =
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests --ignore-files '.*py3[6-9]\.py$' {posargs}
+
+[testenv:py35-pytest]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
 [testenv:py36]
 setenv =
@@ -71,12 +83,26 @@ commands =
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests --ignore-files '.*py3[7-9]\.py$' {posargs}
 
+[testenv:py36-pytest]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+
 [testenv:py37]
 setenv =
   RUN_SKIPPED_PY3_TESTS=0
 commands =
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests --ignore-files '.*py3[8-9]\.py$' {posargs}
+
+[testenv:py37-pytest]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
 [testenv:py27-cython]
 # cython tests are only expected to work in linux (2.x and 3.x)
@@ -87,6 +113,16 @@ platform = linux2
 commands =
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests --ignore-files '.*py3\d?\.py$' {posargs}
+
+[testenv:py27-cython-pytest]
+# cython tests are only expected to work in linux (2.x and 3.x)
+# If we want to add other platforms in the future, it should be:
+# `platform = linux2|darwin|...`
+# See https://docs.python.org/2/library/sys.html#sys.platform for platform codes
+platform = linux2
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
 [testenv:py35-cython]
 # cython tests are only expected to work in linux (2.x and 3.x)
@@ -100,6 +136,18 @@ commands =
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests --ignore-files '.*py3[5-9]\.py$' {posargs}
 
+[testenv:py35-cython-pytest]
+# cython tests are only expected to work in linux (2.x and 3.x)
+# If we want to add other platforms in the future, it should be:
+# `platform = linux2|darwin|...`
+# See https://docs.python.org/2/library/sys.html#sys.platform for platform codes
+platform = linux
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+
 [testenv:py36-cython]
 # cython tests are only expected to work in linux (2.x and 3.x)
 # If we want to add other platforms in the future, it should be:
@@ -111,6 +159,18 @@ setenv =
 commands =
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests --ignore-files '.*py3[7-9]\.py$' {posargs}
+
+[testenv:py36-cython-pytest]
+# cython tests are only expected to work in linux (2.x and 3.x)
+# If we want to add other platforms in the future, it should be:
+# `platform = linux2|darwin|...`
+# See https://docs.python.org/2/library/sys.html#sys.platform for platform codes
+platform = linux
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
 [testenv:py37-cython]
 # cython tests are only expected to work in linux (2.x and 3.x)
@@ -124,6 +184,18 @@ commands =
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py nosetests --ignore-files '.*py3[8-9]\.py$' {posargs}
 
+[testenv:py37-cython-pytest]
+# cython tests are only expected to work in linux (2.x and 3.x)
+# If we want to add other platforms in the future, it should be:
+# `platform = linux2|darwin|...`
+# See https://docs.python.org/2/library/sys.html#sys.platform for platform codes
+platform = linux
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+
 [testenv:py27-gcp]
 extras = test,gcp
 commands =
@@ -136,12 +208,25 @@ commands =
   python setup.py nosetests {posargs} --tests apache_beam.io.gcp.datastore.v1
   python setup.py nosetests {posargs} --tests apache_beam.io.gcp.datastore.v1new
 
+[testenv:py27-gcp-pytest]
+extras = test,gcp
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+
 [testenv:py35-gcp]
 setenv =
   RUN_SKIPPED_PY3_TESTS=0
 extras = test,gcp
 commands =
   python setup.py nosetests --ignore-files '.*py3[6-9]\.py$' {posargs}
+
+[testenv:py35-gcp-pytest]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+extras = test,gcp
+commands =
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
 [testenv:py36-gcp]
 setenv =
@@ -150,12 +235,26 @@ extras = test,gcp
 commands =
   python setup.py nosetests --ignore-files '.*py3[7-9]\.py$' {posargs}
 
+[testenv:py36-gcp-pytest]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+extras = test,gcp
+commands =
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+
 [testenv:py37-gcp]
 setenv =
   RUN_SKIPPED_PY3_TESTS=0
 extras = test,gcp
 commands =
   python setup.py nosetests --ignore-files '.*py3[8-9]\.py$' {posargs}
+
+[testenv:py37-gcp-pytest]
+setenv =
+  RUN_SKIPPED_PY3_TESTS=0
+extras = test,gcp
+commands =
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
 [testenv:py27-lint]
 # Checks for py2 syntax errors


### PR DESCRIPTION
This is #7949 without IT support.

This does not replace regular precommit/postcommit/tox environments.
Pytest will replace nose once we can verify all tests are collected by pytest and blocking bugs are solved (see BEAM-3713).

- Runs unit tests using pytest
  - tox: `tox -e py27-gcp-pytest,py36-pytest,etc.`
  - gradle: `../../gradlew pythonPreCommitPytest`
  - github PR phrase: `run python_pytest precommit`
- Tests run in parallel (still single-threaded but on multiple worker
processes).
  - no_xdist marker used for tests that don't work the xdist plugin.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
