### PR TITLE
[BEAM-6335] Test GBK streaming reading SyntheticSources

### DIFF
--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/SyntheticDataPublisher.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/SyntheticDataPublisher.java
@@ -26,9 +26,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
-import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
@@ -73,8 +73,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
  */
 public class SyntheticDataPublisher {
 
-  private static final KvCoder<byte[], byte[]> RECORD_CODER =
-      KvCoder.of(ByteArrayCoder.of(), ByteArrayCoder.of());
+  private static final Coder RECORD_CODER = StringUtf8Coder.of();
 
   private static Options options;
 
@@ -215,7 +214,7 @@ public class SyntheticDataPublisher {
 
   private static byte[] encodeInputElement(KV<byte[], byte[]> input) {
     try {
-      return encodeToByteArray(RECORD_CODER, input);
+      return encodeToByteArray(RECORD_CODER, new String(input.getValue(), UTF_8));
     } catch (CoderException e) {
       throw new RuntimeException(String.format("Couldn't encode element. Exception: %s", e));
     }

--- a/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher.py
@@ -47,9 +47,9 @@ class PubSubMessageMatcher(BaseMatcher):
   subscription until all expected messages are shown or timeout.
   """
 
-  def __init__(self, project, sub_name, expected_msg,
-               timeout=DEFAULT_TIMEOUT, with_attributes=False,
-               strip_attributes=None):
+  def __init__(self, project, sub_name, expected_msg=None,
+               expected_msg_len=None, timeout=DEFAULT_TIMEOUT,
+               with_attributes=False, strip_attributes=None):
     """Initialize PubSubMessageMatcher object.
 
     Args:
@@ -73,12 +73,18 @@ class PubSubMessageMatcher(BaseMatcher):
       raise ValueError('Invalid project %s.' % project)
     if not sub_name:
       raise ValueError('Invalid subscription %s.' % sub_name)
-    if not isinstance(expected_msg, list):
+    if not expected_msg_len and not expected_msg:
+      raise ValueError('Required expected_msg: {} or expected_msg_len: {}.'
+                       .format(expected_msg, expected_msg_len))
+    if expected_msg and not isinstance(expected_msg, list):
       raise ValueError('Invalid expected messages %s.' % expected_msg)
+    if expected_msg_len and not isinstance(expected_msg_len, int):
+      raise ValueError('Invalid expected messages %s.' % expected_msg_len)
 
     self.project = project
     self.sub_name = sub_name
     self.expected_msg = expected_msg
+    self.expected_msg_len = expected_msg_len or len(self.expected_msg)
     self.timeout = timeout
     self.messages = None
     self.with_attributes = with_attributes
@@ -86,9 +92,12 @@ class PubSubMessageMatcher(BaseMatcher):
 
   def _matches(self, _):
     if self.messages is None:
-      self.messages = self._wait_for_messages(len(self.expected_msg),
+      self.messages = self._wait_for_messages(self.expected_msg_len,
                                               self.timeout)
-    return Counter(self.messages) == Counter(self.expected_msg)
+    if self.expected_msg:
+      return Counter(self.messages) == Counter(self.expected_msg)
+    else:
+      return len(self.messages) == self.expected_msg_len
 
   def _wait_for_messages(self, expected_num, timeout):
     """Wait for messages from given subscription."""
@@ -129,18 +138,21 @@ class PubSubMessageMatcher(BaseMatcher):
 
   def describe_to(self, description):
     description.append_text(
-        'Expected %d messages.' % len(self.expected_msg))
+        'Expected %d messages.' % self.expected_msg_len)
 
   def describe_mismatch(self, _, mismatch_description):
     c_expected = Counter(self.expected_msg)
     c_actual = Counter(self.messages)
     mismatch_description.append_text(
-        "Got %d messages. "
-        "Diffs (item, count):\n"
-        "  Expected but not in actual: %s\n"
-        "  Unexpected: %s" % (
-            len(self.messages), (c_expected - c_actual).items(),
-            (c_actual - c_expected).items()))
+        "Got %d messages. " % (
+            len(self.messages)))
+    if self.expected_msg:
+      mismatch_description.append_text(
+          "Diffs (item, count):\n"
+          "  Expected but not in actual: %s\n"
+          "  Unexpected: %s" % (
+              (c_expected - c_actual).items(),
+              (c_actual - c_expected).items()))
     if self.with_attributes and self.strip_attributes:
       mismatch_description.append_text(
           '\n  Stripped attributes: %r' % self.strip_attributes)

--- a/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher_test.py
@@ -33,7 +33,6 @@ from apache_beam.io.gcp.tests.pubsub_matcher import PubSubMessageMatcher
 from apache_beam.testing.test_utils import PullResponseMessage
 from apache_beam.testing.test_utils import create_pull_response
 
-# Protect against environments where pubsub library is not available.
 try:
   from google.cloud import pubsub
 except ImportError:
@@ -54,14 +53,18 @@ class PubSubMatcherTest(unittest.TestCase):
   def setUp(self):
     self.mock_presult = mock.MagicMock()
 
-  def init_matcher(self, with_attributes=False, strip_attributes=None):
+  def init_matcher(self, expected_msg=None,
+                   with_attributes=False, strip_attributes=None):
     self.pubsub_matcher = PubSubMessageMatcher(
-        'mock_project', 'mock_sub_name', ['mock_expected_msg'],
+        'mock_project', 'mock_sub_name', expected_msg,
         with_attributes=with_attributes, strip_attributes=strip_attributes)
 
+  def init_counter_matcher(self, expected_msg_len=1):
+    self.pubsub_matcher = PubSubMessageMatcher(
+        'mock_project', 'mock_sub_name', expected_msg_len=expected_msg_len)
+
   def test_message_matcher_success(self, mock_get_sub, unsued_mock):
-    self.init_matcher()
-    self.pubsub_matcher.expected_msg = [b'a', b'b']
+    self.init_matcher(expected_msg=[b'a', b'b'])
     mock_sub = mock_get_sub.return_value
     mock_sub.pull.side_effect = [
         create_pull_response([PullResponseMessage(b'a', {})]),
@@ -72,8 +75,8 @@ class PubSubMatcherTest(unittest.TestCase):
     self.assertEqual(mock_sub.acknowledge.call_count, 2)
 
   def test_message_matcher_attributes_success(self, mock_get_sub, unsued_mock):
-    self.init_matcher(with_attributes=True)
-    self.pubsub_matcher.expected_msg = [PubsubMessage(b'a', {'k': 'v'})]
+    self.init_matcher(expected_msg=[PubsubMessage(b'a', {'k': 'v'})],
+                      with_attributes=True)
     mock_sub = mock_get_sub.return_value
     mock_sub.pull.side_effect = [
         create_pull_response([PullResponseMessage(b'a', {'k': 'v'})])
@@ -83,8 +86,8 @@ class PubSubMatcherTest(unittest.TestCase):
     self.assertEqual(mock_sub.acknowledge.call_count, 1)
 
   def test_message_matcher_attributes_fail(self, mock_get_sub, unsued_mock):
-    self.init_matcher(with_attributes=True)
-    self.pubsub_matcher.expected_msg = [PubsubMessage(b'a', {})]
+    self.init_matcher(expected_msg=[PubsubMessage(b'a', {})],
+                      with_attributes=True)
     mock_sub = mock_get_sub.return_value
     # Unexpected attribute 'k'.
     mock_sub.pull.side_effect = [
@@ -96,9 +99,9 @@ class PubSubMatcherTest(unittest.TestCase):
     self.assertEqual(mock_sub.acknowledge.call_count, 1)
 
   def test_message_matcher_strip_success(self, mock_get_sub, unsued_mock):
-    self.init_matcher(with_attributes=True,
+    self.init_matcher(expected_msg=[PubsubMessage(b'a', {'k': 'v'})],
+                      with_attributes=True,
                       strip_attributes=['id', 'timestamp'])
-    self.pubsub_matcher.expected_msg = [PubsubMessage(b'a', {'k': 'v'})]
     mock_sub = mock_get_sub.return_value
     mock_sub.pull.side_effect = [create_pull_response([
         PullResponseMessage(b'a', {'id': 'foo', 'timestamp': 'bar', 'k': 'v'})
@@ -108,9 +111,9 @@ class PubSubMatcherTest(unittest.TestCase):
     self.assertEqual(mock_sub.acknowledge.call_count, 1)
 
   def test_message_matcher_strip_fail(self, mock_get_sub, unsued_mock):
-    self.init_matcher(with_attributes=True,
+    self.init_matcher(expected_msg=[PubsubMessage(b'a', {'k': 'v'})],
+                      with_attributes=True,
                       strip_attributes=['id', 'timestamp'])
-    self.pubsub_matcher.expected_msg = [PubsubMessage(b'a', {'k': 'v'})]
     mock_sub = mock_get_sub.return_value
     # Message is missing attribute 'timestamp'.
     mock_sub.pull.side_effect = [create_pull_response([
@@ -122,8 +125,7 @@ class PubSubMatcherTest(unittest.TestCase):
     self.assertEqual(mock_sub.acknowledge.call_count, 1)
 
   def test_message_matcher_mismatch(self, mock_get_sub, unused_mock):
-    self.init_matcher()
-    self.pubsub_matcher.expected_msg = [b'a']
+    self.init_matcher(expected_msg=[b'a'])
     mock_sub = mock_get_sub.return_value
     mock_sub.pull.side_effect = [
         create_pull_response([PullResponseMessage(b'c', {}),
@@ -140,7 +142,7 @@ class PubSubMatcherTest(unittest.TestCase):
     self.assertEqual(mock_sub.acknowledge.call_count, 1)
 
   def test_message_matcher_timeout(self, mock_get_sub, unused_mock):
-    self.init_matcher()
+    self.init_matcher(expected_msg=[b'a'])
     mock_sub = mock_get_sub.return_value
     mock_sub.return_value.full_name.return_value = 'mock_sub'
     self.pubsub_matcher.timeout = 0.1
@@ -148,6 +150,41 @@ class PubSubMatcherTest(unittest.TestCase):
       hc_assert_that(self.mock_presult, self.pubsub_matcher)
     self.assertTrue(mock_sub.pull.called)
     self.assertEqual(mock_sub.acknowledge.call_count, 0)
+
+  def test_message_count_matcher_below_fail(self, mock_get_sub, unused_mock):
+    self.init_counter_matcher(expected_msg_len=1)
+    mock_sub = mock_get_sub.return_value
+    mock_sub.pull.side_effect = [
+        create_pull_response([PullResponseMessage(b'c', {}),
+                              PullResponseMessage(b'd', {})]),
+    ]
+    with self.assertRaises(AssertionError) as error:
+      hc_assert_that(self.mock_presult, self.pubsub_matcher)
+    self.assertEqual(mock_sub.pull.call_count, 1)
+    self.assertTrue(
+        '\nExpected: Expected 1 messages.\n     but: Got 2 messages.'
+        in str(error.exception.args[0]))
+
+  def test_message_count_matcher_above_fail(self, mock_get_sub, unused_mock):
+    self.init_counter_matcher(expected_msg_len=1)
+    mock_sub = mock_get_sub.return_value
+    self.pubsub_matcher.timeout = 0.1
+    with self.assertRaisesRegex(AssertionError, r'Expected 1.*\n.*Got 0'):
+      hc_assert_that(self.mock_presult, self.pubsub_matcher)
+    self.assertTrue(mock_sub.pull.called)
+    self.assertEqual(mock_sub.acknowledge.call_count, 0)
+
+  def test_message_count_matcher_success(self, mock_get_sub, unused_mock):
+    self.init_counter_matcher(expected_msg_len=15)
+    mock_sub = mock_get_sub.return_value
+    mock_sub.pull.side_effect = [create_pull_response(
+        [PullResponseMessage(
+            b'a', {'foo': 'bar'})
+         for _ in range(15)]
+        )]
+    hc_assert_that(self.mock_presult, self.pubsub_matcher)
+    self.assertEqual(mock_sub.pull.call_count, 1)
+    self.assertEqual(mock_sub.acknowledge.call_count, 1)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/testing/load_tests/load_test_metrics_utils.py
+++ b/sdks/python/apache_beam/testing/load_tests/load_test_metrics_utils.py
@@ -199,7 +199,7 @@ class MetricsReader(object):
     # required to prepare metrics for publishing purposes. Expected is to have
     # a list of dictionaries matching the schema.
     insert_dicts = self._prepare_all_metrics(metrics)
-    if len(insert_dicts):
+    if len(insert_dicts) > 0:
       for publisher in self.publishers:
         publisher.publish(insert_dicts)
 
@@ -222,10 +222,11 @@ class MetricsReader(object):
     matching_namsespace, not_matching_namespace = \
       split_metrics_by_namespace_and_name(distributions, self._namespace,
                                           RUNTIME_METRIC)
-    runtime_metric = RuntimeMetric(matching_namsespace, metric_id)
-    rows.append(runtime_metric.as_dict())
-
-    rows += get_generic_distributions(not_matching_namespace, metric_id)
+    if len(matching_namsespace) > 0:
+      runtime_metric = RuntimeMetric(matching_namsespace, metric_id)
+      rows.append(runtime_metric.as_dict())
+    if len(not_matching_namespace) > 0:
+      rows += get_generic_distributions(not_matching_namespace, metric_id)
     return rows
 
 

--- a/sdks/python/apache_beam/testing/load_tests/streaming/__init__.py
+++ b/sdks/python/apache_beam/testing/load_tests/streaming/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/sdks/python/apache_beam/testing/load_tests/streaming/group_by_key_streaming_pipeline.py
+++ b/sdks/python/apache_beam/testing/load_tests/streaming/group_by_key_streaming_pipeline.py
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Streaming pipeline which reads, GBK and ungroup data from PubSub.
+Pipeline is cancelled when matcher achieves expected elements
+amount or reaches timeout. To cancel pipeline by matcher it is
+required to use TestRunner (TestDataflowRunner or TestDirectRunner).
+Data from pubsub is parsed into pair of strings so it
+would be possible group it by key.
+
+Values have to be reparsed again to bytes
+"""
+
+from __future__ import absolute_import
+
+import argparse
+import logging
+
+import apache_beam as beam
+from apache_beam.io.gcp.pubsub import ReadFromPubSub
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+from apache_beam.options.pipeline_options import StandardOptions
+from apache_beam.testing.load_tests.load_test_metrics_utils import CountMessages
+from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
+from apache_beam.transforms import window
+
+
+def run(argv=None):
+  class MessageParser(beam.DoFn):
+    # It is required to parse messages for GBK operation.
+    # Otherwise there are encoding problems.
+    def process(self, item):
+      if item.attributes:
+        k, v = item.attributes.popitem()
+        yield (str(k), str(v))
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--input_subscription',
+      help=('Input PubSub subscription of the form '
+            '"projects/<PROJECT>/subscriptions/<SUBSCRIPTION>."'))
+  parser.add_argument(
+      '--metrics_namespace',
+      help=('Namespace of metrics '
+            '"string".'))
+  known_args, pipeline_args = parser.parse_known_args(argv)
+
+  pipeline_options = PipelineOptions(pipeline_args)
+  pipeline_options.view_as(SetupOptions).save_main_session = True
+  pipeline_options.view_as(StandardOptions).streaming = True
+  p = beam.Pipeline(options=pipeline_options)
+
+  # pylint: disable=expression-not-assigned
+  (p
+   | ReadFromPubSub(subscription=known_args.input_subscription,
+                    with_attributes=True)
+   | 'Window' >> beam.WindowInto(window.FixedWindows(1000, 0))
+   | 'Measure time: Start' >> beam.ParDo(
+       MeasureTime(known_args.metrics_namespace))
+   | 'Count messages' >> beam.ParDo(CountMessages(known_args.metrics_namespace))
+   | 'Parse' >> beam.ParDo(MessageParser())
+   | 'GroupByKey' >> beam.GroupByKey()
+   | 'Ungroup' >> beam.FlatMap(lambda elm: [(elm[0], v) for v in elm[1]])
+   | 'Measure time: End' >> beam.ParDo(
+       MeasureTime(known_args.metrics_namespace))
+  )
+
+  result = p.run()
+  result.wait_until_finish()
+  logging.error(result)
+  return result

--- a/sdks/python/apache_beam/testing/load_tests/streaming/group_by_key_streaming_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/streaming/group_by_key_streaming_test.py
@@ -1,0 +1,112 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Performance GBK streaming test that uses PubSub SyntheticSources
+messages.
+
+Test requires --test-pipeline-options with following options:
+* --pubsub_topic_name=name - name of PubSub topic which is
+    already created
+* --project=project-name
+* --num_of_records=1000 - expected number of records
+* --runner=TestDataflowRunner or TestDirectRunner - only
+    test runners supports matchers
+
+Optional pipeline options:
+* --timeout=1000 max time that test will be run and wait
+    for all messages.
+* --publish_to_big_query=true/false
+* --metrics_dataset=python_load_tests
+* --metrics_table=gbk_stream
+"""
+
+from __future__ import absolute_import
+
+import logging
+import os
+import unittest
+import uuid
+
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.testing.load_tests.load_test import LoadTest
+from apache_beam.testing.load_tests.streaming import group_by_key_streaming_pipeline
+
+load_test_enabled = False
+if os.environ.get('LOAD_TEST_ENABLED') == 'true':
+  load_test_enabled = True
+
+DEFAULT_TIMEOUT = 800
+WAIT_UNTIL_FINISH_DURATION = 1 * 60 * 1000
+
+class TestOptions(PipelineOptions):
+  @classmethod
+  def _add_argparse_args(cls, parser):
+    parser.add_argument('--test-pipeline-options')
+
+
+@unittest.skipIf(not load_test_enabled, 'Enabled only for phase triggering.')
+class GroupByKeyStreamingTest(LoadTest):
+  ID_LABEL = 'id'
+
+  def setUp(self):
+    super(GroupByKeyStreamingTest, self).setUp()
+    self.topic_short_name = self.pipeline.get_option('pubsub_topic_name')
+    self.setup_pubsub()
+
+    self.extra_opts = {
+        'input_subscription': self.input_sub.name,
+        'metrics_namespace': self.metrics_namespace,
+        'wait_until_finish_duration': WAIT_UNTIL_FINISH_DURATION,
+    }
+
+  def setup_pubsub(self):
+    self.uuid = str(uuid.uuid4())
+
+    # Set up PubSub environment.
+    from google.cloud import pubsub
+    self.pub_client = pubsub.PublisherClient()
+    input_topic_full_name = "projects/{}/topics/{}"\
+      .format(self.project_id, self.topic_short_name)
+    self.input_topic = self.pub_client.get_topic(input_topic_full_name)
+    self.output_topic_name = self.topic_short_name + '_out_' + self.uuid
+    self.output_topic = self.pub_client.create_topic(
+        self.pub_client.topic_path(self.project_id, self.output_topic_name))
+
+    self.sub_client = pubsub.SubscriberClient()
+    self.input_sub_name = self.topic_short_name + '_sub_in_' + self.uuid
+    self.input_sub = self.sub_client.create_subscription(
+        self.sub_client.subscription_path(self.project_id, self.input_sub_name),
+        self.input_topic.name)
+    self.output_sub_name = self.topic_short_name + '_sub_out_' + self.uuid
+    self.output_sub = self.sub_client.create_subscription(
+        self.sub_client.subscription_path(self.project_id,
+                                          self.output_sub_name),
+        self.output_topic.name,
+        ack_deadline_seconds=60)
+
+  # If the test timeouts on Dataflow it may not cleanup pubsub after
+  def tearDown(self):
+    super(GroupByKeyStreamingTest, self).tearDown()
+
+  def testGroupByKey(self):
+    args = self.pipeline.get_full_options_as_args(**self.extra_opts)
+    self.result = group_by_key_streaming_pipeline.run(args)
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/testing/load_tests/streaming/requirements.txt
+++ b/sdks/python/apache_beam/testing/load_tests/streaming/requirements.txt
@@ -1,0 +1,1 @@
+pyhamcrest

--- a/sdks/python/apache_beam/testing/load_tests/streaming/requirements.txt
+++ b/sdks/python/apache_beam/testing/load_tests/streaming/requirements.txt
@@ -1,1 +1,18 @@
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License")# you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
 pyhamcrest


### PR DESCRIPTION
Test that reads SyntheticSources from PubSub in streaming mode in Python SDK. Test parses data and runs group by key and ungroup. Test stops when a pubsub matcher reaches timeout or there was enough data arrived to output PubSub topic.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
