### PR TITLE
[BEAM-8382] Add rate limit policy to KinesisIO.Read

### DIFF
--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisClientThrottledException.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisClientThrottledException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kinesis;
+
+import com.amazonaws.AmazonClientException;
+
+/** Thrown when the Kinesis client was throttled due to rate limits. */
+class KinesisClientThrottledException extends TransientKinesisException {
+
+  public KinesisClientThrottledException(String s, AmazonClientException e) {
+    super(s, e);
+  }
+}

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisIO.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisIO.java
@@ -40,6 +40,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.io.Read.Unbounded;
@@ -94,7 +95,6 @@ import org.slf4j.LoggerFactory;
  *
  * <pre>{@code
  * public class MyCustomKinesisClientProvider implements AWSClientsProvider {
- *   {@literal @}Override
  *   public AmazonKinesis getKinesisClient() {
  *     // set up your client here
  *   }
@@ -148,12 +148,10 @@ import org.slf4j.LoggerFactory;
  *       this.customWatermarkPolicy = new WatermarkPolicyFactory.CustomWatermarkPolicy(WatermarkParameters.create());
  *     }
  *
- *     @Override
  *     public Instant getWatermark() {
  *       return customWatermarkPolicy.getWatermark();
  *     }
  *
- *     @Override
  *     public void update(KinesisRecord record) {
  *       customWatermarkPolicy.update(record);
  *     }
@@ -161,7 +159,6 @@ import org.slf4j.LoggerFactory;
  *
  * // custom factory
  * class MyCustomPolicyFactory implements WatermarkPolicyFactory {
- *     @Override
  *     public WatermarkPolicy createWatermarkPolicy() {
  *       return new MyCustomPolicy();
  *     }
@@ -171,6 +168,69 @@ import org.slf4j.LoggerFactory;
  *    .withStreamName("streamName")
  *    .withInitialPositionInStream(InitialPositionInStream.LATEST)
  *    .withCustomWatermarkPolicy(new MyCustomPolicyFactory())
+ * }</pre>
+ *
+ * <p>By default Kinesis IO will poll the Kinesis getRecords() API as fast as possible which may
+ * lead to excessive read throttling. To limit the rate of getRecords() calls you can set a rate
+ * limit policy. For example, the default fixed delay policy will limit the rate to one API call per
+ * second per shard:
+ *
+ * <pre>{@code
+ * p.apply(KinesisIO.read()
+ *    .withStreamName("streamName")
+ *    .withInitialPositionInStream(InitialPositionInStream.LATEST)
+ *    .withFixedDelayRateLimitPolicy())
+ * }</pre>
+ *
+ * <p>You can also use a fixed delay policy with a specified delay interval, for example:
+ *
+ * <pre>{@code
+ * p.apply(KinesisIO.read()
+ *    .withStreamName("streamName")
+ *    .withInitialPositionInStream(InitialPositionInStream.LATEST)
+ *    .withFixedDelayRateLimitPolicy(Duration.millis(500))
+ * }</pre>
+ *
+ * <p>If you need to change the polling interval of a Kinesis pipeline at runtime, for example to
+ * compensate for adding and removing additional consumers to the stream, then you can supply the
+ * delay interval as a function so that you can obtain the current delay interval from some external
+ * source:
+ *
+ * <pre>{@code
+ * p.apply(KinesisIO.read()
+ *    .withStreamName("streamName")
+ *    .withInitialPositionInStream(InitialPositionInStream.LATEST)
+ *    .withDynamicDelayRateLimitPolicy(() -> Duration.millis(<some delay interval>))
+ * }</pre>
+ *
+ * <p>Finally, you can create a custom rate limit policy that responds to successful read calls
+ * and/or read throttling exceptions with your own rate-limiting logic:
+ *
+ * <pre>{@code
+ * // custom policy
+ * public class MyCustomPolicy implements RateLimitPolicy {
+ *
+ *   public void onSuccess(List<KinesisRecord> records) throws InterruptedException {
+ *     // handle successful getRecords() call
+ *   }
+ *
+ *   public void onThrottle(KinesisClientThrottledException e) throws InterruptedException {
+ *     // handle Kinesis read throttling exception
+ *   }
+ * }
+ *
+ * // custom factory
+ * class MyCustomPolicyFactory implements RateLimitPolicyFactory {
+ *
+ *   public RateLimitPolicy getRateLimitPolicy() {
+ *     return new MyCustomPolicy();
+ *   }
+ * }
+ *
+ * p.apply(KinesisIO.read()
+ *    .withStreamName("streamName")
+ *    .withInitialPositionInStream(InitialPositionInStream.LATEST)
+ *    .withCustomRateLimitPolicy(new MyCustomPolicyFactory())
  * }</pre>
  *
  * <h3>Writing to Kinesis</h3>
@@ -430,15 +490,13 @@ public final class KinesisIO {
       return toBuilder().setWatermarkPolicyFactory(watermarkPolicyFactory).build();
     }
 
-    /**
-     * Specifies the rate limit policy as FixedDelayRateLimiter with the default delay of 1 second.
-     */
+    /** Specifies a fixed delay rate limit policy with the default delay of 1 second. */
     public Read withFixedDelayRateLimitPolicy() {
       return toBuilder().setRateLimitPolicyFactory(RateLimitPolicyFactory.withFixedDelay()).build();
     }
 
     /**
-     * Specifies the rate limit policy as FixedDelayRateLimiter with the given delay.
+     * Specifies a fixed delay rate limit policy with the given delay.
      *
      * @param delay Denotes the fixed delay duration.
      */
@@ -447,6 +505,18 @@ public final class KinesisIO {
       return toBuilder()
           .setRateLimitPolicyFactory(RateLimitPolicyFactory.withFixedDelay(delay))
           .build();
+    }
+
+    /**
+     * Specifies a dynamic delay rate limit policy with the given function being called at each
+     * polling interval to get the next delay value. This can be used to change the polling interval
+     * of a running pipeline based on some external configuration source, for example.
+     *
+     * @param delay The function to invoke to get the next delay duration.
+     */
+    public Read withDynamicDelayRateLimitPolicy(Supplier<Duration> delay) {
+      checkArgument(delay != null, "delay cannot be null");
+      return toBuilder().setRateLimitPolicyFactory(RateLimitPolicyFactory.withDelay(delay)).build();
     }
 
     /**

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisReader.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisReader.java
@@ -40,6 +40,7 @@ class KinesisReader extends UnboundedSource.UnboundedReader<KinesisRecord> {
   private final KinesisSource source;
   private final CheckpointGenerator initialCheckpointGenerator;
   private final WatermarkPolicyFactory watermarkPolicyFactory;
+  private final RateLimitPolicyFactory rateLimitPolicyFactory;
   private final Duration upToDateThreshold;
   private final Duration backlogBytesCheckThreshold;
   private CustomOptional<KinesisRecord> currentRecord = CustomOptional.absent();
@@ -53,6 +54,7 @@ class KinesisReader extends UnboundedSource.UnboundedReader<KinesisRecord> {
       CheckpointGenerator initialCheckpointGenerator,
       KinesisSource source,
       WatermarkPolicyFactory watermarkPolicyFactory,
+      RateLimitPolicyFactory rateLimitPolicyFactory,
       Duration upToDateThreshold,
       Integer maxCapacityPerShard) {
     this(
@@ -60,6 +62,7 @@ class KinesisReader extends UnboundedSource.UnboundedReader<KinesisRecord> {
         initialCheckpointGenerator,
         source,
         watermarkPolicyFactory,
+        rateLimitPolicyFactory,
         upToDateThreshold,
         Duration.standardSeconds(30),
         maxCapacityPerShard);
@@ -70,6 +73,7 @@ class KinesisReader extends UnboundedSource.UnboundedReader<KinesisRecord> {
       CheckpointGenerator initialCheckpointGenerator,
       KinesisSource source,
       WatermarkPolicyFactory watermarkPolicyFactory,
+      RateLimitPolicyFactory rateLimitPolicyFactory,
       Duration upToDateThreshold,
       Duration backlogBytesCheckThreshold,
       Integer maxCapacityPerShard) {
@@ -77,6 +81,7 @@ class KinesisReader extends UnboundedSource.UnboundedReader<KinesisRecord> {
     this.initialCheckpointGenerator =
         checkNotNull(initialCheckpointGenerator, "initialCheckpointGenerator");
     this.watermarkPolicyFactory = watermarkPolicyFactory;
+    this.rateLimitPolicyFactory = rateLimitPolicyFactory;
     this.source = source;
     this.upToDateThreshold = upToDateThreshold;
     this.backlogBytesCheckThreshold = backlogBytesCheckThreshold;
@@ -185,6 +190,7 @@ class KinesisReader extends UnboundedSource.UnboundedReader<KinesisRecord> {
         kinesis,
         initialCheckpointGenerator.generate(kinesis),
         watermarkPolicyFactory,
+        rateLimitPolicyFactory,
         maxCapacityPerShard);
   }
 }

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisSource.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisSource.java
@@ -38,6 +38,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
   private final String streamName;
   private final Duration upToDateThreshold;
   private final WatermarkPolicyFactory watermarkPolicyFactory;
+  private final RateLimitPolicyFactory rateLimitPolicyFactory;
   private CheckpointGenerator initialCheckpointGenerator;
   private final Integer limit;
   private final Integer maxCapacityPerShard;
@@ -48,6 +49,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
       StartingPoint startingPoint,
       Duration upToDateThreshold,
       WatermarkPolicyFactory watermarkPolicyFactory,
+      RateLimitPolicyFactory rateLimitPolicyFactory,
       Integer limit,
       Integer maxCapacityPerShard) {
     this(
@@ -56,6 +58,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
         streamName,
         upToDateThreshold,
         watermarkPolicyFactory,
+        rateLimitPolicyFactory,
         limit,
         maxCapacityPerShard);
   }
@@ -66,6 +69,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
       String streamName,
       Duration upToDateThreshold,
       WatermarkPolicyFactory watermarkPolicyFactory,
+      RateLimitPolicyFactory rateLimitPolicyFactory,
       Integer limit,
       Integer maxCapacityPerShard) {
     this.awsClientsProvider = awsClientsProvider;
@@ -73,6 +77,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
     this.streamName = streamName;
     this.upToDateThreshold = upToDateThreshold;
     this.watermarkPolicyFactory = watermarkPolicyFactory;
+    this.rateLimitPolicyFactory = rateLimitPolicyFactory;
     this.limit = limit;
     this.maxCapacityPerShard = maxCapacityPerShard;
     validate();
@@ -98,6 +103,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
               streamName,
               upToDateThreshold,
               watermarkPolicyFactory,
+              rateLimitPolicyFactory,
               limit,
               maxCapacityPerShard));
     }
@@ -126,6 +132,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
         checkpointGenerator,
         this,
         watermarkPolicyFactory,
+        rateLimitPolicyFactory,
         upToDateThreshold,
         maxCapacityPerShard);
   }
@@ -139,6 +146,8 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
   public void validate() {
     checkNotNull(awsClientsProvider);
     checkNotNull(initialCheckpointGenerator);
+    checkNotNull(watermarkPolicyFactory);
+    checkNotNull(rateLimitPolicyFactory);
   }
 
   @Override

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/RateLimitPolicy.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/RateLimitPolicy.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kinesis;
+
+import java.util.List;
+
+public interface RateLimitPolicy {
+
+  /**
+   * Called after Kinesis records are successfully retrieved.
+   *
+   * @param records The list of retrieved records.
+   */
+  default void onSuccess(List<KinesisRecord> records) throws InterruptedException {}
+
+  /**
+   * Called after the Kinesis client is throttled.
+   *
+   * @param e The {@code KinesisClientThrottledException} thrown by the client.
+   */
+  default void onThrottle(KinesisClientThrottledException e) throws InterruptedException {}
+}

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/RateLimitPolicyFactory.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/RateLimitPolicyFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kinesis;
+
+import java.io.Serializable;
+import java.util.List;
+import org.joda.time.Duration;
+
+/**
+ * Implement this interface to create a {@code RateLimitPolicy}. Used to create a rate limiter for
+ * each shard.
+ */
+public interface RateLimitPolicyFactory extends Serializable {
+
+  RateLimitPolicy getRateLimitPolicy();
+
+  static RateLimitPolicyFactory withoutLimiter() {
+    return () -> new RateLimitPolicy() {};
+  }
+
+  static RateLimitPolicyFactory withFixedDelay() {
+    return FixedDelayRateLimiter::new;
+  }
+
+  static RateLimitPolicyFactory withFixedDelay(Duration delay) {
+    return () -> new FixedDelayRateLimiter(delay);
+  }
+
+  class FixedDelayRateLimiter implements RateLimitPolicy {
+
+    private static final Duration DEFAULT_DELAY = Duration.standardSeconds(1);
+
+    private final Duration delay;
+
+    public FixedDelayRateLimiter() {
+      this(DEFAULT_DELAY);
+    }
+
+    public FixedDelayRateLimiter(Duration delay) {
+      this.delay = delay;
+    }
+
+    @Override
+    public void onSuccess(List<KinesisRecord> records) throws InterruptedException {
+      Thread.sleep(delay.getMillis());
+    }
+  }
+}

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/SimplifiedKinesisClient.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/SimplifiedKinesisClient.java
@@ -211,7 +211,7 @@ class SimplifiedKinesisClient {
     } catch (ExpiredIteratorException e) {
       throw e;
     } catch (LimitExceededException | ProvisionedThroughputExceededException e) {
-      throw new TransientKinesisException(
+      throw new KinesisClientThrottledException(
           "Too many requests to Kinesis. Wait some time and retry.", e);
     } catch (AmazonServiceException e) {
       if (e.getErrorType() == AmazonServiceException.ErrorType.Service) {

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisReaderTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisReaderTest.java
@@ -69,6 +69,7 @@ public class KinesisReaderTest {
         generator,
         kinesisSource,
         WatermarkPolicyFactory.withArrivalTimePolicy(),
+        RateLimitPolicyFactory.withoutLimiter(),
         Duration.ZERO,
         backlogBytesCheckThreshold,
         ShardReadersPool.DEFAULT_CAPACITY_PER_SHARD) {

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/RateLimitPolicyFactoryTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/RateLimitPolicyFactoryTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kinesis;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.joda.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RateLimitPolicyFactory.class)
+public class RateLimitPolicyFactoryTest {
+
+  @Test
+  public void defaultPolicyShouldDoNothing() throws Exception {
+    PowerMockito.spy(Thread.class);
+    PowerMockito.doNothing().when(Thread.class);
+    Thread.sleep(anyLong());
+    RateLimitPolicy rateLimitPolicy = RateLimitPolicyFactory.withoutLimiter().getRateLimitPolicy();
+    rateLimitPolicy.onSuccess(ImmutableList.of());
+    verifyStatic(Thread.class, never());
+    Thread.sleep(anyLong());
+  }
+
+  @Test
+  public void shouldDelayDefaultInterval() throws Exception {
+    PowerMockito.spy(Thread.class);
+    PowerMockito.doNothing().when(Thread.class);
+    Thread.sleep(anyLong());
+    RateLimitPolicy rateLimitPolicy = RateLimitPolicyFactory.withFixedDelay().getRateLimitPolicy();
+    rateLimitPolicy.onSuccess(ImmutableList.of());
+    verifyStatic(Thread.class);
+    Thread.sleep(eq(1000L));
+  }
+
+  @Test
+  public void shouldDelayFixedInterval() throws Exception {
+    PowerMockito.spy(Thread.class);
+    PowerMockito.doNothing().when(Thread.class);
+    Thread.sleep(anyLong());
+    RateLimitPolicy rateLimitPolicy =
+        RateLimitPolicyFactory.withFixedDelay(Duration.millis(500)).getRateLimitPolicy();
+    rateLimitPolicy.onSuccess(ImmutableList.of());
+    verifyStatic(Thread.class);
+    Thread.sleep(eq(500L));
+  }
+
+  @Test
+  public void shouldDelayDynamicInterval() throws Exception {
+    PowerMockito.spy(Thread.class);
+    PowerMockito.doNothing().when(Thread.class);
+    Thread.sleep(anyLong());
+    AtomicLong delay = new AtomicLong(0L);
+    RateLimitPolicy rateLimitPolicy =
+        RateLimitPolicyFactory.withDelay(() -> Duration.millis(delay.getAndUpdate(d -> d ^ 1)))
+            .getRateLimitPolicy();
+    rateLimitPolicy.onSuccess(ImmutableList.of());
+    verifyStatic(Thread.class);
+    Thread.sleep(eq(0L));
+    Thread.sleep(eq(1L));
+    Thread.sleep(eq(0L));
+    Thread.sleep(eq(1L));
+  }
+}

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/SimplifiedKinesisClientTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/SimplifiedKinesisClientTest.java
@@ -116,13 +116,13 @@ public class SimplifiedKinesisClientTest {
   @Test
   public void shouldHandleLimitExceededExceptionForGetShardIterator() {
     shouldHandleGetShardIteratorError(
-        new LimitExceededException(""), TransientKinesisException.class);
+        new LimitExceededException(""), KinesisClientThrottledException.class);
   }
 
   @Test
   public void shouldHandleProvisionedThroughputExceededExceptionForGetShardIterator() {
     shouldHandleGetShardIteratorError(
-        new ProvisionedThroughputExceededException(""), TransientKinesisException.class);
+        new ProvisionedThroughputExceededException(""), KinesisClientThrottledException.class);
   }
 
   @Test
@@ -190,13 +190,14 @@ public class SimplifiedKinesisClientTest {
 
   @Test
   public void shouldHandleLimitExceededExceptionForShardListing() {
-    shouldHandleShardListingError(new LimitExceededException(""), TransientKinesisException.class);
+    shouldHandleShardListingError(
+        new LimitExceededException(""), KinesisClientThrottledException.class);
   }
 
   @Test
   public void shouldHandleProvisionedThroughputExceededExceptionForShardListing() {
     shouldHandleShardListingError(
-        new ProvisionedThroughputExceededException(""), TransientKinesisException.class);
+        new ProvisionedThroughputExceededException(""), KinesisClientThrottledException.class);
   }
 
   @Test
@@ -281,13 +282,13 @@ public class SimplifiedKinesisClientTest {
   @Test
   public void shouldHandleLimitExceededExceptionForGetBacklogBytes() {
     shouldHandleGetBacklogBytesError(
-        new LimitExceededException(""), TransientKinesisException.class);
+        new LimitExceededException(""), KinesisClientThrottledException.class);
   }
 
   @Test
   public void shouldHandleProvisionedThroughputExceededExceptionForGetBacklogBytes() {
     shouldHandleGetBacklogBytesError(
-        new ProvisionedThroughputExceededException(""), TransientKinesisException.class);
+        new ProvisionedThroughputExceededException(""), KinesisClientThrottledException.class);
   }
 
   @Test


### PR DESCRIPTION
This PR adds an optional rate limit policy to KinesisIO.Read that can be configured with the following methods:

`withFixedDelayRateLimitPolicy()`
Specifies a fixed delay rate limit policy with the default delay of 1 second.

`withFixedDelayRateLimitPolicy(Duration delay)`
Specifies a fixed delay rate limit policy with the given delay.

`withDynamicDelayRateLimitPolicy(Supplier<Duration> delay)`
Specifies a dynamic delay rate limit policy with the given function being called at each polling interval to get the next delay value.

`withCustomRateLimitPolicy(RateLimitPolicyFactory rateLimitPolicyFactory)`
Specifies the RateLimitPolicyFactory for a custom rate limiter.

This provides a strategy interface for dealing with the Kinesis hard limit of 5 read requests per second per shard. The FixedDelayRateLimiter will apply a fixed delay between read calls. The default is a "no limiter" policy which preserves the behavior of the current implementation.
 R: @aromanenko-dev

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
