### PR TITLE
[BEAM-8503] Improve TestBigQuery and TestPubsub

### DIFF
--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
@@ -237,9 +236,9 @@ public class PubsubJsonIT implements Serializable {
 
     // Poll the signaling topic for success message
     resultSignal.waitForSuccess(Duration.standardMinutes(2));
-    assertThat(
-        dlqTopic.pull(),
-        containsInAnyOrder(messageLike(ts(4), "{ - }"), messageLike(ts(5), "{ + }")));
+    dlqTopic
+        .assertThatTopicEventuallyReceives(messageLike(ts(4), "{ - }"), messageLike(ts(5), "{ + }"))
+        .waitForUpTo(Duration.standardSeconds(20));
   }
 
   @Test
@@ -335,12 +334,12 @@ public class PubsubJsonIT implements Serializable {
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(5));
 
-    assertThat(
-        eventsTopic.pull(),
-        containsInAnyOrder(
+    eventsTopic
+        .assertThatTopicEventuallyReceives(
             messageLike("{\"name\":\"person1\"}"),
             messageLike("{\"name\":\"person3\"}"),
-            messageLike("{\"name\":\"person5\"}")));
+            messageLike("{\"name\":\"person5\"}"))
+        .waitForUpTo(Duration.standardSeconds(20));
   }
 
   private static String toArg(Object o) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -18,12 +18,17 @@
 package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasProperty;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -38,6 +43,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.extensions.sql.SqlTransform;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
 import org.apache.beam.sdk.extensions.sql.impl.JdbcConnection;
 import org.apache.beam.sdk.extensions.sql.impl.JdbcDriver;
@@ -46,13 +52,14 @@ import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.store.InMemoryMetaStore;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder;
 import org.apache.beam.sdk.io.gcp.pubsub.TestPubsub;
 import org.apache.beam.sdk.io.gcp.pubsub.TestPubsubSignal;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.ToJson;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
@@ -61,6 +68,7 @@ import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.Immutabl
 import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Supplier;
+import org.hamcrest.Matcher;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Ignore;
@@ -90,7 +98,6 @@ public class PubsubJsonIT implements Serializable {
   @Rule public transient TestPubsub eventsTopic = TestPubsub.create();
   @Rule public transient TestPubsub dlqTopic = TestPubsub.create();
   @Rule public transient TestPubsubSignal resultSignal = TestPubsubSignal.create();
-  @Rule public transient TestPubsubSignal dlqSignal = TestPubsubSignal.create();
   @Rule public transient TestPipeline pipeline = TestPipeline.create();
 
   /**
@@ -219,36 +226,20 @@ public class PubsubJsonIT implements Serializable {
     Supplier<Void> start = resultSignal.waitForStart(Duration.standardMinutes(5));
     pipeline.begin().apply("signal query results started", resultSignal.signalStart());
 
-    // Another PCollection, reads from DLQ
-    PCollection<PubsubMessage> dlq =
-        pipeline.apply(
-            PubsubIO.readMessagesWithAttributes().fromTopic(dlqTopic.topicPath().getPath()));
-
-    // Observe DLQ contents and send success signal after seeing the expected messages
-    dlq.apply(
-        "waitForDlq",
-        dlqSignal.signalSuccessWhen(
-            PubsubMessageWithAttributesCoder.of(),
-            dlqMessages ->
-                containsAll(dlqMessages, message(ts(4), "{ - }"), message(ts(5), "{ + }"))));
-
-    // Send the start signal to make sure the signaling topic is initialized
-    Supplier<Void> startDlq = dlqSignal.waitForStart(Duration.standardMinutes(5));
-    pipeline.begin().apply("signal DLQ started", dlqSignal.signalStart());
-
     // Start the pipeline
     pipeline.run();
 
     // Wait until got the response from the signalling topics
     start.get();
-    startDlq.get();
 
     // Start publishing the messages when main pipeline is started and signaling topics are ready
     eventsTopic.publish(messages);
 
     // Poll the signaling topic for success message
     resultSignal.waitForSuccess(Duration.standardMinutes(2));
-    dlqSignal.waitForSuccess(Duration.standardMinutes(2));
+    assertThat(
+        dlqTopic.pull(),
+        containsInAnyOrder(messageLike(ts(4), "{ - }"), messageLike(ts(5), "{ + }")));
   }
 
   @Test
@@ -317,6 +308,41 @@ public class PubsubJsonIT implements Serializable {
     pool.shutdown();
   }
 
+  @Test
+  public void testWritesJsonRowsToPubsub() throws Exception {
+    Schema personSchema =
+        Schema.builder()
+            .addStringField("name")
+            .addInt32Field("height")
+            .addBooleanField("knowsJavascript")
+            .build();
+    PCollection<Row> rows =
+        pipeline
+            .apply(
+                Create.of(
+                    row(personSchema, "person1", 80, true),
+                    row(personSchema, "person2", 70, false),
+                    row(personSchema, "person3", 60, true),
+                    row(personSchema, "person4", 50, false),
+                    row(personSchema, "person5", 40, true)))
+            .setRowSchema(personSchema)
+            .apply(
+                SqlTransform.query(
+                    "SELECT name FROM PCOLLECTION AS person WHERE person.knowsJavascript"));
+
+    // Convert rows to JSON and write to pubsub
+    rows.apply(ToJson.of()).apply(PubsubIO.writeStrings().to(eventsTopic.topicPath().getPath()));
+
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(5));
+
+    assertThat(
+        eventsTopic.pull(),
+        containsInAnyOrder(
+            messageLike("{\"name\":\"person1\"}"),
+            messageLike("{\"name\":\"person3\"}"),
+            messageLike("{\"name\":\"person5\"}")));
+  }
+
   private static String toArg(Object o) {
     try {
       String jsonRepr = MAPPER.writeValueAsString(o);
@@ -378,6 +404,16 @@ public class PubsubJsonIT implements Serializable {
   private PubsubMessage message(Instant timestamp, String jsonPayload) {
     return new PubsubMessage(
         jsonPayload.getBytes(UTF_8), ImmutableMap.of("ts", String.valueOf(timestamp.getMillis())));
+  }
+
+  private Matcher<PubsubMessage> messageLike(Instant timestamp, String jsonPayload) {
+    return allOf(
+        hasProperty("payload", equalTo(jsonPayload.getBytes(StandardCharsets.US_ASCII))),
+        hasProperty("attributeMap", hasEntry("ts", String.valueOf(timestamp.getMillis()))));
+  }
+
+  private Matcher<PubsubMessage> messageLike(String jsonPayload) {
+    return hasProperty("payload", equalTo(jsonPayload.getBytes(StandardCharsets.US_ASCII)));
   }
 
   private String jsonString(int id, String name) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSource.java
@@ -69,7 +69,8 @@ class BigQueryTableSource<T> extends BigQuerySourceBase<T> {
       TableReference tableRef = tableDef.getTableReference(bqOptions);
       Table table = bqServices.getDatasetService(bqOptions).getTable(tableRef);
       Long numBytes = table.getNumBytes();
-      if (table.getStreamingBuffer() != null) {
+      if (table.getStreamingBuffer() != null
+          && table.getStreamingBuffer().getEstimatedBytes() != null) {
         numBytes += table.getStreamingBuffer().getEstimatedBytes().longValue();
       }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessage.java
@@ -21,6 +21,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 
 /**
  * Class representing a Pub/Sub message. Each message contains a single message payload, a map of
@@ -65,5 +66,14 @@ public class PubsubMessage {
   @Nullable
   public String getMessageId() {
     return messageId;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("message", message)
+        .add("attributes", attributes)
+        .add("messageId", messageId)
+        .toString();
   }
 }


### PR DESCRIPTION
This PR adds some features to `TestBigQuery` and `TestPubsub`, and modifies some integration tests to use these new features.

### TestBigQuery
- Add ability to insert data in the test table prior to running a test.
- Can now assert on table data `now` as well as `eventually`.

### TestPubsub
- `TestPubsub` now initializes a randomized subscription when its created, so that users can pull all messages received during test execution.
- Adds `TestPubsub#{pull, waitForNMessages, assertThatTopicEventuallyReceives}` for accessing received messages.

### TestBigQueryReadWriteIT
- Original `testSQLRead*` tests are renamed to `testSQLReadWrite*` since they test separate Read and Write SQL pipelines.
- Add `testSQLRead` and `testSQLWrite` tests to just test read path and write path, respectively.

### PubsubJsonIT
- Modifies `testUsesDlq` to access dlq data with `TestPubsub#pull` instead of signaling (although this test is still ignored as I haven't verified that it no longer flakes).
- Adds `testWritesJsonRowsToPubsub`.

### DataCatalogBigQueryIT
- Removes `writeToBqPipeline` and instead uses `TestBigQuery#insertRows` at the start of the test.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
