### PR TITLE
[BEAM-8474] A microbenchmark for Python FnApiRunner:

### DIFF
--- a/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
@@ -37,16 +37,16 @@ the fixed cost of ovehead for the data path of the FnApiRunner.
 
 Initial results were:
 
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 1 of 10, per element time cost: 3.6778 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 2 of 10, per element time cost: 0.053498 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 3 of 10, per element time cost: 0.0299434 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 4 of 10, per element time cost: 0.0211154 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 5 of 10, per element time cost: 0.0170031 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 6 of 10, per element time cost: 0.0150809 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 7 of 10, per element time cost: 0.013218 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 8 of 10, per element time cost: 0.0119685 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 9 of 10, per element time cost: 0.0107382 sec
-run_single_pipeline, 1 element(s) at start, 100 growth per run: run 10 of 10, per element time cost: 0.0103208 sec
+run 1 of 10, per element time cost: 3.6778 sec
+run 2 of 10, per element time cost: 0.053498 sec
+run 3 of 10, per element time cost: 0.0299434 sec
+run 4 of 10, per element time cost: 0.0211154 sec
+run 5 of 10, per element time cost: 0.0170031 sec
+run 6 of 10, per element time cost: 0.0150809 sec
+run 7 of 10, per element time cost: 0.013218 sec
+run 8 of 10, per element time cost: 0.0119685 sec
+run 9 of 10, per element time cost: 0.0107382 sec
+run 10 of 10, per element time cost: 0.0103208 sec
 
 
 Fixed cost   4.537164939085642

--- a/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
@@ -15,6 +15,8 @@
 #
 
 """A microbenchmark for measuring changes in the critical path of FnApiRunner.
+This microbenchmark attempts to measure the overhead of the main data paths
+for the FnApiRunner. Specifically state, timers, and shuffling of data.
 
 This runs a series of N parallel pipelines with M parallel stages each. Each
 stage does the following:
@@ -29,6 +31,27 @@ workers, but is generally easier to run (locally) and more stable..
 Run as
 
    python -m apache_beam.tools.fn_api_runner_microbenchmark
+
+The main metric to work with for this benchmark is Fixed Cost. This represents
+the fixed cost of ovehead for the data path of the FnApiRunner.
+
+Initial results were:
+
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 1 of 10, per element time cost: 3.6778 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 2 of 10, per element time cost: 0.053498 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 3 of 10, per element time cost: 0.0299434 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 4 of 10, per element time cost: 0.0211154 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 5 of 10, per element time cost: 0.0170031 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 6 of 10, per element time cost: 0.0150809 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 7 of 10, per element time cost: 0.013218 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 8 of 10, per element time cost: 0.0119685 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 9 of 10, per element time cost: 0.0107382 sec
+run_single_pipeline, 1 element(s) at start, 100 growth per run: run 10 of 10, per element time cost: 0.0103208 sec
+
+
+Fixed cost   4.537164939085642
+Per-element  0.005474923321695039
+R^2          0.95189
 """
 
 from __future__ import absolute_import

--- a/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A microbenchmark for measuring changes in overhead for critical code paths.
+
+This runs a sequence of trivial Maps over a variable number of inputs to
+estimate the per-element processing time.  It can be useful to run this
+benchmark before and after a proposed set of changes.  A typical per-element
+cost should be 1-2 microseconds.
+
+This executes the same codepaths that are run on the Fn API (and Dataflow)
+workers, but is generally easier to run (locally) and more stable.  It does
+not, on the other hand, excercise any non-trivial amount of IO (e.g. shuffle).
+
+Run as
+
+   python -m apache_beam.tools.fn_api_runner_microbenchmark
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import random
+import time
+from builtins import range
+from builtins import zip
+
+import apache_beam as beam
+from apache_beam.coders import VarIntCoder
+from apache_beam.runners.portability.fn_api_runner import FnApiRunner
+from apache_beam.tools import utils
+from apache_beam.transforms.timeutil import TimeDomain
+import apache_beam.typehints.typehints as typehints
+from apache_beam.transforms.userstate import on_timer
+from apache_beam.transforms.userstate import SetStateSpec
+from apache_beam.transforms.userstate import TimerSpec
+from scipy import stats
+
+
+class BagInStateOutputAfterTimer(beam.DoFn):
+
+  SET_STATE = SetStateSpec('buffer', VarIntCoder())
+  EMIT_TIMER = TimerSpec('emit_timer', TimeDomain.WATERMARK)
+
+  def process(self,
+      element,
+      set_state=beam.DoFn.StateParam(SET_STATE),
+      emit_timer=beam.DoFn.TimerParam(EMIT_TIMER)):
+    key, values = element
+    for v in values:
+      set_state.add(v)
+    emit_timer.set(1)
+
+  @on_timer(EMIT_TIMER)
+  def emit_values(self, set_state=beam.DoFn.StateParam(SET_STATE)):
+    values = set_state.read()
+    return [(random.randint(0, 1000), v) for v in values]
+
+
+def _build_serial_stages(pipeline,
+                         num_serial_stages,
+                         num_elements,
+                         stage_count):
+  pc = (pipeline |
+        ('start_stage%s' % stage_count) >> beam.Create([
+            (random.randint(0, 1000), i) for i in range(num_elements)])
+        | ('gbk_start_stage%s' % stage_count) >> beam.GroupByKey())
+
+  for i in range(num_serial_stages):
+    pc = (pc
+          | ('stage%s_map%s' % (stage_count, i)) >> beam.ParDo(
+              BagInStateOutputAfterTimer()).with_output_types(
+                  typehints.KV[int, int])
+          | ('stage%s_gbk%s' % (stage_count, i)) >> beam.GroupByKey())
+
+  return pc
+
+
+def run_benchmark(num_parallel_stages=7,
+                  num_serial_stages=5,
+                  num_runs=10,
+                  num_elements_step=100):
+  timings = {}
+  for run in range(num_runs):
+    num_elements = num_elements_step * run + 1
+    start = time.time()
+    with beam.Pipeline(runner=FnApiRunner()) as p:
+      for i in range(num_parallel_stages):
+        _build_serial_stages(p, num_serial_stages, num_elements, i)
+    timings[num_elements] = time.time() - start
+    print("%6d element%s %g sec" % (
+        num_elements, " " if num_elements == 1 else "s", timings[num_elements]))
+
+  print()
+  # pylint: disable=unused-variable
+  gradient, intercept, r_value, p_value, std_err = stats.linregress(
+      *list(zip(*list(timings.items()))))
+  # Fixed cost is the most important variable, as it represents the fixed cost
+  #   of running all the bundles through all the stages.
+  print("Fixed cost  ", intercept)
+  print("Per-element ", gradient / (num_serial_stages * num_parallel_stages))
+  print("R^2         ", r_value**2)
+
+
+if __name__ == '__main__':
+  utils.check_compiled('apache_beam.runners.common')
+  run_benchmark()

--- a/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
@@ -37,7 +37,6 @@ from __future__ import print_function
 
 import argparse
 import random
-import time
 from builtins import range
 
 import apache_beam as beam

--- a/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
@@ -58,10 +58,10 @@ class BagInStateOutputAfterTimer(beam.DoFn):
   EMIT_TIMER = TimerSpec('emit_timer', TimeDomain.WATERMARK)
 
   def process(self,
-      element,
-      set_state=beam.DoFn.StateParam(SET_STATE),
-      emit_timer=beam.DoFn.TimerParam(EMIT_TIMER)):
-    key, values = element
+              element,
+              set_state=beam.DoFn.StateParam(SET_STATE),
+              emit_timer=beam.DoFn.TimerParam(EMIT_TIMER)):
+    _, values = element
     for v in values:
       set_state.add(v)
     emit_timer.set(1)

--- a/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/fn_api_runner_microbenchmark.py
@@ -14,16 +14,17 @@
 # limitations under the License.
 #
 
-"""A microbenchmark for measuring changes in overhead for critical code paths.
+"""A microbenchmark for measuring changes in the critical path of FnApiRunner.
 
-This runs a sequence of trivial Maps over a variable number of inputs to
-estimate the per-element processing time.  It can be useful to run this
-benchmark before and after a proposed set of changes.  A typical per-element
-cost should be 1-2 microseconds.
+This runs a series of N parallel pipelines with M parallel stages each. Each
+stage does the following:
+
+1) Put all the PCollection elements in state
+2) Set a timer for the future
+3) When the timer fires, change the key and output all the elements downstream
 
 This executes the same codepaths that are run on the Fn API (and Dataflow)
-workers, but is generally easier to run (locally) and more stable.  It does
-not, on the other hand, excercise any non-trivial amount of IO (e.g. shuffle).
+workers, but is generally easier to run (locally) and more stable..
 
 Run as
 

--- a/sdks/python/apache_beam/tools/utils.py
+++ b/sdks/python/apache_beam/tools/utils.py
@@ -180,7 +180,8 @@ def run_benchmarks(benchmark_suite, verbose=True):
             numpy.median(cost_series[name]) / benchmark_config.size)
         std = numpy.std(cost_series[name]) / benchmark_config.size
 
-        print("%s: per element median time cost: %g sec, relative std: %.2f%%" % (
+        print(
+            "%s: p. element median time cost: %g sec, relative std: %.2f%%" % (
             name.ljust(pad_length, " "), per_element_median_cost,
             std * 100 / per_element_median_cost))
 

--- a/sdks/python/apache_beam/tools/utils.py
+++ b/sdks/python/apache_beam/tools/utils.py
@@ -28,6 +28,7 @@ import os
 import time
 
 import numpy
+from scipy import stats
 
 
 def check_compiled(module):
@@ -72,6 +73,38 @@ class BenchmarkConfig(
         str(self.size))
 
 
+class LinearRegressionBenchmarkConfig(
+    collections.namedtuple(
+        "LinearRegressionBenchmarkConfig",
+        ["benchmark", "starting_point", "increment", "num_runs"])):
+  """
+  Attributes:
+    benchmark: a callable that takes an int argument - benchmark size,
+      and returns a callable. A returned callable must run the code being
+      benchmarked on an input of specified size.
+
+      For example, one can implement a benchmark as:
+
+      class MyBenchmark(object):
+        def __init__(self, size):
+          [do necessary initialization]
+        def __call__(self):
+          [run the code in question]
+
+    starting_point: int, an initial size of the input. Regression results are
+      calculated based on the input.
+    increment: int, the rate of growth of the input for each run of the
+      benchmark.
+    num_runs: int, number of times to run each benchmark.
+  """
+  def __str__(self):
+    return "%s, %s element(s) at start, %s growth per run" % (
+        getattr(self.benchmark, '__name__', str(self.benchmark)),
+        str(self.starting_point), str(self.increment))
+
+
+
+
 def run_benchmarks(benchmark_suite, verbose=True):
   """Runs benchmarks, and collects execution times.
 
@@ -96,20 +129,34 @@ def run_benchmarks(benchmark_suite, verbose=True):
     return time.time() - start
 
   cost_series = collections.defaultdict(list)
+  size_series = collections.defaultdict(list)
   for benchmark_config in benchmark_suite:
     name = str(benchmark_config)
     num_runs = benchmark_config.num_runs
-    size = benchmark_config.size
+
+    if isinstance(benchmark_config, LinearRegressionBenchmarkConfig):
+      size = benchmark_config.starting_point
+      step = benchmark_config.increment
+    else:
+      assert isinstance(benchmark_config, BenchmarkConfig)
+      size = benchmark_config.size
+      step = 0
+
     for run_id in range(num_runs):
       # Do a proactive GC before each run to minimize side-effects of different
       # runs.
       gc.collect()
       time_cost = run(benchmark_config.benchmark, size)
+      # Appending size and time cost to perform linear regression
       cost_series[name].append(time_cost)
+      size_series[name].append(size)
       if verbose:
         per_element_cost = time_cost / size
         print("%s: run %d of %d, per element time cost: %g sec" % (
             name, run_id + 1, num_runs, per_element_cost))
+
+      # Incrementing the size of the benchmark run by the step size
+      size += step
     if verbose:
       print("")
 
@@ -118,12 +165,23 @@ def run_benchmarks(benchmark_suite, verbose=True):
 
     for benchmark_config in benchmark_suite:
       name = str(benchmark_config)
-      per_element_median_cost = (
-          numpy.median(cost_series[name]) / benchmark_config.size)
-      std = numpy.std(cost_series[name]) / benchmark_config.size
 
-      print("%s: per element median time cost: %g sec, relative std: %.2f%%" % (
-          name.ljust(pad_length, " "), per_element_median_cost,
-          std * 100 / per_element_median_cost))
+      if isinstance(benchmark_config, LinearRegressionBenchmarkConfig):
+        print()
+        # pylint: disable=unused-variable
+        gradient, intercept, r_value, p_value, std_err = stats.linregress(
+            size_series[name], cost_series[name])
+        print("Fixed cost  ", intercept)
+        print("Per-element ", gradient)
+        print("R^2         ", r_value**2)
+      else:
+        assert isinstance(benchmark_config, BenchmarkConfig)
+        per_element_median_cost = (
+            numpy.median(cost_series[name]) / benchmark_config.size)
+        std = numpy.std(cost_series[name]) / benchmark_config.size
 
-  return cost_series
+        print("%s: per element median time cost: %g sec, relative std: %.2f%%" % (
+            name.ljust(pad_length, " "), per_element_median_cost,
+            std * 100 / per_element_median_cost))
+
+  return size_series, cost_series

--- a/sdks/python/apache_beam/tools/utils.py
+++ b/sdks/python/apache_beam/tools/utils.py
@@ -28,7 +28,6 @@ import os
 import time
 
 import numpy
-from scipy import stats
 
 
 def check_compiled(module):
@@ -167,6 +166,7 @@ def run_benchmarks(benchmark_suite, verbose=True):
       name = str(benchmark_config)
 
       if isinstance(benchmark_config, LinearRegressionBenchmarkConfig):
+        from scipy import stats
         print()
         # pylint: disable=unused-variable
         gradient, intercept, r_value, p_value, std_err = stats.linregress(
@@ -182,7 +182,7 @@ def run_benchmarks(benchmark_suite, verbose=True):
 
         print(
             "%s: p. element median time cost: %g sec, relative std: %.2f%%" % (
-            name.ljust(pad_length, " "), per_element_median_cost,
-            std * 100 / per_element_median_cost))
+                name.ljust(pad_length, " "), per_element_median_cost,
+                std * 100 / per_element_median_cost))
 
   return size_series, cost_series


### PR DESCRIPTION
Overall runtime of this microbenchmark is about one minute.

This runs a series of N parallel pipelines with M parallel stages each. Each
stage does the following:

1) Put all the PCollection elements in state
2) Set a timer for the future
3) When the timer fires, change the key and output all the elements downstream

Results:
```
python -m apache_beam.tools.fn_api_runner_microbenchmark
     1 element  3.97874 sec
   101 elements 5.81925 sec
   201 elements 6.12566 sec
   301 elements 6.57774 sec
   401 elements 7.43154 sec
   501 elements 7.97614 sec
   601 elements 8.63536 sec
   701 elements 9.10238 sec
   801 elements 9.17786 sec
   901 elements 10.0178 sec

Fixed cost   4.765602442423502
Per-element  0.00017222933748583773
R^2          0.9607312619599335
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
