### PR TITLE
[BEAM-8492] Allow None, Optional return hints for DoFn.process and friends

### DIFF
--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -311,6 +311,11 @@ class IOTypeHints(object):
     Only affects instances with simple output types, otherwise is a no-op.
     Does not modify self.
 
+    Designed to be used with type hints from callables of ParDo, FlatMap, DoFn.
+    Output type may be Optional[T], in which case the result of stripping T is
+    used as the output type.
+    Output type may be None/NoneType, in which case nothing is done.
+
     Example: Generator[Tuple(int, int)] becomes Tuple(int, int)
 
     Returns:
@@ -321,7 +326,20 @@ class IOTypeHints(object):
     """
     if not self.has_simple_output_type():
       return self
-    yielded_type = typehints.get_yielded_type(self.output_types[0][0])
+    output_type = self.output_types[0][0]
+    if output_type is None or isinstance(output_type, type(None)):
+      return self
+    # If output_type == Optional[T]: output_type = T.
+    if isinstance(output_type, typehints.UnionConstraint):
+      types = list(output_type.union_types)
+      if len(types) == 2:
+        try:
+          types.remove(type(None))
+          output_type = types[0]
+        except KeyError:
+          pass
+
+    yielded_type = typehints.get_yielded_type(output_type)
     res = self.copy()
     res.output_types = ((yielded_type,), {})
     return res

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -336,7 +336,7 @@ class IOTypeHints(object):
         try:
           types.remove(type(None))
           output_type = types[0]
-        except KeyError:
+        except ValueError:
           pass
 
     yielded_type = typehints.get_yielded_type(output_type)

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -90,8 +90,7 @@ class IOTypeHintsTest(unittest.TestCase):
       self._test_strip_iterable(before, None)
 
   def test_strip_iterable(self):
-    # TODO(BEAM-8492): Uncomment once #9895 is merged.
-    # self._test_strip_iterable(None, None)
+    self._test_strip_iterable(None, None)
     self._test_strip_iterable(typehints.Any, typehints.Any)
     self._test_strip_iterable(typehints.Iterable[str], str)
     self._test_strip_iterable(typehints.List[str], str)

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -126,6 +126,31 @@ class MainInputTest(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, r'str.*is not iterable'):
       _ = [1, 2, 3] | beam.ParDo(MyDoFn())
 
+  def test_typed_dofn_method_return_none(self):
+    class MyDoFn(beam.DoFn):
+      def process(self, unused_element: int) -> None:
+        pass
+
+    result = [1, 2, 3] | beam.ParDo(MyDoFn())
+    self.assertListEqual([], result)
+
+  def test_typed_dofn_method_return_optional(self):
+    class MyDoFn(beam.DoFn):
+      def process(self, unused_element: int) -> typehints.Optional[
+          typehints.Iterable[int]]:
+        pass
+
+    result = [1, 2, 3] | beam.ParDo(MyDoFn())
+    self.assertListEqual([], result)
+
+  def test_typed_dofn_method_return_optional_not_iterable(self):
+    class MyDoFn(beam.DoFn):
+      def process(self, unused_element: int) -> typehints.Optional[int]:
+        pass
+
+    with self.assertRaisesRegex(ValueError, r'int.*is not iterable'):
+      _ = [1, 2, 3] | beam.ParDo(MyDoFn())
+
   def test_typed_callable_not_iterable(self):
     def do_fn(element: int) -> int:
       return [element]  # Return a list to not fail the pipeline.

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -203,6 +203,56 @@ class MainInputTest(unittest.TestCase):
     result = [1, 2] | beam.ParDo(MyDoFn())
     self.assertEqual([['1', '1'], ['2', '2']], sorted(result))
 
+  def test_typed_map(self):
+    def fn(element: int) -> int:
+      return element * 2
+
+    result = [1, 2, 3] | beam.Map(fn)
+    self.assertEqual([2, 4, 6], sorted(result))
+
+  def test_typed_map_return_optional(self):
+    # None is a valid element value for Map.
+    def fn(element: int) -> typehints.Optional[int]:
+      if element > 1:
+        return element
+
+    result = [1, 2, 3] | beam.Map(fn)
+    self.assertCountEqual([None, 2, 3], result)
+
+  def test_typed_flatmap(self):
+    def fn(element: int) -> typehints.Iterable[int]:
+      yield element * 2
+
+    result = [1, 2, 3] | beam.FlatMap(fn)
+    self.assertCountEqual([2, 4, 6], result)
+
+  def test_typed_flatmap_output_hint_not_iterable(self):
+    def fn(element: int) -> int:
+      return element * 2
+
+    with self.assertRaisesRegex(typehints.TypeCheckError,
+                                r'int.*is not iterable'):
+      _ = [1, 2, 3] | beam.FlatMap(fn)
+
+  def test_typed_flatmap_output_value_not_iterable(self):
+    def fn(element: int) -> typehints.Iterable[int]:
+      return element * 2
+
+    with self.assertRaisesRegex(TypeError, r'int.*is not iterable'):
+      _ = [1, 2, 3] | beam.FlatMap(fn)
+
+  def test_typed_flatmap_optional(self):
+    def fn(element: int) -> typehints.Optional[typehints.Iterable[int]]:
+      if element > 1:
+        yield element * 2
+
+    # Verify that the output type of fn is int and not Optional[int].
+    def fn2(element: int) -> int:
+      return element
+
+    result = [1, 2, 3] | beam.FlatMap(fn) | beam.Map(fn2)
+    self.assertCountEqual([4, 6], result)
+
 
 class AnnotationsTest(unittest.TestCase):
 
@@ -257,6 +307,15 @@ class AnnotationsTest(unittest.TestCase):
     self.assertEqual(th.input_types, ((int,), {}))
     self.assertEqual(th.output_types, ((int,), {}))
 
+  def test_flat_map_wrapper_optional_output(self):
+    # Optional should not affect output type (Nones are ignored).
+    def map_fn(element: int) -> typehints.Optional[typehints.Iterable[int]]:
+      return [element, element + 1]
+
+    th = beam.FlatMap(map_fn).get_type_hints()
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((int,), {}))
+
   @unittest.skip('BEAM-8662: Py3 annotations not yet supported for MapTuple')
   def test_flat_map_tuple_wrapper(self):
     # TODO(BEAM-8662): Also test with a fn that accepts default arguments.
@@ -274,6 +333,15 @@ class AnnotationsTest(unittest.TestCase):
     th = beam.Map(map_fn).get_type_hints()
     self.assertEqual(th.input_types, ((int,), {}))
     self.assertEqual(th.output_types, ((int,), {}))
+
+  def test_map_wrapper_optional_output(self):
+    # Optional does affect output type (Nones are NOT ignored).
+    def map_fn(unused_element: int) -> typehints.Optional[int]:
+      return 1
+
+    th = beam.Map(map_fn).get_type_hints()
+    self.assertEqual(th.input_types, ((int,), {}))
+    self.assertEqual(th.output_types, ((typehints.Optional[int],), {}))
 
   @unittest.skip('BEAM-8662: Py3 annotations not yet supported for MapTuple')
   def test_map_tuple(self):

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test_py3.py
@@ -230,8 +230,9 @@ class MainInputTest(unittest.TestCase):
     def fn(element: int) -> int:
       return element * 2
 
-    with self.assertRaisesRegex(typehints.TypeCheckError,
-                                r'int.*is not iterable'):
+    # TODO(BEAM-8466): This case currently only generates a warning instead of a
+    #   typehints.TypeCheckError.
+    with self.assertRaisesRegex(TypeError, r'int.*is not iterable'):
       _ = [1, 2, 3] | beam.FlatMap(fn)
 
   def test_typed_flatmap_output_value_not_iterable(self):


### PR DESCRIPTION

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
