### PR TITLE
[BEAM-7389] Show code snippet outputs as stdout

### DIFF
--- a/sdks/python/.pylintrc
+++ b/sdks/python/.pylintrc
@@ -178,6 +178,7 @@ indent-after-paren=4
 ignore-long-lines=(?x)
   (^\s*(import|from)\s
    |^\s*(\#\ )?<?(https?|ftp):\/\/[^\s\/$.?#].[^\s]*>?$
+   |^\s*@mock\.patch
    )
 
 [VARIABLES]

--- a/sdks/python/.pylintrc
+++ b/sdks/python/.pylintrc
@@ -178,7 +178,6 @@ indent-after-paren=4
 ignore-long-lines=(?x)
   (^\s*(import|from)\s
    |^\s*(\#\ )?<?(https?|ftp):\/\/[^\s\/$.?#].[^\s]*>?$
-   |^\s*@mock\.patch
    )
 
 [VARIABLES]

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/filter_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/filter_test.py
@@ -23,9 +23,8 @@ import unittest
 
 import mock
 
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import filter
 
@@ -36,7 +35,7 @@ def check_perennials(actual):
 {'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'}
 {'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'}
 [END perennials]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_valid_plants(actual):
@@ -46,12 +45,12 @@ def check_valid_plants(actual):
 {'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'}
 {'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'}
 [END valid_plants]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.filter.print', str)
-# pylint: enable=line-too-long
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.filter.print', str)
 class FilterTest(unittest.TestCase):
   def test_filter_function(self):
     filter.filter_function(check_perennials)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/filter_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/filter_test.py
@@ -31,31 +31,26 @@ from . import filter
 
 
 def check_perennials(actual):
-  # [START perennials]
-  perennials = [
-      {'icon': '🍓', 'name': 'Strawberry', 'duration': 'perennial'},
-      {'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'},
-      {'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'},
-  ]
-  # [END perennials]
-  assert_that(actual, equal_to(perennials))
+  expected = '''[START perennials]
+{'icon': '🍓', 'name': 'Strawberry', 'duration': 'perennial'}
+{'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'}
+{'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'}
+[END perennials]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_valid_plants(actual):
-  # [START valid_plants]
-  valid_plants = [
-      {'icon': '🍓', 'name': 'Strawberry', 'duration': 'perennial'},
-      {'icon': '🥕', 'name': 'Carrot', 'duration': 'biennial'},
-      {'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'},
-      {'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'},
-  ]
-  # [END valid_plants]
-  assert_that(actual, equal_to(valid_plants))
+  expected = '''[START valid_plants]
+{'icon': '🍓', 'name': 'Strawberry', 'duration': 'perennial'}
+{'icon': '🥕', 'name': 'Carrot', 'duration': 'biennial'}
+{'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'}
+{'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'}
+[END valid_plants]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.filter.print', lambda elem: elem)
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.filter.print', str)
 # pylint: enable=line-too-long
 class FilterTest(unittest.TestCase):
   def test_filter_function(self):

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/flatmap_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/flatmap_test.py
@@ -23,9 +23,8 @@ import unittest
 
 import mock
 
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import flatmap
 
@@ -38,7 +37,7 @@ def check_plants(actual):
 🍅Tomato
 🥔Potato
 [END plants]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_valid_plants(actual):
@@ -48,11 +47,12 @@ def check_valid_plants(actual):
 {'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'}
 {'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'}
 [END valid_plants]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.flatmap.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.flatmap.print', str)
 class FlatMapTest(unittest.TestCase):
   def test_flatmap_simple(self):
     flatmap.flatmap_simple(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/flatmap_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/flatmap_test.py
@@ -31,34 +31,28 @@ from . import flatmap
 
 
 def check_plants(actual):
-  # [START plants]
-  plants = [
-      '🍓Strawberry',
-      '🥕Carrot',
-      '🍆Eggplant',
-      '🍅Tomato',
-      '🥔Potato',
-  ]
-  # [END plants]
-  assert_that(actual, equal_to(plants))
+  expected = '''[START plants]
+🍓Strawberry
+🥕Carrot
+🍆Eggplant
+🍅Tomato
+🥔Potato
+[END plants]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_valid_plants(actual):
-  # [START valid_plants]
-  valid_plants = [
-      {'icon': '🍓', 'name': 'Strawberry', 'duration': 'perennial'},
-      {'icon': '🥕', 'name': 'Carrot', 'duration': 'biennial'},
-      {'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'},
-      {'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'},
-  ]
-  # [END valid_plants]
-  assert_that(actual, equal_to(valid_plants))
+  expected = '''[START valid_plants]
+{'icon': '🍓', 'name': 'Strawberry', 'duration': 'perennial'}
+{'icon': '🥕', 'name': 'Carrot', 'duration': 'biennial'}
+{'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'}
+{'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'}
+[END valid_plants]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.flatmap.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.flatmap.print', str)
 class FlatMapTest(unittest.TestCase):
   def test_flatmap_simple(self):
     flatmap.flatmap_simple(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/keys_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/keys_test.py
@@ -31,22 +31,18 @@ from . import keys
 
 
 def check_icons(actual):
-  # [START icons]
-  icons = [
-      '🍓',
-      '🥕',
-      '🍆',
-      '🍅',
-      '🥔',
-  ]
-  # [END icons]
-  assert_that(actual, equal_to(icons))
+  expected = '''[START icons]
+🍓
+🥕
+🍆
+🍅
+🥔
+[END icons]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.keys.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.keys.print', str)
 class KeysTest(unittest.TestCase):
   def test_keys(self):
     keys.keys(check_icons)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/keys_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/keys_test.py
@@ -23,9 +23,8 @@ import unittest
 
 import mock
 
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import keys
 
@@ -38,11 +37,12 @@ def check_icons(actual):
 🍅
 🥔
 [END icons]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.keys.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.keys.print', str)
 class KeysTest(unittest.TestCase):
   def test_keys(self):
     keys.keys(check_icons)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/kvswap_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/kvswap_test.py
@@ -23,9 +23,8 @@ import unittest
 
 import mock
 
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import kvswap
 
@@ -38,11 +37,12 @@ def check_plants(actual):
 ('Tomato', '🍅')
 ('Potato', '🥔')
 [END plants]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.kvswap.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.kvswap.print', str)
 class KvSwapTest(unittest.TestCase):
   def test_kvswap(self):
     kvswap.kvswap(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/kvswap_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/kvswap_test.py
@@ -31,22 +31,18 @@ from . import kvswap
 
 
 def check_plants(actual):
-  # [START plants]
-  plants = [
-      ('Strawberry', '🍓'),
-      ('Carrot', '🥕'),
-      ('Eggplant', '🍆'),
-      ('Tomato', '🍅'),
-      ('Potato', '🥔'),
-  ]
-  # [END plants]
-  assert_that(actual, equal_to(plants))
+  expected = '''[START plants]
+('Strawberry', '🍓')
+('Carrot', '🥕')
+('Eggplant', '🍆')
+('Tomato', '🍅')
+('Potato', '🥔')
+[END plants]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.kvswap.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.kvswap.print', str)
 class KvSwapTest(unittest.TestCase):
   def test_kvswap(self):
     kvswap.kvswap(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/map_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/map_test.py
@@ -31,35 +31,29 @@ from . import map
 
 
 def check_plants(actual):
-  # [START plants]
-  plants = [
-      '🍓Strawberry',
-      '🥕Carrot',
-      '🍆Eggplant',
-      '🍅Tomato',
-      '🥔Potato',
-  ]
-  # [END plants]
-  assert_that(actual, equal_to(plants))
+  expected = '''[START plants]
+🍓Strawberry
+🥕Carrot
+🍆Eggplant
+🍅Tomato
+🥔Potato
+[END plants]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_plant_details(actual):
-  # [START plant_details]
-  plant_details = [
-      {'icon': '🍓', 'name': 'Strawberry', 'duration': 'perennial'},
-      {'icon': '🥕', 'name': 'Carrot', 'duration': 'biennial'},
-      {'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'},
-      {'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'},
-      {'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'},
-  ]
-  # [END plant_details]
-  assert_that(actual, equal_to(plant_details))
+  expected = '''[START plant_details]
+{'icon': '🍓', 'name': 'Strawberry', 'duration': 'perennial'}
+{'icon': '🥕', 'name': 'Carrot', 'duration': 'biennial'}
+{'icon': '🍆', 'name': 'Eggplant', 'duration': 'perennial'}
+{'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'}
+{'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'}
+[END plant_details]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.map.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.map.print', str)
 class MapTest(unittest.TestCase):
   def test_map_simple(self):
     map.map_simple(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/map_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/map_test.py
@@ -23,9 +23,8 @@ import unittest
 
 import mock
 
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import map
 
@@ -38,7 +37,7 @@ def check_plants(actual):
 🍅Tomato
 🥔Potato
 [END plants]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_plant_details(actual):
@@ -49,11 +48,12 @@ def check_plant_details(actual):
 {'icon': '🍅', 'name': 'Tomato', 'duration': 'annual'}
 {'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'}
 [END plant_details]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.map.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.map.print', str)
 class MapTest(unittest.TestCase):
   def test_map_simple(self):
     map.map_simple(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/pardo.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/pardo.py
@@ -18,7 +18,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from __future__ import unicode_literals
 
 
 def pardo_dofn(test=None):

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/pardo_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/pardo_test.py
@@ -35,21 +35,19 @@ from . import pardo
 
 
 def check_plants(actual):
-  # [START plants]
-  plants = [
-      '🍓Strawberry',
-      '🥕Carrot',
-      '🍆Eggplant',
-      '🍅Tomato',
-      '🥔Potato',
-  ]
-  # [END plants]
-  assert_that(actual, equal_to(plants))
+  expected = '''[START plants]
+🍓Strawberry
+🥕Carrot
+🍆Eggplant
+🍅Tomato
+🥔Potato
+[END plants]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_dofn_params(actual):
   # pylint: disable=line-too-long
-  dofn_params = '\n'.join('''[START dofn_params]
+  expected = '\n'.join('''[START dofn_params]
 # timestamp
 type(timestamp) -> <class 'apache_beam.utils.timestamp.Timestamp'>
 timestamp.micros -> 1584675660000000
@@ -63,7 +61,7 @@ window.end -> Timestamp(1584675690) (2020-03-20 03:41:30)
 window.max_timestamp() -> Timestamp(1584675689.999999) (2020-03-20 03:41:29.999999)
 [END dofn_params]'''.splitlines()[1:-1])
   # pylint: enable=line-too-long
-  assert_that(actual, equal_to([dofn_params]))
+  assert_that(actual, equal_to([expected]))
 
 
 def check_dofn_methods(actual):
@@ -83,9 +81,7 @@ teardown
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.pardo.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.pardo.print', str)
 class ParDoTest(unittest.TestCase):
   def test_pardo_dofn(self):
     pardo.pardo_dofn(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/pardo_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/pardo_test.py
@@ -18,20 +18,26 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from __future__ import unicode_literals
 
-import io
 import platform
 import sys
 import unittest
 
 import mock
 
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 
 from . import pardo
+
+# TODO: Remove this after Python 2 deprecation.
+# https://issues.apache.org/jira/browse/BEAM-8124
+if sys.version_info[0] == 2:
+  from io import BytesIO as StringIO
+else:
+  from io import StringIO
 
 
 def check_plants(actual):
@@ -42,7 +48,7 @@ def check_plants(actual):
 🍅Tomato
 🥔Potato
 [END plants]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_dofn_params(actual):
@@ -81,21 +87,22 @@ teardown
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.pardo.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.pardo.print', str)
 class ParDoTest(unittest.TestCase):
   def test_pardo_dofn(self):
     pardo.pardo_dofn(check_plants)
 
   # TODO: Remove this after Python 2 deprecation.
   # https://issues.apache.org/jira/browse/BEAM-8124
-  @unittest.skipIf(sys.version_info[0] < 3 and platform.system() == 'Windows',
+  @unittest.skipIf(sys.version_info[0] == 2 and platform.system() == 'Windows',
                    'Python 2 on Windows uses `long` rather than `int`')
   def test_pardo_dofn_params(self):
     pardo.pardo_dofn_params(check_dofn_params)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('sys.stdout', new_callable=io.StringIO)
+@mock.patch('sys.stdout', new_callable=StringIO)
 class ParDoStdoutTest(unittest.TestCase):
   def test_pardo_dofn_methods(self, mock_stdout):
     expected = pardo.pardo_dofn_methods(check_dofn_methods)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/partition.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/partition.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 
 def partition_function(test=None):
+  # pylint: disable=line-too-long, expression-not-assigned
   # [START partition_function]
   import apache_beam as beam
 
@@ -41,24 +42,18 @@ def partition_function(test=None):
         ])
         | 'Partition' >> beam.Partition(by_duration, len(durations))
     )
-    _ = (
-        annuals
-        | 'Annuals' >> beam.Map(lambda x: print('annual: ' + str(x)))
-    )
-    _ = (
-        biennials
-        | 'Biennials' >> beam.Map(lambda x: print('biennial: ' + str(x)))
-    )
-    _ = (
-        perennials
-        | 'Perennials' >> beam.Map(lambda x: print('perennial: ' + str(x)))
-    )
+
+    annuals | 'Annuals' >> beam.Map(lambda x: print('annual: {}'.format(x)))
+    biennials | 'Biennials' >> beam.Map(lambda x: print('biennial: {}'.format(x)))
+    perennials | 'Perennials' >> beam.Map(lambda x: print('perennial: {}'.format(x)))
     # [END partition_function]
+    # pylint: enable=line-too-long, expression-not-assigned
     if test:
       test(annuals, biennials, perennials)
 
 
 def partition_lambda(test=None):
+  # pylint: disable=line-too-long, expression-not-assigned
   # [START partition_lambda]
   import apache_beam as beam
 
@@ -79,24 +74,18 @@ def partition_lambda(test=None):
             len(durations),
         )
     )
-    _ = (
-        annuals
-        | 'Annuals' >> beam.Map(lambda x: print('annual: ' + str(x)))
-    )
-    _ = (
-        biennials
-        | 'Biennials' >> beam.Map(lambda x: print('biennial: ' + str(x)))
-    )
-    _ = (
-        perennials
-        | 'Perennials' >> beam.Map(lambda x: print('perennial: ' + str(x)))
-    )
+
+    annuals | 'Annuals' >> beam.Map(lambda x: print('annual: {}'.format(x)))
+    biennials | 'Biennials' >> beam.Map(lambda x: print('biennial: {}'.format(x)))
+    perennials | 'Perennials' >> beam.Map(lambda x: print('perennial: {}'.format(x)))
     # [END partition_lambda]
+    # pylint: enable=line-too-long, expression-not-assigned
     if test:
       test(annuals, biennials, perennials)
 
 
 def partition_multiple_arguments(test=None):
+  # pylint: disable=expression-not-assigned
   # [START partition_multiple_arguments]
   import apache_beam as beam
   import json
@@ -123,14 +112,10 @@ def partition_multiple_arguments(test=None):
         ])
         | 'Partition' >> beam.Partition(split_dataset, 2, ratio=[8, 2])
     )
-    _ = (
-        train_dataset
-        | 'Train' >> beam.Map(lambda x: print('train: ' + str(x)))
-    )
-    _ = (
-        test_dataset
-        | 'Test'  >> beam.Map(lambda x: print('test: ' + str(x)))
-    )
+
+    train_dataset | 'Train' >> beam.Map(lambda x: print('train: {}'.format(x)))
+    test_dataset | 'Test'  >> beam.Map(lambda x: print('test: {}'.format(x)))
     # [END partition_multiple_arguments]
+    # pylint: enable=expression-not-assigned
     if test:
       test(train_dataset, test_dataset)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/partition_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/partition_test.py
@@ -23,10 +23,8 @@ import unittest
 
 import mock
 
-import apache_beam as beam
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import partition
 
@@ -56,12 +54,9 @@ perennial: {'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'}
       if line.split(':', 1)[0] == 'perennial'
   ]
 
-  assert_that(actual1 | 'annuals str' >> beam.Map(str),
-              equal_to(annuals), label='assert annuals')
-  assert_that(actual2 | 'biennials str' >> beam.Map(str),
-              equal_to(biennials), label='assert biennials')
-  assert_that(actual3 | 'perennials str' >> beam.Map(str),
-              equal_to(perennials), label='assert perennials')
+  assert_matches_stdout(actual1, annuals, 'annuals')
+  assert_matches_stdout(actual2, biennials, 'biennials')
+  assert_matches_stdout(actual3, perennials, 'perennials')
 
 
 def check_split_datasets(actual1, actual2):
@@ -84,14 +79,14 @@ train: {'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'}
       if line.split(':', 1)[0] == 'test'
   ]
 
-  assert_that(actual1 | 'train str' >> beam.Map(str),
-              equal_to(train_dataset), label='assert train')
-  assert_that(actual2 | 'test str' >> beam.Map(str),
-              equal_to(test_dataset), label='assert test')
+  assert_matches_stdout(actual1, train_dataset, 'train_dataset')
+  assert_matches_stdout(actual2, test_dataset, 'test_dataset')
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.partition.print', lambda x: x)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.partition.print',
+    lambda elem: elem)
 class PartitionTest(unittest.TestCase):
   def test_partition_function(self):
     partition.partition_function(check_partitions)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/regex_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/regex_test.py
@@ -23,9 +23,8 @@ import unittest
 
 import mock
 
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import regex
 
@@ -38,7 +37,7 @@ def check_matches(actual):
 🍅, Tomato, annual
 🥔, Potato, perennial
 [END plants_matches]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_all_matches(actual):
@@ -49,7 +48,7 @@ def check_all_matches(actual):
 ['🍅, Tomato, annual', '🍅', 'Tomato', 'annual']
 ['🥔, Potato, perennial', '🥔', 'Potato', 'perennial']
 [END plants_all_matches]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_matches_kv(actual):
@@ -60,7 +59,7 @@ def check_matches_kv(actual):
 ('🍅', '🍅, Tomato, annual')
 ('🥔', '🥔, Potato, perennial')
 [END plants_matches_kv]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_find_all(actual):
@@ -71,7 +70,7 @@ def check_find_all(actual):
 ['🍅, Tomato, annual', '🍉, Watermelon, annual']
 ['🥔, Potato, perennial']
 [END plants_find_all]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_find_kv(actual):
@@ -84,7 +83,7 @@ def check_find_kv(actual):
 ('🍉', '🍉, Watermelon, annual')
 ('🥔', '🥔, Potato, perennial')
 [END plants_find_kv]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_replace_all(actual):
@@ -95,7 +94,7 @@ def check_replace_all(actual):
 🍅,Tomato,annual
 🥔,Potato,perennial
 [END plants_replace_all]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_replace_first(actual):
@@ -106,7 +105,7 @@ def check_replace_first(actual):
 🍅: Tomato, annual
 🥔: Potato, perennial
 [END plants_replace_first]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_split(actual):
@@ -117,11 +116,12 @@ def check_split(actual):
 ['🍅', 'Tomato', 'annual']
 ['🥔', 'Potato', 'perennial']
 [END plants_split]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.regex.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.regex.print', str)
 class RegexTest(unittest.TestCase):
   def test_matches(self):
     regex.regex_matches(check_matches)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/regex_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/regex_test.py
@@ -31,115 +31,97 @@ from . import regex
 
 
 def check_matches(actual):
-  # [START plants_matches]
-  plants_matches = [
-      '🍓, Strawberry, perennial',
-      '🥕, Carrot, biennial',
-      '🍆, Eggplant, perennial',
-      '🍅, Tomato, annual',
-      '🥔, Potato, perennial',
-  ]
-  # [END plants_matches]
-  assert_that(actual, equal_to(plants_matches))
+  expected = '''[START plants_matches]
+🍓, Strawberry, perennial
+🥕, Carrot, biennial
+🍆, Eggplant, perennial
+🍅, Tomato, annual
+🥔, Potato, perennial
+[END plants_matches]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_all_matches(actual):
-  # [START plants_all_matches]
-  plants_all_matches = [
-      ['🍓, Strawberry, perennial', '🍓', 'Strawberry', 'perennial'],
-      ['🥕, Carrot, biennial', '🥕', 'Carrot', 'biennial'],
-      ['🍆, Eggplant, perennial', '🍆', 'Eggplant', 'perennial'],
-      ['🍅, Tomato, annual', '🍅', 'Tomato', 'annual'],
-      ['🥔, Potato, perennial', '🥔', 'Potato', 'perennial'],
-  ]
-  # [END plants_all_matches]
-  assert_that(actual, equal_to(plants_all_matches))
+  expected = '''[START plants_all_matches]
+['🍓, Strawberry, perennial', '🍓', 'Strawberry', 'perennial']
+['🥕, Carrot, biennial', '🥕', 'Carrot', 'biennial']
+['🍆, Eggplant, perennial', '🍆', 'Eggplant', 'perennial']
+['🍅, Tomato, annual', '🍅', 'Tomato', 'annual']
+['🥔, Potato, perennial', '🥔', 'Potato', 'perennial']
+[END plants_all_matches]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_matches_kv(actual):
-  # [START plants_matches_kv]
-  plants_matches_kv = [
-      ('🍓', '🍓, Strawberry, perennial'),
-      ('🥕', '🥕, Carrot, biennial'),
-      ('🍆', '🍆, Eggplant, perennial'),
-      ('🍅', '🍅, Tomato, annual'),
-      ('🥔', '🥔, Potato, perennial'),
-  ]
-  # [END plants_matches_kv]
-  assert_that(actual, equal_to(plants_matches_kv))
+  expected = '''[START plants_matches_kv]
+('🍓', '🍓, Strawberry, perennial')
+('🥕', '🥕, Carrot, biennial')
+('🍆', '🍆, Eggplant, perennial')
+('🍅', '🍅, Tomato, annual')
+('🥔', '🥔, Potato, perennial')
+[END plants_matches_kv]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_find_all(actual):
-  # [START plants_find_all]
-  plants_find_all = [
-      ['🍓, Strawberry, perennial'],
-      ['🥕, Carrot, biennial'],
-      ['🍆, Eggplant, perennial', '🍌, Banana, perennial'],
-      ['🍅, Tomato, annual', '🍉, Watermelon, annual'],
-      ['🥔, Potato, perennial'],
-  ]
-  # [END plants_find_all]
-  assert_that(actual, equal_to(plants_find_all))
+  expected = '''[START plants_find_all]
+['🍓, Strawberry, perennial']
+['🥕, Carrot, biennial']
+['🍆, Eggplant, perennial', '🍌, Banana, perennial']
+['🍅, Tomato, annual', '🍉, Watermelon, annual']
+['🥔, Potato, perennial']
+[END plants_find_all]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_find_kv(actual):
-  # [START plants_find_kv]
-  plants_find_all = [
-      ('🍓', '🍓, Strawberry, perennial'),
-      ('🥕', '🥕, Carrot, biennial'),
-      ('🍆', '🍆, Eggplant, perennial'),
-      ('🍌', '🍌, Banana, perennial'),
-      ('🍅', '🍅, Tomato, annual'),
-      ('🍉', '🍉, Watermelon, annual'),
-      ('🥔', '🥔, Potato, perennial'),
-  ]
-  # [END plants_find_kv]
-  assert_that(actual, equal_to(plants_find_all))
+  expected = '''[START plants_find_kv]
+('🍓', '🍓, Strawberry, perennial')
+('🥕', '🥕, Carrot, biennial')
+('🍆', '🍆, Eggplant, perennial')
+('🍌', '🍌, Banana, perennial')
+('🍅', '🍅, Tomato, annual')
+('🍉', '🍉, Watermelon, annual')
+('🥔', '🥔, Potato, perennial')
+[END plants_find_kv]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_replace_all(actual):
-  # [START plants_replace_all]
-  plants_replace_all = [
-      '🍓,Strawberry,perennial',
-      '🥕,Carrot,biennial',
-      '🍆,Eggplant,perennial',
-      '🍅,Tomato,annual',
-      '🥔,Potato,perennial',
-  ]
-  # [END plants_replace_all]
-  assert_that(actual, equal_to(plants_replace_all))
+  expected = '''[START plants_replace_all]
+🍓,Strawberry,perennial
+🥕,Carrot,biennial
+🍆,Eggplant,perennial
+🍅,Tomato,annual
+🥔,Potato,perennial
+[END plants_replace_all]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_replace_first(actual):
-  # [START plants_replace_first]
-  plants_replace_first = [
-      '🍓: Strawberry, perennial',
-      '🥕: Carrot, biennial',
-      '🍆: Eggplant, perennial',
-      '🍅: Tomato, annual',
-      '🥔: Potato, perennial',
-  ]
-  # [END plants_replace_first]
-  assert_that(actual, equal_to(plants_replace_first))
+  expected = '''[START plants_replace_first]
+🍓: Strawberry, perennial
+🥕: Carrot, biennial
+🍆: Eggplant, perennial
+🍅: Tomato, annual
+🥔: Potato, perennial
+[END plants_replace_first]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_split(actual):
-  # [START plants_split]
-  plants_split = [
-      ['🍓', 'Strawberry', 'perennial'],
-      ['🥕', 'Carrot', 'biennial'],
-      ['🍆', 'Eggplant', 'perennial'],
-      ['🍅', 'Tomato', 'annual'],
-      ['🥔', 'Potato', 'perennial'],
-  ]
-  # [END plants_split]
-  assert_that(actual, equal_to(plants_split))
+  expected = '''[START plants_split]
+['🍓', 'Strawberry', 'perennial']
+['🥕', 'Carrot', 'biennial']
+['🍆', 'Eggplant', 'perennial']
+['🍅', 'Tomato', 'annual']
+['🥔', 'Potato', 'perennial']
+[END plants_split]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.regex.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.regex.print', str)
 class RegexTest(unittest.TestCase):
   def test_matches(self):
     regex.regex_matches(check_matches)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/tostring_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/tostring_test.py
@@ -24,6 +24,7 @@ import unittest
 
 import mock
 
+import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
@@ -32,32 +33,26 @@ from . import tostring
 
 
 def check_plants(actual):
-  # [START plants]
-  plants = [
-      '🍓,Strawberry',
-      '🥕,Carrot',
-      '🍆,Eggplant',
-      '🍅,Tomato',
-      '🥔,Potato',
-  ]
-  # [END plants]
-  assert_that(actual, equal_to(plants))
+  expected = '''[START plants]
+🍓,Strawberry
+🥕,Carrot
+🍆,Eggplant
+🍅,Tomato
+🥔,Potato
+[END plants]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_plant_lists(actual):
-  # [START plant_lists]
-  plant_lists = [
-      "['🍓', 'Strawberry', 'perennial']",
-      "['🥕', 'Carrot', 'biennial']",
-      "['🍆', 'Eggplant', 'perennial']",
-      "['🍅', 'Tomato', 'annual']",
-      "['🥔', 'Potato', 'perennial']",
-  ]
-  # [END plant_lists]
+  expected = '''[START plant_lists]
+['🍓', 'Strawberry', 'perennial']
+['🥕', 'Carrot', 'biennial']
+['🍆', 'Eggplant', 'perennial']
+['🍅', 'Tomato', 'annual']
+['🥔', 'Potato', 'perennial']
+[END plant_lists]'''.splitlines()[1:-1]
 
   # Some unicode characters become escaped with double backslashes.
-  import apache_beam as beam
-
   def normalize_escaping(elem):
     # In Python 2 all utf-8 characters are escaped with double backslashes.
     # TODO: Remove this after Python 2 deprecation.
@@ -70,26 +65,22 @@ def check_plant_lists(actual):
       return bytes(elem, 'utf-8').decode('unicode-escape')
     return elem
   actual = actual | beam.Map(normalize_escaping)
-  assert_that(actual, equal_to(plant_lists))
+  assert_that(actual, equal_to(expected))
 
 
 def check_plants_csv(actual):
-  # [START plants_csv]
-  plants_csv = [
-      '🍓,Strawberry,perennial',
-      '🥕,Carrot,biennial',
-      '🍆,Eggplant,perennial',
-      '🍅,Tomato,annual',
-      '🥔,Potato,perennial',
-  ]
-  # [END plants_csv]
-  assert_that(actual, equal_to(plants_csv))
+  expected = '''[START plants_csv]
+🍓,Strawberry,perennial
+🥕,Carrot,biennial
+🍆,Eggplant,perennial
+🍅,Tomato,annual
+🥔,Potato,perennial
+[END plants_csv]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.tostring.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.tostring.print', str)
 class ToStringTest(unittest.TestCase):
   def test_tostring_kvs(self):
     tostring.tostring_kvs(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/tostring_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/tostring_test.py
@@ -19,15 +19,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import sys
 import unittest
 
 import mock
 
-import apache_beam as beam
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import tostring
 
@@ -40,7 +37,7 @@ def check_plants(actual):
 🍅,Tomato
 🥔,Potato
 [END plants]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_plant_lists(actual):
@@ -51,21 +48,7 @@ def check_plant_lists(actual):
 ['🍅', 'Tomato', 'annual']
 ['🥔', 'Potato', 'perennial']
 [END plant_lists]'''.splitlines()[1:-1]
-
-  # Some unicode characters become escaped with double backslashes.
-  def normalize_escaping(elem):
-    # In Python 2 all utf-8 characters are escaped with double backslashes.
-    # TODO: Remove this after Python 2 deprecation.
-    # https://issues.apache.org/jira/browse/BEAM-8124
-    if sys.version_info.major == 2:
-      return elem.decode('string-escape')
-
-    # In Python 3.5 some utf-8 characters are escaped with double backslashes.
-    if '\\' in elem:
-      return bytes(elem, 'utf-8').decode('unicode-escape')
-    return elem
-  actual = actual | beam.Map(normalize_escaping)
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_plants_csv(actual):
@@ -76,11 +59,12 @@ def check_plants_csv(actual):
 🍅,Tomato,annual
 🥔,Potato,perennial
 [END plants_csv]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.tostring.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.tostring.print', str)
 class ToStringTest(unittest.TestCase):
   def test_tostring_kvs(self):
     tostring.tostring_kvs(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/values_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/values_test.py
@@ -31,22 +31,18 @@ from . import values
 
 
 def check_plants(actual):
-  # [START plants]
-  plants = [
-      'Strawberry',
-      'Carrot',
-      'Eggplant',
-      'Tomato',
-      'Potato',
-  ]
-  # [END plants]
-  assert_that(actual, equal_to(plants))
+  expected = '''[START plants]
+Strawberry
+Carrot
+Eggplant
+Tomato
+Potato
+[END plants]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.values.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.values.print', str)
 class ValuesTest(unittest.TestCase):
   def test_values(self):
     values.values(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/values_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/values_test.py
@@ -23,9 +23,8 @@ import unittest
 
 import mock
 
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import values
 
@@ -38,11 +37,12 @@ Eggplant
 Tomato
 Potato
 [END plants]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.values.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.values.print', str)
 class ValuesTest(unittest.TestCase):
   def test_values(self):
     values.values(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/withtimestamps_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/withtimestamps_test.py
@@ -24,9 +24,8 @@ import unittest
 import mock
 
 import apache_beam as beam
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import withtimestamps
 
@@ -39,7 +38,7 @@ def check_plant_timestamps(actual):
 2020-05-01 00:00:00 - Tomato
 2020-09-01 00:00:00 - Potato
 [END plant_timestamps]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_plant_events(actual):
@@ -50,7 +49,7 @@ def check_plant_events(actual):
 3 - Tomato
 5 - Potato
 [END plant_events]'''.splitlines()[1:-1]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 def check_plant_processing_times(actual):
@@ -66,11 +65,13 @@ def check_plant_processing_times(actual):
   # simply strip the timestamp information before testing the results.
   actual = actual | beam.Map(lambda row: row.split('-')[-1].strip())
   expected = [row.split('-')[-1].strip() for row in expected]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.withtimestamps.print', str)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.elementwise.withtimestamps.print',
+    str)
 class WithTimestampsTest(unittest.TestCase):
   def test_event_time(self):
     withtimestamps.withtimestamps_event_time(check_plant_timestamps)

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/withtimestamps_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/withtimestamps_test.py
@@ -23,6 +23,7 @@ import unittest
 
 import mock
 
+import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
@@ -31,55 +32,45 @@ from . import withtimestamps
 
 
 def check_plant_timestamps(actual):
-  # [START plant_timestamps]
-  plant_timestamps = [
-      '2020-04-01 00:00:00 - Strawberry',
-      '2020-06-01 00:00:00 - Carrot',
-      '2020-03-01 00:00:00 - Artichoke',
-      '2020-05-01 00:00:00 - Tomato',
-      '2020-09-01 00:00:00 - Potato',
-  ]
-  # [END plant_timestamps]
-  assert_that(actual, equal_to(plant_timestamps))
+  expected = '''[START plant_timestamps]
+2020-04-01 00:00:00 - Strawberry
+2020-06-01 00:00:00 - Carrot
+2020-03-01 00:00:00 - Artichoke
+2020-05-01 00:00:00 - Tomato
+2020-09-01 00:00:00 - Potato
+[END plant_timestamps]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_plant_events(actual):
-  # [START plant_events]
-  plant_events = [
-      '1 - Strawberry',
-      '4 - Carrot',
-      '2 - Artichoke',
-      '3 - Tomato',
-      '5 - Potato',
-  ]
-  # [END plant_events]
-  assert_that(actual, equal_to(plant_events))
+  expected = '''[START plant_events]
+1 - Strawberry
+4 - Carrot
+2 - Artichoke
+3 - Tomato
+5 - Potato
+[END plant_events]'''.splitlines()[1:-1]
+  assert_that(actual, equal_to(expected))
 
 
 def check_plant_processing_times(actual):
-  import apache_beam as beam
-
-  # [START plant_processing_times]
-  plant_processing_times = [
-      '2020-03-20 20:12:42.145594 - Strawberry',
-      '2020-03-20 20:12:42.145827 - Carrot',
-      '2020-03-20 20:12:42.145962 - Artichoke',
-      '2020-03-20 20:12:42.146093 - Tomato',
-      '2020-03-20 20:12:42.146216 - Potato',
-  ]
-  # [END plant_processing_times]
+  expected = '''[START plant_processing_times]
+2020-03-20 20:12:42.145594 - Strawberry
+2020-03-20 20:12:42.145827 - Carrot
+2020-03-20 20:12:42.145962 - Artichoke
+2020-03-20 20:12:42.146093 - Tomato
+2020-03-20 20:12:42.146216 - Potato
+[END plant_processing_times]'''.splitlines()[1:-1]
 
   # Since `time.time()` will always give something different, we'll
   # simply strip the timestamp information before testing the results.
   actual = actual | beam.Map(lambda row: row.split('-')[-1].strip())
-  expected = [row.split('-')[-1].strip() for row in plant_processing_times]
+  expected = [row.split('-')[-1].strip() for row in expected]
   assert_that(actual, equal_to(expected))
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.elementwise.withtimestamps.print', lambda elem: elem)
-# pylint: enable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.elementwise.withtimestamps.print', str)
 class WithTimestampsTest(unittest.TestCase):
   def test_event_time(self):
     withtimestamps.withtimestamps_event_time(check_plant_timestamps)

--- a/sdks/python/apache_beam/examples/snippets/util.py
+++ b/sdks/python/apache_beam/examples/snippets/util.py
@@ -37,11 +37,11 @@ def assert_matches_stdout(actual, expected_stdout, label=''):
   def stdout_to_python_object(elem_str):
     try:
       return ast.literal_eval(elem_str)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
       return elem_str
 
   actual = actual | label >> beam.Map(stdout_to_python_object)
-  expected = map(stdout_to_python_object, expected_stdout)
+  expected = list(map(stdout_to_python_object, expected_stdout))
   assert_that(actual, equal_to(expected), 'assert ' + label)
 
 

--- a/sdks/python/apache_beam/examples/snippets/util.py
+++ b/sdks/python/apache_beam/examples/snippets/util.py
@@ -17,28 +17,32 @@
 
 from __future__ import absolute_import
 
-import argparse
+import ast
 import shlex
 import subprocess as sp
 
+import apache_beam as beam
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
 
-def parse_example(argv=None):
-  """Parse the command line arguments and return it as a string function call.
 
-  Examples:
-    python path/to/snippets.py function_name
-    python path/to/snippets.py function_name arg1
-    python path/to/snippets.py function_name arg1 arg2 ... argN
+def assert_matches_stdout(actual, expected_stdout, label=''):
+  """Asserts a PCollection of strings matches the expected stdout elements.
+
+  Args:
+    actual (beam.PCollection): A PCollection.
+    expected (List[str]): A list of stdout elements, one line per element.
+    label (str): [optional] Label to make transform names unique.
   """
-  parser = argparse.ArgumentParser()
-  parser.add_argument('example', help='Name of the example to run.')
-  parser.add_argument('args', nargs=argparse.REMAINDER,
-                      help='Arguments for example.')
-  args = parser.parse_args(argv)
+  def stdout_to_python_object(elem_str):
+    try:
+      return ast.literal_eval(elem_str)
+    except SyntaxError:
+      return elem_str
 
-  # Return the example as a string representing the Python function call.
-  example_args = ', '.join([repr(arg) for arg in args.args])
-  return '{}({})'.format(args.example, example_args)
+  actual = actual | label >> beam.Map(stdout_to_python_object)
+  expected = map(stdout_to_python_object, expected_stdout)
+  assert_that(actual, equal_to(expected), 'assert ' + label)
 
 
 def run_shell_commands(commands, **kwargs):

--- a/sdks/python/apache_beam/examples/snippets/util_test.py
+++ b/sdks/python/apache_beam/examples/snippets/util_test.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -21,30 +22,43 @@ import unittest
 
 from mock import patch
 
-from apache_beam.examples.snippets.util import *
+import apache_beam as beam
+from apache_beam.examples.snippets import util
+from apache_beam.testing.test_pipeline import TestPipeline
 
 
 class UtilTest(unittest.TestCase):
-  def test_parse_example_empty(self):
-    # python path/to/snippets.py
-    argv = []
-    with self.assertRaises(SystemExit):
-      self.assertEqual(parse_example(argv), 'example()')
+  def test_assert_matches_stdout_object(self):
+    expected = [
+        "{'a': '🍓', 'b': True}",
+        "{'a': '🥕', 'b': 42}",
+        "{'a': '🍆', 'b': '\"hello\"'}",
+        "{'a': '🍅', 'b': [1, 2, 3]}",
+        "{'b': 'B', 'a': '🥔'}",
+    ]
+    with TestPipeline() as pipeline:
+      actual = (
+          pipeline
+          | beam.Create([
+              {'a': '🍓', 'b': True},
+              {'a': '🥕', 'b': 42},
+              {'a': '🍆', 'b': '"hello"'},
+              {'a': '🍅', 'b': [1, 2, 3]},
+              {'a': '🥔', 'b': 'B'},
+          ])
+          | beam.Map(str)
+      )
+      util.assert_matches_stdout(actual, expected)
 
-  def test_parse_example_no_arguments(self):
-    # python path/to/snippets.py example
-    argv = ['example']
-    self.assertEqual(parse_example(argv), 'example()')
-
-  def test_parse_example_one_argument(self):
-    # python path/to/snippets.py example A
-    argv = ['example', 'A']
-    self.assertEqual(parse_example(argv), "example('A')")
-
-  def test_parse_example_multiple_arguments(self):
-    # python path/to/snippets.py example A B "C's"
-    argv = ['example', 'A', 'B', "C's"]
-    self.assertEqual(parse_example(argv), "example('A', 'B', \"C's\")")
+  def test_assert_matches_stdout_string(self):
+    expected = ['🍓', '🥕', '🍆', '🍅', '🥔']
+    with TestPipeline() as pipeline:
+      actual = (
+          pipeline
+          | beam.Create(['🍓', '🥕', '🍆', '🍅', '🥔'])
+          | beam.Map(str)
+      )
+      util.assert_matches_stdout(actual, expected)
 
   @patch('subprocess.call', lambda cmd: None)
   def test_run_shell_commands(self):
@@ -54,7 +68,7 @@ class UtilTest(unittest.TestCase):
         '  !echo {variable}  ',
         '  echo "quoted arguments work"  # trailing comment  ',
     ]
-    actual = list(run_shell_commands(commands, variable='hello world'))
+    actual = list(util.run_shell_commands(commands, variable='hello world'))
     expected = [
         ['echo', 'this', 'is', 'a', 'shell', 'command'],
         ['echo', 'hello', 'world'],


### PR DESCRIPTION
It was a little confusing to see the outputs of the code as lists rather than what actually outputs when running the code.

Changing the outputs of the code snippets to what we actually see when running the code, this makes it consistent with the outputs of the notebooks as well.

It's mostly adding some logic to "parse" the stdout outputs, but the logic of the code samples stays the same.

I did some style changes to the `Partition` samples to make them easier to read as well.

R: @aaltay 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
