### PR TITLE
[BEAM-8433] Use JUnit parameterized runner for dialect-sensitive integration tests

### DIFF
--- a/sdks/java/extensions/sql/datacatalog/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/DataCatalogBigQueryIT.java
+++ b/sdks/java/extensions/sql/datacatalog/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/DataCatalogBigQueryIT.java
@@ -24,88 +24,127 @@ import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.beam.sdk.extensions.sql.SqlTransform;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlPipelineOptions;
+import org.apache.beam.sdk.extensions.sql.impl.CalciteQueryPlanner;
+import org.apache.beam.sdk.extensions.sql.impl.QueryPlanner;
+import org.apache.beam.sdk.extensions.sql.zetasql.ZetaSQLQueryPlanner;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder;
 import org.apache.beam.sdk.io.gcp.bigquery.TestBigQuery;
+import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.joda.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 
 /** Integration tests for DataCatalog+BigQuery. */
-@RunWith(JUnit4.class)
+@RunWith(Enclosed.class)
 public class DataCatalogBigQueryIT {
 
-  private static final Schema ID_NAME_SCHEMA =
-      Schema.builder().addNullableField("id", INT64).addNullableField("name", STRING).build();
-  @Rule public transient TestPipeline writeToBQPipeline = TestPipeline.create();
-  @Rule public transient TestPipeline readPipeline = TestPipeline.create();
-  @Rule public transient TestBigQuery bigQuery = TestBigQuery.create(ID_NAME_SCHEMA);
+  @RunWith(Parameterized.class)
+  public static class DialectSensitiveTests {
+    private static final Schema ID_NAME_SCHEMA =
+        Schema.builder().addNullableField("id", INT64).addNullableField("name", STRING).build();
+    @Rule public transient TestPipeline writeToBQPipeline = TestPipeline.create();
+    @Rule public transient TestPipeline readPipeline = TestPipeline.create();
+    @Rule public transient TestBigQuery bigQuery = TestBigQuery.create(ID_NAME_SCHEMA);
 
-  @Test
-  public void testReadWriteCalcite() throws Exception {
-    testReadWriteUtil("org.apache.beam.sdk.extensions.sql.impl.CalciteQueryPlanner");
-  }
+    /** Parameterized by which SQL dialect, since the syntax here is the same. */
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> dialects() {
+      return Arrays.asList(
+          new Object[][] {
+            {"ZetaSQL", ZetaSQLQueryPlanner.class},
+            {"CalciteSQL", CalciteQueryPlanner.class}
+          });
+    }
 
-  @Test
-  public void testReadWriteZetaSQL() throws Exception {
-    testReadWriteUtil("org.apache.beam.sdk.extensions.sql.zetasql.ZetaSQLQueryPlanner");
-  }
+    @Parameterized.Parameter(0)
+    public String dialectName;
 
-  protected void testReadWriteUtil(String plannerName) throws Exception {
-    createBQTableWith(
-        new TableRow().set("id", 1).set("name", "name1"),
-        new TableRow().set("id", 2).set("name", "name2"),
-        new TableRow().set("id", 3).set("name", "name3"));
+    @Parameterized.Parameter(1)
+    public Class<? extends QueryPlanner> queryPlanner;
 
-    TableReference bqTable = bigQuery.tableReference();
-    String tableId =
-        String.format(
-            "bigquery.`table`.`%s`.`%s`.`%s`",
-            bqTable.getProjectId(), bqTable.getDatasetId(), bqTable.getTableId());
+    @Test
+    public void testReadWrite() throws Exception {
+      writeToBQPipeline.apply(
+          createBqTable(
+              new TableRow().set("id", 1).set("name", "name1"),
+              new TableRow().set("id", 2).set("name", "name2"),
+              new TableRow().set("id", 3).set("name", "name3")));
+      writeToBQPipeline.run().waitUntilFinish(Duration.standardMinutes(2));
 
-    readPipeline.getOptions().as(BeamSqlPipelineOptions.class).setPlannerName(plannerName);
+      TableReference bqTable = bigQuery.tableReference();
+      String tableId =
+          String.format(
+              "bigquery.`table`.`%s`.`%s`.`%s`",
+              bqTable.getProjectId(), bqTable.getDatasetId(), bqTable.getTableId());
 
-    PCollection<Row> result =
-        readPipeline.apply(
-            "query",
-            SqlTransform.query("SELECT id, name FROM " + tableId)
-                .withDefaultTableProvider(
-                    "datacatalog",
-                    DataCatalogTableProvider.create(
-                        readPipeline.getOptions().as(DataCatalogPipelineOptions.class))));
+      readPipeline
+          .getOptions()
+          .as(BeamSqlPipelineOptions.class)
+          .setPlannerName(queryPlanner.getCanonicalName());
 
-    PAssert.that(result).containsInAnyOrder(row(1, "name1"), row(2, "name2"), row(3, "name3"));
-    readPipeline.run().waitUntilFinish(Duration.standardMinutes(2));
-  }
+      PCollection<Row> result =
+          readPipeline.apply(
+              "query",
+              SqlTransform.query("SELECT id, name FROM " + tableId)
+                  .withDefaultTableProvider(
+                      "datacatalog",
+                      DataCatalogTableProvider.create(
+                          readPipeline.getOptions().as(DataCatalogPipelineOptions.class))));
 
-  private Row row(long id, String name) {
-    return Row.withSchema(ID_NAME_SCHEMA).addValues(id, name).build();
-  }
+      PAssert.that(result).containsInAnyOrder(row(1, "name1"), row(2, "name2"), row(3, "name3"));
+      readPipeline.run().waitUntilFinish(Duration.standardMinutes(2));
+    }
 
-  private void createBQTableWith(TableRow r1, TableRow r2, TableRow r3) {
-    writeToBQPipeline
-        .apply(Create.of(r1, r2, r3).withCoder(TableRowJsonCoder.of()))
-        .apply(
-            BigQueryIO.writeTableRows()
-                .to(bigQuery.tableSpec())
-                .withSchema(
-                    new TableSchema()
-                        .setFields(
-                            ImmutableList.of(
-                                new TableFieldSchema().setName("id").setType("INTEGER"),
-                                new TableFieldSchema().setName("name").setType("STRING"))))
-                .withoutValidation());
-    writeToBQPipeline.run().waitUntilFinish(Duration.standardMinutes(2));
+    private static Row row(long id, String name) {
+      return Row.withSchema(ID_NAME_SCHEMA).addValues(id, name).build();
+    }
+
+    public CreateBqTable createBqTable(TableRow... rows) {
+      return new CreateBqTable(Arrays.asList(rows));
+    }
+
+    private class CreateBqTable extends PTransform<PInput, WriteResult> {
+
+      private final List<TableRow> rows;
+
+      private CreateBqTable(List<TableRow> rows) {
+        this.rows = rows;
+      }
+
+      @Override
+      public WriteResult expand(PInput input) {
+        return input
+            .getPipeline()
+            .begin()
+            .apply(Create.<TableRow>of(rows).withCoder(TableRowJsonCoder.of()))
+            .apply(
+                BigQueryIO.writeTableRows()
+                    .to(bigQuery.tableSpec())
+                    .withSchema(
+                        new TableSchema()
+                            .setFields(
+                                ImmutableList.of(
+                                    new TableFieldSchema().setName("id").setType("INTEGER"),
+                                    new TableFieldSchema().setName("name").setType("STRING"))))
+                    .withoutValidation());
+      }
+    }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TestBigQuery.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TestBigQuery.java
@@ -171,7 +171,7 @@ public class TestBigQuery implements TestRule {
     }
 
     if (description.getMethodName() != null) {
-      topicName.append(description.getMethodName()).append("_");
+      topicName.append(description.getMethodName().replaceAll("[\\[\\]\\.]", "_")).append("_");
     }
 
     DATETIME_FORMAT.printTo(topicName, Instant.now());


### PR DESCRIPTION
Two commits:

1. Inline base class. It is clearer to have all test code inlined. If you must make a separate utility method, better to do it in the same class. Inheritance is almost never good in test classes.
2. Use JUnit Parameterized test runner instead of utility method. Also converted to a PTransform instead of a method, which is good Beam style for pipelines. Also made the parameterized tests enclosed, because we could also have ITs that do not depend on SQL dialect.

The two commits are independent, please do not squash (for history to be most readable)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
