### PR TITLE
[BEAM-7951] Allow runner to configure customization WindowedValue coder.

### DIFF
--- a/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
+++ b/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
@@ -263,6 +263,44 @@ examples:
 
 ---
 
+# ParamWindowedValueCoder with constant value of:
+# timestamp: Instant.ofEpochMilli(1000)
+# windows: [IntervalWindow(10, 20)]
+# pane info: PaneInfo(false, true, PaneInfo.Timing.ON_TIME, 30, 40)
+coder:
+  urn: "beam:coder:param_windowed_value:v1"
+  payload: "\x80\x00\x00\x00\x00\x00\x03è\x00\x00\x00\x01\x80\x00\x00\x00\x00\x00\x00\x14\n&\x1E(\x00"
+  components: [{urn: "beam:coder:varint:v1"},
+               {urn: "beam:coder:interval_window:v1"}]
+examples:
+  "\u0002": {
+    value: 2,
+    timestamp: 1000,
+    pane: {is_first: False, is_last: True, timing: ON_TIME, index: 30, on_time_index: 40},
+    windows: [{end: 20, span: 10}]
+  }
+
+---
+
+# ParamWindowedValueCoder with constant value of:
+# timestamp: BoundedWindow.TIMESTAMP_MIN_VALUE
+# windows: [GlobalWindow.INSTANCE]
+# pane info: PaneInfo.NO_FIRING
+coder:
+  urn: "beam:coder:param_windowed_value:v1"
+  payload: "\x7Fß;dZ\x1C¬\t\x00\x00\x00\x01\x0F\x00"
+  components: [{urn: "beam:coder:varint:v1"},
+               {urn: "beam:coder:global_window:v1"}]
+examples:
+  "\u0002": {
+    value: 2,
+    timestamp: -9223372036854775,
+    pane: {is_first: True, is_last: True, timing: UNKNOWN, index: 0, on_time_index: 0},
+    windows: ["global"]
+  }
+
+---
+
 coder:
   urn: "beam:coder:double:v1"
 examples:

--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -674,6 +674,16 @@ message StandardCoders {
     // Components: The element coder and the window coder, in that order
     WINDOWED_VALUE = 8 [(beam_urn) = "beam:coder:windowed_value:v1"];
 
+    // A windowed value coder with parameterized timestamp, windows and pane info.
+    // Encodes an element with only the value of the windowed value.
+    // Decodes the value and assign the parameterized timestamp, windows and PaneInfo to the
+    // windowed value
+    // Components: The element coder and the window coder, in that order
+    // The payload of this coder is an encoded windowed value using the
+    // beam:coder:windowed_value:v1 coder parameterized by beam:coder:bytes:v1
+    // elements coder and the window coder that this param_windowed_value uses.
+    PARAM_WINDOWED_VALUE = 14 [(beam_urn) = "beam:coder:param_windowed_value:v1"];
+
     // Encodes an iterable of elements, some of which may be stored elsewhere.
     //
     // The encoding for a state-backed iterable is the same as that for
@@ -1063,6 +1073,21 @@ message SideInput {
   FunctionSpec window_mapping_fn = 3;
 }
 
+// Settings that decide the coder type of wire coder.
+message WireCoderSetting {
+  // (Required) The URN of the wire coder.
+  // Note that only windowed value coder or parameterized windowed value coder are supported.
+  string urn = 1;
+
+  // (Optional) The data specifying any parameters to the URN. If
+  // the URN is beam:coder:windowed_value:v1, this may be omitted. If the URN is
+  // beam:coder:param_windowed_value:v1, the payload is an encoded windowed
+  // value using the beam:coder:windowed_value:v1 coder parameterized by
+  // beam:coder:bytes:v1 elements coder and the window coder that this
+  // param_windowed_value uses.
+  bytes payload = 2;
+}
+
 // An environment for executing UDFs. By default, an SDK container URL, but
 // can also be a process forked by a command, or an externally managed process.
 message Environment {
@@ -1270,6 +1295,9 @@ message ExecutableStagePayload {
   // We use an environment rather than environment id
   // because ExecutableStages use environments directly. This may change in the future.
   Environment environment = 1;
+
+  // set the wire coder of this executable stage
+  WireCoderSetting wire_coder_setting = 9;
 
   // (Required) Input PCollection id. This must be present as a value in the inputs of any
   // PTransform the ExecutableStagePayload is the payload of.

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CoderTranslators.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CoderTranslators.java
@@ -125,6 +125,26 @@ class CoderTranslators {
     };
   }
 
+  static CoderTranslator<WindowedValue.ParamWindowedValueCoder<?>> paramWindowedValue() {
+    return new CoderTranslator<WindowedValue.ParamWindowedValueCoder<?>>() {
+      @Override
+      public List<? extends Coder<?>> getComponents(WindowedValue.ParamWindowedValueCoder<?> from) {
+        return ImmutableList.of(from.getValueCoder(), from.getWindowCoder());
+      }
+
+      @Override
+      public byte[] getPayload(WindowedValue.ParamWindowedValueCoder<?> from) {
+        return WindowedValue.ParamWindowedValueCoder.getPayload(from);
+      }
+
+      @Override
+      public WindowedValue.ParamWindowedValueCoder<?> fromComponents(
+          List<Coder<?>> components, byte[] payload) {
+        return WindowedValue.ParamWindowedValueCoder.fromComponents(components, payload);
+      }
+    };
+  }
+
   static CoderTranslator<RowCoder> row() {
     return new CoderTranslator<RowCoder>() {
       @Override

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ModelCoderRegistrar.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ModelCoderRegistrar.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow.IntervalWindowCoder;
+import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.BiMap;
@@ -60,6 +61,9 @@ public class ModelCoderRegistrar implements CoderTranslatorRegistrar {
           .put(LengthPrefixCoder.class, ModelCoders.LENGTH_PREFIX_CODER_URN)
           .put(GlobalWindow.Coder.class, ModelCoders.GLOBAL_WINDOW_CODER_URN)
           .put(FullWindowedValueCoder.class, ModelCoders.WINDOWED_VALUE_CODER_URN)
+          .put(
+              WindowedValue.ParamWindowedValueCoder.class,
+              ModelCoders.PARAM_WINDOWED_VALUE_CODER_URN)
           .put(DoubleCoder.class, ModelCoders.DOUBLE_CODER_URN)
           .put(RowCoder.class, ModelCoders.ROW_CODER_URN)
           .build();
@@ -80,6 +84,7 @@ public class ModelCoderRegistrar implements CoderTranslatorRegistrar {
           .put(Timer.Coder.class, CoderTranslators.timer())
           .put(LengthPrefixCoder.class, CoderTranslators.lengthPrefix())
           .put(FullWindowedValueCoder.class, CoderTranslators.fullWindowedValue())
+          .put(WindowedValue.ParamWindowedValueCoder.class, CoderTranslators.paramWindowedValue())
           .put(DoubleCoder.class, CoderTranslators.atomic(DoubleCoder.class))
           .put(RowCoder.class, CoderTranslators.row())
           .build();

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ModelCoders.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ModelCoders.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardCoders;
+import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 
 /** Utilities and constants ot interact with coders that are part of the Beam Model. */
@@ -53,6 +54,8 @@ public class ModelCoders {
       getUrn(StandardCoders.Enum.INTERVAL_WINDOW);
 
   public static final String WINDOWED_VALUE_CODER_URN = getUrn(StandardCoders.Enum.WINDOWED_VALUE);
+  public static final String PARAM_WINDOWED_VALUE_CODER_URN =
+      getUrn(StandardCoders.Enum.PARAM_WINDOWED_VALUE);
 
   public static final String ROW_CODER_URN = getUrn(StandardCoders.Enum.ROW);
 
@@ -70,7 +73,8 @@ public class ModelCoders {
           INTERVAL_WINDOW_CODER_URN,
           WINDOWED_VALUE_CODER_URN,
           DOUBLE_CODER_URN,
-          ROW_CODER_URN);
+          ROW_CODER_URN,
+          PARAM_WINDOWED_VALUE_CODER_URN);
 
   public static Set<String> urns() {
     return MODEL_CODER_URNS;
@@ -85,6 +89,18 @@ public class ModelCoders {
   public static Coder windowedValueCoder(String elementCoderId, String windowCoderId) {
     return Coder.newBuilder()
         .setSpec(FunctionSpec.newBuilder().setUrn(WINDOWED_VALUE_CODER_URN))
+        .addComponentCoderIds(elementCoderId)
+        .addComponentCoderIds(windowCoderId)
+        .build();
+  }
+
+  public static Coder paramWindowedValueCoder(
+      String elementCoderId, String windowCoderId, byte[] payload) {
+    return Coder.newBuilder()
+        .setSpec(
+            FunctionSpec.newBuilder()
+                .setUrn(PARAM_WINDOWED_VALUE_CODER_URN)
+                .setPayload(ByteString.copyFrom(payload)))
         .addComponentCoderIds(elementCoderId)
         .addComponentCoderIds(windowCoderId)
         .build();

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPipelineFuser.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPipelineFuser.java
@@ -415,7 +415,8 @@ public class GreedyPipelineFuser {
         stage.getUserStates(),
         stage.getTimers(),
         pTransformNodes,
-        stage.getOutputPCollections());
+        stage.getOutputPCollections(),
+        stage.getWireCoderSetting());
   }
 
   /**

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyStageFuser.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyStageFuser.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.core.construction.graph;
 
+import static org.apache.beam.runners.core.construction.graph.ExecutableStage.DEFAULT_WIRE_CODER_SETTING;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
 import java.util.ArrayDeque;
@@ -138,7 +139,8 @@ public class GreedyStageFuser {
         userStates,
         timers,
         fusedTransforms.build(),
-        materializedPCollections);
+        materializedPCollections,
+        DEFAULT_WIRE_CODER_SETTING);
   }
 
   private static Environment getStageEnvironment(

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/ImmutableExecutableStage.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/ImmutableExecutableStage.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.WireCoderSetting;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
@@ -37,7 +38,8 @@ public abstract class ImmutableExecutableStage implements ExecutableStage {
       Collection<UserStateReference> userStates,
       Collection<TimerReference> timers,
       Collection<PTransformNode> transforms,
-      Collection<PCollectionNode> outputs) {
+      Collection<PCollectionNode> outputs,
+      WireCoderSetting wireCoderSetting) {
     Components prunedComponents =
         components
             .toBuilder()
@@ -47,7 +49,15 @@ public abstract class ImmutableExecutableStage implements ExecutableStage {
                     .collect(Collectors.toMap(PTransformNode::getId, PTransformNode::getTransform)))
             .build();
     return of(
-        prunedComponents, environment, input, sideInputs, userStates, timers, transforms, outputs);
+        prunedComponents,
+        environment,
+        input,
+        sideInputs,
+        userStates,
+        timers,
+        transforms,
+        outputs,
+        wireCoderSetting);
   }
 
   public static ImmutableExecutableStage of(
@@ -58,7 +68,8 @@ public abstract class ImmutableExecutableStage implements ExecutableStage {
       Collection<UserStateReference> userStates,
       Collection<TimerReference> timers,
       Collection<PTransformNode> transforms,
-      Collection<PCollectionNode> outputs) {
+      Collection<PCollectionNode> outputs,
+      WireCoderSetting wireCoderSetting) {
     return new AutoValue_ImmutableExecutableStage(
         components,
         environment,
@@ -67,7 +78,8 @@ public abstract class ImmutableExecutableStage implements ExecutableStage {
         ImmutableSet.copyOf(userStates),
         ImmutableSet.copyOf(timers),
         ImmutableSet.copyOf(transforms),
-        ImmutableSet.copyOf(outputs));
+        ImmutableSet.copyOf(outputs),
+        wireCoderSetting);
   }
 
   @Override
@@ -94,4 +106,7 @@ public abstract class ImmutableExecutableStage implements ExecutableStage {
 
   @Override
   public abstract Collection<PCollectionNode> getOutputPCollections();
+
+  @Override
+  public abstract WireCoderSetting getWireCoderSetting();
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
@@ -308,7 +308,8 @@ class OutputDeduplicator {
         stage.getUserStates(),
         stage.getTimers(),
         updatedTransforms,
-        updatedOutputs);
+        updatedOutputs,
+        stage.getWireCoderSetting());
   }
 
   /**

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CoderTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CoderTranslationTest.java
@@ -51,6 +51,7 @@ import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow.IntervalWindowCoder;
+import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
@@ -79,6 +80,7 @@ public class CoderTranslationTest {
           .add(
               FullWindowedValueCoder.of(
                   IterableCoder.of(VarLongCoder.of()), IntervalWindowCoder.of()))
+          .add(WindowedValue.ParamWindowedValueCoder.of(IterableCoder.of(VarLongCoder.of())))
           .add(DoubleCoder.of())
           .add(
               RowCoder.of(

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CommonCoderTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CommonCoderTest.java
@@ -106,6 +106,9 @@ public class CommonCoderTest {
           .put(
               getUrn(StandardCoders.Enum.WINDOWED_VALUE),
               WindowedValue.FullWindowedValueCoder.class)
+          .put(
+              getUrn(StandardCoders.Enum.PARAM_WINDOWED_VALUE),
+              WindowedValue.ParamWindowedValueCoder.class)
           .put(getUrn(StandardCoders.Enum.ROW), RowCoder.class)
           .build();
 
@@ -272,7 +275,8 @@ public class CommonCoderTest {
       return convertedElements;
     } else if (s.equals(getUrn(StandardCoders.Enum.GLOBAL_WINDOW))) {
       return GlobalWindow.INSTANCE;
-    } else if (s.equals(getUrn(StandardCoders.Enum.WINDOWED_VALUE))) {
+    } else if (s.equals(getUrn(StandardCoders.Enum.WINDOWED_VALUE))
+        || s.equals(getUrn(StandardCoders.Enum.PARAM_WINDOWED_VALUE))) {
       Map<String, Object> kvMap = (Map<String, Object>) value;
       Coder valueCoder = ((WindowedValue.FullWindowedValueCoder) coder).getValueCoder();
       Coder windowCoder = ((WindowedValue.FullWindowedValueCoder) coder).getWindowCoder();
@@ -436,6 +440,9 @@ public class CommonCoderTest {
       assertEquals(expectedValue, actualValue);
 
     } else if (s.equals(getUrn(StandardCoders.Enum.WINDOWED_VALUE))) {
+      assertEquals(expectedValue, actualValue);
+
+    } else if (s.equals(getUrn(StandardCoders.Enum.PARAM_WINDOWED_VALUE))) {
       assertEquals(expectedValue, actualValue);
 
     } else if (s.equals(getUrn(StandardCoders.Enum.DOUBLE))) {

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ExecutableStageTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ExecutableStageTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.core.construction.graph;
 
+import static org.apache.beam.runners.core.construction.graph.ExecutableStage.DEFAULT_WIRE_CODER_SETTING;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -104,7 +105,8 @@ public class ExecutableStageTest {
             Collections.singleton(userStateRef),
             Collections.singleton(timerRef),
             Collections.singleton(PipelineNode.pTransform("pt", pt)),
-            Collections.singleton(PipelineNode.pCollection("output.out", output)));
+            Collections.singleton(PipelineNode.pCollection("output.out", output)),
+            DEFAULT_WIRE_CODER_SETTING);
 
     PTransform stagePTransform = stage.toPTransform("foo");
     assertThat(stagePTransform.getOutputsMap(), hasValue("output.out"));

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ImmutableExecutableStageTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ImmutableExecutableStageTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.core.construction.graph;
 
+import static org.apache.beam.runners.core.construction.graph.ExecutableStage.DEFAULT_WIRE_CODER_SETTING;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -98,7 +99,8 @@ public class ImmutableExecutableStageTest {
             Collections.singleton(userStateRef),
             Collections.singleton(timerRef),
             Collections.singleton(PipelineNode.pTransform("pt", pt)),
-            Collections.singleton(PipelineNode.pCollection("output.out", output)));
+            Collections.singleton(PipelineNode.pCollection("output.out", output)),
+            DEFAULT_WIRE_CODER_SETTING);
 
     assertThat(stage.getComponents().containsTransforms("pt"), is(true));
     assertThat(stage.getComponents().containsTransforms("other_pt"), is(false));

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicatorTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicatorTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.core.construction.graph;
 
+import static org.apache.beam.runners.core.construction.graph.ExecutableStage.DEFAULT_WIRE_CODER_SETTING;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables.getOnlyElement;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -119,7 +120,8 @@ public class OutputDeduplicatorTest {
             ImmutableList.of(),
             ImmutableList.of(),
             ImmutableList.of(PipelineNode.pTransform("one", one)),
-            ImmutableList.of(PipelineNode.pCollection(oneOut.getUniqueName(), oneOut)));
+            ImmutableList.of(PipelineNode.pCollection(oneOut.getUniqueName(), oneOut)),
+            DEFAULT_WIRE_CODER_SETTING);
     ExecutableStage twoStage =
         ImmutableExecutableStage.of(
             components,
@@ -129,7 +131,8 @@ public class OutputDeduplicatorTest {
             ImmutableList.of(),
             ImmutableList.of(),
             ImmutableList.of(PipelineNode.pTransform("two", two)),
-            ImmutableList.of(PipelineNode.pCollection(twoOut.getUniqueName(), twoOut)));
+            ImmutableList.of(PipelineNode.pCollection(twoOut.getUniqueName(), twoOut)),
+            DEFAULT_WIRE_CODER_SETTING);
     PTransformNode redTransform = PipelineNode.pTransform("red", red);
     PTransformNode blueTransform = PipelineNode.pTransform("blue", blue);
     QueryablePipeline pipeline = QueryablePipeline.forPrimitivesIn(components);
@@ -237,7 +240,8 @@ public class OutputDeduplicatorTest {
             ImmutableList.of(),
             ImmutableList.of(
                 PipelineNode.pTransform("one", one), PipelineNode.pTransform("shared", shared)),
-            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)));
+            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)),
+            DEFAULT_WIRE_CODER_SETTING);
     ExecutableStage twoStage =
         ImmutableExecutableStage.of(
             components,
@@ -248,7 +252,8 @@ public class OutputDeduplicatorTest {
             ImmutableList.of(),
             ImmutableList.of(
                 PipelineNode.pTransform("two", two), PipelineNode.pTransform("shared", shared)),
-            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)));
+            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)),
+            DEFAULT_WIRE_CODER_SETTING);
     PTransformNode redTransform = PipelineNode.pTransform("red", red);
     PTransformNode blueTransform = PipelineNode.pTransform("blue", blue);
     QueryablePipeline pipeline = QueryablePipeline.forPrimitivesIn(components);
@@ -367,7 +372,8 @@ public class OutputDeduplicatorTest {
             ImmutableList.of(),
             ImmutableList.of(),
             ImmutableList.of(PipelineNode.pTransform("one", one), sharedTransform),
-            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)));
+            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)),
+            DEFAULT_WIRE_CODER_SETTING);
     PTransformNode redTransform = PipelineNode.pTransform("red", red);
     PTransformNode blueTransform = PipelineNode.pTransform("blue", blue);
     QueryablePipeline pipeline = QueryablePipeline.forPrimitivesIn(components);
@@ -540,7 +546,8 @@ public class OutputDeduplicatorTest {
                 PipelineNode.pTransform("otherShared", otherShared)),
             ImmutableList.of(
                 PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut),
-                PipelineNode.pCollection(otherSharedOut.getUniqueName(), otherSharedOut)));
+                PipelineNode.pCollection(otherSharedOut.getUniqueName(), otherSharedOut)),
+            DEFAULT_WIRE_CODER_SETTING);
     ExecutableStage oneStage =
         ImmutableExecutableStage.of(
             components,
@@ -551,7 +558,8 @@ public class OutputDeduplicatorTest {
             ImmutableList.of(),
             ImmutableList.of(
                 PipelineNode.pTransform("one", one), PipelineNode.pTransform("shared", shared)),
-            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)));
+            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)),
+            DEFAULT_WIRE_CODER_SETTING);
     ExecutableStage twoStage =
         ImmutableExecutableStage.of(
             components,
@@ -564,7 +572,8 @@ public class OutputDeduplicatorTest {
                 PipelineNode.pTransform("two", two),
                 PipelineNode.pTransform("otherShared", otherShared)),
             ImmutableList.of(
-                PipelineNode.pCollection(otherSharedOut.getUniqueName(), otherSharedOut)));
+                PipelineNode.pCollection(otherSharedOut.getUniqueName(), otherSharedOut)),
+            DEFAULT_WIRE_CODER_SETTING);
     PTransformNode redTransform = PipelineNode.pTransform("red", red);
     PTransformNode blueTransform = PipelineNode.pTransform("blue", blue);
     QueryablePipeline pipeline = QueryablePipeline.forPrimitivesIn(components);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/graph/CreateExecutableStageNodeFunction.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/graph/CreateExecutableStageNodeFunction.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.dataflow.worker.graph;
 
+import static org.apache.beam.runners.core.construction.graph.ExecutableStage.DEFAULT_WIRE_CODER_SETTING;
 import static org.apache.beam.runners.dataflow.util.Structs.getBytes;
 import static org.apache.beam.runners.dataflow.util.Structs.getString;
 import static org.apache.beam.runners.dataflow.worker.graph.LengthPrefixUnknownCoders.forSideInputInfos;
@@ -485,7 +486,8 @@ public class CreateExecutableStageNodeFunction
             executableStageUserStateReference,
             executableStageTimers,
             executableStageTransforms,
-            executableStageOutputs);
+            executableStageOutputs,
+            DEFAULT_WIRE_CODER_SETTING);
     return ExecutableStageNode.create(
         executableStage,
         ptransformIdToNameContexts.build(),

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/translation/BatchSideInputHandlerFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/translation/BatchSideInputHandlerFactoryTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.fnexecution.translation;
 
+import static org.apache.beam.runners.core.construction.graph.ExecutableStage.DEFAULT_WIRE_CODER_SETTING;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -234,6 +235,7 @@ public class BatchSideInputHandlerFactoryTest {
         Collections.emptyList(),
         Collections.emptyList(),
         Collections.emptyList(),
-        Collections.emptyList());
+        Collections.emptyList(),
+        DEFAULT_WIRE_CODER_SETTING);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
@@ -20,8 +20,12 @@ package org.apache.beam.sdk.util;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.CollectionCoder;
@@ -505,6 +510,11 @@ public abstract class WindowedValue<T> {
     return ValueOnlyWindowedValueCoder.of(valueCoder);
   }
 
+  /** Returns the {@code ParamWindowedValueCoder} from the given valueCoder. */
+  public static <T> ParamWindowedValueCoder<T> getParamWindowedValueCoder(Coder<T> valueCoder) {
+    return ParamWindowedValueCoder.of(valueCoder);
+  }
+
   /** Abstract class for {@code WindowedValue} coder. */
   public abstract static class WindowedValueCoder<T> extends StructuredCoder<WindowedValue<T>> {
     final Coder<T> valueCoder;
@@ -637,7 +647,11 @@ public abstract class WindowedValue<T> {
    *
    * <p>A {@code ValueOnlyWindowedValueCoder} only encodes and decodes the value. It drops timestamp
    * and windows for encoding, and uses defaults timestamp, and windows for decoding.
+   *
+   * @deprecated Use ParamWindowedValueCoder instead it is general purpose implementation of the
+   *     same concept but makes timestamp, windows and pane info configurable.
    */
+  @Deprecated
   public static class ValueOnlyWindowedValueCoder<T> extends WindowedValueCoder<T> {
     public static <T> ValueOnlyWindowedValueCoder<T> of(Coder<T> valueCoder) {
       return new ValueOnlyWindowedValueCoder<>(valueCoder);
@@ -691,6 +705,183 @@ public abstract class WindowedValue<T> {
     @Override
     public List<? extends Coder<?>> getCoderArguments() {
       return Collections.singletonList(valueCoder);
+    }
+  }
+
+  /**
+   * A parameterized Coder for {@code WindowedValue}.
+   *
+   * <p>A {@code ParamWindowedValueCoder} only encodes and decodes the value. It drops timestamp,
+   * windows, and pane info during encoding, and uses the supplied parameterized timestamp, windows
+   * and pane info values during decoding when reconstructing the windowed value.
+   */
+  public static class ParamWindowedValueCoder<T> extends FullWindowedValueCoder<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient Instant timestamp;
+    private transient Collection<? extends BoundedWindow> windows;
+    private transient PaneInfo pane;
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
+    /**
+     * Returns the {@link ParamWindowedValueCoder} from the given valueCoder, windowCoder and the
+     * supplied parameterized timestamp, windows and pane info for {@link WindowedValue}.
+     */
+    public static <T> ParamWindowedValueCoder<T> of(
+        Coder<T> valueCoder,
+        Coder<? extends BoundedWindow> windowCoder,
+        Instant timestamp,
+        Collection<? extends BoundedWindow> windows,
+        PaneInfo pane) {
+      return new ParamWindowedValueCoder<>(valueCoder, windowCoder, timestamp, windows, pane);
+    }
+
+    /**
+     * Returns the {@link ParamWindowedValueCoder} from the given valueCoder, windowCoder and the
+     * supplied parameterized {@link BoundedWindow#TIMESTAMP_MIN_VALUE}, {@link #GLOBAL_WINDOWS} and
+     * {@link PaneInfo#NO_FIRING} for {@link WindowedValue}.
+     */
+    public static <T> ParamWindowedValueCoder<T> of(
+        Coder<T> valueCoder, Coder<? extends BoundedWindow> windowCoder) {
+      return ParamWindowedValueCoder.of(
+          valueCoder,
+          windowCoder,
+          BoundedWindow.TIMESTAMP_MIN_VALUE,
+          GLOBAL_WINDOWS,
+          PaneInfo.NO_FIRING);
+    }
+
+    /**
+     * Returns the {@link ParamWindowedValueCoder} from the given valueCoder, {@link
+     * GlobalWindow.Coder#INSTANCE} and the supplied parameterized {@link
+     * BoundedWindow#TIMESTAMP_MIN_VALUE}, {@link #GLOBAL_WINDOWS} and {@link PaneInfo#NO_FIRING}
+     * for {@link WindowedValue}.
+     */
+    public static <T> ParamWindowedValueCoder<T> of(Coder<T> valueCoder) {
+      return ParamWindowedValueCoder.of(valueCoder, GlobalWindow.Coder.INSTANCE);
+    }
+
+    ParamWindowedValueCoder(
+        Coder<T> valueCoder,
+        Coder<? extends BoundedWindow> windowCoder,
+        Instant timestamp,
+        Collection<? extends BoundedWindow> windows,
+        PaneInfo pane) {
+      super(valueCoder, windowCoder);
+      this.timestamp = timestamp;
+      this.windows = windows;
+      this.pane = pane;
+    }
+
+    @Override
+    public <NewT> WindowedValueCoder<NewT> withValueCoder(Coder<NewT> valueCoder) {
+      return new ParamWindowedValueCoder<>(valueCoder, getWindowCoder(), timestamp, windows, pane);
+    }
+
+    @Override
+    public void encode(WindowedValue<T> windowedElem, OutputStream outStream)
+        throws CoderException, IOException {
+      encode(windowedElem, outStream, Context.NESTED);
+    }
+
+    @Override
+    public void encode(WindowedValue<T> windowedElem, OutputStream outStream, Context context)
+        throws CoderException, IOException {
+      valueCoder.encode(windowedElem.getValue(), outStream, context);
+    }
+
+    @Override
+    public WindowedValue<T> decode(InputStream inStream) throws CoderException, IOException {
+      return decode(inStream, Context.NESTED);
+    }
+
+    @Override
+    public WindowedValue<T> decode(InputStream inStream, Context context)
+        throws CoderException, IOException {
+      T value = valueCoder.decode(inStream, context);
+      return WindowedValue.of(value, this.timestamp, this.windows, this.pane);
+    }
+
+    @Override
+    public void verifyDeterministic() throws NonDeterministicException {
+      verifyDeterministic(
+          this, "ParamWindowedValueCoder requires a deterministic valueCoder", valueCoder);
+    }
+
+    @Override
+    public void registerByteSizeObserver(WindowedValue<T> value, ElementByteSizeObserver observer)
+        throws Exception {
+      valueCoder.registerByteSizeObserver(value.getValue(), observer);
+    }
+
+    public Instant getTimestamp() {
+      return timestamp;
+    }
+
+    public Collection<? extends BoundedWindow> getWindows() {
+      return windows;
+    }
+
+    public PaneInfo getPane() {
+      return pane;
+    }
+
+    /** Returns the serialized payload that will be provided when deserializing this coder. */
+    public static byte[] getPayload(ParamWindowedValueCoder<?> from) {
+      // Use FullWindowedValueCoder to encode the constant members(timestamp, window, pane) in
+      // ParamWindowedValueCoder
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      WindowedValue<byte[]> windowedValue =
+          WindowedValue.of(EMPTY_BYTES, from.getTimestamp(), from.getWindows(), from.getPane());
+      WindowedValue.FullWindowedValueCoder<byte[]> windowedValueCoder =
+          WindowedValue.FullWindowedValueCoder.of(ByteArrayCoder.of(), from.getWindowCoder());
+      try {
+        windowedValueCoder.encode(windowedValue, baos);
+      } catch (IOException e) {
+        throw new RuntimeException(
+            "Unable to encode constant members of ParamWindowedValueCoder: ", e);
+      }
+      return baos.toByteArray();
+    }
+
+    /** Create a {@link Coder} from its component {@link Coder coders}. */
+    public static WindowedValue.ParamWindowedValueCoder<?> fromComponents(
+        List<Coder<?>> components, byte[] payload) {
+      Coder<? extends BoundedWindow> windowCoder =
+          (Coder<? extends BoundedWindow>) components.get(1);
+      WindowedValue.FullWindowedValueCoder<byte[]> windowedValueCoder =
+          WindowedValue.FullWindowedValueCoder.of(ByteArrayCoder.of(), windowCoder);
+
+      try {
+        ByteArrayInputStream bais = new ByteArrayInputStream(payload);
+        WindowedValue<byte[]> windowedValue = windowedValueCoder.decode(bais);
+        return WindowedValue.ParamWindowedValueCoder.of(
+            components.get(0),
+            windowCoder,
+            windowedValue.getTimestamp(),
+            windowedValue.getWindows(),
+            windowedValue.getPane());
+      } catch (IOException e) {
+        throw new RuntimeException(
+            "Unable to decode constant members from payload for ParamWindowedValueCoder: ", e);
+      }
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+      out.defaultWriteObject();
+      out.writeObject(getPayload(this));
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      byte[] payload = (byte[]) in.readObject();
+      ParamWindowedValueCoder<?> paramWindowedValueCoder =
+          fromComponents(Arrays.asList(valueCoder, getWindowCoder()), payload);
+      this.timestamp = paramWindowedValueCoder.timestamp;
+      this.windows = paramWindowedValueCoder.windows;
+      this.pane = paramWindowedValueCoder.pane;
     }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/WindowedValueTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/WindowedValueTest.java
@@ -78,6 +78,12 @@ public class WindowedValueTest {
   }
 
   @Test
+  public void testParamWindowedValueCoderIsSerializableWithWellKnownCoderType() {
+    CoderProperties.coderSerializable(
+        WindowedValue.getParamWindowedValueCoder(GlobalWindow.Coder.INSTANCE));
+  }
+
+  @Test
   public void testValueOnlyWindowedValueCoderIsSerializableWithWellKnownCoderType() {
     CoderProperties.coderSerializable(WindowedValue.getValueOnlyCoder(GlobalWindow.Coder.INSTANCE));
   }

--- a/sdks/python/apache_beam/coders/coder_impl.pxd
+++ b/sdks/python/apache_beam/coders/coder_impl.pxd
@@ -211,5 +211,12 @@ cdef class WindowedValueCoderImpl(StreamCoderImpl):
   cpdef encode_to_stream(self, value, OutputStream stream, bint nested)
 
 
+cdef class ParamWindowedValueCoderImpl(WindowedValueCoderImpl):
+  """A coder for windowed values with constant timestamp, windows and pane info."""
+  cdef readonly libc.stdint.int64_t _timestamp
+  cdef readonly object _windows
+  cdef readonly windowed_value.PaneInfo _pane_info
+
+
 cdef class LengthPrefixCoderImpl(StreamCoderImpl):
   cdef CoderImpl _value_coder

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -41,6 +41,8 @@ from apache_beam.transforms.window import IntervalWindow
 from apache_beam.typehints import schemas
 from apache_beam.utils import windowed_value
 from apache_beam.utils.timestamp import Timestamp
+from apache_beam.utils.windowed_value import PaneInfo
+from apache_beam.utils.windowed_value import PaneInfoTiming
 
 STANDARD_CODERS_YAML = os.path.normpath(os.path.join(
     os.path.dirname(__file__), '../portability/api/standard_coders.yaml'))
@@ -125,6 +127,16 @@ class StandardCodersTest(unittest.TestCase):
           lambda x, value_parser, window_parser: windowed_value.create(
               value_parser(x['value']), x['timestamp'] * 1000,
               tuple([window_parser(w) for w in x['windows']])),
+      'beam:coder:param_windowed_value:v1':
+          lambda x, value_parser, window_parser: windowed_value.create(
+              value_parser(x['value']), x['timestamp'] * 1000,
+              tuple([window_parser(w) for w in x['windows']]),
+              PaneInfo(
+                  x['pane']['is_first'],
+                  x['pane']['is_last'],
+                  PaneInfoTiming.from_string(x['pane']['timing']),
+                  x['pane']['index'],
+                  x['pane']['on_time_index'])),
       'beam:coder:timer:v1':
           lambda x, payload_parser: dict(
               payload=payload_parser(x['payload']),

--- a/sdks/python/apache_beam/utils/windowed_value.py
+++ b/sdks/python/apache_beam/utils/windowed_value.py
@@ -61,6 +61,15 @@ class PaneInfoTiming(object):
         cls.UNKNOWN: 'UNKNOWN',
     }[value]
 
+  @classmethod
+  def from_string(cls, value):
+    return {
+        'EARLY': cls.EARLY,
+        'ON_TIME': cls.ON_TIME,
+        'LATE': cls.LATE,
+        'UNKNOWN': cls.UNKNOWN
+    }[value]
+
 
 class PaneInfo(object):
   """Describes the trigger firing information for a given WindowedValue.


### PR DESCRIPTION
Motivation:
The coder of WindowedValue cannot be configured and it’s always FullWindowedValueCoder. We don't need to serialize the timestamp, window and pane properties in Flink and so it will be better to make the coder configurable (i.e. allowing to use ValueOnlyWindowedValueCoder)

Detail changes:
- Add ValueOnlyWindowedValueCoder into MODEL_CODER so that we can use value only coder between runner and harness.
- To make it configurable and also maybe for other configurations in futher(i.e., more general), we add a `configurations` map in Components.
- Add python ValueOnlyWindowedValueCoder.

Some concerns reviewers may have:
- Do we have any other options instead of adding the configurations in Components(beam_runner_api.proto).
  Yes, we have other options. For example, we can add some flags in the methods when call `addSdkWireCoder` and `addRunnerWireCoder`. However, the call stack is very deep(from DefaultJobBundleFactory.forStage() to WireCoders.addSdkWireCoder()). It would be a mess if we add a flag for all these methods.
- The current changes are not used in Beam project.
  Due to the doFn can emit timestamp in beam, it seems we can't tell when we can ignore encode or decode the timestamp field, i.e., currently, we only use FullWindowedValueCoder in Beam. However, in Flink we don't have such problem and can make use of the ValueOnlyWindowedValueCoder.
- Have not add support for other SDKs(go)?
  Maybe we can add support for other SDKs later when we find it is useful?
Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
