### PR TITLE
[BEAM-8507] Fix 'flink_master' parameter for the upcoming release

### DIFF
--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
@@ -17,10 +17,10 @@
  */
 package org.apache.beam.runners.flink;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -380,6 +380,42 @@ public class FlinkExecutionEnvironmentsTest {
     assertThat(
         Whitebox.getInternalState(sev, "host"), is("FE80:CD00:0000:0CDE:1257:0000:211E:729C"));
     assertThat(Whitebox.getInternalState(sev, "port"), is(RestOptions.PORT.defaultValue()));
+  }
+
+  @Test
+  public void shouldRemoveHttpProtocolFromHostBatch() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+
+    for (String flinkMaster :
+        new String[] {
+          "http://host:1234", " http://host:1234", "https://host:1234", " https://host:1234"
+        }) {
+      options.setFlinkMaster(flinkMaster);
+      ExecutionEnvironment sev =
+          FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+              options, Collections.emptyList());
+      assertThat(Whitebox.getInternalState(sev, "host"), is("host"));
+      assertThat(Whitebox.getInternalState(sev, "port"), is(1234));
+    }
+  }
+
+  @Test
+  public void shouldRemoveHttpProtocolFromHostStreaming() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(FlinkRunner.class);
+
+    for (String flinkMaster :
+        new String[] {
+          "http://host:1234", " http://host:1234", "https://host:1234", " https://host:1234"
+        }) {
+      options.setFlinkMaster(flinkMaster);
+      StreamExecutionEnvironment sev =
+          FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+              options, Collections.emptyList());
+      assertThat(Whitebox.getInternalState(sev, "host"), is("host"));
+      assertThat(Whitebox.getInternalState(sev, "port"), is(1234));
+    }
   }
 
   private String extractFlinkConfig() throws IOException {

--- a/sdks/python/apache_beam/runners/portability/flink_runner.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner.py
@@ -30,6 +30,7 @@ from apache_beam.runners.portability import job_server
 from apache_beam.runners.portability import portable_runner
 
 PUBLISHED_FLINK_VERSIONS = ['1.7', '1.8', '1.9']
+MAGIC_HOST_NAMES = ['[local]', '[auto]']
 
 
 class FlinkRunner(portable_runner.PortableRunner):
@@ -37,19 +38,20 @@ class FlinkRunner(portable_runner.PortableRunner):
     flink_master = self.add_http_scheme(
         options.view_as(FlinkRunnerOptions).flink_master)
     options.view_as(FlinkRunnerOptions).flink_master = flink_master
-    if flink_master in ['[local]', '[auto]'] or sys.version_info < (3, 6):
-      portable_options = options.view_as(pipeline_options.PortableOptions)
-      if flink_master == '[local]' and not portable_options.environment_type:
-        portable_options.environment_type = 'LOOPBACK'
+    if flink_master in MAGIC_HOST_NAMES or sys.version_info < (3, 6):
       return job_server.StopOnExitJobServer(FlinkJarJobServer(options))
     else:
+      # This has to be changed [auto], otherwise we will attempt to submit a
+      # the pipeline remotely on the Flink JobMaster which will _fail_.
+      # DO NOT CHANGE the following line, unless you have tested this.
+      options.view_as(FlinkRunnerOptions).flink_master = '[auto]'
       return flink_uber_jar_job_server.FlinkUberJarJobServer(flink_master)
 
   @staticmethod
   def add_http_scheme(flink_master):
     """Adds a http protocol scheme if none provided."""
     flink_master = flink_master.strip()
-    if not flink_master in ['[local]', '[auto]'] and \
+    if not flink_master in MAGIC_HOST_NAMES and \
           not re.search('^http[s]?://', flink_master):
       logging.info('Adding HTTP protocol scheme to flink_master parameter: '
                    'http://%s', flink_master)

--- a/sdks/python/apache_beam/runners/portability/flink_runner.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner.py
@@ -20,6 +20,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
+import re
 import sys
 
 from apache_beam.options import pipeline_options
@@ -32,7 +34,9 @@ PUBLISHED_FLINK_VERSIONS = ['1.7', '1.8', '1.9']
 
 class FlinkRunner(portable_runner.PortableRunner):
   def default_job_server(self, options):
-    flink_master = options.view_as(FlinkRunnerOptions).flink_master
+    flink_master = self.add_http_scheme(
+        options.view_as(FlinkRunnerOptions).flink_master)
+    options.view_as(FlinkRunnerOptions).flink_master = flink_master
     if flink_master in ['[local]', '[auto]'] or sys.version_info < (3, 6):
       portable_options = options.view_as(pipeline_options.PortableOptions)
       if flink_master == '[local]' and not portable_options.environment_type:
@@ -40,6 +44,17 @@ class FlinkRunner(portable_runner.PortableRunner):
       return job_server.StopOnExitJobServer(FlinkJarJobServer(options))
     else:
       return flink_uber_jar_job_server.FlinkUberJarJobServer(flink_master)
+
+  @staticmethod
+  def add_http_scheme(flink_master):
+    """Adds a http protocol scheme if none provided."""
+    flink_master = flink_master.strip()
+    if not flink_master in ['[local]', '[auto]'] and \
+          not re.search('^http[s]?://', flink_master):
+      logging.info('Adding HTTP protocol scheme to flink_master parameter: '
+                   'http://%s', flink_master)
+      flink_master = 'http://' + flink_master
+    return flink_master
 
 
 class FlinkRunnerOptions(pipeline_options.PipelineOptions):

--- a/sdks/python/apache_beam/runners/portability/flink_runner.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner.py
@@ -33,10 +33,10 @@ PUBLISHED_FLINK_VERSIONS = ['1.7', '1.8', '1.9']
 class FlinkRunner(portable_runner.PortableRunner):
   def default_job_server(self, options):
     flink_master = options.view_as(FlinkRunnerOptions).flink_master
-    if flink_master == '[local]' or sys.version_info < (3, 6):
+    if flink_master in ['[local]', '[auto]'] or sys.version_info < (3, 6):
       portable_options = options.view_as(pipeline_options.PortableOptions)
       if flink_master == '[local]' and not portable_options.environment_type:
-        portable_options.environment_type == 'LOOPBACK'
+        portable_options.environment_type = 'LOOPBACK'
       return job_server.StopOnExitJobServer(FlinkJarJobServer(options))
     else:
       return flink_uber_jar_job_server.FlinkUberJarJobServer(flink_master)
@@ -47,11 +47,11 @@ class FlinkRunnerOptions(pipeline_options.PipelineOptions):
   def _add_argparse_args(cls, parser):
     parser.add_argument('--flink_master',
                         default='[auto]',
-                        help='Flink master address (host:port) to submit the'
-                             ' job against. Use "[local]" to start a local'
-                             ' cluster for the execution. Use "[auto]" if you'
-                             ' plan to either execute locally or submit through'
-                             ' Flink\'s CLI.')
+                        help='Flink master address (http://host:port)'
+                             ' Use "[local]" to start a local cluster'
+                             ' for the execution. Use "[auto]" if you'
+                             ' plan to either execute locally or let the'
+                             ' Flink job server infer the cluster address.')
     parser.add_argument('--flink_version',
                         default=PUBLISHED_FLINK_VERSIONS[-1],
                         choices=PUBLISHED_FLINK_VERSIONS,

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -95,6 +95,11 @@ class PortableRunner(runner.PipelineRunner):
   @staticmethod
   def _create_environment(options):
     portable_options = options.view_as(PortableOptions)
+    # Do not set a Runner. Otherwise this can cause problems in Java's
+    # PipelineOptions, i.e. ClassNotFoundException, if the corresponding Runner
+    # does not exist in the Java SDK. In portability, the entry point is clearly
+    # defined via the JobService.
+    portable_options.view_as(StandardOptions).runner = None
     environment_urn = common_urns.environments.DOCKER.urn
     if portable_options.environment_type == 'DOCKER':
       environment_urn = common_urns.environments.DOCKER.urn


### PR DESCRIPTION
## Add '[auto]' as a supported execution mode for Python FlinkRunner

The `[auto]` mode would work if the Flink job server had a config with the cluster
address. Change default back to '[local]' until it is clear how exactly '[auto]'
would be used.


## Support http protocol scheme for Flink master address

Python uses the requests library to communicate with the Flink master via the
REST API and requires a protocol scheme.

Despite also using the REST API, the Java client does not expect the master
address to contain a protocol scheme. In order to support Python specifying one
in Python, we can remove it in Java.



Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
