### PR TITLE
[BEAM-7948] Add time-based cache threshold support in the Java data s…

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/TimerReceiverTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/TimerReceiverTest.java
@@ -101,7 +101,10 @@ public class TimerReceiverTest implements Serializable {
     InProcessServerFactory serverFactory = InProcessServerFactory.create();
     dataServer =
         GrpcFnServer.allocatePortAndCreateFor(
-            GrpcDataService.create(serverExecutor, OutboundObserverFactory.serverDirect()),
+            GrpcDataService.create(
+                PipelineOptionsFactory.create(),
+                serverExecutor,
+                OutboundObserverFactory.serverDirect()),
             serverFactory);
     loggingServer =
         GrpcFnServer.allocatePortAndCreateFor(

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
@@ -405,7 +405,8 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
             StaticGrpcProvisionService.create(jobInfo.toProvisionInfo()), serverFactory);
     GrpcFnServer<GrpcDataService> dataServer =
         GrpcFnServer.allocatePortAndCreateFor(
-            GrpcDataService.create(executor, OutboundObserverFactory.serverDirect()),
+            GrpcDataService.create(
+                portableOptions, executor, OutboundObserverFactory.serverDirect()),
             serverFactory);
     GrpcFnServer<GrpcStateService> stateServer =
         GrpcFnServer.allocatePortAndCreateFor(GrpcStateService.create(), serverFactory);

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/EmbeddedSdkHarness.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/EmbeddedSdkHarness.java
@@ -79,7 +79,8 @@ public class EmbeddedSdkHarness extends ExternalResource implements TestRule {
             GrpcLoggingService.forWriter(Slf4jLogWriter.getDefault()), serverFactory);
     dataServer =
         GrpcFnServer.allocatePortAndCreateFor(
-            GrpcDataService.create(executor, OutboundObserverFactory.serverDirect()),
+            GrpcDataService.create(
+                PipelineOptionsFactory.create(), executor, OutboundObserverFactory.serverDirect()),
             serverFactory);
     controlServer = GrpcFnServer.allocatePortAndCreateFor(clientPoolService, serverFactory);
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -164,7 +164,10 @@ public class RemoteExecutionTest implements Serializable {
     InProcessServerFactory serverFactory = InProcessServerFactory.create();
     dataServer =
         GrpcFnServer.allocatePortAndCreateFor(
-            GrpcDataService.create(serverExecutor, OutboundObserverFactory.serverDirect()),
+            GrpcDataService.create(
+                PipelineOptionsFactory.create(),
+                serverExecutor,
+                OutboundObserverFactory.serverDirect()),
             serverFactory);
     loggingServer =
         GrpcFnServer.allocatePortAndCreateFor(

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/SingleEnvironmentInstanceJobBundleFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/SingleEnvironmentInstanceJobBundleFactoryTest.java
@@ -48,6 +48,7 @@ import org.apache.beam.runners.fnexecution.state.GrpcStateService;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.fn.IdGenerators;
 import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.junit.After;
@@ -79,7 +80,8 @@ public class SingleEnvironmentInstanceJobBundleFactoryTest {
     InProcessServerFactory serverFactory = InProcessServerFactory.create();
     dataServer =
         GrpcFnServer.allocatePortAndCreateFor(
-            GrpcDataService.create(executor, OutboundObserverFactory.serverDirect()),
+            GrpcDataService.create(
+                PipelineOptionsFactory.create(), executor, OutboundObserverFactory.serverDirect()),
             serverFactory);
     stateServer = GrpcFnServer.allocatePortAndCreateFor(GrpcStateService.create(), serverFactory);
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/data/GrpcDataServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/data/GrpcDataServiceTest.java
@@ -45,6 +45,7 @@ import org.apache.beam.sdk.fn.data.InboundDataClient;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
 import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
 import org.apache.beam.sdk.fn.test.TestStreams;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p21p0.io.grpc.ManagedChannel;
@@ -68,7 +69,9 @@ public class GrpcDataServiceTest {
     final CountDownLatch waitForInboundElements = new CountDownLatch(1);
     GrpcDataService service =
         GrpcDataService.create(
-            Executors.newCachedThreadPool(), OutboundObserverFactory.serverDirect());
+            PipelineOptionsFactory.create(),
+            Executors.newCachedThreadPool(),
+            OutboundObserverFactory.serverDirect());
     try (GrpcFnServer<GrpcDataService> server =
         GrpcFnServer.allocatePortAndCreateFor(service, InProcessServerFactory.create())) {
       Collection<Future<Void>> clientFutures = new ArrayList<>();
@@ -116,7 +119,9 @@ public class GrpcDataServiceTest {
     final CountDownLatch waitForInboundElements = new CountDownLatch(1);
     GrpcDataService service =
         GrpcDataService.create(
-            Executors.newCachedThreadPool(), OutboundObserverFactory.serverDirect());
+            PipelineOptionsFactory.create(),
+            Executors.newCachedThreadPool(),
+            OutboundObserverFactory.serverDirect());
     try (GrpcFnServer<GrpcDataService> server =
         GrpcFnServer.allocatePortAndCreateFor(service, InProcessServerFactory.create())) {
       Collection<Future<Void>> clientFutures = new ArrayList<>();

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaExecutionContext.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaExecutionContext.java
@@ -105,7 +105,8 @@ public class SamzaExecutionContext implements ApplicationContainerContext {
 
         fnDataServer =
             GrpcFnServer.allocatePortAndCreateFor(
-                GrpcDataService.create(dataExecutor, OutboundObserverFactory.serverDirect()),
+                GrpcDataService.create(
+                    options, dataExecutor, OutboundObserverFactory.serverDirect()),
                 ServerFactory.createDefault());
         LOG.info("Started data server on port {}", fnDataServer.getServer().getPort());
 

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataBufferingOutboundObserver.java
@@ -17,14 +17,14 @@
  */
 package org.apache.beam.sdk.fn.data;
 
-import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.ByteString;
+import org.apache.beam.sdk.options.ExperimentalOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.vendor.grpc.v1p21p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A buffering outbound {@link FnDataReceiver} for the Beam Fn Data API.
@@ -32,117 +32,59 @@ import org.slf4j.LoggerFactory;
  * <p>Encodes individually consumed elements with the provided {@link Coder} producing a single
  * {@link BeamFnApi.Elements} message when the buffer threshold is surpassed.
  *
- * <p>The default buffer threshold can be overridden by specifying the experiment {@code
- * beam_fn_api_data_buffer_limit=<bytes>}
+ * <p>The default size-based buffer threshold can be overridden by specifying the experiment {@code
+ * beam_fn_api_data_buffer_size_limit=<bytes>}
  *
- * <p>TODO: Handle outputting large elements (&gt; 2GiBs). Note that this also applies to the input
- * side as well.
- *
- * <p>TODO: Handle outputting elements that are zero bytes by outputting a single byte as a marker,
- * detect on the input side that no bytes were read and force reading a single byte.
+ * <p>The default time-based buffer threshold can be overridden by specifying the experiment {@code
+ * beam_fn_api_data_buffer_time_limit=<milliseconds>}
  */
-public class BeamFnDataBufferingOutboundObserver<T> implements CloseableFnDataReceiver<T> {
-  // TODO: Consider moving this constant out of this class
-  public static final String BEAM_FN_API_DATA_BUFFER_LIMIT = "beam_fn_api_data_buffer_limit=";
-  @VisibleForTesting static final int DEFAULT_BUFFER_LIMIT_BYTES = 1_000_000;
-  private static final Logger LOG =
-      LoggerFactory.getLogger(BeamFnDataBufferingOutboundObserver.class);
+public interface BeamFnDataBufferingOutboundObserver<T> extends CloseableFnDataReceiver<T> {
+  // TODO: Consider moving this constant out of this interface
+  /** @deprecated Use BEAM_FN_API_DATA_BUFFER_SIZE_LIMIT instead. */
+  @Deprecated String BEAM_FN_API_DATA_BUFFER_LIMIT = "beam_fn_api_data_buffer_limit=";
 
-  public static <T> BeamFnDataBufferingOutboundObserver<T> forLocation(
+  String BEAM_FN_API_DATA_BUFFER_SIZE_LIMIT = "beam_fn_api_data_buffer_size_limit=";
+  @VisibleForTesting int DEFAULT_BUFFER_LIMIT_BYTES = 1_000_000;
+
+  String BEAM_FN_API_DATA_BUFFER_TIME_LIMIT = "beam_fn_api_data_buffer_time_limit=";
+  long DEFAULT_BUFFER_LIMIT_TIME_MS = -1L;
+
+  static <T> BeamFnDataSizeBasedBufferingOutboundObserver<T> forLocation(
+      PipelineOptions options,
       LogicalEndpoint endpoint,
       Coder<T> coder,
       StreamObserver<BeamFnApi.Elements> outboundObserver) {
-    return forLocationWithBufferLimit(
-        DEFAULT_BUFFER_LIMIT_BYTES, endpoint, coder, outboundObserver);
-  }
-
-  public static <T> BeamFnDataBufferingOutboundObserver<T> forLocationWithBufferLimit(
-      int bufferLimit,
-      LogicalEndpoint endpoint,
-      Coder<T> coder,
-      StreamObserver<BeamFnApi.Elements> outboundObserver) {
-    return new BeamFnDataBufferingOutboundObserver<>(
-        bufferLimit, endpoint, coder, outboundObserver);
-  }
-
-  private long byteCounter;
-  private long counter;
-  private boolean closed;
-  private final int bufferLimit;
-  private final Coder<T> coder;
-  private final LogicalEndpoint outputLocation;
-  private final StreamObserver<BeamFnApi.Elements> outboundObserver;
-  private final ByteString.Output bufferedElements;
-
-  private BeamFnDataBufferingOutboundObserver(
-      int bufferLimit,
-      LogicalEndpoint outputLocation,
-      Coder<T> coder,
-      StreamObserver<BeamFnApi.Elements> outboundObserver) {
-    this.bufferLimit = bufferLimit;
-    this.outputLocation = outputLocation;
-    this.coder = coder;
-    this.outboundObserver = outboundObserver;
-    this.bufferedElements = ByteString.newOutput();
-    this.closed = false;
-  }
-
-  @Override
-  public void close() throws Exception {
-    if (closed) {
-      throw new IllegalStateException("Already closed.");
-    }
-    closed = true;
-    BeamFnApi.Elements.Builder elements = convertBufferForTransmission();
-    // This will add an empty data block representing the end of stream.
-    elements
-        .addDataBuilder()
-        .setInstructionId(outputLocation.getInstructionId())
-        .setTransformId(outputLocation.getTransformId());
-
-    LOG.debug(
-        "Closing stream for instruction {} and "
-            + "transform {} having transmitted {} values {} bytes",
-        outputLocation.getInstructionId(),
-        outputLocation.getTransformId(),
-        counter,
-        byteCounter);
-    outboundObserver.onNext(elements.build());
-  }
-
-  @Override
-  public void flush() throws IOException {
-    if (bufferedElements.size() > 0) {
-      outboundObserver.onNext(convertBufferForTransmission().build());
+    int sizeLimit = getSizeLimit(options);
+    long timeLimit = getTimeLimit(options);
+    if (timeLimit > 0) {
+      return new BeamFnDataTimeBasedBufferingOutboundObserver<>(
+          sizeLimit, timeLimit, endpoint, coder, outboundObserver);
+    } else {
+      return new BeamFnDataSizeBasedBufferingOutboundObserver<>(
+          sizeLimit, endpoint, coder, outboundObserver);
     }
   }
 
-  @Override
-  public void accept(T t) throws IOException {
-    if (closed) {
-      throw new IllegalStateException("Already closed.");
+  static int getSizeLimit(PipelineOptions options) {
+    List<String> experiments = options.as(ExperimentalOptions.class).getExperiments();
+    for (String experiment : experiments == null ? Collections.<String>emptyList() : experiments) {
+      if (experiment.startsWith(BEAM_FN_API_DATA_BUFFER_SIZE_LIMIT)) {
+        return Integer.parseInt(experiment.substring(BEAM_FN_API_DATA_BUFFER_SIZE_LIMIT.length()));
+      }
+      if (experiment.startsWith(BEAM_FN_API_DATA_BUFFER_LIMIT)) {
+        return Integer.parseInt(experiment.substring(BEAM_FN_API_DATA_BUFFER_LIMIT.length()));
+      }
     }
-    coder.encode(t, bufferedElements);
-    counter += 1;
-    if (bufferedElements.size() >= bufferLimit) {
-      flush();
-    }
+    return DEFAULT_BUFFER_LIMIT_BYTES;
   }
 
-  private BeamFnApi.Elements.Builder convertBufferForTransmission() {
-    BeamFnApi.Elements.Builder elements = BeamFnApi.Elements.newBuilder();
-    if (bufferedElements.size() == 0) {
-      return elements;
+  static long getTimeLimit(PipelineOptions options) {
+    List<String> experiments = options.as(ExperimentalOptions.class).getExperiments();
+    for (String experiment : experiments == null ? Collections.<String>emptyList() : experiments) {
+      if (experiment.startsWith(BEAM_FN_API_DATA_BUFFER_TIME_LIMIT)) {
+        return Long.parseLong(experiment.substring(BEAM_FN_API_DATA_BUFFER_TIME_LIMIT.length()));
+      }
     }
-
-    elements
-        .addDataBuilder()
-        .setInstructionId(outputLocation.getInstructionId())
-        .setTransformId(outputLocation.getTransformId())
-        .setData(bufferedElements.toByteString());
-
-    byteCounter += bufferedElements.size();
-    bufferedElements.reset();
-    return elements;
+    return DEFAULT_BUFFER_LIMIT_TIME_MS;
   }
 }

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserver.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.fn.data;
+
+import java.io.IOException;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.ByteString;
+import org.apache.beam.vendor.grpc.v1p21p0.io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A size-based buffering outbound {@link FnDataReceiver} for the Beam Fn Data API.
+ *
+ * <p>TODO: Handle outputting large elements (&gt; 2GiBs). Note that this also applies to the input
+ * side as well.
+ *
+ * <p>TODO: Handle outputting elements that are zero bytes by outputting a single byte as a marker,
+ * detect on the input side that no bytes were read and force reading a single byte.
+ */
+public class BeamFnDataSizeBasedBufferingOutboundObserver<T>
+    implements BeamFnDataBufferingOutboundObserver<T> {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BeamFnDataSizeBasedBufferingOutboundObserver.class);
+
+  private long byteCounter;
+  private long counter;
+  private boolean closed;
+  private final int sizeLimit;
+  private final Coder<T> coder;
+  private final LogicalEndpoint outputLocation;
+  private final StreamObserver<BeamFnApi.Elements> outboundObserver;
+  private final ByteString.Output bufferedElements;
+
+  BeamFnDataSizeBasedBufferingOutboundObserver(
+      int sizeLimit,
+      LogicalEndpoint outputLocation,
+      Coder<T> coder,
+      StreamObserver<BeamFnApi.Elements> outboundObserver) {
+    this.sizeLimit = sizeLimit;
+    this.outputLocation = outputLocation;
+    this.coder = coder;
+    this.outboundObserver = outboundObserver;
+    this.bufferedElements = ByteString.newOutput();
+    this.closed = false;
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (closed) {
+      throw new IllegalStateException("Already closed.");
+    }
+    closed = true;
+    BeamFnApi.Elements.Builder elements = convertBufferForTransmission();
+    // This will add an empty data block representing the end of stream.
+    elements
+        .addDataBuilder()
+        .setInstructionId(outputLocation.getInstructionId())
+        .setTransformId(outputLocation.getTransformId());
+
+    LOG.debug(
+        "Closing stream for instruction {} and "
+            + "transform {} having transmitted {} values {} bytes",
+        outputLocation.getInstructionId(),
+        outputLocation.getTransformId(),
+        counter,
+        byteCounter);
+    outboundObserver.onNext(elements.build());
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if (bufferedElements.size() > 0) {
+      outboundObserver.onNext(convertBufferForTransmission().build());
+    }
+  }
+
+  @Override
+  public void accept(T t) throws IOException {
+    if (closed) {
+      throw new IllegalStateException("Already closed.");
+    }
+    coder.encode(t, bufferedElements);
+    counter += 1;
+    if (bufferedElements.size() >= sizeLimit) {
+      flush();
+    }
+  }
+
+  private BeamFnApi.Elements.Builder convertBufferForTransmission() {
+    BeamFnApi.Elements.Builder elements = BeamFnApi.Elements.newBuilder();
+    if (bufferedElements.size() == 0) {
+      return elements;
+    }
+
+    elements
+        .addDataBuilder()
+        .setInstructionId(outputLocation.getInstructionId())
+        .setTransformId(outputLocation.getTransformId())
+        .setData(bufferedElements.toByteString());
+
+    byteCounter += bufferedElements.size();
+    bufferedElements.reset();
+    return elements;
+  }
+}

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserver.java
@@ -85,7 +85,7 @@ public class BeamFnDataSizeBasedBufferingOutboundObserver<T>
   }
 
   @Override
-  public synchronized void flush() throws IOException {
+  public void flush() throws IOException {
     if (bufferedElements.size() > 0) {
       outboundObserver.onNext(convertBufferForTransmission().build());
     }

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserver.java
@@ -85,7 +85,7 @@ public class BeamFnDataSizeBasedBufferingOutboundObserver<T>
   }
 
   @Override
-  public void flush() throws IOException {
+  public synchronized void flush() throws IOException {
     if (bufferedElements.size() > 0) {
       outboundObserver.onNext(convertBufferForTransmission().build());
     }

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataTimeBasedBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataTimeBasedBufferingOutboundObserver.java
@@ -69,6 +69,11 @@ public class BeamFnDataTimeBasedBufferingOutboundObserver<T>
   }
 
   @Override
+  public synchronized void flush() throws IOException {
+    super.flush();
+  }
+
+  @Override
   public void accept(T t) throws IOException {
     checkFlushThreadException();
     super.accept(t);

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataTimeBasedBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataTimeBasedBufferingOutboundObserver.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.fn.data;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.vendor.grpc.v1p21p0.io.grpc.stub.StreamObserver;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+/**
+ * A buffering outbound {@link FnDataReceiver} with both size-based buffer and time-based buffer
+ * enabled for the Beam Fn Data API.
+ */
+public class BeamFnDataTimeBasedBufferingOutboundObserver<T>
+    extends BeamFnDataSizeBasedBufferingOutboundObserver<T> {
+
+  private final Object lock;
+  private final ScheduledFuture<?> flushFuture;
+  @VisibleForTesting final AtomicReference<IOException> flushException;
+
+  BeamFnDataTimeBasedBufferingOutboundObserver(
+      int sizeLimit,
+      long timeLimit,
+      LogicalEndpoint outputLocation,
+      Coder<T> coder,
+      StreamObserver<BeamFnApi.Elements> outboundObserver) {
+    super(sizeLimit, outputLocation, coder, outboundObserver);
+    this.lock = new Object();
+    this.flushFuture =
+        Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder()
+                    .setDaemon(true)
+                    .setNameFormat("DataBufferOutboundFlusher-thread")
+                    .build())
+            .scheduleAtFixedRate(this::periodicFlush, timeLimit, timeLimit, TimeUnit.MILLISECONDS);
+    this.flushException = new AtomicReference<>(null);
+  }
+
+  @Override
+  public void close() throws Exception {
+    checkFlushThreadException();
+    synchronized (lock) {
+      flushFuture.cancel(true);
+      try {
+        flushFuture.get();
+      } catch (CancellationException | ExecutionException | InterruptedException exn) {
+        // expected
+      }
+    }
+    super.close();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    synchronized (lock) {
+      super.flush();
+    }
+  }
+
+  @Override
+  public void accept(T t) throws IOException {
+    checkFlushThreadException();
+    super.accept(t);
+  }
+
+  private void periodicFlush() {
+    try {
+      flush();
+    } catch (Throwable t) {
+      if (t instanceof IOException) {
+        flushException.set((IOException) t);
+      } else {
+        flushException.set(new IOException(t));
+      }
+      throw new RuntimeException(t);
+    }
+  }
+
+  /** Check if the flush thread failed with an exception. */
+  private void checkFlushThreadException() throws IOException {
+    IOException e = flushException.get();
+    if (e != null) {
+      throw e;
+    }
+  }
+}

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataTimeBasedBufferingOutboundObserverTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataTimeBasedBufferingOutboundObserverTest.java
@@ -22,7 +22,6 @@ import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -98,7 +97,7 @@ public class BeamFnDataTimeBasedBufferingOutboundObserverTest {
     // Test that it emits when time passed the time limit
     consumer.accept(valueInGlobalWindow(new byte[1]));
     // wait the flush thread to flush the buffer
-    while (consumer.flushException.get() == null) {
+    while (!consumer.flushFuture.isDone()) {
       Thread.sleep(1);
     }
     try {
@@ -106,7 +105,7 @@ public class BeamFnDataTimeBasedBufferingOutboundObserverTest {
       // the main thread when processing the next element
       consumer.accept(valueInGlobalWindow(new byte[1]));
       fail();
-    } catch (IOException e) {
+    } catch (Exception e) {
       // expected
     }
 
@@ -124,7 +123,7 @@ public class BeamFnDataTimeBasedBufferingOutboundObserverTest {
                     .build());
     consumer.accept(valueInGlobalWindow(new byte[1]));
     // wait the flush thread to flush the buffer
-    while (consumer.flushException.get() == null) {
+    while (!consumer.flushFuture.isDone()) {
       Thread.sleep(1);
     }
     try {
@@ -132,7 +131,7 @@ public class BeamFnDataTimeBasedBufferingOutboundObserverTest {
       // the main thread when closing
       consumer.close();
       fail();
-    } catch (IOException e) {
+    } catch (Exception e) {
       // expected
     }
   }

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataTimeBasedBufferingOutboundObserverTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataTimeBasedBufferingOutboundObserverTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.fn.data;
+
+import static org.apache.beam.sdk.fn.data.BeamFnDataSizeBasedBufferingOutboundObserverTest.messageWithData;
+import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.Elements;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.LengthPrefixCoder;
+import org.apache.beam.sdk.fn.test.TestStreams;
+import org.apache.beam.sdk.options.ExperimentalOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link BeamFnDataTimeBasedBufferingOutboundObserver}. */
+@RunWith(JUnit4.class)
+public class BeamFnDataTimeBasedBufferingOutboundObserverTest {
+  private static final LogicalEndpoint OUTPUT_LOCATION = LogicalEndpoint.of("777L", "555L");
+  private static final Coder<WindowedValue<byte[]>> CODER =
+      LengthPrefixCoder.of(WindowedValue.getValueOnlyCoder(ByteArrayCoder.of()));
+
+  @Test
+  public void testConfiguredTimeLimit() throws Exception {
+    Collection<Elements> values = new ArrayList<>();
+    PipelineOptions options = PipelineOptionsFactory.create();
+    options
+        .as(ExperimentalOptions.class)
+        .setExperiments(Arrays.asList("beam_fn_api_data_buffer_time_limit=1"));
+    final CountDownLatch waitForFlush = new CountDownLatch(1);
+    CloseableFnDataReceiver<WindowedValue<byte[]>> consumer =
+        BeamFnDataBufferingOutboundObserver.forLocation(
+            options,
+            OUTPUT_LOCATION,
+            CODER,
+            TestStreams.withOnNext(
+                    (Consumer<Elements>)
+                        e -> {
+                          values.add(e);
+                          waitForFlush.countDown();
+                        })
+                .build());
+
+    // Test that it emits when time passed the time limit
+    consumer.accept(valueInGlobalWindow(new byte[1]));
+    waitForFlush.await(); // wait the flush thread to flush the buffer
+    assertEquals(messageWithData(new byte[1]), Iterables.get(values, 0));
+  }
+
+  @Test
+  public void testConfiguredTimeLimitExceptionPropagation() throws Exception {
+    PipelineOptions options = PipelineOptionsFactory.create();
+    options
+        .as(ExperimentalOptions.class)
+        .setExperiments(Arrays.asList("beam_fn_api_data_buffer_time_limit=1"));
+    BeamFnDataTimeBasedBufferingOutboundObserver<WindowedValue<byte[]>> consumer =
+        (BeamFnDataTimeBasedBufferingOutboundObserver<WindowedValue<byte[]>>)
+            BeamFnDataBufferingOutboundObserver.forLocation(
+                options,
+                OUTPUT_LOCATION,
+                CODER,
+                TestStreams.withOnNext(
+                        (Consumer<Elements>)
+                            e -> {
+                              throw new RuntimeException("");
+                            })
+                    .build());
+
+    // Test that it emits when time passed the time limit
+    consumer.accept(valueInGlobalWindow(new byte[1]));
+    // wait the flush thread to flush the buffer
+    while (consumer.flushException.get() == null) {
+      Thread.sleep(1);
+    }
+    try {
+      // Test that the exception caught in the flush thread is propagate to
+      // the main thread when processing the next element
+      consumer.accept(valueInGlobalWindow(new byte[1]));
+      fail();
+    } catch (IOException e) {
+      // expected
+    }
+
+    consumer =
+        (BeamFnDataTimeBasedBufferingOutboundObserver<WindowedValue<byte[]>>)
+            BeamFnDataBufferingOutboundObserver.forLocation(
+                options,
+                OUTPUT_LOCATION,
+                CODER,
+                TestStreams.withOnNext(
+                        (Consumer<Elements>)
+                            e -> {
+                              throw new RuntimeException("");
+                            })
+                    .build());
+    consumer.accept(valueInGlobalWindow(new byte[1]));
+    // wait the flush thread to flush the buffer
+    while (consumer.flushException.get() == null) {
+      Thread.sleep(1);
+    }
+    try {
+      // Test that the exception caught in the flush thread is propagate to
+      // the main thread when closing
+      consumer.close();
+      fail();
+    } catch (IOException e) {
+      // expected
+    }
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClient.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClient.java
@@ -17,9 +17,6 @@
  */
 package org.apache.beam.fn.harness.data;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -35,7 +32,6 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.data.InboundDataClient;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
 import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
-import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.vendor.grpc.v1p21p0.io.grpc.ManagedChannel;
 import org.slf4j.Logger;
@@ -48,7 +44,6 @@ import org.slf4j.LoggerFactory;
  */
 public class BeamFnDataGrpcClient implements BeamFnDataClient {
   private static final Logger LOG = LoggerFactory.getLogger(BeamFnDataGrpcClient.class);
-  private static final String BEAM_FN_API_DATA_BUFFER_LIMIT = "beam_fn_api_data_buffer_limit=";
 
   private final ConcurrentMap<Endpoints.ApiServiceDescriptor, BeamFnDataGrpcMultiplexer> cache;
   private final Function<Endpoints.ApiServiceDescriptor, ManagedChannel> channelFactory;
@@ -112,26 +107,8 @@ public class BeamFnDataGrpcClient implements BeamFnDataClient {
         "Creating output consumer for instruction {} and transform {}",
         outputLocation.getInstructionId(),
         outputLocation.getTransformId());
-    Optional<Integer> bufferLimit = getBufferLimit(options);
-    if (bufferLimit.isPresent()) {
-      return BeamFnDataBufferingOutboundObserver.forLocationWithBufferLimit(
-          bufferLimit.get(), outputLocation, coder, client.getOutboundObserver());
-    } else {
-      return BeamFnDataBufferingOutboundObserver.forLocation(
-          outputLocation, coder, client.getOutboundObserver());
-    }
-  }
-
-  /** Returns the {@code beam_fn_api_data_buffer_limit=<int>} experiment value if set. */
-  private static Optional<Integer> getBufferLimit(PipelineOptions options) {
-    List<String> experiments = options.as(ExperimentalOptions.class).getExperiments();
-    for (String experiment : experiments == null ? Collections.<String>emptyList() : experiments) {
-      if (experiment.startsWith(BEAM_FN_API_DATA_BUFFER_LIMIT)) {
-        return Optional.of(
-            Integer.parseInt(experiment.substring(BEAM_FN_API_DATA_BUFFER_LIMIT.length())));
-      }
-    }
-    return Optional.empty();
+    return BeamFnDataBufferingOutboundObserver.forLocation(
+        options, outputLocation, coder, client.getOutboundObserver());
   }
 
   private BeamFnDataGrpcMultiplexer getClientFor(

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClientTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClientTest.java
@@ -292,7 +292,7 @@ public class BeamFnDataGrpcClientTest {
       BeamFnDataGrpcClient clientFactory =
           new BeamFnDataGrpcClient(
               PipelineOptionsFactory.fromArgs(
-                      new String[] {"--experiments=beam_fn_api_data_buffer_limit=20"})
+                      new String[] {"--experiments=beam_fn_api_data_buffer_size_limit=20"})
                   .create(),
               (Endpoints.ApiServiceDescriptor descriptor) -> channel,
               OutboundObserverFactory.trivial());


### PR DESCRIPTION
Currently only size-based cache threshold is supported in data service. It should also support the time-based cache threshold. This is very important, especially for streaming jobs which are sensitive to the delay. So, This PR add the time-based cache threshold support in the Java data service.


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
