### PR TITLE
[BEAM-8590] Support unsubscripted native types

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -61,7 +61,10 @@ def _get_args(typ):
     # __union_params__ argument respectively.
     if (3, 0, 0) <= sys.version_info[0:3] < (3, 5, 3):
       if getattr(typ, '__tuple_params__', None) is not None:
-        return typ.__tuple_params__
+        if typ.__tuple_use_ellipsis__:
+          return typ.__tuple_params__ + (Ellipsis,)
+        else:
+          return typ.__tuple_params__
       elif getattr(typ, '__union_params__', None) is not None:
         return typ.__union_params__
     return ()

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -98,11 +98,6 @@ def _match_issubclass(match_against):
   return lambda user_type: _safe_issubclass(user_type, match_against)
 
 
-def _match_same_type(match_against):
-  # For types that can't be compared with isinstance or _safe_issubclass.
-  return lambda user_type: type(user_type) == type(match_against)
-
-
 def _match_is_exactly_mapping(user_type):
   # Avoid unintentionally catching all subtypes (e.g. strings and mappings).
   if sys.version_info < (3, 7):

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -26,7 +26,6 @@ import logging
 import sys
 import typing
 from builtins import next
-from builtins import range
 
 from apache_beam.typehints import typehints
 
@@ -41,54 +40,31 @@ _TypeMapEntry = collections.namedtuple(
     '_TypeMapEntry', ['match', 'arity', 'beam_type'])
 
 
-def _get_compatible_args(typ):
-  if isinstance(typ, typing.TypeVar):
-    return (typ.__name__,)
-  # On Python versions < 3.5.3, the Tuple and Union type from typing do
-  # not have an __args__ attribute, but a __tuple_params__, and a
-  # __union_params__ argument respectively.
-  if (3, 0, 0) <= sys.version_info[0:3] < (3, 5, 3):
-    if getattr(typ, '__tuple_params__', None) is not None:
-      if typ.__tuple_use_ellipsis__:
-        return typ.__tuple_params__ + (Ellipsis,)
-      else:
-        return typ.__tuple_params__
-    elif getattr(typ, '__union_params__', None) is not None:
-      return typ.__union_params__
-  return None
-
-
 def _get_args(typ):
-  """Returns the index-th argument to the given type."""
+  """Returns a list of arguments to the given type.
+
+  Args:
+    typ: A typing module typing type.
+
+  Returns:
+    A tuple of args.
+  """
   try:
+    if typ.__args__ is None:
+      return ()
     return typ.__args__
   except AttributeError:
-    compatible_args = _get_compatible_args(typ)
-    if compatible_args is None:
-      raise
-    return compatible_args
-
-
-def _get_arg(typ, index):
-  """Returns the index-th argument to the given type."""
-  try:
-    return typ.__args__[index]
-  except AttributeError:
-    compatible_args = _get_compatible_args(typ)
-    if compatible_args is None:
-      raise
-    return compatible_args[index]
-
-
-def _len_arg(typ):
-  """Returns the length of the arguments to the given type."""
-  try:
-    return len(typ.__args__)
-  except AttributeError:
-    compatible_args = _get_compatible_args(typ)
-    if compatible_args is None:
-      return 0
-    return len(compatible_args)
+    if isinstance(typ, typing.TypeVar):
+      return (typ.__name__,)
+    # On Python versions < 3.5.3, the Tuple and Union type from typing do
+    # not have an __args__ attribute, but a __tuple_params__, and a
+    # __union_params__ argument respectively.
+    if (3, 0, 0) <= sys.version_info[0:3] < (3, 5, 3):
+      if getattr(typ, '__tuple_params__', None) is not None:
+        return typ.__tuple_params__
+      elif getattr(typ, '__union_params__', None) is not None:
+        return typ.__union_params__
+    return ()
 
 
 def _safe_issubclass(derived, parent):
@@ -134,6 +110,8 @@ def _match_is_exactly_mapping(user_type):
 
 
 def _match_is_exactly_iterable(user_type):
+  if user_type is typing.Iterable:
+    return True
   # Avoid unintentionally catching all subtypes (e.g. strings and mappings).
   if sys.version_info < (3, 7):
     expected_origin = typing.Iterable
@@ -269,14 +247,27 @@ def convert_to_beam_type(typ):
     _LOGGER.info('Using Any for unsupported type: %s', typ)
     return typehints.Any
 
-  if matched_entry.arity == -1:
-    arity = _len_arg(typ)
+  args = _get_args(typ)
+  len_args = len(args)
+  if len_args == 0 and len_args != matched_entry.arity:
+    arity = matched_entry.arity
+    # Handle unsubscripted types.
+    if _match_issubclass(typing.Tuple)(typ):
+      args = (typehints.Any, Ellipsis)
+    elif _match_is_union(typ):
+      raise ValueError('Unsupported Union with no arguments.')
+    elif _match_issubclass(typing.Generator)(typ):
+      raise ValueError('Unsupported Generator with no arguments.')
+    else:
+      args = (typehints.Any,) * arity
+  elif matched_entry.arity == -1:
+    arity = len_args
   else:
     arity = matched_entry.arity
-    if _len_arg(typ) != arity:
+    if len_args != arity:
       raise ValueError('expecting type %s to have arity %d, had arity %d '
-                       'instead' % (str(typ), arity, _len_arg(typ)))
-  typs = [convert_to_beam_type(_get_arg(typ, i)) for i in range(arity)]
+                       'instead' % (str(typ), arity, len_args))
+  typs = convert_to_beam_types(args)
   if arity == 0:
     # Nullary types (e.g. Any) don't accept empty tuples as arguments.
     return matched_entry.beam_type

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -117,6 +117,38 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
         typehints.List[typing.Dict[int, str]],
         typehints.List[typehints.Dict[int, str]])
 
+  def test_convert_bare_types(self):
+    # Conversions for unsubscripted types that have implicit subscripts.
+    test_cases = [
+        ('bare list', typing.List, typehints.List[typehints.Any]),
+        ('bare dict', typing.Dict,
+         typehints.Dict[typehints.Any, typehints.Any]),
+        ('bare tuple', typing.Tuple, typehints.Tuple[typehints.Any, ...]),
+        ('bare set', typing.Set, typehints.Set[typehints.Any]),
+        ('bare iterator', typing.Iterator, typehints.Iterator[typehints.Any]),
+        ('bare iterable', typing.Iterable, typehints.Iterable[typehints.Any]),
+        ('nested bare', typing.Tuple[typing.Iterator],
+         typehints.Tuple[typehints.Iterator[typehints.Any]]),
+    ]
+    for test_case in test_cases:
+      description = test_case[0]
+      typing_type = test_case[1]
+      expected_beam_type = test_case[2]
+      converted_beam_type = convert_to_beam_type(typing_type)
+      self.assertEqual(expected_beam_type, converted_beam_type, description)
+
+  def test_convert_bare_types_fail(self):
+    # These conversions should fail.
+    test_cases = [
+        ('bare union', typing.Union),
+        ('bare generator', typing.Generator),
+    ]
+    for test_case in test_cases:
+      description = test_case[0]
+      typing_type = test_case[1]
+      with self.assertRaises(ValueError, msg=description):
+        convert_to_beam_type(typing_type)
+
   def test_convert_to_beam_types(self):
     typing_types = [bytes, typing.List[bytes],
                     typing.List[typing.Tuple[bytes, int]],

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -177,11 +177,11 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
 
   def test_is_any(self):
     test_cases = [
-      (True, typing.Any),
-      (False, typing.List[int]),
-      (False, typing.Union),
-      (False, 1),
-      (False, 'a'),
+        (True, typing.Any),
+        (False, typing.List[int]),
+        (False, typing.Union),
+        (False, 1),
+        (False, 'a'),
     ]
     for expected, typ in test_cases:
       self.assertEqual(expected, is_Any(typ), msg='%s' % typ)


### PR DESCRIPTION
Missing args are filled in with type variables, following the defaults in Python 3.7.

For instance:
```py
>>> typing.Dict.__args__
(~KT, ~VT)
>>> typing.List.__args__
(~T,)
```

So a bare `typing.List` type hint will be converted to `typehints.List[typehints.TypeVariable('T')]`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
