### PR TITLE
[BEAM-8587] TestStream for Dataflow runner

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -1223,7 +1223,8 @@ class DataflowRunner(PipelineRunner):
           element.encoded_element = output_coder.encode(tv.value)
           element.timestamp = tv.timestamp.micros
       elif isinstance(event, ProcessingTimeEvent):
-        new_event.processing_time_event.advance_duration = event.advance_by.micros
+        new_event.processing_time_event.advance_duration = (
+            event.advance_by.micros)
       elif isinstance(event, WatermarkEvent):
         new_event.watermark_event.new_watermark = event.new_watermark.micros
     serialized_payload = self.byte_array_to_json_string(

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -30,6 +30,7 @@ import sys
 import threading
 import time
 import traceback
+import unittest
 import urllib
 from builtins import hex
 from collections import defaultdict
@@ -1195,6 +1196,7 @@ class DataflowRunner(PipelineRunner):
          PropertyNames.STEP_NAME: input_step.proto.name,
          PropertyNames.OUTPUT_NAME: input_step.get_output(input_tag)})
 
+  @unittest.skip("This is not a test, despite the name.")
   def run_TestStream(self, transform_node, options):
     from apache_beam.portability.api import beam_runner_api_pb2
     from apache_beam.testing.test_stream import ElementEvent

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -30,7 +30,6 @@ import sys
 import threading
 import time
 import traceback
-import unittest
 import urllib
 from builtins import hex
 from collections import defaultdict
@@ -1196,7 +1195,6 @@ class DataflowRunner(PipelineRunner):
          PropertyNames.STEP_NAME: input_step.proto.name,
          PropertyNames.OUTPUT_NAME: input_step.get_output(input_tag)})
 
-  @unittest.skip("This is not a test, despite the name.")
   def run_TestStream(self, transform_node, options):
     from apache_beam.portability.api import beam_runner_api_pb2
     from apache_beam.testing.test_stream import ElementEvent
@@ -1238,6 +1236,10 @@ class DataflowRunner(PipelineRunner):
         PropertyNames.ENCODING: step.encoding,
         PropertyNames.OUTPUT_NAME: PropertyNames.OUT
     }])
+
+  # We must mark this method as not a test or else its name is a matcher for
+  # nosetest tests.
+  run_TestStream.__test__ = False
 
   @classmethod
   def serialize_windowing_strategy(cls, windowing):

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -1195,6 +1195,47 @@ class DataflowRunner(PipelineRunner):
          PropertyNames.STEP_NAME: input_step.proto.name,
          PropertyNames.OUTPUT_NAME: input_step.get_output(input_tag)})
 
+  def run_TestStream(self, transform_node, options):
+    from apache_beam.portability.api import beam_runner_api_pb2
+    from apache_beam.testing.test_stream import ElementEvent
+    from apache_beam.testing.test_stream import ProcessingTimeEvent
+    from apache_beam.testing.test_stream import WatermarkEvent
+    standard_options = options.view_as(StandardOptions)
+    if not standard_options.streaming:
+      raise ValueError('TestStream is currently available for use '
+                       'only in streaming pipelines.')
+
+    transform = transform_node.transform
+    step = self._add_step(TransformNames.READ, transform_node.full_label,
+                          transform_node)
+    step.add_property(PropertyNames.FORMAT, 'test_stream')
+    test_stream_payload = beam_runner_api_pb2.TestStreamPayload()
+    # TestStream source doesn't do any decoding of elements,
+    # so we won't set test_stream_payload.coder_id.
+    output_coder = transform._infer_output_coder()  # pylint: disable=protected-access
+    for event in transform.events:
+      new_event = test_stream_payload.events.add()
+      if isinstance(event, ElementEvent):
+        for tv in event.timestamped_values:
+          element = new_event.element_event.elements.add()
+          element.encoded_element = output_coder.encode(tv.value)
+          element.timestamp = tv.timestamp.micros
+      elif isinstance(event, ProcessingTimeEvent):
+        new_event.processing_time_event.advance_duration = event.advance_by.micros
+      elif isinstance(event, WatermarkEvent):
+        new_event.watermark_event.new_watermark = event.new_watermark.micros
+    serialized_payload = self.byte_array_to_json_string(
+        test_stream_payload.SerializeToString())
+    step.add_property(PropertyNames.SERIALIZED_TEST_STREAM, serialized_payload)
+
+    step.encoding = self._get_encoded_output_coder(transform_node)
+    step.add_property(PropertyNames.OUTPUT_INFO, [{
+        PropertyNames.USER_NAME:
+            ('%s.%s' % (transform_node.full_label, PropertyNames.OUT)),
+        PropertyNames.ENCODING: step.encoding,
+        PropertyNames.OUTPUT_NAME: PropertyNames.OUT
+    }])
+
   @classmethod
   def serialize_windowing_strategy(cls, windowing):
     from apache_beam.runners import pipeline_context

--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -45,8 +45,8 @@ BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20191029'
 
 # TODO(BEAM-5939): Remove these shared names once Dataflow worker is updated.
 PICKLED_MAIN_SESSION_FILE = 'pickled_main_session'
-STAGED_PIPELINE_FILENAME = "pipeline.pb"
-STAGED_PIPELINE_URL_METADATA_FIELD = "pipeline_url"
+STAGED_PIPELINE_FILENAME = 'pipeline.pb'
+STAGED_PIPELINE_URL_METADATA_FIELD = 'pipeline_url'
 
 # Package names for different distributions
 BEAM_PACKAGE_NAME = 'apache-beam'
@@ -61,7 +61,8 @@ DATAFLOW_CONTAINER_IMAGE_REPOSITORY = 'gcr.io/cloud-dataflow/v1beta3'
 class TransformNames(object):
   """For internal use only; no backwards-compatibility guarantees.
 
-  Transform strings as they are expected in the CloudWorkflow protos."""
+  Transform strings as they are expected in the CloudWorkflow protos.
+  """
   COLLECTION_TO_SINGLETON = 'CollectionToSingleton'
   COMBINE = 'CombineValues'
   CREATE_PCOLLECTION = 'CreateCollection'
@@ -75,7 +76,8 @@ class TransformNames(object):
 class PropertyNames(object):
   """For internal use only; no backwards-compatibility guarantees.
 
-  Property strings as they are expected in the CloudWorkflow protos."""
+  Property strings as they are expected in the CloudWorkflow protos.
+  """
   BIGQUERY_CREATE_DISPOSITION = 'create_disposition'
   BIGQUERY_DATASET = 'dataset'
   BIGQUERY_EXPORT_FORMAT = 'bigquery_export_format'
@@ -113,6 +115,7 @@ class PropertyNames(object):
   SERIALIZED_FN = 'serialized_fn'
   SHARD_NAME_TEMPLATE = 'shard_template'
   SOURCE_STEP_INPUT = 'custom_source_step_input'
+  SERIALIZED_TEST_STREAM = 'serialized_test_stream'
   STEP_NAME = 'step_name'
   USER_FN = 'user_fn'
   USER_NAME = 'user_name'

--- a/sdks/python/apache_beam/runners/internal/names.py
+++ b/sdks/python/apache_beam/runners/internal/names.py
@@ -15,16 +15,111 @@
 # limitations under the License.
 #
 
-"""Various names shared by more than one runner."""
+"""Various names for properties, transforms, etc."""
 
 # All constants are for internal use only; no backwards-compatibility
 # guarantees.
 
+from __future__ import absolute_import
+
+# Standard file names used for staging files.
+from builtins import object
+
+DATAFLOW_SDK_TARBALL_FILE = 'dataflow_python_sdk.tar'
+
+# String constants related to sources framework
+SOURCE_FORMAT = 'custom_source'
+SOURCE_TYPE = 'CustomSourcesType'
+SERIALIZED_SOURCE_KEY = 'serialized_source'
+
+# In a released SDK, container tags are selected based on the SDK version.
+# Unreleased versions use container versions based on values of
+# BEAM_CONTAINER_VERSION and BEAM_FNAPI_CONTAINER_VERSION (see below).
+
+# Update this version to the next version whenever there is a change that will
+# require changes to legacy Dataflow worker execution environment.
+BEAM_CONTAINER_VERSION = 'beam-master-20191029'
+# Update this version to the next version whenever there is a change that
+# requires changes to SDK harness container or SDK harness launcher.
+BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20191029'
+
+# TODO(BEAM-5939): Remove these shared names once Dataflow worker is updated.
 PICKLED_MAIN_SESSION_FILE = 'pickled_main_session'
-STAGED_PIPELINE_FILENAME = "pipeline.pb"
+STAGED_PIPELINE_FILENAME = 'pipeline.pb'
+STAGED_PIPELINE_URL_METADATA_FIELD = 'pipeline_url'
 
 # Package names for different distributions
 BEAM_PACKAGE_NAME = 'apache-beam'
 
 # SDK identifiers for different distributions
 BEAM_SDK_NAME = 'Apache Beam SDK for Python'
+# TODO(BEAM-5393): End duplicated constants (see above).
+
+DATAFLOW_CONTAINER_IMAGE_REPOSITORY = 'gcr.io/cloud-dataflow/v1beta3'
+
+
+class TransformNames(object):
+  """For internal use only; no backwards-compatibility guarantees.
+
+  Transform strings as they are expected in the CloudWorkflow protos.
+  """
+  COLLECTION_TO_SINGLETON = 'CollectionToSingleton'
+  COMBINE = 'CombineValues'
+  CREATE_PCOLLECTION = 'CreateCollection'
+  DO = 'ParallelDo'
+  FLATTEN = 'Flatten'
+  GROUP = 'GroupByKey'
+  READ = 'ParallelRead'
+  WRITE = 'ParallelWrite'
+
+
+class PropertyNames(object):
+  """For internal use only; no backwards-compatibility guarantees.
+
+  Property strings as they are expected in the CloudWorkflow protos.
+  """
+  BIGQUERY_CREATE_DISPOSITION = 'create_disposition'
+  BIGQUERY_DATASET = 'dataset'
+  BIGQUERY_EXPORT_FORMAT = 'bigquery_export_format'
+  BIGQUERY_FLATTEN_RESULTS = 'bigquery_flatten_results'
+  BIGQUERY_KMS_KEY = 'bigquery_kms_key'
+  BIGQUERY_PROJECT = 'project'
+  BIGQUERY_QUERY = 'bigquery_query'
+  BIGQUERY_SCHEMA = 'schema'
+  BIGQUERY_TABLE = 'table'
+  BIGQUERY_USE_LEGACY_SQL = 'bigquery_use_legacy_sql'
+  BIGQUERY_WRITE_DISPOSITION = 'write_disposition'
+  DISPLAY_DATA = 'display_data'
+  ELEMENT = 'element'
+  ELEMENTS = 'elements'
+  ENCODING = 'encoding'
+  FILE_PATTERN = 'filepattern'
+  FILE_NAME_PREFIX = 'filename_prefix'
+  FILE_NAME_SUFFIX = 'filename_suffix'
+  FORMAT = 'format'
+  INPUTS = 'inputs'
+  IMPULSE_ELEMENT = 'impulse_element'
+  NON_PARALLEL_INPUTS = 'non_parallel_inputs'
+  NUM_SHARDS = 'num_shards'
+  OUT = 'out'
+  OUTPUT = 'output'
+  OUTPUT_INFO = 'output_info'
+  OUTPUT_NAME = 'output_name'
+  PARALLEL_INPUT = 'parallel_input'
+  PUBSUB_ID_LABEL = 'pubsub_id_label'
+  PUBSUB_SERIALIZED_ATTRIBUTES_FN = 'pubsub_serialized_attributes_fn'
+  PUBSUB_SUBSCRIPTION = 'pubsub_subscription'
+  PUBSUB_TIMESTAMP_ATTRIBUTE = 'pubsub_timestamp_label'
+  PUBSUB_TOPIC = 'pubsub_topic'
+  RESTRICTION_ENCODING = 'restriction_encoding'
+  SERIALIZED_FN = 'serialized_fn'
+  SHARD_NAME_TEMPLATE = 'shard_template'
+  SOURCE_STEP_INPUT = 'custom_source_step_input'
+  SERIALIZED_TEST_STREAM = 'serialized_test_stream'
+  STEP_NAME = 'step_name'
+  USER_FN = 'user_fn'
+  USER_NAME = 'user_name'
+  VALIDATE_SINK = 'validate_sink'
+  VALIDATE_SOURCE = 'validate_source'
+  VALUE = 'value'
+  WINDOWING_STRATEGY = 'windowing_strategy'

--- a/sdks/python/apache_beam/runners/internal/names.py
+++ b/sdks/python/apache_beam/runners/internal/names.py
@@ -15,111 +15,16 @@
 # limitations under the License.
 #
 
-"""Various names for properties, transforms, etc."""
+"""Various names shared by more than one runner."""
 
 # All constants are for internal use only; no backwards-compatibility
 # guarantees.
 
-from __future__ import absolute_import
-
-# Standard file names used for staging files.
-from builtins import object
-
-DATAFLOW_SDK_TARBALL_FILE = 'dataflow_python_sdk.tar'
-
-# String constants related to sources framework
-SOURCE_FORMAT = 'custom_source'
-SOURCE_TYPE = 'CustomSourcesType'
-SERIALIZED_SOURCE_KEY = 'serialized_source'
-
-# In a released SDK, container tags are selected based on the SDK version.
-# Unreleased versions use container versions based on values of
-# BEAM_CONTAINER_VERSION and BEAM_FNAPI_CONTAINER_VERSION (see below).
-
-# Update this version to the next version whenever there is a change that will
-# require changes to legacy Dataflow worker execution environment.
-BEAM_CONTAINER_VERSION = 'beam-master-20191029'
-# Update this version to the next version whenever there is a change that
-# requires changes to SDK harness container or SDK harness launcher.
-BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20191029'
-
-# TODO(BEAM-5939): Remove these shared names once Dataflow worker is updated.
 PICKLED_MAIN_SESSION_FILE = 'pickled_main_session'
-STAGED_PIPELINE_FILENAME = 'pipeline.pb'
-STAGED_PIPELINE_URL_METADATA_FIELD = 'pipeline_url'
+STAGED_PIPELINE_FILENAME = "pipeline.pb"
 
 # Package names for different distributions
 BEAM_PACKAGE_NAME = 'apache-beam'
 
 # SDK identifiers for different distributions
 BEAM_SDK_NAME = 'Apache Beam SDK for Python'
-# TODO(BEAM-5393): End duplicated constants (see above).
-
-DATAFLOW_CONTAINER_IMAGE_REPOSITORY = 'gcr.io/cloud-dataflow/v1beta3'
-
-
-class TransformNames(object):
-  """For internal use only; no backwards-compatibility guarantees.
-
-  Transform strings as they are expected in the CloudWorkflow protos.
-  """
-  COLLECTION_TO_SINGLETON = 'CollectionToSingleton'
-  COMBINE = 'CombineValues'
-  CREATE_PCOLLECTION = 'CreateCollection'
-  DO = 'ParallelDo'
-  FLATTEN = 'Flatten'
-  GROUP = 'GroupByKey'
-  READ = 'ParallelRead'
-  WRITE = 'ParallelWrite'
-
-
-class PropertyNames(object):
-  """For internal use only; no backwards-compatibility guarantees.
-
-  Property strings as they are expected in the CloudWorkflow protos.
-  """
-  BIGQUERY_CREATE_DISPOSITION = 'create_disposition'
-  BIGQUERY_DATASET = 'dataset'
-  BIGQUERY_EXPORT_FORMAT = 'bigquery_export_format'
-  BIGQUERY_FLATTEN_RESULTS = 'bigquery_flatten_results'
-  BIGQUERY_KMS_KEY = 'bigquery_kms_key'
-  BIGQUERY_PROJECT = 'project'
-  BIGQUERY_QUERY = 'bigquery_query'
-  BIGQUERY_SCHEMA = 'schema'
-  BIGQUERY_TABLE = 'table'
-  BIGQUERY_USE_LEGACY_SQL = 'bigquery_use_legacy_sql'
-  BIGQUERY_WRITE_DISPOSITION = 'write_disposition'
-  DISPLAY_DATA = 'display_data'
-  ELEMENT = 'element'
-  ELEMENTS = 'elements'
-  ENCODING = 'encoding'
-  FILE_PATTERN = 'filepattern'
-  FILE_NAME_PREFIX = 'filename_prefix'
-  FILE_NAME_SUFFIX = 'filename_suffix'
-  FORMAT = 'format'
-  INPUTS = 'inputs'
-  IMPULSE_ELEMENT = 'impulse_element'
-  NON_PARALLEL_INPUTS = 'non_parallel_inputs'
-  NUM_SHARDS = 'num_shards'
-  OUT = 'out'
-  OUTPUT = 'output'
-  OUTPUT_INFO = 'output_info'
-  OUTPUT_NAME = 'output_name'
-  PARALLEL_INPUT = 'parallel_input'
-  PUBSUB_ID_LABEL = 'pubsub_id_label'
-  PUBSUB_SERIALIZED_ATTRIBUTES_FN = 'pubsub_serialized_attributes_fn'
-  PUBSUB_SUBSCRIPTION = 'pubsub_subscription'
-  PUBSUB_TIMESTAMP_ATTRIBUTE = 'pubsub_timestamp_label'
-  PUBSUB_TOPIC = 'pubsub_topic'
-  RESTRICTION_ENCODING = 'restriction_encoding'
-  SERIALIZED_FN = 'serialized_fn'
-  SHARD_NAME_TEMPLATE = 'shard_template'
-  SOURCE_STEP_INPUT = 'custom_source_step_input'
-  SERIALIZED_TEST_STREAM = 'serialized_test_stream'
-  STEP_NAME = 'step_name'
-  USER_FN = 'user_fn'
-  USER_NAME = 'user_name'
-  VALIDATE_SINK = 'validate_sink'
-  VALIDATE_SOURCE = 'validate_source'
-  VALUE = 'value'
-  WINDOWING_STRATEGY = 'windowing_strategy'

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -123,7 +123,7 @@ class TestStream(PTransform):
   output.
   """
 
-  def __init__(self, coder=coders.FastPrimitivesCoder):
+  def __init__(self, coder=coders.FastPrimitivesCoder()):
     assert coder is not None
     self.coder = coder
     self.current_watermark = timestamp.MIN_TIMESTAMP


### PR DESCRIPTION
Adds TestStream support for the DataflowRunner by converting the TestStream PTransform into a TestStreamPayload that is then handled by a corresponding read operation.

I also fixed a few lint errors in nearby code and fixed TestStream's coder, which was set to the class and not an instance of the class (it looks like no other code is actually using this coder, so that's why it wasn't detected).

R: @lukecwik

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
