### PR TITLE
[BEAM-7434] [BEAM-5895] and [BEAM-5894] Upgrade to rabbit amqp-client 5.x

### DIFF
--- a/sdks/java/io/rabbitmq/build.gradle
+++ b/sdks/java/io/rabbitmq/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   compile library.java.vendored_guava_26_0_jre
   compile project(path: ":sdks:java:core", configuration: "shadow")
   compile library.java.joda_time
-  compile "com.rabbitmq:amqp-client:4.9.3"
+  compile "com.rabbitmq:amqp-client:5.7.3"
   testCompile project(path: ":sdks:java:io:common", configuration: "testRuntime")
   testCompile "org.apache.qpid:qpid-broker:0.28"
   testCompile "org.apache.qpid:qpid-broker-core:0.28"

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -20,7 +20,11 @@ package org.apache.beam.sdk.io.rabbitmq;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
-import com.rabbitmq.client.*;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.GetResponse;
+import com.rabbitmq.client.MessageProperties;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqMessage.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqMessage.java
@@ -20,9 +20,8 @@ package org.apache.beam.sdk.io.rabbitmq;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.LongString;
-import com.rabbitmq.client.QueueingConsumer;
-import com.rabbitmq.client.QueueingConsumer.Delivery;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Date;
@@ -44,11 +43,11 @@ public class RabbitMqMessage implements Serializable {
    * @param processed
    * @return
    */
-  private static Delivery serializableDeliveryOf(Delivery processed) {
+  private static GetResponse serializableDeliveryOf(GetResponse processed) {
     // All content of envelope is serializable, so no problem there
     Envelope envelope = processed.getEnvelope();
     // in basicproperties, there may be LongString, which are *not* serializable
-    BasicProperties properties = processed.getProperties();
+    BasicProperties properties = processed.getProps();
     BasicProperties nextProperties =
         new BasicProperties.Builder()
             .appId(properties.getAppId())
@@ -66,7 +65,8 @@ public class RabbitMqMessage implements Serializable {
             .type(properties.getType())
             .userId(properties.getUserId())
             .build();
-    return new Delivery(envelope, nextProperties, processed.getBody());
+    return new GetResponse(
+        envelope, nextProperties, processed.getBody(), processed.getMessageCount());
   }
 
   private static Map<String, Object> serializableHeaders(Map<String, Object> headers) {
@@ -134,24 +134,24 @@ public class RabbitMqMessage implements Serializable {
     clusterId = null;
   }
 
-  public RabbitMqMessage(String routingKey, QueueingConsumer.Delivery delivery) {
+  public RabbitMqMessage(String routingKey, GetResponse delivery) {
     this.routingKey = routingKey;
     delivery = serializableDeliveryOf(delivery);
     body = delivery.getBody();
-    contentType = delivery.getProperties().getContentType();
-    contentEncoding = delivery.getProperties().getContentEncoding();
-    headers = delivery.getProperties().getHeaders();
-    deliveryMode = delivery.getProperties().getDeliveryMode();
-    priority = delivery.getProperties().getPriority();
-    correlationId = delivery.getProperties().getCorrelationId();
-    replyTo = delivery.getProperties().getReplyTo();
-    expiration = delivery.getProperties().getExpiration();
-    messageId = delivery.getProperties().getMessageId();
-    timestamp = delivery.getProperties().getTimestamp();
-    type = delivery.getProperties().getType();
-    userId = delivery.getProperties().getUserId();
-    appId = delivery.getProperties().getAppId();
-    clusterId = delivery.getProperties().getClusterId();
+    contentType = delivery.getProps().getContentType();
+    contentEncoding = delivery.getProps().getContentEncoding();
+    headers = delivery.getProps().getHeaders();
+    deliveryMode = delivery.getProps().getDeliveryMode();
+    priority = delivery.getProps().getPriority();
+    correlationId = delivery.getProps().getCorrelationId();
+    replyTo = delivery.getProps().getReplyTo();
+    expiration = delivery.getProps().getExpiration();
+    messageId = delivery.getProps().getMessageId();
+    timestamp = delivery.getProps().getTimestamp();
+    type = delivery.getProps().getType();
+    userId = delivery.getProps().getUserId();
+    appId = delivery.getProps().getAppId();
+    clusterId = delivery.getProps().getClusterId();
   }
 
   public RabbitMqMessage(


### PR DESCRIPTION
Primarily addresses BEAM-7434 which notes that the use of the java RabbitMQ client's `QueueingConsumer` is deprecated in the 4.x line and is slated for removal in 5.x. 

This PR:
* upgrades the java library to 5.x (addressing BEAM-5894 and BEAM-5895)
* replaces QueueingConsumer ([Consumer/push api](https://www.rabbitmq.com/api-guide.html#consuming)) with `Channel.basicGet` directly ([pull api](https://www.rabbitmq.com/api-guide.html#getting))

Notes:
The 4.x use of QueueingConsumer was (presumably) done for two reasons: 1) thread safety between Channel/Consumer (see history notes in QueueingConsumer); 2) to apply backpressure on `push` by pushing to a blocking queue. Number 1 is no longer an issue, and I've circumvented number 2 by using a pull-based api rather than the consumer push-based.

There are some tradeoffs in place in this PR. Previously, using the push-based, Consumer api, messages could be internally buffered/queued by each shard of the unbounded source, which saves round-trip latency if there are messages ready. Both before and after my changes, "prefetch" values were set at the default "unlimited" (0) value so messages would enqueue/buffer as soon as they're able. The trade-off there would be higher memory usage, although it's unlikely this is a practical concern for many. 

Using the pull-based api (`channel.basicGet`), each message pull will require a round-trip to the rabbitmq server, albeit on an already-open Connection. It should have a nice property where pulling is 'fairer' than the previous approach, as each shard will only request a message when explicitly prompted to by the Runner rather than potentially being unacked/buffered within some other shard. 

I'm expecting this API should not cause any real-world problems and the throughput should be high enough without local buffering. If local buffering/minimal round-trip time is of concern, I would suggest a follow-up PR allowing for configuring prefetch (and perhaps other QoS settings).

Note this is not binary compatible with previous releases, both in terms of the underlying RabbitMQ API as well as the wire format of the Beam RabbitMqIO implementation as it switches from `QueueingConsumer.Delivery` to `GetResult`.

R: @jbonofre 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
