### PR TITLE
[BEAM-7389] Add code snippet for CoGroupByKey

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/transforms/aggregation/__init__.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/aggregation/__init__.py
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/examples/snippets/transforms/aggregation/cogroupbykey.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/aggregation/cogroupbykey.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+
+def cogroupbykey(test=None):
+  # [START cogroupbykey]
+  import apache_beam as beam
+
+  with beam.Pipeline() as pipeline:
+    icon_pairs = pipeline | 'Create icons' >> beam.Create([
+        ('Apple', '🍎'),
+        ('Apple', '🍏'),
+        ('Eggplant', '🍆'),
+        ('Tomato', '🍅'),
+    ])
+
+    duration_pairs = pipeline | 'Create durations' >> beam.Create([
+        ('Apple', 'perennial'),
+        ('Carrot', 'biennial'),
+        ('Tomato', 'perennial'),
+        ('Tomato', 'annual'),
+    ])
+
+    plants = (
+        ({'icons': icon_pairs, 'durations': duration_pairs})
+        | 'Merge' >> beam.CoGroupByKey()
+        | beam.Map(print)
+    )
+    # [END cogroupbykey]
+    if test:
+      test(plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/aggregation/cogroupbykey_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/aggregation/cogroupbykey_test.py
@@ -19,15 +19,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import ast
 import unittest
 
 import mock
 
-import apache_beam as beam
+from apache_beam.examples.snippets.util import assert_matches_stdout
 from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 from . import cogroupbykey
 
@@ -41,20 +38,18 @@ def check_plants(actual):
 [END plants]'''.splitlines()[1:-1]
 
   # Make it deterministic by sorting all sublists in each element.
-  def normalize_element(plant_str):
-    name, details = ast.literal_eval(plant_str)
+  def normalize_element(elem):
+    name, details = elem
     details['icons'] = sorted(details['icons'])
     details['durations'] = sorted(details['durations'])
     return name, details
-  actual = actual | beam.Map(normalize_element)
-  expected = [normalize_element(elem) for elem in expected]
-  assert_that(actual, equal_to(expected))
+  assert_matches_stdout(actual, expected, normalize_element)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)
-# pylint: disable=line-too-long
-@mock.patch('apache_beam.examples.snippets.transforms.aggregation.cogroupbykey.print', str)
-# pylint: enable=line-too-long
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.aggregation.cogroupbykey.print',
+    str)
 class CoGroupByKeyTest(unittest.TestCase):
   def test_cogroupbykey(self):
     cogroupbykey.cogroupbykey(check_plants)

--- a/sdks/python/apache_beam/examples/snippets/transforms/aggregation/cogroupbykey_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/aggregation/cogroupbykey_test.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import ast
+import unittest
+
+import mock
+
+import apache_beam as beam
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+
+from . import cogroupbykey
+
+
+def check_plants(actual):
+  expected = '''[START plants]
+('Apple', {'icons': ['🍎', '🍏'], 'durations': ['perennial']})
+('Carrot', {'icons': [], 'durations': ['biennial']})
+('Tomato', {'icons': ['🍅'], 'durations': ['perennial', 'annual']})
+('Eggplant', {'icons': ['🍆'], 'durations': []})
+[END plants]'''.splitlines()[1:-1]
+
+  # Make it deterministic by sorting all sublists in each element.
+  def normalize_element(plant_str):
+    name, details = ast.literal_eval(plant_str)
+    details['icons'] = sorted(details['icons'])
+    details['durations'] = sorted(details['durations'])
+    return name, details
+  actual = actual | beam.Map(normalize_element)
+  expected = [normalize_element(elem) for elem in expected]
+  assert_that(actual, equal_to(expected))
+
+
+@mock.patch('apache_beam.Pipeline', TestPipeline)
+# pylint: disable=line-too-long
+@mock.patch('apache_beam.examples.snippets.transforms.aggregation.cogroupbykey.print', str)
+# pylint: enable=line-too-long
+class CoGroupByKeyTest(unittest.TestCase):
+  def test_cogroupbykey(self):
+    cogroupbykey.cogroupbykey(check_plants)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/examples/snippets/transforms/elementwise/partition_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/elementwise/partition_test.py
@@ -54,9 +54,9 @@ perennial: {'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'}
       if line.split(':', 1)[0] == 'perennial'
   ]
 
-  assert_matches_stdout(actual1, annuals, 'annuals')
-  assert_matches_stdout(actual2, biennials, 'biennials')
-  assert_matches_stdout(actual3, perennials, 'perennials')
+  assert_matches_stdout(actual1, annuals, label='annuals')
+  assert_matches_stdout(actual2, biennials, label='biennials')
+  assert_matches_stdout(actual3, perennials, label='perennials')
 
 
 def check_split_datasets(actual1, actual2):
@@ -79,8 +79,8 @@ train: {'icon': '🥔', 'name': 'Potato', 'duration': 'perennial'}
       if line.split(':', 1)[0] == 'test'
   ]
 
-  assert_matches_stdout(actual1, train_dataset, 'train_dataset')
-  assert_matches_stdout(actual2, test_dataset, 'test_dataset')
+  assert_matches_stdout(actual1, train_dataset, label='train_dataset')
+  assert_matches_stdout(actual2, test_dataset, label='test_dataset')
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)

--- a/sdks/python/apache_beam/examples/snippets/util.py
+++ b/sdks/python/apache_beam/examples/snippets/util.py
@@ -26,19 +26,23 @@ from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 
 
-def assert_matches_stdout(actual, expected_stdout, label=''):
+def assert_matches_stdout(
+    actual, expected_stdout, normalize_fn=lambda elem: elem, label=''):
   """Asserts a PCollection of strings matches the expected stdout elements.
 
   Args:
     actual (beam.PCollection): A PCollection.
     expected (List[str]): A list of stdout elements, one line per element.
+    normalize_fn (Function[any]): A function to normalize elements before
+        comparing them. Can be used to sort lists before comparing.
     label (str): [optional] Label to make transform names unique.
   """
   def stdout_to_python_object(elem_str):
     try:
-      return ast.literal_eval(elem_str)
+      elem = ast.literal_eval(elem_str)
     except (SyntaxError, ValueError):
-      return elem_str
+      elem = elem_str
+    return normalize_fn(elem)
 
   actual = actual | label >> beam.Map(stdout_to_python_object)
   expected = list(map(stdout_to_python_object, expected_stdout))

--- a/sdks/python/apache_beam/examples/snippets/util_test.py
+++ b/sdks/python/apache_beam/examples/snippets/util_test.py
@@ -60,6 +60,17 @@ class UtilTest(unittest.TestCase):
       )
       util.assert_matches_stdout(actual, expected)
 
+  def test_assert_matches_stdout_sorted_keys(self):
+    expected = [{'sorted': [1, 2]}, {'sorted': [3, 4]}]
+    with TestPipeline() as pipeline:
+      actual = (
+          pipeline
+          | beam.Create([{'list': [2, 1]}, {'list': [4, 3]}])
+          | beam.Map(str)
+      )
+      util.assert_matches_stdout(
+          actual, expected, lambda elem: {'sorted': sorted(elem['list'])})
+
   @patch('subprocess.call', lambda cmd: None)
   def test_run_shell_commands(self):
     commands = [

--- a/sdks/python/apache_beam/examples/snippets/util_test.py
+++ b/sdks/python/apache_beam/examples/snippets/util_test.py
@@ -61,7 +61,7 @@ class UtilTest(unittest.TestCase):
       util.assert_matches_stdout(actual, expected)
 
   def test_assert_matches_stdout_sorted_keys(self):
-    expected = [{'sorted': [1, 2]}, {'sorted': [3, 4]}]
+    expected = [{'list': [1, 2]}, {'list': [3, 4]}]
     with TestPipeline() as pipeline:
       actual = (
           pipeline


### PR DESCRIPTION
Adding the code snippet for `CoGroupByKey`

R: @aaltay 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
