### PR TITLE
[BEAM-8581] and [BEAM-8582] watermark and trigger fixes

### DIFF
--- a/sdks/python/apache_beam/runners/direct/util.py
+++ b/sdks/python/apache_beam/runners/direct/util.py
@@ -64,9 +64,9 @@ class TimerFiring(object):
     self.timestamp = timestamp
 
   def __repr__(self):
-    return 'TimerFiring(%r, %r, %s, %s)' % (self.encoded_key,
-                                            self.name, self.time_domain,
-                                            self.timestamp)
+    return 'TimerFiring({}, {}, {}, {})'.format(self.encoded_key,
+                                                self.name, self.time_domain,
+                                                self.timestamp)
 
 
 class KeyedWorkItem(object):
@@ -75,3 +75,8 @@ class KeyedWorkItem(object):
     self.encoded_key = encoded_key
     self.timer_firings = timer_firings or []
     self.elements = elements or []
+
+  def __repr__(self):
+    return 'KeyedWorkItem({}, {}, {})'.format(self.encoded_key,
+                                              self.timer_firings,
+                                              self.elements)

--- a/sdks/python/apache_beam/testing/test_stream_test.py
+++ b/sdks/python/apache_beam/testing/test_stream_test.py
@@ -169,7 +169,6 @@ class TestStreamTest(unittest.TestCase):
     assert_that(
         records,
         equal_to_per_window(expected_window_to_elements),
-        use_global_window=False,
         label='assert per window')
 
     p.run()
@@ -177,8 +176,9 @@ class TestStreamTest(unittest.TestCase):
   def test_gbk_execution_after_watermark_trigger(self):
     test_stream = (TestStream()
                    .advance_watermark_to(10)
-                   .add_elements(['a'])
+                   .add_elements([TimestampedValue('a', 11)])
                    .advance_watermark_to(20)
+                   .add_elements([TimestampedValue('b', 21)])
                    .advance_watermark_to_infinity())
 
     options = PipelineOptions()
@@ -199,15 +199,18 @@ class TestStreamTest(unittest.TestCase):
 
     # assert per window
     expected_window_to_elements = {
-        window.IntervalWindow(15, 30): [
+        window.IntervalWindow(0, 15): [
             ('k', ['a']),
-            ('k', []),
+            ('k', [])
+        ],
+        window.IntervalWindow(15, 30): [
+            ('k', ['b']),
+            ('k', [])
         ],
     }
     assert_that(
         records,
         equal_to_per_window(expected_window_to_elements),
-        use_global_window=False,
         label='assert per window')
 
     p.run()
@@ -247,7 +250,6 @@ class TestStreamTest(unittest.TestCase):
     assert_that(
         records,
         equal_to_per_window(expected_window_to_elements),
-        use_global_window=False,
         label='assert per window')
 
     p.run()
@@ -349,7 +351,6 @@ class TestStreamTest(unittest.TestCase):
     assert_that(
         records,
         equal_to_per_window(expected_window_to_elements),
-        use_global_window=False,
         label='assert per window')
 
     p.run()
@@ -403,7 +404,6 @@ class TestStreamTest(unittest.TestCase):
     assert_that(
         records,
         equal_to_per_window(expected_window_to_elements),
-        use_global_window=False,
         label='assert per window')
 
     p.run()

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -39,6 +39,7 @@ from apache_beam.utils.annotations import experimental
 __all__ = [
     'assert_that',
     'equal_to',
+    'equal_to_per_window',
     'is_empty',
     'is_not_empty',
     'matches_all',
@@ -85,30 +86,67 @@ def contains_in_any_order(iterable):
 
   return InAnyOrder(iterable)
 
+class _EqualToPerWindowMatcher(object):
+  def __init__(self, expected_window_to_elements):
+    self._expected_window_to_elements = expected_window_to_elements
+
+  def __call__(self, value):
+    # Short-hand.
+    _expected = self._expected_window_to_elements
+
+    # Match the given windowed value to an expected window. Fails if the window
+    # doesn't exist or the element wasn't found in the window.
+    def match(windowed_value):
+      actual = windowed_value.value
+      window_key = windowed_value.windows[0]
+      try:
+        expected = _expected[window_key]
+      except KeyError:
+        raise BeamAssertException(
+            'Failed assert: window {} not found in any expected ' \
+            'windows {}'.format(window_key, list(_expected.keys())))
+
+      # Remove any matched elements from the window. This is used later on to
+      # assert that all elements in the window were matched with actual
+      # elements.
+      try:
+        _expected[window_key].remove(actual)
+      except ValueError:
+        raise BeamAssertException(
+            'Failed assert: element {} not found in window ' \
+            '{}:{}'.format(actual, window_key, _expected[window_key]))
+
+    # Run the matcher for each window and value pair. Fails if the
+    # windowed_value is not a TestWindowedValue.
+    for windowed_value in value:
+      if not isinstance(windowed_value, TestWindowedValue):
+        raise BeamAssertException(
+            'Failed assert: Received element {} is not of type ' \
+            'TestWindowedValue. Did you forget to set reify_windows=True ' \
+            'on the assertion?'.format(windowed_value))
+      match(windowed_value)
+
+    # Finally, some elements may not have been matched. Assert that we removed
+    # all the elements that we received from the expected list. If the list is
+    # non-empty, then there are unmatched elements.
+    for win in _expected:
+      if _expected[win]:
+        raise BeamAssertException(
+            'Failed assert: unmatched elements {} in window {}'.format(
+                _expected[win], win))
 
 def equal_to_per_window(expected_window_to_elements):
-  """Matcher used by assert_that to check on values for specific windows.
+  """Matcher used by assert_that to check to assert expected windows.
+
+  The 'assert_that' statement must have reify_windows=True. This assertion works
+  when elements are emitted and are finally checked at the end of the window.
 
   Arguments:
     expected_window_to_elements: A dictionary where the keys are the windows
       to check and the values are the elements associated with each window.
   """
-  def matcher(elements):
-    actual_elements_in_window, window = elements
-    if window in expected_window_to_elements:
-      expected_elements_in_window = list(
-          expected_window_to_elements[window])
-      sorted_expected = sorted(expected_elements_in_window)
-      sorted_actual = sorted(actual_elements_in_window)
-      if sorted_expected != sorted_actual:
-        # Results for the same window don't necessarily come all
-        # at once. Hence the same actual window may contain only
-        # subsets of the expected elements for the window.
-        # For example, in the presence of early triggers.
-        if all(elem in sorted_expected for elem in sorted_actual) is False:
-          raise BeamAssertException(
-              'Failed assert: %r not in %r' % (sorted_actual, sorted_expected))
-  return matcher
+
+  return _EqualToPerWindowMatcher(expected_window_to_elements)
 
 
 # Note that equal_to checks if expected and actual are permutations of each
@@ -214,6 +252,10 @@ def assert_that(actual, matcher, label='assert_that',
       pvalue.PCollection), ('%s is not a supported type for Beam assert'
                             % type(actual))
 
+  if isinstance(matcher, _EqualToPerWindowMatcher):
+    reify_windows = True
+    use_global_window = True
+
   class ReifyTimestampWindow(DoFn):
     def process(self, element, timestamp=DoFn.TimestampParam,
                 window=DoFn.WindowParam):
@@ -239,6 +281,8 @@ def assert_that(actual, matcher, label='assert_that',
 
       keyed_actual = pcoll | "ToVoidKey" >> Map(lambda v: (None, v))
 
+      # This is a CoGroupByKey so that the matcher always runs, even if the
+      # PCollection is empty.
       plain_actual = ((keyed_singleton, keyed_actual)
                       | "Group" >> CoGroupByKey()
                       | "Unkey" >> Map(lambda k_values: k_values[1][1]))

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -1075,8 +1075,8 @@ class BatchGlobalTriggerDriver(TriggerDriver):
       nonspeculative_index=0)
 
   def process_elements(self, state, windowed_values,
-                       unused_output_watermark=None,
-                       unused_input_watermark=None):
+                       unused_output_watermark,
+                       unused_input_watermark=MIN_TIMESTAMP):
     yield WindowedValue(
         _UnwindowedValues(windowed_values),
         MIN_TIMESTAMP,

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -67,9 +67,6 @@ __all__ = [
     ]
 
 
-_LOGGER = logging.getLogger(__name__)
-
-
 class AccumulationMode(object):
   """Controls what to do with data when a trigger fires multiple times."""
   DISCARDING = beam_runner_api_pb2.AccumulationMode.DISCARDING
@@ -215,6 +212,16 @@ class TriggerFn(with_metaclass(ABCMeta, object)):
     pass
 
   @abstractmethod
+  def has_ontime_pane(self):
+    """Whether this trigger creates an empty pane even if there are no elements.
+
+    Returns:
+      True if this trigger guarantees that there will always be an ON_TIME pane
+      even if there are no elements in that pane.
+    """
+    pass
+
+  @abstractmethod
   def on_fire(self, watermark, window, context):
     """Called when a trigger actually fires.
 
@@ -280,6 +287,10 @@ class DefaultTrigger(TriggerFn):
         context.clear_timer('', TimeDomain.WATERMARK)
 
   def should_fire(self, time_domain, watermark, window, context):
+    if watermark >= window.end:
+      # Explicitly clear the timer so that late elements are not emitted again
+      # when the timer is fired.
+      context.clear_timer('', TimeDomain.WATERMARK)
     return watermark >= window.end
 
   def on_fire(self, watermark, window, context):
@@ -301,6 +312,9 @@ class DefaultTrigger(TriggerFn):
   def to_runner_api(self, unused_context):
     return beam_runner_api_pb2.Trigger(
         default=beam_runner_api_pb2.Trigger.Default())
+
+  def has_ontime_pane(self):
+    return True
 
 
 class AfterProcessingTime(TriggerFn):
@@ -350,6 +364,9 @@ class AfterProcessingTime(TriggerFn):
     return beam_runner_api_pb2.Trigger(
         after_processing_time=beam_runner_api_pb2.Trigger.AfterProcessingTime(
             timestamp_transforms=[delay_proto]))
+
+  def has_ontime_pane(self):
+    return False
 
 
 class AfterWatermark(TriggerFn):
@@ -406,6 +423,9 @@ class AfterWatermark(TriggerFn):
       return self.late.should_fire(time_domain, watermark,
                                    window, NestedContext(context, 'late'))
     elif watermark >= window.end:
+      # Explicitly clear the timer so that late elements are not emitted again
+      # when the timer is fired.
+      context.clear_timer('', TimeDomain.WATERMARK)
       return True
     elif self.early:
       return self.early.should_fire(time_domain, watermark,
@@ -461,6 +481,9 @@ class AfterWatermark(TriggerFn):
             early_firings=early_proto,
             late_firings=late_proto))
 
+  def has_ontime_pane(self):
+    return True
+
 
 class AfterCount(TriggerFn):
   """Fire when there are at least count elements in this window pane.
@@ -509,6 +532,8 @@ class AfterCount(TriggerFn):
         element_count=beam_runner_api_pb2.Trigger.ElementCount(
             element_count=self.count))
 
+  def has_ontime_pane(self):
+    return False
 
 class Repeatedly(TriggerFn):
   """Repeatedly invoke the given trigger, never finishing."""
@@ -551,6 +576,9 @@ class Repeatedly(TriggerFn):
     return beam_runner_api_pb2.Trigger(
         repeat=beam_runner_api_pb2.Trigger.Repeat(
             subtrigger=self.underlying.to_runner_api(context)))
+
+  def has_ontime_pane(self):
+    return self.underlying.has_ontime_pane()
 
 
 class _ParallelTriggerFn(with_metaclass(ABCMeta, TriggerFn)):
@@ -630,6 +658,8 @@ class _ParallelTriggerFn(with_metaclass(ABCMeta, TriggerFn)):
     else:
       raise NotImplementedError(self)
 
+  def has_ontime_pane(self):
+    return any(t.has_ontime_pane() for t in self.triggers)
 
 class AfterAny(_ParallelTriggerFn):
   """Fires when any subtrigger fires.
@@ -717,6 +747,8 @@ class AfterEach(TriggerFn):
                 subtrigger.to_runner_api(context)
                 for subtrigger in self.triggers]))
 
+  def has_ontime_pane(self):
+    return any(t.has_ontime_pane() for t in self.triggers)
 
 class OrFinally(AfterAny):
 
@@ -968,18 +1000,21 @@ class TriggerDriver(with_metaclass(ABCMeta, object)):
   """Breaks a series of bundle and timer firings into window (pane)s."""
 
   @abstractmethod
-  def process_elements(self, state, windowed_values, output_watermark):
+  def process_elements(self, state, windowed_values, output_watermark,
+                       input_watermark=MIN_TIMESTAMP):
     pass
 
   @abstractmethod
-  def process_timer(self, window_id, name, time_domain, timestamp, state):
+  def process_timer(self, window_id, name, time_domain, timestamp, state,
+                    input_watermark=None):
     pass
 
-  def process_entire_key(
-      self, key, windowed_values, output_watermark=MIN_TIMESTAMP):
+  def process_entire_key(self, key, windowed_values,
+                         unused_output_watermark=None,
+                         unused_input_watermark=None):
     state = InMemoryUnmergedState()
     for wvalue in self.process_elements(
-        state, windowed_values, output_watermark):
+        state, windowed_values, MIN_TIMESTAMP, MIN_TIMESTAMP):
       yield wvalue.with_value((key, wvalue.value))
     while state.timers:
       fired = state.get_and_clear_timers()
@@ -1039,14 +1074,17 @@ class BatchGlobalTriggerDriver(TriggerDriver):
       index=0,
       nonspeculative_index=0)
 
-  def process_elements(self, state, windowed_values, unused_output_watermark):
+  def process_elements(self, state, windowed_values,
+                       unused_output_watermark=None,
+                       unused_input_watermark=None):
     yield WindowedValue(
         _UnwindowedValues(windowed_values),
         MIN_TIMESTAMP,
         self.GLOBAL_WINDOW_TUPLE,
         self.ONLY_FIRING)
 
-  def process_timer(self, window_id, name, time_domain, timestamp, state):
+  def process_timer(self, window_id, name, time_domain, timestamp, state,
+                    input_watermark=None):
     raise TypeError('Triggers never set or called for batch default windowing.')
 
 
@@ -1057,15 +1095,19 @@ class CombiningTriggerDriver(TriggerDriver):
     self.phased_combine_fn = phased_combine_fn
     self.underlying = underlying
 
-  def process_elements(self, state, windowed_values, output_watermark):
+  def process_elements(self, state, windowed_values, output_watermark,
+                       input_watermark=MIN_TIMESTAMP):
     uncombined = self.underlying.process_elements(state, windowed_values,
-                                                  output_watermark)
+                                                  output_watermark,
+                                                  input_watermark)
     for output in uncombined:
       yield output.with_value(self.phased_combine_fn.apply(output.value))
 
-  def process_timer(self, window_id, name, time_domain, timestamp, state):
+  def process_timer(self, window_id, name, time_domain, timestamp, state,
+                    input_watermark=None):
     uncombined = self.underlying.process_timer(window_id, name, time_domain,
-                                               timestamp, state)
+                                               timestamp, state,
+                                               input_watermark)
     for output in uncombined:
       yield output.with_value(self.phased_combine_fn.apply(output.value))
 
@@ -1094,7 +1136,8 @@ class GeneralTriggerDriver(TriggerDriver):
     self.accumulation_mode = windowing.accumulation_mode
     self.is_merging = True
 
-  def process_elements(self, state, windowed_values, output_watermark):
+  def process_elements(self, state, windowed_values, output_watermark,
+                       input_watermark=MIN_TIMESTAMP):
     if self.is_merging:
       state = MergeableStateAdapter(state)
 
@@ -1155,14 +1198,17 @@ class GeneralTriggerDriver(TriggerDriver):
         self.trigger_fn.on_element(value, window, context)
 
       # Maybe fire this window.
-      watermark = MIN_TIMESTAMP
-      if self.trigger_fn.should_fire(TimeDomain.WATERMARK, watermark,
+      if self.trigger_fn.should_fire(TimeDomain.WATERMARK, input_watermark,
                                      window, context):
-        finished = self.trigger_fn.on_fire(watermark, window, context)
-        yield self._output(window, finished, state, output_watermark, False)
+        finished = self.trigger_fn.on_fire(input_watermark, window, context)
+        yield self._output(window, finished, state, input_watermark,
+                           output_watermark, False)
 
   def process_timer(self, window_id, unused_name, time_domain, timestamp,
-                    state):
+                    state, input_watermark=None):
+    if input_watermark is None:
+      input_watermark = timestamp
+
     if self.is_merging:
       state = MergeableStateAdapter(state)
     window = state.get_window(window_id)
@@ -1175,16 +1221,17 @@ class GeneralTriggerDriver(TriggerDriver):
         if self.trigger_fn.should_fire(time_domain, timestamp,
                                        window, context):
           finished = self.trigger_fn.on_fire(timestamp, window, context)
-          yield self._output(window, finished, state, timestamp,
-                             time_domain == TimeDomain.WATERMARK)
+          yield self._output(window, finished, state, input_watermark,
+                             timestamp, time_domain == TimeDomain.WATERMARK)
     else:
       raise Exception('Unexpected time domain: %s' % time_domain)
 
-  def _output(self, window, finished, state, watermark, maybe_ontime):
+  def _output(self, window, finished, state, input_watermark, output_watermark,
+              maybe_ontime):
     """Output window and clean up if appropriate."""
     index = state.get_state(window, self.INDEX)
     state.add_state(window, self.INDEX, 1)
-    if watermark <= window.max_timestamp():
+    if output_watermark <= window.max_timestamp():
       nonspeculative_index = -1
       timing = windowed_value.PaneInfoTiming.EARLY
       if state.get_state(window, self.NONSPECULATIVE_INDEX):
@@ -1192,7 +1239,7 @@ class GeneralTriggerDriver(TriggerDriver):
             window, self.NONSPECULATIVE_INDEX)
         state.add_state(window, self.NONSPECULATIVE_INDEX, 1)
         windowed_value.PaneInfoTiming.LATE
-        _LOGGER.warning('Watermark moved backwards in time '
+        logging.warning('Watermark moved backwards in time '
                         'or late data moved window end forward.')
     else:
       nonspeculative_index = state.get_state(window, self.NONSPECULATIVE_INDEX)
@@ -1220,6 +1267,10 @@ class GeneralTriggerDriver(TriggerDriver):
     if timestamp is None:
       # If no watermark hold was set, output at end of window.
       timestamp = window.max_timestamp()
+    elif input_watermark < window.end and self.trigger_fn.has_ontime_pane():
+      # Hold the watermark in case there is an empty pane that needs to be fired
+      # at the end of the window.
+      pass
     else:
       state.clear_state(window, self.WATERMARK_HOLD)
 
@@ -1322,7 +1373,7 @@ class InMemoryUnmergedState(UnmergedState):
         elif time_domain == TimeDomain.WATERMARK:
           time_marker = watermark
         else:
-          _LOGGER.error(
+          logging.error(
               'TimeDomain error: No timers defined for time domain %s.',
               time_domain)
         if timestamp <= time_marker:

--- a/sdks/python/apache_beam/transforms/trigger_test.py
+++ b/sdks/python/apache_beam/transforms/trigger_test.py
@@ -41,6 +41,7 @@ from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.test_stream import TestStream
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+from apache_beam.transforms import ptransform
 from apache_beam.transforms import trigger
 from apache_beam.transforms.core import Windowing
 from apache_beam.transforms.trigger import AccumulationMode
@@ -634,6 +635,54 @@ def _windowed_value_info(windowed_value):
   }
 
 
+def _windowed_value_info_map_fn(
+    k, vs,
+    window=beam.DoFn.WindowParam,
+    t=beam.DoFn.TimestampParam,
+    p=beam.DoFn.PaneInfoParam):
+  return (
+      k,
+      _windowed_value_info(WindowedValue(
+          vs, windows=[window], timestamp=t, pane_info=p)))
+
+
+def _windowed_value_info_check(actual, expected):
+
+  def format(panes):
+    return '\n[%s]\n' % '\n '.join(str(pane) for pane in sorted(
+        panes, key=lambda pane: pane.get('timestamp', None)))
+
+  if len(actual) > len(expected):
+    raise AssertionError(
+        'Unexpected output: expected %s but got %s' % (
+            format(expected), format(actual)))
+  elif len(expected) > len(actual):
+    raise AssertionError(
+        'Unmatched output: expected %s but got %s' % (
+            format(expected), format(actual)))
+  else:
+
+    def diff(actual, expected):
+      for key in sorted(expected.keys(), reverse=True):
+        if key in actual:
+          if actual[key] != expected[key]:
+            return key
+
+    for output in actual:
+      diffs = [diff(output, pane) for pane in expected]
+      if all(diffs):
+        raise AssertionError(
+            'Unmatched output: %s not found in %s (diffs in %s)' % (
+                output, format(expected), diffs))
+
+
+class _ConcatCombineFn(beam.CombineFn):
+  create_accumulator = lambda self: []
+  add_input = lambda self, acc, element: acc.append(element) or acc
+  merge_accumulators = lambda self, accs: sum(accs, [])
+  extract_output = lambda self, acc: acc
+
+
 class TriggerDriverTranscriptTest(TranscriptTest):
 
   def _execute(
@@ -652,7 +701,7 @@ class TriggerDriverTranscriptTest(TranscriptTest):
       while to_fire:
         for timer_window, (name, time_domain, t_timestamp) in to_fire:
           for wvalue in driver.process_timer(
-              timer_window, name, time_domain, t_timestamp, state, watermark):
+              timer_window, name, time_domain, t_timestamp, state):
             output.append(_windowed_value_info(wvalue))
         to_fire = state.get_and_clear_timers(watermark)
 
@@ -670,8 +719,7 @@ class TriggerDriverTranscriptTest(TranscriptTest):
             for t in params]
         output = [
             _windowed_value_info(wv)
-            for wv in driver.process_elements(state, bundle, watermark,
-                                              watermark)]
+            for wv in driver.process_elements(state, bundle, watermark)]
         fire_timers()
 
       elif action == 'watermark':
@@ -785,42 +833,23 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
         elif action == 'expect':
           actual = list(seen.read())
           seen.clear()
-
-          if len(actual) > len(data):
-            raise AssertionError(
-                'Unexpected output: expected %s but got %s' % (data, actual))
-          elif len(data) > len(actual):
-            raise AssertionError(
-                'Unmatched output: expected %s but got %s' % (data, actual))
-          else:
-
-            def diff(actual, expected):
-              for key in sorted(expected.keys(), reverse=True):
-                if key in actual:
-                  if actual[key] != expected[key]:
-                    return key
-
-            for output in actual:
-              diffs = [diff(output, expected) for expected in data]
-              if all(diffs):
-                raise AssertionError(
-                    'Unmatched output: %s not found in %s (diffs in %s)' % (
-                        output, data, diffs))
+          _windowed_value_info_check(actual, data)
 
         else:
           raise ValueError('Unexpected action: %s' % action)
 
-    with TestPipeline() as p:
-      # TODO(BEAM-8601): Pass this during pipeline construction.
-      p.options.view_as(StandardOptions).streaming = True
+    @ptransform.ptransform_fn
+    def CheckAggregation(inputs_and_expected, aggregation):
       # Split the test stream into a branch of to-be-processed elements, and
       # a branch of expected results.
       inputs, expected = (
-          p
-          | read_test_stream
-          | beam.MapTuple(
-              lambda tag, value: beam.pvalue.TaggedOutput(tag, ('key', value))
-              ).with_outputs('input', 'expect'))
+          inputs_and_expected
+          | beam.FlatMapTuple(
+              lambda tag, value: [
+                  beam.pvalue.TaggedOutput(tag, ('key1', value)),
+                  beam.pvalue.TaggedOutput(tag, ('key2', value)),
+              ]).with_outputs('input', 'expect'))
+
       # Process the inputs with the given windowing to produce actual outputs.
       outputs = (
           inputs
@@ -831,15 +860,8 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
               trigger=trigger_fn,
               accumulation_mode=accumulation_mode,
               timestamp_combiner=timestamp_combiner)
-          | beam.GroupByKey()
-          | beam.MapTuple(
-              lambda k, vs,
-                     window=beam.DoFn.WindowParam,
-                     t=beam.DoFn.TimestampParam,
-                     p=beam.DoFn.PaneInfoParam: (
-                         k,
-                         _windowed_value_info(WindowedValue(
-                             vs, windows=[window], timestamp=t, pane_info=p))))
+          | aggregation
+          | beam.MapTuple(_windowed_value_info_map_fn)
           # Place outputs back into the global window to allow flattening
           # and share a single state in Check.
           | 'Global' >> beam.WindowInto(beam.transforms.window.GlobalWindows()))
@@ -853,6 +875,16 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
        | beam.Flatten()
        | beam.ParDo(Check(self.allow_out_of_order)))
 
+    with TestPipeline() as p:
+      # TODO(BEAM-8601): Pass this during pipeline construction.
+      p.options.view_as(StandardOptions).streaming = True
+
+      # We can have at most one test stream per pipeline, so we share it.
+      inputs_and_expected = p | read_test_stream
+      _ = inputs_and_expected | CheckAggregation(beam.GroupByKey())
+      _ = inputs_and_expected | CheckAggregation(beam.CombinePerKey(
+          _ConcatCombineFn()))
+
 
 class TestStreamTranscriptTest(BaseTestStreamTranscriptTest):
   allow_out_of_order = False
@@ -862,6 +894,83 @@ class WeakTestStreamTranscriptTest(BaseTestStreamTranscriptTest):
   allow_out_of_order = True
 
 
+class BatchTranscriptTest(TranscriptTest):
+
+  def _execute(
+      self, window_fn, trigger_fn, accumulation_mode, timestamp_combiner,
+      transcript, spec):
+    if timestamp_combiner == TimestampCombiner.OUTPUT_AT_EARLIEST_TRANSFORMED:
+      self.skipTest(
+          'Non-fnapi timestamp combiner: %s' % spec.get('timestamp_combiner'))
+
+    if accumulation_mode != AccumulationMode.ACCUMULATING:
+      self.skipTest('Batch mode only makes sense for accumulating.')
+
+    watermark = MIN_TIMESTAMP
+    for action, params in transcript:
+      if action == 'watermark':
+        watermark = params
+      elif action == 'input':
+        if any(t <= watermark for t in params):
+          self.skipTest('Batch mode never has late data.')
+
+    inputs = sum([vs for action, vs in transcript if action == 'input'], [])
+    final_panes_by_window = {}
+    for action, params in transcript:
+      if action == 'expect':
+        for expected in params:
+          trimmed = {}
+          for field in ('window', 'values', 'timestamp'):
+            if field in expected:
+              trimmed[field] = expected[field]
+          final_panes_by_window[tuple(expected['window'])] = trimmed
+    final_panes = list(final_panes_by_window.values())
+
+    if window_fn.is_merging():
+      merged_away = set()
+      class MergeContext(WindowFn.MergeContext):
+        def merge(_, to_be_merged, merge_result):
+          for window in to_be_merged:
+            if window != merge_result:
+              merged_away.add(window)
+      all_windows = [IntervalWindow(*pane['window']) for pane in final_panes]
+      window_fn.merge(MergeContext(all_windows))
+      final_panes = [
+          pane for pane in final_panes
+          if IntervalWindow(*pane['window']) not in merged_away]
+
+    with TestPipeline() as p:
+      input_pc = (
+          p
+          | beam.Create(inputs)
+          | beam.Map(lambda t: TimestampedValue(('key', t), t))
+          | beam.WindowInto(
+              window_fn,
+              trigger=trigger_fn,
+              accumulation_mode=accumulation_mode,
+              timestamp_combiner=timestamp_combiner))
+
+      grouped = input_pc | 'Grouped' >> (
+          beam.GroupByKey()
+          | beam.MapTuple(_windowed_value_info_map_fn)
+          | beam.MapTuple(lambda _, value: value))
+
+      combined = input_pc | 'Combined' >> (
+          beam.CombinePerKey(_ConcatCombineFn())
+          | beam.MapTuple(_windowed_value_info_map_fn)
+          | beam.MapTuple(lambda _, value: value))
+
+      assert_that(
+          grouped,
+          lambda actual: _windowed_value_info_check(actual, final_panes),
+          label='CheckGrouped')
+
+      assert_that(
+          combined,
+          lambda actual: _windowed_value_info_check(actual, final_panes),
+          label='CheckCombined')
+
+
 TRANSCRIPT_TEST_FILE = os.path.join(
     os.path.dirname(__file__), '..', 'testing', 'data',
     'trigger_transcripts.yaml')
@@ -869,6 +978,7 @@ if os.path.exists(TRANSCRIPT_TEST_FILE):
   TriggerDriverTranscriptTest._create_tests(TRANSCRIPT_TEST_FILE)
   TestStreamTranscriptTest._create_tests(TRANSCRIPT_TEST_FILE)
   WeakTestStreamTranscriptTest._create_tests(TRANSCRIPT_TEST_FILE)
+  BatchTranscriptTest._create_tests(TRANSCRIPT_TEST_FILE)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The GeneralTriggerDriver does not put watermark holds on timers, leading to the ontime empty pane being considered late data.

The DefaultTrigger and AfterWatermark do not clear their timers after the watermark passed the end of the endow, leading to duplicate records being emitted.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
