### PR TITLE
[Go SDK] Propagate data channel failures to Process Bundle readers.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
@@ -144,6 +144,9 @@ type DataChannel struct {
 	readers map[clientID]*dataReader
 	// TODO: early/late closed, bad instructions, finer locks, reconnect?
 
+	// readErr indicates a client.Recv error and is used to prevent new readers.
+	readErr error
+
 	mu sync.Mutex // guards both the readers and writers maps.
 }
 
@@ -174,7 +177,12 @@ func makeDataChannel(ctx context.Context, id string, client dataClient) *DataCha
 
 // OpenRead returns an io.ReadCloser of the data elements for the given instruction and ptransform.
 func (c *DataChannel) OpenRead(ctx context.Context, ptransformID string, instID instructionID) io.ReadCloser {
-	return c.makeReader(ctx, clientID{ptransformID: ptransformID, instID: instID})
+	cid := clientID{ptransformID: ptransformID, instID: instID}
+	if c.readErr != nil {
+		log.Errorf(ctx, "opening a reader %v on a closed channel", cid)
+		return &errReader{c.readErr}
+	}
+	return c.makeReader(ctx, cid)
 }
 
 // OpenWrite returns an io.WriteCloser of the data elements for the given instruction and ptransform.
@@ -187,8 +195,21 @@ func (c *DataChannel) read(ctx context.Context) {
 	for {
 		msg, err := c.client.Recv()
 		if err != nil {
+			// This connection is bad, so we should close and delete all extant streams.
+			c.mu.Lock()
+			c.readErr = err // prevent not yet opened readers from hanging.
+			for _, r := range c.readers {
+				log.Errorf(ctx, "DataChannel.read %v reader %v closing due to error on channel", c.id, r.id)
+				if !r.completed {
+					r.completed = true
+					r.err = err
+					close(r.buf)
+				}
+				delete(cache, r.id)
+			}
+			c.mu.Unlock()
+
 			if err == io.EOF {
-				// TODO(herohde) 10/12/2017: can this happen before shutdown? Reconnect?
 				log.Warnf(ctx, "DataChannel.read %v closed", c.id)
 				return
 			}
@@ -204,8 +225,6 @@ func (c *DataChannel) read(ctx context.Context) {
 
 		for _, elm := range msg.GetData() {
 			id := clientID{ptransformID: elm.TransformId, instID: instructionID(elm.GetInstructionId())}
-
-			// log.Printf("Chan read (%v): %v\n", sid, elm.GetData())
 
 			var r *dataReader
 			if local, ok := cache[id]; ok {
@@ -224,6 +243,7 @@ func (c *DataChannel) read(ctx context.Context) {
 			}
 			if len(elm.GetData()) == 0 {
 				// Sentinel EOF segment for stream. Close buffer to signal EOF.
+				r.completed = true
 				close(r.buf)
 
 				// Clean up local bookkeeping. We'll never see another message
@@ -242,9 +262,22 @@ func (c *DataChannel) read(ctx context.Context) {
 			case r.buf <- elm.GetData():
 			case <-r.done:
 				r.completed = true
+				close(r.buf)
 			}
 		}
 	}
+}
+
+type errReader struct {
+	err error
+}
+
+func (r *errReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
+func (r *errReader) Close() error {
+	return r.err
 }
 
 func (c *DataChannel) makeReader(ctx context.Context, id clientID) *dataReader {
@@ -286,6 +319,7 @@ type dataReader struct {
 	cur       []byte
 	channel   *DataChannel
 	completed bool
+	err       error
 }
 
 func (r *dataReader) Close() error {
@@ -298,7 +332,11 @@ func (r *dataReader) Read(buf []byte) (int, error) {
 	if r.cur == nil {
 		b, ok := <-r.buf
 		if !ok {
-			return 0, io.EOF
+			log.Errorf(context.TODO(), "dataReader.Read %v channel closed: %v", r.id, r.err)
+			if r.err == nil {
+				return 0, io.EOF
+			}
+			return 0, r.err
 		}
 		r.cur = b
 	}
@@ -378,7 +416,7 @@ func (w *dataWriter) Write(p []byte) (n int, err error) {
 		l := len(w.buf)
 		// We can't fit this message into the buffer. We need to flush the buffer
 		if err := w.Flush(); err != nil {
-			return 0, errors.Wrapf(err, "datamgr.go: error flushing buffer of length %d", l)
+			return 0, errors.Wrapf(err, "datamgr.go [%v]: error flushing buffer of length %d", w.id, l)
 		}
 	}
 

--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr_test.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr_test.go
@@ -17,6 +17,7 @@ package harness
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -25,10 +26,13 @@ import (
 	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 )
 
+const extraData = 2
+
 type fakeClient struct {
 	t     *testing.T
 	done  chan bool
 	calls int
+	err   error
 }
 
 func (f *fakeClient) Recv() (*pb.Elements, error) {
@@ -42,7 +46,8 @@ func (f *fakeClient) Recv() (*pb.Elements, error) {
 
 	msg := pb.Elements{}
 
-	for i := 0; i < bufElements+1; i++ {
+	// Send extraData more than the number of elements buffered in the channel.
+	for i := 0; i < bufElements+extraData; i++ {
 		msg.Data = append(msg.Data, &elemData)
 	}
 
@@ -51,16 +56,16 @@ func (f *fakeClient) Recv() (*pb.Elements, error) {
 	// Subsequent calls return no data.
 	switch f.calls {
 	case 1:
-		return &msg, nil
+		return &msg, f.err
 	case 2:
-		return &msg, nil
+		return &msg, f.err
 	case 3:
 		elemData.Data = []byte{}
 		msg.Data = []*pb.Elements_Data{&elemData}
 		// Broadcasting done here means that this code providing messages
 		// has not been blocked by the bug blocking the dataReader
 		// from getting more messages.
-		return &msg, nil
+		return &msg, f.err
 	default:
 		f.done <- true
 		return nil, io.EOF
@@ -74,24 +79,102 @@ func (f *fakeClient) Send(*pb.Elements) error {
 func TestDataChannelTerminateOnClose(t *testing.T) {
 	// The logging of channels closed is quite noisy for this test
 	log.SetOutput(ioutil.Discard)
-	done := make(chan bool, 1)
-	client := &fakeClient{t: t, done: done}
-	c := makeDataChannel(context.Background(), "id", client)
 
-	r := c.OpenRead(context.Background(), "ptr", "inst_ref")
-	var read = make([]byte, 4)
+	tests := []struct {
+		name   string
+		caseFn func(t *testing.T, r io.ReadCloser, client *fakeClient, c *DataChannel)
+	}{
+		{
+			name: "onClose",
+			caseFn: func(t *testing.T, r io.ReadCloser, client *fakeClient, c *DataChannel) {
+				// We don't read up all the buffered data, but immediately close the reader.
+				// Previously, since nothing was consuming the incoming gRPC data, the whole
+				// data channel would get stuck, and the client.Recv() call was eventually
+				// no longer called.
+				r.Close()
 
-	// We don't read up all the buffered data, but immediately close the reader.
-	// Previously, since nothing was consuming the incoming gRPC data, the whole
-	// data channel would get stuck, and the client.Recv() call was eventually
-	// no longer called.
-	_, err := r.Read(read)
-	if err != nil {
-		t.Errorf("Unexpected error from read: %v", err)
+				// If done is signaled, that means client.Recv() has been called to flush the
+				// channel, meaning consumer code isn't stuck.
+				<-client.done
+				i := 1 // For the earlier Read.
+				for {
+					read := make([]byte, 4)
+					if n, err := r.Read(read); err != io.EOF {
+						i++
+						// There are bufElements+extraData available from the fakeClient, so drain the channel
+						// before marking a test failure.
+						if i > bufElements+extraData {
+							t.Errorf("Unexpected error from read: %v, read %d bytes, %v", err, n, read)
+						}
+						continue
+					}
+					break
+				}
+				// This Test can hang on failure.
+			},
+		}, {
+			name: "onRecvError",
+			caseFn: func(t *testing.T, r io.ReadCloser, client *fakeClient, c *DataChannel) {
+				// Set the 3rd Recv call to have an error.
+				// The SDK starts reading in a goroutine immeadiately after open.
+				expectedError := fmt.Errorf("EXPECTED ERROR")
+				client.err = expectedError
+				t.Log("ERROR SET")
+
+				i := 1 // For the earlier Read.
+				for {
+					read := make([]byte, 4)
+					i++
+					if n, err := r.Read(read); err != expectedError {
+						// There are bufElements+extraData available from the fakeClient, so drain the channel
+						// before marking a test failure.
+						if i > bufElements+extraData {
+							t.Errorf("Unexpected error from read %d: %v, read %d bytes, %v", i, err, n, read)
+						}
+						continue
+					}
+					break
+				}
+				t.Logf("exited after %d Read calls", i)
+
+				// Verify that new readers return errors on their reads after a client.Recv error.
+				if n, err := c.OpenRead(context.Background(), "ptr", "inst_ref").Read(make([]byte, 4)); err != expectedError {
+					t.Errorf("Unexpected error from read: got %v, want, %v read %d bytes.", err, expectedError, n)
+				}
+			},
+		}, {
+			name: "onSentinel",
+			caseFn: func(t *testing.T, r io.ReadCloser, client *fakeClient, c *DataChannel) {
+				i := 1 // For the earlier Read.
+				for {
+					read := make([]byte, 4)
+					i++
+					if n, err := r.Read(read); err == io.EOF {
+						break
+					} else if err != nil {
+						t.Errorf("Unexpected error from read %d: %v, read %d bytes, %v", i, err, n, read)
+					}
+					continue
+				}
+				t.Logf("exited after %d Read calls", i)
+				// This Test can hang on failure.
+			},
+		},
 	}
-	r.Close()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			done := make(chan bool, 1)
+			client := &fakeClient{t: t, done: done}
+			c := makeDataChannel(context.Background(), "id", client)
 
-	// If done is signaled, that means client.Recv() has been called to flush the
-	// channel, meaning consumer code isn't stuck.
-	<-done
+			r := c.OpenRead(context.Background(), "ptr", "inst_ref")
+
+			n, err := r.Read(make([]byte, 4))
+			if err != nil {
+				t.Errorf("Unexpected error from read: %v, read %d bytes.", err, n)
+			}
+			test.caseFn(t, r, client, c)
+		})
+	}
+
 }


### PR DESCRIPTION
When failures occur on the data channel, the Process Bundle requests that depend on them should fail with the same error message. Further, since the data channel is suspect, no further reads should occur on that channel, and process bundle should terminate.

Previously, this would lead to bundles being stuck waiting forever for data, which would never arrive. Bad data channel errors include the GRPC receive buffer being set too small, from which there is no recovery for the pipeline, and clear bundle failure and abort is the only reasonable option.

This commit additionally makes logging a bit noisier and the context of each failure clearer.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
