### PR TITLE
[BEAM-8526] Turn on metrics publishing in load tests on Flink

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Python.groovy
@@ -33,7 +33,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 pipelineOptions: [
                         job_name            : 'load-tests-python-flink-batch-combine-1-' + now,
                         project             : 'apache-beam-testing',
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         metrics_dataset     : datasetName,
                         metrics_table       : 'python_flink_batch_combine_1',
                         input_options       : '\'{' +
@@ -54,7 +54,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 pipelineOptions: [
                         job_name            : 'load-tests-python-flink-batch-combine-4-' + now,
                         project             : 'apache-beam-testing',
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         metrics_dataset     : datasetName,
                         metrics_table       : 'python_flink_batch_combine_4',
                         input_options       : '\'{' +
@@ -76,7 +76,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 pipelineOptions: [
                         job_name            : 'load-tests-python-flink-batch-combine-5-' + now,
                         project             : 'apache-beam-testing',
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         metrics_dataset     : datasetName,
                         metrics_table       : 'python_flink_batch_combine_5',
                         input_options       : '\'{' +

--- a/.test-infra/jenkins/job_LoadTests_GBK_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Flink_Python.groovy
@@ -32,7 +32,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_1_${now}",
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         project             : 'apache-beam-testing',
                         metrics_dataset     : datasetName,
                         metrics_table       : "python_flink_batch_GBK_1",
@@ -51,7 +51,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_2_${now}",
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         project             : 'apache-beam-testing',
                         metrics_dataset     : datasetName,
                         metrics_table       : "python_flink_batch_GBK_2",
@@ -70,7 +70,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_3_${now}",
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         project             : 'apache-beam-testing',
                         metrics_dataset     : datasetName,
                         metrics_table       : "python_flink_batch_GBK_3",
@@ -89,7 +89,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_4_${now}",
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         project             : 'apache-beam-testing',
                         metrics_dataset     : datasetName,
                         metrics_table       : "python_flink_batch_GBK_4",
@@ -108,7 +108,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_5_${now}",
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         project             : 'apache-beam-testing',
                         metrics_dataset     : datasetName,
                         metrics_table       : "python_flink_batch_GBK_5",
@@ -127,7 +127,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_6_${now}",
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         project             : 'apache-beam-testing',
                         metrics_dataset     : datasetName,
                         metrics_table       : "python_flink_batch_GBK_6",
@@ -146,7 +146,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_7_${now}",
-                        publish_to_big_query: false,
+                        publish_to_big_query: true,
                         project             : 'apache-beam-testing',
                         metrics_dataset     : datasetName,
                         metrics_table       : "python_flink_batch_GBK_7",

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Flink_Python.groovy
@@ -33,7 +33,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 pipelineOptions: [
                         job_name             : 'load-tests-python-flink-batch-pardo-1-' + now,
                         project              : 'apache-beam-testing',
-                        publish_to_big_query : false,
+                        publish_to_big_query : true,
                         metrics_dataset      : datasetName,
                         metrics_table        : 'python_flink_batch_pardo_1',
                         input_options        : '\'{' +
@@ -56,7 +56,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 pipelineOptions: [
                         job_name             : 'load-tests-python-flink-batch-pardo-2-' + now,
                         project              : 'apache-beam-testing',
-                        publish_to_big_query : false,
+                        publish_to_big_query : true,
                         metrics_dataset      : datasetName,
                         metrics_table        : 'python_flink_batch_pardo_2',
                         input_options        : '\'{' +
@@ -79,7 +79,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 pipelineOptions: [
                         job_name             : 'load-tests-python-flink-batch-pardo-3-' + now,
                         project              : 'apache-beam-testing',
-                        publish_to_big_query : false,
+                        publish_to_big_query : true,
                         metrics_dataset      : datasetName,
                         metrics_table        : 'python_flink_batch_pardo_3',
                         input_options        : '\'{' +
@@ -102,7 +102,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                 pipelineOptions: [
                         job_name             : 'load-tests-python-flink-batch-pardo-4-' + now,
                         project              : 'apache-beam-testing',
-                        publish_to_big_query : false,
+                        publish_to_big_query : true,
                         metrics_dataset      : datasetName,
                         metrics_table        : 'python_flink_batch_pardo_4',
                         input_options        : '\'{' +

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Python.groovy
@@ -34,7 +34,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                         project              : 'apache-beam-testing',
                         job_name             : 'load-tests-python-flink-batch-cogbk-1-' + now,
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
-                        publish_to_big_query : false,
+                        publish_to_big_query : true,
                         metrics_dataset      : datasetName,
                         metrics_table        : "python_flink_batch_cogbk_1",
                         input_options        : '\'{' +
@@ -64,7 +64,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                         project              : 'apache-beam-testing',
                         job_name             : 'load-tests-python-flink-batch-cogbk-2-' + now,
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
-                        publish_to_big_query : false,
+                        publish_to_big_query : true,
                         metrics_dataset      : datasetName,
                         metrics_table        : 'python_flink_batch_cogbk_2',
                         input_options        : '\'{' +
@@ -94,7 +94,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                         project              : 'apache-beam-testing',
                         job_name             : 'load-tests-python-flink-batch-cogbk-3-' + now,
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
-                        publish_to_big_query : false,
+                        publish_to_big_query : true,
                         metrics_dataset      : datasetName,
                         metrics_table        : "python_flink_batch_cogbk_3",
                         input_options        : '\'{' +
@@ -124,7 +124,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
                         project              : 'apache-beam-testing',
                         job_name             : 'load-tests-python-flink-batch-cogbk-4-' + now,
                         temp_location        : 'gs://temp-storage-for-perf-tests/loadtests',
-                        publish_to_big_query : false,
+                        publish_to_big_query : true,
                         metrics_dataset      : datasetName,
                         metrics_table        : 'python_flink_batch_cogbk_4',
                         input_options        : '\'{' +


### PR DESCRIPTION


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
