### PR TITLE
[BEAM-8434] Translate trigger transcripts into validates runner tests.

### DIFF
--- a/sdks/python/apache_beam/testing/data/trigger_transcripts.yaml
+++ b/sdks/python/apache_beam/testing/data/trigger_transcripts.yaml
@@ -98,6 +98,8 @@ transcript:
 ---
 # Test that custom timestamping is in fact invoked.
 name: timestamp_combiner_custom_timestamping_earliest
+broken_on:
+  - SwitchingDirectRunner  # unsupported OUTPUT_AT_EARLIEST_TRANSFORMED
 window_fn: CustomTimestampingFixedWindowsWindowFn(10)
 trigger_fn: Default
 timestamp_combiner: OUTPUT_AT_EARLIEST_TRANSFORMED
@@ -134,6 +136,8 @@ transcript:
 
 ---
 name: garbage_collection
+broken_on:
+  - SwitchingDirectRunner  # claims pipeline stall
 window_fn: FixedWindows(10)
 trigger_fn: AfterCount(2)
 timestamp_combiner: OUTPUT_AT_EOW
@@ -151,6 +155,8 @@ transcript:
 
 ---
 name: known_late_data_watermark
+broken_on:
+  - SwitchingDirectRunner  # bad timestamp
 window_fn: FixedWindows(10)
 trigger_fn: Default
 timestamp_combiner: OUTPUT_AT_EARLIEST
@@ -163,6 +169,8 @@ transcript:
 
 ---
 name: known_late_data_no_watermark_hold_possible
+broken_on:
+  - SwitchingDirectRunner  # bad timestamp
 window_fn: FixedWindows(10)
 trigger_fn: Default
 timestamp_combiner: OUTPUT_AT_EARLIEST

--- a/sdks/python/apache_beam/transforms/trigger_test.py
+++ b/sdks/python/apache_beam/transforms/trigger_test.py
@@ -512,7 +512,7 @@ class TranscriptTest(unittest.TestCase):
   def _run_log_test(self, spec):
     if 'error' in spec:
       self.assertRaisesRegex(
-          AssertionError, spec['error'], self._run_log, spec)
+          Exception, spec['error'], self._run_log, spec)
     else:
       self._run_log(spec)
 
@@ -594,6 +594,23 @@ class TranscriptTest(unittest.TestCase):
         TimestampCombiner,
         spec.get('timestamp_combiner', 'OUTPUT_AT_EOW').upper())
 
+    def only_element(xs):
+      x, = list(xs)
+      return x
+
+    transcript = [only_element(line.items()) for line in spec['transcript']]
+
+    self._execute(
+        window_fn, trigger_fn, accumulation_mode, timestamp_combiner,
+        transcript, spec)
+
+
+class TriggerDriverTranscriptTest(TranscriptTest):
+
+  def _execute(
+      self, window_fn, trigger_fn, accumulation_mode, timestamp_combiner,
+      transcript, unused_spec):
+
     driver = GeneralTriggerDriver(
         Windowing(window_fn, trigger_fn, accumulation_mode, timestamp_combiner),
         TestClock())
@@ -613,14 +630,13 @@ class TranscriptTest(unittest.TestCase):
                            'timestamp': wvalue.timestamp})
         to_fire = state.get_and_clear_timers(watermark)
 
-    for line in spec['transcript']:
-
-      action, params = list(line.items())[0]
+    for action, params in transcript:
 
       if action != 'expect':
         # Fail if we have output that was not expected in the transcript.
         self.assertEqual(
-            [], output, msg='Unexpected output: %s before %s' % (output, line))
+            [], output, msg='Unexpected output: %s before %s: %s' % (
+                output, action, params))
 
       if action == 'input':
         bundle = [
@@ -659,11 +675,132 @@ class TranscriptTest(unittest.TestCase):
     self.assertEqual([], output, msg='Unexpected output: %s' % output)
 
 
+class TestStreamTranscriptTest(TranscriptTest):
+  """A suite of TestStream-based tests based on trigger transcript entries.
+  """
+
+  def _execute(
+      self, window_fn, trigger_fn, accumulation_mode, timestamp_combiner,
+      transcript, spec):
+
+    runner_name = TestPipeline().runner.__class__.__name__
+    if runner_name in spec.get('broken_on', ()):
+      self.skipTest('Known to be broken on %s' % runner_name)
+
+    test_stream = TestStream()
+    for action, params in transcript:
+      if action == 'expect':
+        test_stream.add_elements([('expect', params)])
+      else:
+        test_stream.add_elements([('expect', [])])
+        if action == 'input':
+          test_stream.add_elements([('input', e) for e in params])
+        elif action == 'watermark':
+          test_stream.advance_watermark_to(params)
+        elif action == 'clock':
+          test_stream.advance_processing_time(params)
+        elif action == 'state':
+          pass  # Requires inspection of implementation details.
+        else:
+          raise ValueError('Unexpected action: %s' % action)
+    test_stream.add_elements([('expect', [])])
+
+    class Check(beam.DoFn):
+      """A StatefulDoFn that verifies outputs are produced as expected.
+
+      This DoFn takes in two kinds of inputs, actual outputs and
+      expected outputs.  When an actual output is received, it is buffered
+      into state, and when an expected output is received, this buffered
+      state is retrieved and compared against the expected value(s) to ensure
+      they match.
+
+      The key is ignored, but all items must be on the same key to share state.
+      """
+      def process(
+          self, element, seen=beam.DoFn.StateParam(
+              beam.transforms.userstate.BagStateSpec(
+                  'seen',
+                  beam.coders.FastPrimitivesCoder()))):
+        _, (action, data) = element
+        if action == 'actual':
+          seen.add(data)
+
+        elif action == 'expect':
+          actual = list(seen.read())
+          seen.clear()
+
+          if len(actual) > len(data):
+            raise AssertionError(
+                'Unexpected output: expected %s but got %s' % (data, actual))
+          elif len(data) > len(actual):
+            raise AssertionError(
+                'Unmatched output: expected %s but got %s' % (data, actual))
+          else:
+
+            def diff(actual, expected):
+              for key in sorted(expected.keys(), reverse=True):
+                if key in actual:
+                  if actual[key] != expected[key]:
+                    return key
+
+            for output in actual:
+              diffs = [diff(output, expected) for expected in data]
+              if all(diffs):
+                raise AssertionError(
+                    'Unmatched output: %s not found in %s (diffs in %s)' % (
+                        output, data, diffs))
+
+        else:
+          raise ValueError('Unexpected action: %s' % action)
+
+    with TestPipeline(options=PipelineOptions(streaming=True)) as p:
+      # Split the test stream into a branch of to-be-processed elements, and
+      # a branch of expected results.
+      inputs, expected = (
+          p
+          | test_stream
+          | beam.MapTuple(
+              lambda tag, value: beam.pvalue.TaggedOutput(tag, ('key', value))
+              ).with_outputs('input', 'expect'))
+      # Process the inputs with the given windowing to produce actual outputs.
+      outputs = (
+          inputs
+          | beam.MapTuple(
+              lambda key, value: TimestampedValue((key, value), value))
+          | beam.WindowInto(
+              window_fn,
+              trigger=trigger_fn,
+              accumulation_mode=accumulation_mode,
+              timestamp_combiner=timestamp_combiner)
+          | beam.GroupByKey()
+          | beam.MapTuple(
+              lambda k, vs,
+              window=beam.DoFn.WindowParam,
+              t=beam.DoFn.TimestampParam: (
+                  k,
+                  {
+                      'values': sorted(vs),
+                      'window': [int(window.start), int(window.end - 1)],
+                      'timestamp': t
+                  }))
+          # Place outputs back into the global window to allow flattening
+          # and share a single state in Check.
+          | 'Global' >> beam.WindowInto(beam.transforms.window.GlobalWindows()))
+      # Feed both the expected and actual outputs to Check() for comparison.
+      tagged_expected = (
+          expected | beam.MapTuple(lambda key, value: (key, ('expect', value))))
+      tagged_outputs = (
+          outputs | beam.MapTuple(lambda key, value: (key, ('actual', value))))
+      # pylint: disable=expression-not-assigned
+      (tagged_expected, tagged_outputs) | beam.Flatten() | beam.ParDo(Check())
+
+
 TRANSCRIPT_TEST_FILE = os.path.join(
     os.path.dirname(__file__), '..', 'testing', 'data',
     'trigger_transcripts.yaml')
 if os.path.exists(TRANSCRIPT_TEST_FILE):
-  TranscriptTest._create_tests(TRANSCRIPT_TEST_FILE)
+  TriggerDriverTranscriptTest._create_tests(TRANSCRIPT_TEST_FILE)
+  TestStreamTranscriptTest._create_tests(TRANSCRIPT_TEST_FILE)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/transforms/trigger_test.py
+++ b/sdks/python/apache_beam/transforms/trigger_test.py
@@ -775,14 +775,14 @@ class TestStreamTranscriptTest(TranscriptTest):
           | beam.GroupByKey()
           | beam.MapTuple(
               lambda k, vs,
-              window=beam.DoFn.WindowParam,
-              t=beam.DoFn.TimestampParam: (
-                  k,
-                  {
-                      'values': sorted(vs),
-                      'window': [int(window.start), int(window.end - 1)],
-                      'timestamp': t
-                  }))
+                     window=beam.DoFn.WindowParam,
+                     t=beam.DoFn.TimestampParam: (
+                         k,
+                         {
+                             'values': sorted(vs),
+                             'window': [int(window.start), int(window.end - 1)],
+                             'timestamp': t
+                         }))
           # Place outputs back into the global window to allow flattening
           # and share a single state in Check.
           | 'Global' >> beam.WindowInto(beam.transforms.window.GlobalWindows()))


### PR DESCRIPTION

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
