### PR TITLE
[Go SDK] Harness logging fixes.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
@@ -79,6 +79,7 @@ func (s *ScopedDataManager) open(ctx context.Context, port exec.Port) (*DataChan
 	return local.Open(ctx, port) // don't hold lock over potentially slow operation
 }
 
+// Close prevents new IO for this instruction.
 func (s *ScopedDataManager) Close() error {
 	s.mu.Lock()
 	s.closed = true
@@ -171,10 +172,12 @@ func makeDataChannel(ctx context.Context, id string, client dataClient) *DataCha
 	return ret
 }
 
+// OpenRead returns an io.ReadCloser of the data elements for the given instruction and ptransform.
 func (c *DataChannel) OpenRead(ctx context.Context, ptransformID string, instID instructionID) io.ReadCloser {
 	return c.makeReader(ctx, clientID{ptransformID: ptransformID, instID: instID})
 }
 
+// OpenWrite returns an io.WriteCloser of the data elements for the given instruction and ptransform.
 func (c *DataChannel) OpenWrite(ctx context.Context, ptransformID string, instID instructionID) io.WriteCloser {
 	return c.makeWriter(ctx, clientID{ptransformID: ptransformID, instID: instID})
 }
@@ -189,7 +192,7 @@ func (c *DataChannel) read(ctx context.Context) {
 				log.Warnf(ctx, "DataChannel.read %v closed", c.id)
 				return
 			}
-			log.Errorf(ctx, "DataChannel.read %v bad", c.id)
+			log.Errorf(ctx, "DataChannel.read %v bad: %v", c.id, err)
 			return
 		}
 

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -82,8 +82,9 @@ func Main(ctx context.Context, loggingEndpoint, controlEndpoint string) error {
 	}()
 
 	ctrl := &control{
-		plans:  make(map[string]*exec.Plan),
-		active: make(map[string]*exec.Plan),
+		plans:  make(map[bundleDescriptorID]*exec.Plan),
+		active: make(map[instructionID]*exec.Plan),
+		failed: make(map[instructionID]error),
 		data:   &DataChannelManager{},
 		state:  &StateChannelManager{},
 	}
@@ -132,12 +133,17 @@ func Main(ctx context.Context, loggingEndpoint, controlEndpoint string) error {
 	}
 }
 
+type bundleDescriptorID string
+type instructionID string
+
 type control struct {
 	// plans that are candidates for execution.
-	plans map[string]*exec.Plan // protected by mu
+	plans map[bundleDescriptorID]*exec.Plan // protected by mu
 	// plans that are actively being executed.
 	// a plan can only be in one of these maps at any time.
-	active map[string]*exec.Plan // protected by mu
+	active map[instructionID]*exec.Plan // protected by mu
+	// plans that have failed during execution
+	failed map[instructionID]error // protected by mu
 	mu     sync.Mutex
 
 	data  *DataChannelManager
@@ -145,8 +151,8 @@ type control struct {
 }
 
 func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRequest) *fnpb.InstructionResponse {
-	id := req.GetInstructionId()
-	ctx = setInstID(ctx, id)
+	instID := instructionID(req.GetInstructionId())
+	ctx = setInstID(ctx, instID)
 
 	switch {
 	case req.GetRegister() != nil:
@@ -155,19 +161,19 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 		for _, desc := range msg.GetProcessBundleDescriptor() {
 			p, err := exec.UnmarshalPlan(desc)
 			if err != nil {
-				return fail(id, "Invalid bundle desc: %v", err)
+				return fail(ctx, instID, "Invalid bundle desc: %v", err)
 			}
 
-			pid := desc.GetId()
-			log.Debugf(ctx, "Plan %v: %v", pid, p)
+			bdID := bundleDescriptorID(desc.GetId())
+			log.Debugf(ctx, "Plan %v: %v", bdID, p)
 
 			c.mu.Lock()
-			c.plans[pid] = p
+			c.plans[bdID] = p
 			c.mu.Unlock()
 		}
 
 		return &fnpb.InstructionResponse{
-			InstructionId: id,
+			InstructionId: string(instID),
 			Response: &fnpb.InstructionResponse_Register{
 				Register: &fnpb.RegisterResponse{},
 			},
@@ -178,40 +184,43 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 
 		// NOTE: the harness sends a 0-length process bundle request to sources (changed?)
 
-		log.Debugf(ctx, "PB: %v", msg)
-
-		ref := msg.GetProcessBundleDescriptorId()
+		bdID := bundleDescriptorID(msg.GetProcessBundleDescriptorId())
+		log.Debugf(ctx, "PB [%v]: %v", instID, msg)
 		c.mu.Lock()
-		plan, ok := c.plans[ref]
+		plan, ok := c.plans[bdID]
 		// Make the plan active, and remove it from candidates
 		// since a plan can't be run concurrently.
-		c.active[id] = plan
-		delete(c.plans, ref)
+		c.active[instID] = plan
+		delete(c.plans, bdID)
 		c.mu.Unlock()
 
 		if !ok {
-			return fail(id, "execution plan for %v not found", ref)
+			return fail(ctx, instID, "execution plan for %v not found", bdID)
 		}
 
-		data := NewScopedDataManager(c.data, id)
-		state := NewScopedStateReader(c.state, id)
-		err := plan.Execute(ctx, id, exec.DataContext{Data: data, State: state})
+		data := NewScopedDataManager(c.data, instID)
+		state := NewScopedStateReader(c.state, instID)
+		err := plan.Execute(ctx, string(instID), exec.DataContext{Data: data, State: state})
 		data.Close()
 		state.Close()
 
 		m := plan.Metrics()
 		// Move the plan back to the candidate state
 		c.mu.Lock()
-		c.plans[plan.ID()] = plan
-		delete(c.active, id)
+		// Mark the instruction as failed.
+		if err != nil {
+			c.failed[instID] = err
+		}
+		c.plans[bdID] = plan
+		delete(c.active, instID)
 		c.mu.Unlock()
 
 		if err != nil {
-			return fail(id, "execute failed: %v", err)
+			return fail(ctx, instID, "process bundle failed for instruction %v using plan %v : %v", instID, bdID, err)
 		}
 
 		return &fnpb.InstructionResponse{
-			InstructionId: id,
+			InstructionId: string(instID),
 			Response: &fnpb.InstructionResponse_ProcessBundle{
 				ProcessBundle: &fnpb.ProcessBundleResponse{
 					Metrics: m,
@@ -222,20 +231,22 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 	case req.GetProcessBundleProgress() != nil:
 		msg := req.GetProcessBundleProgress()
 
-		// log.Debugf(ctx, "PB Progress: %v", msg)
-
-		ref := msg.GetInstructionId()
+		ref := instructionID(msg.GetInstructionId())
 		c.mu.Lock()
 		plan, ok := c.active[ref]
+		err := c.failed[ref]
 		c.mu.Unlock()
+		if err != nil {
+			return fail(ctx, instID, "failed to return progress: instruction %v failed: %v", ref, err)
+		}
 		if !ok {
-			return fail(id, "execution plan for %v not found", ref)
+			return fail(ctx, instID, "failed to return progress: instruction %v not active", ref)
 		}
 
 		m := plan.Metrics()
 
 		return &fnpb.InstructionResponse{
-			InstructionId: id,
+			InstructionId: string(instID),
 			Response: &fnpb.InstructionResponse_ProcessBundleProgress{
 				ProcessBundleProgress: &fnpb.ProcessBundleProgressResponse{
 					Metrics: m,
@@ -247,27 +258,31 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 		msg := req.GetProcessBundleSplit()
 
 		log.Debugf(ctx, "PB Split: %v", msg)
-		ref := msg.GetInstructionId()
+		ref := instructionID(msg.GetInstructionId())
 		c.mu.Lock()
 		plan, ok := c.active[ref]
+		err := c.failed[ref]
 		c.mu.Unlock()
+		if err != nil {
+			return fail(ctx, instID, "failed to split: instruction %v failed: %v", ref, err)
+		}
 		if !ok {
-			return fail(id, "execution plan for %v not found", ref)
+			return fail(ctx, instID, "failed to split: execution plan for %v not active", ref)
 		}
 
 		// Get the desired splits for the root FnAPI read operation.
 		ds := msg.GetDesiredSplits()[plan.SourcePTransformID()]
 		if ds == nil {
-			return fail(id, "failed to split: desired splits for root was empty.")
+			return fail(ctx, instID, "failed to split: desired splits for root of %v was empty.", ref)
 		}
-		split, err := plan.Split(exec.SplitPoints{ds.GetAllowedSplitPoints(), ds.GetFractionOfRemainder()})
+		split, err := plan.Split(exec.SplitPoints{Splits: ds.GetAllowedSplitPoints(), Frac: ds.GetFractionOfRemainder()})
 
 		if err != nil {
-			return fail(id, "unable to split: %v", err)
+			return fail(ctx, instID, "unable to split %v: %v", ref, err)
 		}
 
 		return &fnpb.InstructionResponse{
-			InstructionId: id,
+			InstructionId: string(instID),
 			Response: &fnpb.InstructionResponse_ProcessBundleSplit{
 				ProcessBundleSplit: &fnpb.ProcessBundleSplitResponse{
 					ChannelSplits: []*fnpb.ProcessBundleSplitResponse_ChannelSplit{
@@ -281,15 +296,16 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 		}
 
 	default:
-		return fail(id, "Unexpected request: %v", req)
+		return fail(ctx, instID, "Unexpected request: %v", req)
 	}
 }
 
-func fail(id, format string, args ...interface{}) *fnpb.InstructionResponse {
+func fail(ctx context.Context, id instructionID, format string, args ...interface{}) *fnpb.InstructionResponse {
+	log.Output(ctx, log.SevError, 1, fmt.Sprintf(format, args...))
 	dummy := &fnpb.InstructionResponse_Register{Register: &fnpb.RegisterResponse{}}
 
 	return &fnpb.InstructionResponse{
-		InstructionId: id,
+		InstructionId: string(id),
 		Error:         fmt.Sprintf(format, args...),
 		Response:      dummy,
 	}

--- a/sdks/go/pkg/beam/core/runtime/harness/logging.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/logging.go
@@ -37,7 +37,7 @@ type contextKey string
 
 const instKey contextKey = "beam:inst"
 
-func setInstID(ctx context.Context, id string) context.Context {
+func setInstID(ctx context.Context, id instructionID) context.Context {
 	return context.WithValue(ctx, instKey, id)
 }
 

--- a/sdks/go/pkg/beam/core/runtime/harness/logging.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/logging.go
@@ -61,7 +61,7 @@ func (l *logger) Log(ctx context.Context, sev log.Severity, calldepth int, msg s
 		Severity:  convertSeverity(sev),
 		Message:   msg,
 	}
-	if _, file, line, ok := runtime.Caller(calldepth); ok {
+	if _, file, line, ok := runtime.Caller(calldepth + 1); ok {
 		entry.LogLocation = fmt.Sprintf("%v:%v", file, line)
 	}
 	if id, ok := tryGetInstID(ctx); ok {

--- a/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
@@ -34,7 +34,7 @@ import (
 // for side input use. The indirection makes it easier to control access.
 type ScopedStateReader struct {
 	mgr    *StateChannelManager
-	instID string
+	instID instructionID
 
 	opened []io.Closer // track open readers to force close all
 	closed bool
@@ -42,7 +42,7 @@ type ScopedStateReader struct {
 }
 
 // NewScopedStateReader returns a ScopedStateReader for the given instruction.
-func NewScopedStateReader(mgr *StateChannelManager, instID string) *ScopedStateReader {
+func NewScopedStateReader(mgr *StateChannelManager, instID instructionID) *ScopedStateReader {
 	return &ScopedStateReader{mgr: mgr, instID: instID}
 }
 
@@ -103,7 +103,7 @@ func (s *ScopedStateReader) Close() error {
 }
 
 type stateKeyReader struct {
-	instID string
+	instID instructionID
 	key    *pb.StateKey
 
 	token []byte
@@ -115,7 +115,7 @@ type stateKeyReader struct {
 	mu     sync.Mutex
 }
 
-func newSideInputReader(ch *StateChannel, id exec.StreamID, sideInputID string, instID string, k, w []byte) *stateKeyReader {
+func newSideInputReader(ch *StateChannel, id exec.StreamID, sideInputID string, instID instructionID, k, w []byte) *stateKeyReader {
 	key := &pb.StateKey{
 		Type: &pb.StateKey_MultimapSideInput_{
 			MultimapSideInput: &pb.StateKey_MultimapSideInput{
@@ -133,7 +133,7 @@ func newSideInputReader(ch *StateChannel, id exec.StreamID, sideInputID string, 
 	}
 }
 
-func newRunnerReader(ch *StateChannel, instID string, k []byte) *stateKeyReader {
+func newRunnerReader(ch *StateChannel, instID instructionID, k []byte) *stateKeyReader {
 	key := &pb.StateKey{
 		Type: &pb.StateKey_Runner_{
 			Runner: &pb.StateKey_Runner{
@@ -166,7 +166,7 @@ func (r *stateKeyReader) Read(buf []byte) (int, error) {
 
 		req := &pb.StateRequest{
 			// Id: set by channel
-			InstructionId: r.instID,
+			InstructionId: string(r.instID),
 			StateKey:      r.key,
 			Request: &pb.StateRequest_Get{
 				Get: &pb.StateGetRequest{

--- a/sdks/go/pkg/beam/log/log.go
+++ b/sdks/go/pkg/beam/log/log.go
@@ -68,80 +68,80 @@ func Output(ctx context.Context, sev Severity, calldepth int, msg string) {
 // Debug writes the fmt.Sprint-formatted arguments to the global logger with
 // debug severity.
 func Debug(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevDebug, 2, fmt.Sprint(v...))
+	Output(ctx, SevDebug, 1, fmt.Sprint(v...))
 }
 
 // Debugf writes the fmt.Sprintf-formatted arguments to the global logger with
 // debug severity.
 func Debugf(ctx context.Context, format string, v ...interface{}) {
-	Output(ctx, SevDebug, 2, fmt.Sprintf(format, v...))
+	Output(ctx, SevDebug, 1, fmt.Sprintf(format, v...))
 }
 
 // Debugln writes the fmt.Sprintln-formatted arguments to the global logger with
 // debug severity.
 func Debugln(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevDebug, 2, fmt.Sprintln(v...))
+	Output(ctx, SevDebug, 1, fmt.Sprintln(v...))
 }
 
 // Info writes the fmt.Sprint-formatted arguments to the global logger with
 // info severity.
 func Info(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevInfo, 2, fmt.Sprint(v...))
+	Output(ctx, SevInfo, 1, fmt.Sprint(v...))
 }
 
 // Infof writes the fmt.Sprintf-formatted arguments to the global logger with
 // info severity.
 func Infof(ctx context.Context, format string, v ...interface{}) {
-	Output(ctx, SevInfo, 2, fmt.Sprintf(format, v...))
+	Output(ctx, SevInfo, 1, fmt.Sprintf(format, v...))
 }
 
 // Infoln writes the fmt.Sprintln-formatted arguments to the global logger with
 // info severity.
 func Infoln(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevInfo, 2, fmt.Sprintln(v...))
+	Output(ctx, SevInfo, 1, fmt.Sprintln(v...))
 }
 
 // Warn writes the fmt.Sprint-formatted arguments to the global logger with
 // warn severity.
 func Warn(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevWarn, 2, fmt.Sprint(v...))
+	Output(ctx, SevWarn, 1, fmt.Sprint(v...))
 }
 
 // Warnf writes the fmt.Sprintf-formatted arguments to the global logger with
 // warn severity.
 func Warnf(ctx context.Context, format string, v ...interface{}) {
-	Output(ctx, SevWarn, 2, fmt.Sprintf(format, v...))
+	Output(ctx, SevWarn, 1, fmt.Sprintf(format, v...))
 }
 
 // Warnln writes the fmt.Sprintln-formatted arguments to the global logger with
 // warn severity.
 func Warnln(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevWarn, 2, fmt.Sprintln(v...))
+	Output(ctx, SevWarn, 1, fmt.Sprintln(v...))
 }
 
 // Error writes the fmt.Sprint-formatted arguments to the global logger with
 // error severity.
 func Error(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevError, 2, fmt.Sprint(v...))
+	Output(ctx, SevError, 1, fmt.Sprint(v...))
 }
 
 // Errorf writes the fmt.Sprintf-formatted arguments to the global logger with
 // error severity.
 func Errorf(ctx context.Context, format string, v ...interface{}) {
-	Output(ctx, SevError, 2, fmt.Sprintf(format, v...))
+	Output(ctx, SevError, 1, fmt.Sprintf(format, v...))
 }
 
 // Errorln writes the fmt.Sprintln-formatted arguments to the global logger with
 // error severity.
 func Errorln(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevError, 2, fmt.Sprintln(v...))
+	Output(ctx, SevError, 1, fmt.Sprintln(v...))
 }
 
 // Fatal writes the fmt.Sprint-formatted arguments to the global logger with
 // fatal severity. It then panics.
 func Fatal(ctx context.Context, v ...interface{}) {
 	msg := fmt.Sprint(v...)
-	Output(ctx, SevFatal, 2, msg)
+	Output(ctx, SevFatal, 1, msg)
 	panic(msg)
 }
 
@@ -149,7 +149,7 @@ func Fatal(ctx context.Context, v ...interface{}) {
 // fatal severity. It then panics.
 func Fatalf(ctx context.Context, format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
-	Output(ctx, SevFatal, 2, msg)
+	Output(ctx, SevFatal, 1, msg)
 	panic(msg)
 }
 
@@ -157,27 +157,27 @@ func Fatalf(ctx context.Context, format string, v ...interface{}) {
 // fatal severity. It then panics.
 func Fatalln(ctx context.Context, v ...interface{}) {
 	msg := fmt.Sprintln(v...)
-	Output(ctx, SevFatal, 2, msg)
+	Output(ctx, SevFatal, 1, msg)
 	panic(msg)
 }
 
 // Exit writes the fmt.Sprint-formatted arguments to the global logger with
 // fatal severity. It then exits.
 func Exit(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevFatal, 2, fmt.Sprint(v...))
+	Output(ctx, SevFatal, 1, fmt.Sprint(v...))
 	os.Exit(1)
 }
 
 // Exitf writes the fmt.Sprintf-formatted arguments to the global logger with
 // fatal severity. It then exits.
 func Exitf(ctx context.Context, format string, v ...interface{}) {
-	Output(ctx, SevFatal, 2, fmt.Sprintf(format, v...))
+	Output(ctx, SevFatal, 1, fmt.Sprintf(format, v...))
 	os.Exit(1)
 }
 
 // Exitln writes the fmt.Sprintln-formatted arguments to the global logger with
 // fatal severity. It then exits.
 func Exitln(ctx context.Context, v ...interface{}) {
-	Output(ctx, SevFatal, 2, fmt.Sprintln(v...))
+	Output(ctx, SevFatal, 1, fmt.Sprintln(v...))
 	os.Exit(1)
 }


### PR DESCRIPTION
Three commits to improve logging from the Go SDK harness, to prep for a more involved change to improve datamgr.go.
* Logging call depths were spuriously one higher than they should have been. The lowest level in the standard logger was not adding 1 for it's own stack frame. This made logs refer to the wrong line if the standard logger was replaced.
* It's been unclear if instructions that depend on others being active (like Progress and Split) were failing because their reference instruction was terminated or not. This change resolves that for error cases by repeating the root error message on those channels. To add clarity, I've added some light types to ensure we aren't getting our BundleIDs mixed up with our InstructionIDs, and renamed the trickier variables, since we were calling everything "ref".
* Finally, if the data channel fails on receive, we were swallowing the root error and not logging it.

Otherwise, adding some missing documentation lines for exported methods since the linter was unhappy with them.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
