### PR TITLE
[BEAM-8532] Output timestamp should be the inclusive, not exclusive, end of window.

### DIFF
--- a/sdks/python/apache_beam/testing/data/trigger_transcripts.yaml
+++ b/sdks/python/apache_beam/testing/data/trigger_transcripts.yaml
@@ -34,12 +34,12 @@ transcript:
   - input: [1, 2, 3, 10, 11, 25]
   - watermark: 100
   - expect:
-      - {window: [0, 9], values: [1, 2, 3], timestamp: 10, final: false}
-      - {window: [10, 19], values: [10, 11], timestamp: 20}
-      - {window: [20, 29], values: [25], timestamp: 30, late: false}
+      - {window: [0, 9], values: [1, 2, 3], timestamp: 9, final: false}
+      - {window: [10, 19], values: [10, 11], timestamp: 19}
+      - {window: [20, 29], values: [25], timestamp: 29, late: false}
   - input: [7]
   - expect:
-      - {window: [0, 9], values: [1, 2, 3, 7], timestamp: 10, late: true}
+      - {window: [0, 9], values: [1, 2, 3, 7], timestamp: 9, late: true}
 
 ---
 name: timestamp_combiner_earliest
@@ -77,9 +77,9 @@ transcript:
   - input: [1, 2, 3, 10, 11, 25]
   - watermark: 100
   - expect:
-      - {window: [0, 9], values: [1, 2, 3], timestamp: 10, final: false}
-      - {window: [10, 19], values: [10, 11], timestamp: 20}
-      - {window: [20, 29], values: [25], timestamp: 30, late: false}
+      - {window: [0, 9], values: [1, 2, 3], timestamp: 9, final: false}
+      - {window: [10, 19], values: [10, 11], timestamp: 19}
+      - {window: [20, 29], values: [25], timestamp: 29, late: false}
 
 ---
 # Test that custom timestamping is not invoked.
@@ -119,20 +119,20 @@ timestamp_combiner: OUTPUT_AT_EOW
 transcript:
     - input: [1, 2, 3]
     - expect:
-        - {window: [1, 12], values: [1, 2, 3], timestamp: 13, early: true}
+        - {window: [1, 12], values: [1, 2, 3], timestamp: 12, early: true}
     - input: [4]    # no output
     - input: [5]
     - expect:
-        - {window: [1, 14], values: [1, 2, 3, 4, 5], timestamp: 15, early: true}
+        - {window: [1, 14], values: [1, 2, 3, 4, 5], timestamp: 14, early: true}
     - input: [6]
     - watermark: 100
     - expect:
-        - {window: [1, 15], values:[1, 2, 3, 4, 5, 6], timestamp: 16,
+        - {window: [1, 15], values:[1, 2, 3, 4, 5, 6], timestamp: 15,
            final: true}
     - input: [1]
     - input: [3, 4]
     - expect:
-        - {window: [1, 15], values: [1, 1, 2, 3, 3, 4, 4, 5, 6], timestamp: 16}
+        - {window: [1, 15], values: [1, 1, 2, 3, 3, 4, 4, 5, 6], timestamp: 15}
 
 ---
 name: garbage_collection
@@ -146,8 +146,8 @@ accumulation_mode: discarding
 transcript:
   - input: [1, 2, 3, 10, 11, 25]
   - expect:
-      - {window: [0, 9], timestamp: 10}
-      - {window: [10, 19], timestamp: 20}
+      - {window: [0, 9], timestamp: 9}
+      - {window: [10, 19], timestamp: 19}
   - state:
       present: [[20, 29]]
       absent: [[0, 9]]
@@ -179,7 +179,7 @@ transcript:
   - input: [2, 3, 7]
   - watermark: 11
   - expect:
-      - {window: [0, 9], values: [2, 3, 7], timestamp: 10}
+      - {window: [0, 9], values: [2, 3, 7], timestamp: 9}
 
 # These next examples test that bad/incomplete transcripts are rejected.
 ---

--- a/sdks/python/apache_beam/transforms/timeutil.py
+++ b/sdks/python/apache_beam/transforms/timeutil.py
@@ -136,4 +136,4 @@ class OutputAtEndOfWindowImpl(DependsOnlyOnWindow):
   """TimestampCombinerImpl outputting at end of window."""
 
   def assign_output_time(self, window, unused_input_timestamp):
-    return window.end
+    return window.max_timestamp()

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -1180,7 +1180,7 @@ class GeneralTriggerDriver(TriggerDriver):
     timestamp = state.get_state(window, self.WATERMARK_HOLD)
     if timestamp is None:
       # If no watermark hold was set, output at end of window.
-      timestamp = window.end
+      timestamp = window.max_timestamp()
     else:
       state.clear_state(window, self.WATERMARK_HOLD)
 

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -323,7 +323,7 @@ class ReshuffleTest(unittest.TestCase):
   def test_reshuffle_windows_unchanged(self):
     pipeline = TestPipeline()
     data = [(1, 1), (2, 1), (3, 1), (1, 2), (2, 2), (1, 4)]
-    expected_data = [TestWindowedValue(v, t, [w]) for (v, t, w) in [
+    expected_data = [TestWindowedValue(v, t - .001, [w]) for (v, t, w) in [
         ((1, contains_in_any_order([2, 1])), 4.0, IntervalWindow(1.0, 4.0)),
         ((2, contains_in_any_order([2, 1])), 4.0, IntervalWindow(1.0, 4.0)),
         ((3, [1]), 3.0, IntervalWindow(1.0, 3.0)),
@@ -351,11 +351,12 @@ class ReshuffleTest(unittest.TestCase):
         ((1, 2), 2.0, IntervalWindow(2.0, 4.0)),
         ((2, 2), 2.0, IntervalWindow(2.0, 4.0)),
         ((1, 4), 4.0, IntervalWindow(4.0, 6.0))]]
-    expected_merged_windows = [TestWindowedValue(v, t, [w]) for (v, t, w) in [
-        ((1, contains_in_any_order([2, 1])), 4.0, IntervalWindow(1.0, 4.0)),
-        ((2, contains_in_any_order([2, 1])), 4.0, IntervalWindow(1.0, 4.0)),
-        ((3, [1]), 3.0, IntervalWindow(1.0, 3.0)),
-        ((1, [4]), 6.0, IntervalWindow(4.0, 6.0))]]
+    expected_merged_windows = [
+        TestWindowedValue(v, t - .001, [w]) for (v, t, w) in [
+            ((1, contains_in_any_order([2, 1])), 4.0, IntervalWindow(1.0, 4.0)),
+            ((2, contains_in_any_order([2, 1])), 4.0, IntervalWindow(1.0, 4.0)),
+            ((3, [1]), 3.0, IntervalWindow(1.0, 3.0)),
+            ((1, [4]), 6.0, IntervalWindow(4.0, 6.0))]]
     before_reshuffle = (pipeline
                         | 'start' >> beam.Create(data)
                         | 'add_timestamp' >> beam.Map(

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -22,14 +22,17 @@ from __future__ import division
 import unittest
 from builtins import range
 
+import apache_beam as beam
 from apache_beam.runners import pipeline_context
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.transforms import CombinePerKey
 from apache_beam.transforms import Create
+from apache_beam.transforms import FlatMapTuple
 from apache_beam.transforms import GroupByKey
 from apache_beam.transforms import Map
+from apache_beam.transforms import MapTuple
 from apache_beam.transforms import WindowInto
 from apache_beam.transforms import combiners
 from apache_beam.transforms import core
@@ -220,6 +223,34 @@ class WindowTest(unittest.TestCase):
                 | GroupByKey())
       assert_that(result, equal_to([('key', sorted([0, 1, 2, 3, 4] * 3)),
                                     ('key', sorted([5, 6, 7, 8, 9] * 3))]))
+
+  def test_rewindow_regroup(self):
+    with TestPipeline() as p:
+      grouped = (p
+                 | Create(range(5))
+                 | Map(lambda t: TimestampedValue(('key', t), t))
+                 | 'window' >> WindowInto(FixedWindows(5, offset=3))
+                 | GroupByKey()
+                 | MapTuple(lambda k, vs: (k, sorted(vs))))
+      # Both of these group-and-ungroup sequences should be idempotent.
+      regrouped1 = (grouped
+                    | 'w1' >> WindowInto(FixedWindows(5, offset=3))
+                    | 'g1' >> GroupByKey()
+                    | FlatMapTuple(lambda k, vs: [(k, v) for v in vs]))
+      regrouped2 = (grouped
+                    | FlatMapTuple(lambda k, vs: [(k, v) for v in vs])
+                    | 'w2' >> WindowInto(FixedWindows(5, offset=3))
+                    | 'g2' >> GroupByKey()
+                    | MapTuple(lambda k, vs: (k, sorted(vs))))
+      with_windows = Map(lambda e, w=beam.DoFn.WindowParam: (e, w))
+      expected = [(('key', [0, 1, 2]), IntervalWindow(-2, 3)),
+                  (('key', [3, 4]), IntervalWindow(3, 8))]
+
+      assert_that(grouped | 'ww' >> with_windows, equal_to(expected))
+      assert_that(
+          regrouped1 | 'ww1' >> with_windows, equal_to(expected), label='r1')
+      assert_that(
+          regrouped2 | 'ww2' >> with_windows, equal_to(expected), label='r2')
 
   def test_timestamped_with_combiners(self):
     with TestPipeline() as p:


### PR DESCRIPTION


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
