### PR TITLE
WIP: Deprecate TestPipelineOptions

### DIFF
--- a/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.examples;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.ArrayList;
@@ -28,7 +29,6 @@ import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.examples.common.ExampleUtils;
 import org.apache.beam.examples.common.WriteOneFilePerWindow.PerWindowFiles;
-import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.FileBasedSink;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
@@ -73,6 +73,10 @@ public class WindowedWordCountIT {
       FluentBackoff.DEFAULT
           .withInitialBackoff(DEFAULT_SLEEP_DURATION)
           .withMaxRetries(MAX_READ_RETRIES);
+
+  public static WordCountsMatcher containsWordCounts(SortedMap<String, Long> expectedWordCounts) {
+    return new WordCountsMatcher(expectedWordCounts);
+  }
 
   /** Options for the {@link WindowedWordCount} Integration Test. */
   public interface WindowedWordCountITOptions
@@ -183,30 +187,27 @@ public class WindowedWordCountIT {
       }
     }
 
-    options.setOnSuccessMatcher(new WordCountsMatcher(expectedWordCounts, expectedOutputFiles));
-
     WindowedWordCount.runWindowedWordCount(options);
+
+    assertThat(expectedOutputFiles, containsWordCounts(expectedWordCounts));
   }
 
   /**
    * A matcher that bakes in expected word counts, so they can be read directly via some other
    * mechanism, and compares a sharded output file with the result.
    */
-  private static class WordCountsMatcher extends TypeSafeMatcher<PipelineResult>
-      implements SerializableMatcher<PipelineResult> {
+  private static class WordCountsMatcher extends TypeSafeMatcher<List<ShardedFile>>
+      implements SerializableMatcher<List<ShardedFile>> {
 
     private final SortedMap<String, Long> expectedWordCounts;
-    private final List<ShardedFile> outputFiles;
     private SortedMap<String, Long> actualCounts;
 
-    public WordCountsMatcher(
-        SortedMap<String, Long> expectedWordCounts, List<ShardedFile> outputFiles) {
+    private WordCountsMatcher(SortedMap<String, Long> expectedWordCounts) {
       this.expectedWordCounts = expectedWordCounts;
-      this.outputFiles = outputFiles;
     }
 
     @Override
-    public boolean matchesSafely(PipelineResult pipelineResult) {
+    public boolean matchesSafely(List<ShardedFile> outputFiles) {
       try {
         // Load output data
         List<String> outputLines = new ArrayList<>();
@@ -238,7 +239,7 @@ public class WindowedWordCountIT {
     }
 
     @Override
-    public void describeMismatchSafely(PipelineResult pResult, Description description) {
+    public void describeMismatchSafely(List<ShardedFile> shardedFiles, Description description) {
       equalTo(expectedWordCounts).describeMismatch(actualCounts, description);
     }
   }

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
@@ -17,14 +17,17 @@
  */
 package org.apache.beam.examples;
 
+import static org.apache.beam.sdk.testing.FileChecksumMatcher.fileContentsHaveChecksum;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.util.Date;
 import org.apache.beam.examples.WordCount.WordCountOptions;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.testing.FileChecksumMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.apache.beam.sdk.util.NumberedShardedFile;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,9 +66,9 @@ public class WordCountIT {
             .resolve("output", StandardResolveOptions.RESOLVE_DIRECTORY)
             .resolve("results", StandardResolveOptions.RESOLVE_FILE)
             .toString());
-    options.setOnSuccessMatcher(
-        new FileChecksumMatcher(DEFAULT_OUTPUT_CHECKSUM, options.getOutput() + "*-of-*"));
-
     WordCount.runWordCount(options);
+    assertThat(
+        new NumberedShardedFile(options.getOutput() + "*-of-*"),
+        fileContentsHaveChecksum(DEFAULT_OUTPUT_CHECKSUM));
   }
 }

--- a/examples/java/src/test/java/org/apache/beam/examples/complete/TfIdfIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/TfIdfIT.java
@@ -17,15 +17,18 @@
  */
 package org.apache.beam.examples.complete;
 
+import static org.apache.beam.sdk.testing.FileChecksumMatcher.fileContentsHaveChecksum;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.util.Date;
 import java.util.regex.Pattern;
 import org.apache.beam.examples.complete.TfIdf.Options;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.testing.FileChecksumMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.apache.beam.sdk.util.NumberedShardedFile;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,10 +67,10 @@ public class TfIdfIT {
             .resolve("output", StandardResolveOptions.RESOLVE_DIRECTORY)
             .resolve("results", StandardResolveOptions.RESOLVE_FILE)
             .toString());
-    options.setOnSuccessMatcher(
-        new FileChecksumMatcher(
-            EXPECTED_OUTPUT_CHECKSUM, options.getOutput() + "*-of-*.csv", DEFAULT_SHARD_TEMPLATE));
-
     TfIdf.runTfIdf(options);
+
+    assertThat(
+        new NumberedShardedFile(options.getOutput() + "*-of-*.csv", DEFAULT_SHARD_TEMPLATE),
+        fileContentsHaveChecksum(EXPECTED_OUTPUT_CHECKSUM));
   }
 }

--- a/examples/java/src/test/java/org/apache/beam/examples/complete/TopWikipediaSessionsIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/TopWikipediaSessionsIT.java
@@ -17,13 +17,16 @@
  */
 package org.apache.beam.examples.complete;
 
+import static org.apache.beam.sdk.testing.FileChecksumMatcher.fileContentsHaveChecksum;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.util.Date;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.testing.FileChecksumMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.apache.beam.sdk.util.NumberedShardedFile;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,9 +63,11 @@ public class TopWikipediaSessionsIT {
             .resolve("output", StandardResolveOptions.RESOLVE_DIRECTORY)
             .resolve("results", StandardResolveOptions.RESOLVE_FILE)
             .toString());
-    options.setOnSuccessMatcher(
-        new FileChecksumMatcher(DEFAULT_OUTPUT_CHECKSUM, options.getOutput() + "*-of-*"));
 
     TopWikipediaSessions.run(options);
+
+    assertThat(
+        new NumberedShardedFile(options.getOutput() + "*-of-*"),
+        fileContentsHaveChecksum(DEFAULT_OUTPUT_CHECKSUM));
   }
 }

--- a/examples/java/src/test/java/org/apache/beam/examples/cookbook/BigQueryTornadoesIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/cookbook/BigQueryTornadoesIT.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.examples.cookbook;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.TypedRead.Method;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryOptions;
 import org.apache.beam.sdk.io.gcp.testing.BigqueryMatcher;
@@ -63,11 +65,11 @@ public class BigQueryTornadoesIT {
 
   private void runE2EBigQueryTornadoesTest(BigQueryTornadoesITOptions options) throws Exception {
     String query = String.format("SELECT month, tornado_count FROM [%s]", options.getOutput());
-    options.setOnSuccessMatcher(
-        new BigqueryMatcher(
-            options.getAppName(), options.getProject(), query, DEFAULT_OUTPUT_CHECKSUM));
-
     BigQueryTornadoes.runBigQueryTornadoes(options);
+
+    assertThat(
+        BigqueryMatcher.createQuery(options.getAppName(), options.getProject(), query),
+        BigqueryMatcher.queryResultHasChecksum(DEFAULT_OUTPUT_CHECKSUM));
   }
 
   @Test

--- a/examples/kotlin/src/test/java/org/apache/beam/examples/WordCountITKotlin.java
+++ b/examples/kotlin/src/test/java/org/apache/beam/examples/WordCountITKotlin.java
@@ -17,15 +17,18 @@
  */
 package org.apache.beam.examples;
 
+import static org.apache.beam.sdk.testing.FileChecksumMatcher.fileContentsHaveChecksum;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.util.Date;
 import org.apache.beam.examples.kotlin.WordCount;
 import org.apache.beam.examples.kotlin.WordCount.WordCountOptions;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.testing.FileChecksumMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.apache.beam.sdk.util.NumberedShardedFile;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,9 +67,11 @@ public class WordCountITKotlin {
             .resolve("output", StandardResolveOptions.RESOLVE_DIRECTORY)
             .resolve("results", StandardResolveOptions.RESOLVE_FILE)
             .toString());
-    options.setOnSuccessMatcher(
-        new FileChecksumMatcher(DEFAULT_OUTPUT_CHECKSUM, options.getOutput() + "*-of-*"));
 
     WordCount.runWordCount(options);
+
+    assertThat(
+        new NumberedShardedFile(options.getOutput() + "*-of-*"),
+        fileContentsHaveChecksum(DEFAULT_OUTPUT_CHECKSUM));
   }
 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkRequiresStableInputTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkRequiresStableInputTest.java
@@ -17,9 +17,9 @@
  */
 package org.apache.beam.runners.flink;
 
+import static org.apache.beam.sdk.testing.FileChecksumMatcher.fileContentsHaveChecksum;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -31,8 +31,6 @@ import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.testing.FileChecksumMatcher;
-import org.apache.beam.sdk.testing.SerializableMatchers;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -167,12 +165,11 @@ public class FlinkRequiresStableInputTest {
     waitUntilJobIsDone();
 
     assertThat(
-        new FlinkRunnerResult(Collections.emptyMap(), 1L),
-        SerializableMatchers.allOf(
-            new FileChecksumMatcher(
-                VALUE_CHECKSUM, new FilePatternMatchingShardedFile(singleOutputPrefix + "*")),
-            new FileChecksumMatcher(
-                VALUE_CHECKSUM, new FilePatternMatchingShardedFile(multiOutputPrefix + "*"))));
+        new FilePatternMatchingShardedFile(singleOutputPrefix + "*"),
+        fileContentsHaveChecksum(VALUE_CHECKSUM));
+    assertThat(
+        new FilePatternMatchingShardedFile(multiOutputPrefix + "*"),
+        fileContentsHaveChecksum(VALUE_CHECKSUM));
   }
 
   private JobGraph getJobGraph(Pipeline pipeline) {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TestDataflowRunner.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.dataflow;
 
 import static org.apache.beam.sdk.options.ExperimentalOptions.hasExperiment;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.api.services.dataflow.model.JobMessage;
 import com.google.api.services.dataflow.model.JobMetrics;
@@ -132,8 +131,6 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
       throw new RuntimeException(errorMessage(job, messageHandler));
     }
 
-    // If there is no reason to immediately fail, run the success matcher.
-    assertThat(job, testPipelineOptions.getOnSuccessMatcher());
     return job;
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TestDataflowRunner.java
@@ -102,8 +102,6 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         job.getJobId(),
         expectedNumberOfAssertions);
 
-    assertThat(job, testPipelineOptions.getOnCreateMatcher());
-
     Boolean jobSuccess;
     Optional<Boolean> allAssertionsPassed;
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/TestDataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/TestDataflowRunnerTest.java
@@ -448,54 +448,6 @@ public class TestDataflowRunnerTest {
   }
 
   @Test
-  public void testBatchOnCreateMatcher() throws Exception {
-    Pipeline p = TestPipeline.create(options);
-    PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
-    PAssert.that(pc).containsInAnyOrder(1, 2, 3);
-
-    final DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.DONE);
-    when(mockJob.getProjectId()).thenReturn("test-project");
-    when(mockJob.getJobId()).thenReturn("test-job");
-
-    DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
-    when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
-    options.as(TestPipelineOptions.class).setOnCreateMatcher(new TestSuccessMatcher(mockJob, 0));
-
-    when(mockClient.getJobMetrics(anyString()))
-        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
-    runner.run(p, mockRunner);
-  }
-
-  @Test
-  public void testStreamingOnCreateMatcher() throws Exception {
-    options.setStreaming(true);
-    Pipeline p = TestPipeline.create(options);
-    PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
-    PAssert.that(pc).containsInAnyOrder(1, 2, 3);
-
-    final DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.DONE);
-    when(mockJob.getProjectId()).thenReturn("test-project");
-    when(mockJob.getJobId()).thenReturn("test-job");
-
-    DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
-    when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
-    options.as(TestPipelineOptions.class).setOnCreateMatcher(new TestSuccessMatcher(mockJob, 0));
-
-    when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
-        .thenReturn(State.DONE);
-
-    when(mockClient.getJobMetrics(anyString()))
-        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
-    runner.run(p, mockRunner);
-  }
-
-  @Test
   public void testBatchOnSuccessMatcherWhenPipelineSucceeds() throws Exception {
     Pipeline p = TestPipeline.create(options);
     PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/TestDataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/TestDataflowRunnerTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -44,23 +43,18 @@ import java.util.Map;
 import org.apache.beam.runners.dataflow.util.MonitoringUtil.JobMessagesHandler;
 import org.apache.beam.runners.dataflow.util.TimeUtil;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.extensions.gcp.storage.NoopPathValidator;
 import org.apache.beam.sdk.extensions.gcp.util.Transport;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
-import org.apache.beam.sdk.testing.SerializableMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.TestPipelineOptions;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Optional;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Before;
@@ -445,159 +439,5 @@ public class TestDataflowRunnerTest {
     when(mockClient.getJobMetrics(anyString())).thenThrow(new IOException());
     TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     assertNull(runner.getJobMetrics(job));
-  }
-
-  @Test
-  public void testBatchOnSuccessMatcherWhenPipelineSucceeds() throws Exception {
-    Pipeline p = TestPipeline.create(options);
-    PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
-    PAssert.that(pc).containsInAnyOrder(1, 2, 3);
-
-    final DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.DONE);
-    when(mockJob.getProjectId()).thenReturn("test-project");
-    when(mockJob.getJobId()).thenReturn("test-job");
-
-    DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
-    when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
-    options.as(TestPipelineOptions.class).setOnSuccessMatcher(new TestSuccessMatcher(mockJob, 1));
-
-    when(mockClient.getJobMetrics(anyString()))
-        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
-    runner.run(p, mockRunner);
-  }
-
-  /**
-   * Tests that when a streaming pipeline terminates and doesn't fail due to {@link PAssert} that
-   * the {@link TestPipelineOptions#setOnSuccessMatcher(SerializableMatcher) on success matcher} is
-   * invoked.
-   */
-  @Test
-  public void testStreamingOnSuccessMatcherWhenPipelineSucceeds() throws Exception {
-    options.setStreaming(true);
-    Pipeline p = TestPipeline.create(options);
-    PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
-    PAssert.that(pc).containsInAnyOrder(1, 2, 3);
-
-    final DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.DONE);
-    when(mockJob.getProjectId()).thenReturn("test-project");
-    when(mockJob.getJobId()).thenReturn("test-job");
-
-    DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
-    when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
-    options.as(TestPipelineOptions.class).setOnSuccessMatcher(new TestSuccessMatcher(mockJob, 1));
-
-    when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
-        .thenReturn(State.DONE);
-
-    when(mockClient.getJobMetrics(anyString()))
-        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
-    runner.run(p, mockRunner);
-  }
-
-  @Test
-  public void testBatchOnSuccessMatcherWhenPipelineFails() throws Exception {
-    Pipeline p = TestPipeline.create(options);
-    PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
-    PAssert.that(pc).containsInAnyOrder(1, 2, 3);
-
-    final DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.FAILED);
-    when(mockJob.getProjectId()).thenReturn("test-project");
-    when(mockJob.getJobId()).thenReturn("test-job");
-
-    DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
-    when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
-    options.as(TestPipelineOptions.class).setOnSuccessMatcher(new TestFailureMatcher());
-
-    when(mockClient.getJobMetrics(anyString()))
-        .thenReturn(generateMockMetricResponse(false /* success */, true /* tentative */));
-    try {
-      runner.run(p, mockRunner);
-    } catch (AssertionError expected) {
-      verify(mockJob, Mockito.times(1))
-          .waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class));
-      return;
-    }
-    fail("Expected an exception on pipeline failure.");
-  }
-
-  /**
-   * Tests that when a streaming pipeline terminates in FAIL that the {@link
-   * TestPipelineOptions#setOnSuccessMatcher(SerializableMatcher) on success matcher} is not
-   * invoked.
-   */
-  @Test
-  public void testStreamingOnSuccessMatcherWhenPipelineFails() throws Exception {
-    options.setStreaming(true);
-    Pipeline p = TestPipeline.create(options);
-    PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
-    PAssert.that(pc).containsInAnyOrder(1, 2, 3);
-
-    final DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.FAILED);
-    when(mockJob.getProjectId()).thenReturn("test-project");
-    when(mockJob.getJobId()).thenReturn("test-job");
-
-    DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
-    when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
-    options.as(TestPipelineOptions.class).setOnSuccessMatcher(new TestFailureMatcher());
-
-    when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
-        .thenReturn(State.FAILED);
-
-    expectedException.expect(RuntimeException.class);
-    runner.run(p, mockRunner);
-    // If the onSuccessMatcher were invoked, it would have crashed here with AssertionError
-  }
-
-  static class TestSuccessMatcher extends BaseMatcher<PipelineResult>
-      implements SerializableMatcher<PipelineResult> {
-    private final transient DataflowPipelineJob mockJob;
-    private final int called;
-
-    public TestSuccessMatcher(DataflowPipelineJob job, int times) {
-      this.mockJob = job;
-      this.called = times;
-    }
-
-    @Override
-    public boolean matches(Object o) {
-      if (!(o instanceof PipelineResult)) {
-        fail(String.format("Expected PipelineResult but received %s", o));
-      }
-      try {
-        verify(mockJob, Mockito.times(called))
-            .waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class));
-      } catch (IOException | InterruptedException e) {
-        throw new AssertionError(e);
-      }
-      assertSame(mockJob, o);
-      return true;
-    }
-
-    @Override
-    public void describeTo(Description description) {}
-  }
-
-  static class TestFailureMatcher extends BaseMatcher<PipelineResult>
-      implements SerializableMatcher<PipelineResult> {
-    @Override
-    public boolean matches(Object o) {
-      fail("OnSuccessMatcher should not be called on pipeline failure.");
-      return false;
-    }
-
-    @Override
-    public void describeTo(Description description) {}
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
@@ -120,8 +120,6 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
           String.format("Finish state %s is not allowed.", finishState),
           finishState,
           is(PipelineResult.State.DONE));
-      // assert via matchers.
-      assertThat(result, testSparkOptions.getOnSuccessMatcher());
     }
     return result;
   }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
@@ -121,7 +121,6 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
           finishState,
           is(PipelineResult.State.DONE));
       // assert via matchers.
-      assertThat(result, testSparkOptions.getOnCreateMatcher());
       assertThat(result, testSparkOptions.getOnSuccessMatcher());
     }
     return result;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/FileChecksumMatcher.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/FileChecksumMatcher.java
@@ -18,17 +18,12 @@
 package org.apache.beam.sdk.testing;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
-import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.util.FluentBackoff;
-import org.apache.beam.sdk.util.NumberedShardedFile;
 import org.apache.beam.sdk.util.ShardedFile;
 import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
@@ -41,25 +36,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Matcher to verify file checksum in E2E test.
+ * Matcher to verify checksum of the contents of an {@link ShardedFile} in E2E test.
  *
  * <p>For example:
  *
  * <pre>{@code
- * assertThat(job, new FileChecksumMatcher(checksumString, filePath));
+ * assertThat(new NumberedShardedFile(filePath), fileContentsHaveChecksum(checksumString));
  * }</pre>
  *
  * or
  *
  * <pre>{@code
- * assertThat(job, new FileChecksumMatcher(checksumString, filePath, shardTemplate));
+ * assertThat(new NumberedShardedFile(filePath, shardTemplate), fileContentsHaveChecksum(checksumString));
  * }</pre>
  *
  * <p>Checksum of outputs is generated based on SHA-1 algorithm. If output file is empty, SHA-1 hash
  * of empty string (da39a3ee5e6b4b0d3255bfef95601890afd80709) is used as expected.
  */
-public class FileChecksumMatcher extends TypeSafeMatcher<PipelineResult>
-    implements SerializableMatcher<PipelineResult> {
+public class FileChecksumMatcher extends TypeSafeMatcher<ShardedFile>
+    implements SerializableMatcher<ShardedFile> {
 
   private static final Logger LOG = LoggerFactory.getLogger(FileChecksumMatcher.class);
 
@@ -70,82 +65,39 @@ public class FileChecksumMatcher extends TypeSafeMatcher<PipelineResult>
           .withInitialBackoff(DEFAULT_SLEEP_DURATION)
           .withMaxRetries(MAX_READ_RETRIES);
 
-  private static final Pattern DEFAULT_SHARD_TEMPLATE =
-      Pattern.compile("(?x) \\S* (?<shardnum> \\d+) -of- (?<numshards> \\d+)");
-
   private final String expectedChecksum;
-  private final ShardedFile shardedFile;
+  private String actualChecksum;
 
-  /** Access via {@link #getActualChecksum()}. */
-  @Nullable private String actualChecksum;
-
-  /**
-   * Constructor that uses default shard template.
-   *
-   * @param checksum expected checksum string used to verify file content.
-   * @param filePath path of files that's to be verified.
-   */
-  public FileChecksumMatcher(String checksum, String filePath) {
-    this(checksum, filePath, DEFAULT_SHARD_TEMPLATE);
-  }
-
-  /**
-   * Constructor using a custom shard template.
-   *
-   * @param checksum expected checksum string used to verify file content.
-   * @param filePath path of files that's to be verified.
-   * @param shardTemplate template of shard name to parse out the total number of shards which is
-   *     used in I/O retry to avoid inconsistency of filesystem. Customized template should assign
-   *     name "numshards" to capturing group - total shard number.
-   */
-  public FileChecksumMatcher(String checksum, String filePath, Pattern shardTemplate) {
+  private FileChecksumMatcher(String checksum) {
     checkArgument(
         !Strings.isNullOrEmpty(checksum), "Expected valid checksum, but received %s", checksum);
-    checkArgument(
-        !Strings.isNullOrEmpty(filePath), "Expected valid file path, but received %s", filePath);
-    checkNotNull(
-        shardTemplate,
-        "Expected non-null shard pattern. "
-            + "Please call the other constructor to use default pattern: %s",
-        DEFAULT_SHARD_TEMPLATE);
-
     this.expectedChecksum = checksum;
-    this.shardedFile = new NumberedShardedFile(filePath, shardTemplate);
   }
 
-  /**
-   * Constructor using an entirely custom {@link ShardedFile} implementation.
-   *
-   * <p>For internal use only.
-   */
-  public FileChecksumMatcher(String expectedChecksum, ShardedFile shardedFile) {
-    this.expectedChecksum = expectedChecksum;
-    this.shardedFile = shardedFile;
+  public static FileChecksumMatcher fileContentsHaveChecksum(String checksum) {
+    return new FileChecksumMatcher(checksum);
   }
 
   @Override
-  public boolean matchesSafely(PipelineResult pipelineResult) {
-    return getActualChecksum().equals(expectedChecksum);
+  public boolean matchesSafely(ShardedFile shardedFile) {
+    return getActualChecksum(shardedFile).equals(expectedChecksum);
   }
 
   /**
-   * Computes a checksum of the sharded file specified in the constructor. Not safe to call until
-   * the writing is complete.
+   * Computes a checksum of the given sharded file. Not safe to call until the writing is complete.
    */
-  private String getActualChecksum() {
-    if (actualChecksum == null) {
-      // Load output data
-      List<String> outputs;
-      try {
-        outputs = shardedFile.readFilesWithRetries(Sleeper.DEFAULT, BACK_OFF_FACTORY.backoff());
-      } catch (Exception e) {
-        throw new RuntimeException(String.format("Failed to read from: %s", shardedFile), e);
-      }
-
-      // Verify outputs. Checksum is computed using SHA-1 algorithm
-      actualChecksum = computeHash(outputs);
-      LOG.debug("Generated checksum: {}", actualChecksum);
+  private String getActualChecksum(ShardedFile shardedFile) {
+    // Load output data
+    List<String> outputs;
+    try {
+      outputs = shardedFile.readFilesWithRetries(Sleeper.DEFAULT, BACK_OFF_FACTORY.backoff());
+    } catch (Exception e) {
+      throw new RuntimeException(String.format("Failed to read from: %s", shardedFile), e);
     }
+
+    // Verify outputs. Checksum is computed using SHA-1 algorithm
+    actualChecksum = computeHash(outputs);
+    LOG.debug("Generated checksum: {}", actualChecksum);
 
     return actualChecksum;
   }
@@ -168,7 +120,7 @@ public class FileChecksumMatcher extends TypeSafeMatcher<PipelineResult>
   }
 
   @Override
-  public void describeMismatchSafely(PipelineResult pResult, Description description) {
-    description.appendText("was (").appendText(getActualChecksum()).appendText(")");
+  public void describeMismatchSafely(ShardedFile shardedFile, Description description) {
+    description.appendText("was (").appendText(actualChecksum).appendText(")");
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipelineOptions.java
@@ -50,10 +50,18 @@ public interface TestPipelineOptions extends PipelineOptions {
   @Deprecated
   void setOnCreateMatcher(SerializableMatcher<PipelineResult> value);
 
+  @Deprecated
   @Default.InstanceFactory(AlwaysPassMatcherFactory.class)
   @JsonIgnore
   SerializableMatcher<PipelineResult> getOnSuccessMatcher();
 
+  /**
+   * Checks the matcher {@code value} when a pipeline finishes successfully.
+   *
+   * @deprecated This feature has limited runner support and will be removed in a future release,
+   *     users should prefer standard assertions instead.
+   */
+  @Deprecated
   void setOnSuccessMatcher(SerializableMatcher<PipelineResult> value);
 
   @Default.Long(10 * 60)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipelineOptions.java
@@ -36,10 +36,18 @@ public interface TestPipelineOptions extends PipelineOptions {
 
   void setTempRoot(String value);
 
+  @Deprecated
   @Default.InstanceFactory(AlwaysPassMatcherFactory.class)
   @JsonIgnore
   SerializableMatcher<PipelineResult> getOnCreateMatcher();
 
+  /**
+   * Checks the matcher {@code value} when a pipeline is created.
+   *
+   * @deprecated This feature has limited runner support and will be removed in a future release,
+   *     users should prefer standard assertions instead.
+   */
+  @Deprecated
   void setOnCreateMatcher(SerializableMatcher<PipelineResult> value);
 
   @Default.InstanceFactory(AlwaysPassMatcherFactory.class)

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsKmsKeyIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsKmsKeyIT.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.gcp.storage;
 
+import static org.apache.beam.sdk.testing.FileChecksumMatcher.fileContentsHaveChecksum;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -36,10 +37,10 @@ import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.testing.FileChecksumMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
 import org.apache.beam.sdk.testing.UsesKms;
+import org.apache.beam.sdk.util.NumberedShardedFile;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -87,7 +88,7 @@ public class GcsKmsKeyIT {
     assertThat(state, equalTo(State.DONE));
 
     String filePattern = filenamePrefix + "*-of-*";
-    assertThat(result, new FileChecksumMatcher(EXPECTED_CHECKSUM, filePattern));
+    assertThat(new NumberedShardedFile(filePattern), fileContentsHaveChecksum(EXPECTED_CHECKSUM));
 
     // Verify objects have KMS key set.
     try {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/testing/BigqueryMatcherTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/testing/BigqueryMatcherTest.java
@@ -26,7 +26,6 @@ import com.google.api.services.bigquery.model.QueryResponse;
 import com.google.api.services.bigquery.model.TableCell;
 import com.google.api.services.bigquery.model.TableRow;
 import java.math.BigInteger;
-import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +48,6 @@ public class BigqueryMatcherTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
   @Mock private BigqueryClient mockBigqueryClient;
-  @Mock private PipelineResult mockResult;
 
   @Before
   public void setUp() {
@@ -61,19 +59,16 @@ public class BigqueryMatcherTest {
   @Test
   public void testBigqueryMatcherThatSucceeds() throws Exception {
     BigqueryMatcher matcher =
-        spy(
-            new BigqueryMatcher(
-                appName, projectId, query, "9bb47f5c90d2a99cad526453dff5ed5ec74650dc"));
+        spy(BigqueryMatcher.queryResultHasChecksum("9bb47f5c90d2a99cad526453dff5ed5ec74650dc"));
     when(mockBigqueryClient.queryWithRetries(anyString(), anyString()))
         .thenReturn(createResponseContainingTestData());
 
-    assertThat(mockResult, matcher);
+    assertThat(BigqueryMatcher.createQuery(appName, projectId, query), matcher);
   }
 
   @Test
   public void testBigqueryMatcherFailsForChecksumMismatch() throws Exception {
-    BigqueryMatcher matcher =
-        spy(new BigqueryMatcher(appName, projectId, query, "incorrect-checksum"));
+    BigqueryMatcher matcher = spy(BigqueryMatcher.queryResultHasChecksum("incorrect-checksum"));
 
     when(mockBigqueryClient.queryWithRetries(anyString(), anyString()))
         .thenReturn(createResponseContainingTestData());
@@ -82,12 +77,12 @@ public class BigqueryMatcherTest {
     thrown.expectMessage("Total number of rows are: 1");
     thrown.expectMessage("abc");
 
-    assertThat(mockResult, matcher);
+    assertThat(BigqueryMatcher.createQuery(appName, projectId, query), matcher);
   }
 
   @Test
   public void testBigqueryMatcherFailsWhenQueryJobNotComplete() throws Exception {
-    BigqueryMatcher matcher = spy(new BigqueryMatcher(appName, projectId, query, "some-checksum"));
+    BigqueryMatcher matcher = spy(BigqueryMatcher.queryResultHasChecksum("some-checksum"));
     when(mockBigqueryClient.queryWithRetries(anyString(), anyString()))
         .thenReturn(new QueryResponse().setJobComplete(false));
 
@@ -95,7 +90,7 @@ public class BigqueryMatcherTest {
     thrown.expectMessage("The query job hasn't completed.");
     thrown.expectMessage("jobComplete=false");
 
-    assertThat(mockResult, matcher);
+    assertThat(BigqueryMatcher.createQuery(appName, projectId, query), matcher);
   }
 
   private QueryResponse createResponseContainingTestData() {


### PR DESCRIPTION
Removing `OnCreateMatcher` actually turned out to be pretty involved because we have several matchers that are intended to be used in this context and match against `PipelineResult`, even though they're actually checking something else, like file or BQ table contents. Rather than plumbing through the `PipelineResult` just so I could pass one to these matchers to make them happy, I refactored them so that they can actually be used fluently, like 
```java
assertThat(expectedOutputFiles, containsWordCounts(expectedWordCounts));
```
and
```java
assertThat(
    new NumberedShardedFile(options.getOutput() + "*-of-*"),
    fileContentsHaveChecksum(DEFAULT_OUTPUT_CHECKSUM));
```

TODO:
- [x] Deprecate, don't remove
- [ ] Remove usages of `setTempRoot` and deprecate (maybe in a separate PR)
- [ ] Remove usages of `setTestTimeoutSeconds` and deprecate (maybe in a separate PR)


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
