### PR TITLE
Avoid polluting Stackdriver logs with noise during autoscaling events.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -708,8 +708,8 @@ public class GrpcWindmillServer extends WindmillServerStub {
           }
           if (errorCount.incrementAndGet() % logEveryNStreamFailures == 0) {
             LOG.debug(
-                "{} streaming Windmill RPC errors for a stream, last was: {} with status {}. " +
-                        "This is normal during autoscaling.",
+                "{} streaming Windmill RPC errors for a stream, last was: {} with status {}. "
+                    + "This is normal during autoscaling.",
                 errorCount.get(),
                 t.toString(),
                 status);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -707,8 +707,9 @@ public class GrpcWindmillServer extends WindmillServerStub {
             status = ((StatusRuntimeException) t).getStatus();
           }
           if (errorCount.incrementAndGet() % logEveryNStreamFailures == 0) {
-            LOG.warn(
-                "{} streaming Windmill RPC errors for a stream, last was: {} with status {}",
+            LOG.debug(
+                "{} streaming Windmill RPC errors for a stream, last was: {} with status {}. " +
+                        "This is normal during autoscaling.",
                 errorCount.get(),
                 t.toString(),
                 status);


### PR DESCRIPTION
Also add message directing users to ignore them when appropriate.

Right now, every time a pipeline using Streaming Engine logs a wall of WARN messages stating that RPC calls to Windmill failed every time it scaled up or down, which causes unnecessary concern to users and complicates troubleshooting by adding noise to the logs.
This patch changes these messages to DEBUG level to keep them out of the way most of the time, and adds context so that people aren't worried when they don't need to be.

Ideally, this message should only be logged when there is an actual communication problem.

R: @lukecwik 
