### PR TITLE
[BEAM-4091] Pass type hints in ptransform_fn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,10 @@
 * In Interactive Beam, ib.show() and ib.collect() now have "n" and "duration" as parameters. These mean read only up to "n" elements and up to "duration" seconds of data read from the recording ([BEAM-10603](https://issues.apache.org/jira/browse/BEAM-10603)).
 * Initial preview of [Dataframes](https://s.apache.org/simpler-python-pipelines-2020#slide=id.g905ac9257b_1_21) support.
     See also example at apache_beam/examples/wordcount_dataframe.py
+* Fixed support for type hints on `@ptransform_fn` decorators in the Python SDK.
+  ([BEAM-4091](https://issues.apache.org/jira/browse/BEAM-4091))
+  This has not enabled by default to preserve backwards compatibility; use the
+  `--type_check_additional=ptransform_fn` flag to enable.
 * X feature added (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 
 ## Breaking Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,7 +76,8 @@
 * Fixed support for type hints on `@ptransform_fn` decorators in the Python SDK.
   ([BEAM-4091](https://issues.apache.org/jira/browse/BEAM-4091))
   This has not enabled by default to preserve backwards compatibility; use the
-  `--type_check_additional=ptransform_fn` flag to enable.
+  `--type_check_additional=ptransform_fn` flag to enable. It may be enabled by
+  default in future versions of Beam.
 * X feature added (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 
 ## Breaking Changes

--- a/sdks/python/apache_beam/options/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator_test.py
@@ -556,6 +556,25 @@ class SetupTest(unittest.TestCase):
         only_contains(
             contains_string('Invalid transform name mapping format.')))
 
+  def test_type_check_additional(self):
+    runner = MockRunners.OtherRunner()
+    options = PipelineOptions(['--type_check_additional=all'])
+    validator = PipelineOptionsValidator(options, runner)
+    errors = validator.validate()
+    self.assertFalse(errors)
+
+    options = PipelineOptions(['--type_check_additional='])
+    validator = PipelineOptionsValidator(options, runner)
+    errors = validator.validate()
+    self.assertFalse(errors)
+
+  def test_type_check_additional_unrecognized_feature(self):
+    runner = MockRunners.OtherRunner()
+    options = PipelineOptions(['--type_check_additional=all,dfgdf'])
+    validator = PipelineOptionsValidator(options, runner)
+    errors = validator.validate()
+    self.assertTrue(errors)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -40,6 +40,7 @@ from __future__ import absolute_import
 
 import copy
 import itertools
+import logging
 import operator
 import os
 import sys
@@ -95,6 +96,8 @@ __all__ = [
     'ptransform_fn',
     'label_from_callable',
 ]
+
+_LOGGER = logging.getLogger(__name__)
 
 T = TypeVar('T')
 PTransformT = TypeVar('PTransformT', bound='PTransform')
@@ -994,6 +997,8 @@ def ptransform_fn(fn):
     # function.
     type_hints = get_type_hints(callable_ptransform_factory)
     res._set_type_hints(type_hints.with_defaults(res.get_type_hints()))
+    _LOGGER.debug(
+        'type hints for %s: %s', res.default_label(), res.get_type_hints())
     return res
 
   return callable_ptransform_factory

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -987,10 +987,10 @@ def ptransform_fn(fn):
   def callable_ptransform_factory(*args, **kwargs):
     res = _PTransformFnPTransform(fn, *args, **kwargs)
     # Apply type hints applied before or after the ptransform_fn decorator,
-    # or uses PTransform defaults.
+    # falling back on PTransform defaults.
     # If the @with_{input,output}_types decorator comes before ptransform_fn,
-    # the type hint gets applied to this function. If it comes after it gets
-    # applied to fn, and @wraps copies the _type_hints attribute to this
+    # the type hints get applied to this function. If it comes after they will
+    # get applied to fn, and @wraps will copy the _type_hints attribute to this
     # function.
     type_hints = get_type_hints(callable_ptransform_factory)
     res._set_type_hints(type_hints.with_defaults(res.get_type_hints()))

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -1009,7 +1009,7 @@ class Regex(object):
 
   @staticmethod
   @typehints.with_input_types(str)
-  @typehints.with_output_types(Union[List[str], Tuple[str, str]])
+  @typehints.with_output_types(Union[List[str], List[Tuple[str, str]]])
   @ptransform_fn
   def find_all(pcoll, regex, group=0, outputEmpty=True):
     """

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -579,6 +579,10 @@ class WithTypeHints(object):
             self.default_type_hints()).with_defaults(
                 get_type_hints(self.__class__)))
 
+  def _set_type_hints(self, type_hints):
+    # type: (IOTypeHints) -> None
+    self._type_hints = type_hints
+
   def default_type_hints(self):
     return None
 

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -206,6 +206,31 @@ class MainInputTest(unittest.TestCase):
       assert_that(res_even, equal_to([2]), label='even_check')
       assert_that(res_odd, equal_to([1, 3]), label='odd_check')
 
+  def test_typed_ptransform_fn_pre_hints(self):
+    # Test that type hints are propagated to the created PTransform.
+    # Decorator appears before type hints. This is the more common style.
+    @beam.ptransform_fn
+    @typehints.with_input_types(int)
+    def MyMap(pcoll):
+      return pcoll | beam.ParDo(lambda x: [x])
+
+    self.assertListEqual([1, 2, 3], [1, 2, 3] | MyMap())
+    with self.assertRaises(typehints.TypeCheckError):
+      _ = ['a'] | MyMap()
+
+  def test_typed_ptransform_fn_post_hints(self):
+    # Test that type hints are propagated to the created PTransform.
+    # Decorator appears after type hints. This style is required for Cython
+    # functions, since they don't accept assigning attributes to them.
+    @typehints.with_input_types(int)
+    @beam.ptransform_fn
+    def MyMap(pcoll):
+      return pcoll | beam.ParDo(lambda x: [x])
+
+    self.assertListEqual([1, 2, 3], [1, 2, 3] | MyMap())
+    with self.assertRaises(typehints.TypeCheckError):
+      _ = ['a'] | MyMap()
+
 
 class NativeTypesTest(unittest.TestCase):
   def test_good_main_input(self):

--- a/sdks/python/conftest.py
+++ b/sdks/python/conftest.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 
 import sys
 
+from apache_beam.options import pipeline_options
+
 MAX_SUPPORTED_PYTHON_VERSION = (3, 8)
 
 # See pytest.ini for main collection rules.
@@ -30,3 +32,8 @@ else:
   for minor in range(sys.version_info.minor + 1,
                      MAX_SUPPORTED_PYTHON_VERSION[1] + 1):
     collect_ignore_glob.append('*_py3%d.py' % minor)
+
+
+def pytest_configure(config):
+  # Enable optional type checks on all tests.
+  pipeline_options.enable_all_additional_type_checks()

--- a/website/www/site/content/en/documentation/sdks/python-type-safety.md
+++ b/website/www/site/content/en/documentation/sdks/python-type-safety.md
@@ -34,6 +34,13 @@ These flags control Beam type safety:
 
   Enables runtime type checking of every element.
   This may affect pipeline performance, so the default is to skip these checks.
+- `--type_check_additional`
+
+  Enables additional type checks. These are no enabled by default to preserve
+  backwards compatibility. This flag accepts a comma-separate list of options:
+  - `all`: Enable all additional checks.
+  - `ptransform_fn`: Enable type hint decorators when used with the
+    `@ptransform_fn` decorator.
 
 ## Benefits of Type Hints
 


### PR DESCRIPTION

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
