### PR TITLE
[BEAM-7516][BEAM-8823] FnApiRunner works with work queues, and a primitive watermark manager

### DIFF
--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -1105,7 +1105,6 @@ class TextSinkTest(unittest.TestCase):
       self.assertEqual(f.read().splitlines(), header.splitlines())
 
   def test_write_dataflow(self):
-    logging.getLogger().setLevel(logging.DEBUG)
     pipeline = TestPipeline()
     pcoll = pipeline | beam.core.Create(self.lines)
     pcoll | 'Write' >> WriteToText(self.path)  # pylint: disable=expression-not-assigned

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -1105,6 +1105,7 @@ class TextSinkTest(unittest.TestCase):
       self.assertEqual(f.read().splitlines(), header.splitlines())
 
   def test_write_dataflow(self):
+    logging.getLogger().setLevel(logging.DEBUG)
     pipeline = TestPipeline()
     pcoll = pipeline | beam.core.Create(self.lines)
     pcoll | 'Write' >> WriteToText(self.path)  # pylint: disable=expression-not-assigned

--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
@@ -60,18 +60,20 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
     pbegin = pvalue.PBegin(self.pipeline)
     pcoll_read = pbegin | 'read' >> root_read
     pcoll_read | FlatMap(lambda x: x)
-    [] | 'flatten' >> root_flatten
+
+    with self.assertRaises(ValueError):
+      [] | 'flatten' >> root_flatten
 
     self.pipeline.visit(self.visitor)
 
     root_transforms = [t.transform for t in self.visitor.root_transforms]
 
-    self.assertCountEqual(root_transforms, [root_read, root_flatten])
+    self.assertCountEqual(root_transforms, [root_read])
 
     pbegin_consumers = [c.transform
                         for c in self.visitor.value_to_consumers[pbegin]]
     self.assertCountEqual(pbegin_consumers, [root_read])
-    self.assertEqual(len(self.visitor.step_names), 3)
+    self.assertEqual(len(self.visitor.step_names), 2)
 
   def test_side_inputs(self):
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -732,7 +732,7 @@ class FnApiRunner(runner.PipelineRunner):
 
     execution_context = PipelineExecutionContext(stage_context.components,
                                                  stages)
-    execution_context.show()
+    #execution_context.show()
 
     self._enqueue_all_initial_inputs(stages, input_queue_manager)
     try:
@@ -954,14 +954,12 @@ class FnApiRunner(runner.PipelineRunner):
     """TODO(pabloem)"""
     logging.debug('Processing output bundles: %s', output_bundles)
     for (bundle_watermark, buffer_id), data in output_bundles:
-      consumer_stage = execution_context.get_consuming_stage(buffer_id)
-      consumer_transform = execution_context.get_consuming_transform(buffer_id)
+      consumer_stages = execution_context.get_consuming_stages(buffer_id)
+      consumer_transforms = execution_context.get_consuming_transforms(
+          buffer_id)
 
-      consuming_stage_name = (consumer_stage.name if consumer_stage else None)
-      consuming_transform_name = (consumer_transform.unique_name
-                                  if consumer_transform else None)
       kind, _ = split_buffer_id(buffer_id)
-      if not consuming_stage_name or not consuming_transform_name:
+      if not consumer_stages or not consumer_transforms:
         # This means that the PCollection is not consumed by any transforms,
         # and we can discard the elements.
         continue
@@ -970,23 +968,31 @@ class FnApiRunner(runner.PipelineRunner):
         # Empty timer collections should not be rescheduled.
         continue
 
+      consuming_stage_names = [stage.name if stage else None
+                               for stage in consumer_stages]
+      consuming_transform_names = [transform.unique_name if transform else None
+                                   for transform in consumer_transforms]
+
       # In this case, `data` may be an empty buffer, but we still schedule it
       # for execution (unless it's a timer pcollection) because otherwise the
       # watermark for the consumer will not be pushed forward later.
       # As mentioned above, empty timer bundles are not scheduled again,
       # because they hold back the pipeline.
-      stage_watermark_mgr = execution_context.watermark_manager.get_node(
-          consuming_stage_name)
-      stage_input_watermark = stage_watermark_mgr.input_watermark()
-      if stage_input_watermark >= bundle_watermark:
-        logging.debug('Enqueuing bundle output after execution, '
-                      'to be consumed by stage: %s', consuming_stage_name)
-        input_queue_manager.ready_inputs.enque(
-            (consuming_stage_name, {consuming_transform_name: data}))
-      else:
-        input_queue_manager.watermark_pending_inputs.enque(
-            ((consuming_stage_name, bundle_watermark),
-             {consuming_transform_name: data}))
+
+      for consuming_stage_name, consuming_transform_name in zip(
+          consuming_stage_names, consuming_transform_names):
+        stage_watermark_mgr = execution_context.watermark_manager.get_node(
+            consuming_stage_name)
+        stage_input_watermark = stage_watermark_mgr.input_watermark()
+        if stage_input_watermark >= bundle_watermark:
+          logging.debug('Enqueuing bundle output after execution, '
+                        'to be consumed by stage: %s', consuming_stage_name)
+          input_queue_manager.ready_inputs.enque(
+              (consuming_stage_name, {consuming_transform_name: data}))
+        else:
+          input_queue_manager.watermark_pending_inputs.enque(
+              ((consuming_stage_name, bundle_watermark),
+               {consuming_transform_name: data}))
 
   def _run_bundle_multiple_times_for_testing(
       self, worker_handler_list, process_bundle_descriptor, data_input,

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -58,7 +58,7 @@ from apache_beam.portability.api import beam_provision_api_pb2
 from apache_beam.portability.api import beam_provision_api_pb2_grpc
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.portability.api import endpoints_pb2
-from apache_beam.runners import pipeline_context
+from apache_beam.runners.pipeline_context import PipelineContext
 from apache_beam.runners import runner
 from apache_beam.runners.portability import artifact_service
 from apache_beam.runners.portability import fn_api_runner_transforms
@@ -309,6 +309,261 @@ class _WindowGroupingBuffer(object):
       yield encoded_key, encoded_window, output_stream.get()
 
 
+class _FnApiRunnerExecution(object):
+  """Provides a set of utilities for the execution of a pipeline by FnApiRunner.
+
+  This class must not be instantiated. It is meant to provide static utilites.
+  """
+
+  @staticmethod
+  def make_iterable_state_write(worker_handler):
+    def iterable_state_write(values, element_coder_impl):
+      token = unique_name(None, 'iter').encode('ascii')
+      out = create_OutputStream()
+      for element in values:
+        element_coder_impl.encode_to_stream(element, out, True)
+      worker_handler.state.append_raw(
+          beam_fn_api_pb2.StateKey(
+              runner=beam_fn_api_pb2.StateKey.Runner(key=token)),
+          out.get())
+      return token
+    return iterable_state_write
+
+  @staticmethod
+  def make_input_coder_getter(pipeline_context,
+                              process_bundle_descriptor,
+                              safe_coders):
+    def input_coder_getter_impl(transform_id):
+      return pipeline_context.coders[safe_coders[
+        beam_fn_api_pb2.RemoteGrpcPort.FromString(
+            process_bundle_descriptor.transforms[transform_id].spec.payload
+        ).coder_id
+      ]].get_impl()
+    return input_coder_getter_impl
+
+  @staticmethod
+  def make_input_buffer_fetcher(
+      pipeline_context,
+      pcoll_buffers,
+      pipeline_components,
+      safe_coders):
+    # type: (PipelineContext, Dict[str, Union[_ListBuffer, _GroupingBuffer], beam_runner_api_pb2.Components, Dict[str, str]]) -> Callable
+    """Returns a callable to fetch the buffer containing a PCollection to input
+       to a PTransform.
+
+      For grouping-typed operations, we produce a ``_GroupingBuffer``. For
+      others, we produce a ``_ListBuffer``.
+    """
+    def buffer_fetcher(buffer_id):
+      # type: (str) -> Union[_ListBuffer, _GroupingBuffer]
+      kind, name = split_buffer_id(buffer_id)
+      if kind in ('materialize', 'timers'):
+        # If `buffer_id` is not a key in `pcoll_buffers`, it will be added by
+        # the `defaultdict`.
+        return pcoll_buffers[buffer_id]
+      elif kind == 'group':
+        # This is a grouping write, create a grouping buffer if needed.
+        if buffer_id not in pcoll_buffers:
+          original_gbk_transform = name
+          transform_proto = pipeline_components.transforms[
+            original_gbk_transform]
+          input_pcoll = only_element(list(transform_proto.inputs.values()))
+          output_pcoll = only_element(list(transform_proto.outputs.values()))
+          pre_gbk_coder = pipeline_context.coders[safe_coders[
+            pipeline_components.pcollections[input_pcoll].coder_id]]
+          post_gbk_coder = pipeline_context.coders[safe_coders[
+            pipeline_components.pcollections[output_pcoll].coder_id]]
+          windowing_strategy = pipeline_context.windowing_strategies[
+            pipeline_components
+              .pcollections[output_pcoll].windowing_strategy_id]
+          pcoll_buffers[buffer_id] = _GroupingBuffer(
+              pre_gbk_coder, post_gbk_coder, windowing_strategy)
+      else:
+        # These should be the only two identifiers we produce for now,
+        # but special side input writes may go here.
+        raise NotImplementedError(buffer_id)
+      return pcoll_buffers[buffer_id]
+    return buffer_fetcher
+
+  @staticmethod
+  def get_input_operation_name(
+      process_bundle_descriptor, transform_id, input_id):
+    # type: (beam_fn_api_pb2.ProcessBundleDescriptor, str, str) -> str
+    """Returns a callable to find the ID of the data input operation that
+    feeds an input PCollection to a PTransform. """
+    input_pcoll = process_bundle_descriptor.transforms[
+      transform_id].inputs[input_id]
+    for read_id, proto in process_bundle_descriptor.transforms.items():
+      if (proto.spec.urn == bundle_processor.DATA_INPUT_URN
+          and input_pcoll in proto.outputs.values()):
+        return read_id
+    raise RuntimeError(
+        'No IO transform feeds %s' % transform_id)
+
+
+  @staticmethod
+  def _store_side_inputs_in_state(worker_handler,
+      context,
+      pipeline_components,
+      data_side_input,
+      pcoll_buffers,
+      safe_coders):
+    for (transform_id, tag), (buffer_id, si) in data_side_input.items():
+      _, pcoll_id = split_buffer_id(buffer_id)
+      value_coder = context.coders[safe_coders[
+        pipeline_components.pcollections[pcoll_id].coder_id]]
+      elements_by_window = _WindowGroupingBuffer(si, value_coder)
+      for element_data in pcoll_buffers[buffer_id]:
+        elements_by_window.append(element_data)
+      for key, window, elements_data in elements_by_window.encoded_items():
+        state_key = beam_fn_api_pb2.StateKey(
+            multimap_side_input=beam_fn_api_pb2.StateKey.MultimapSideInput(
+                transform_id=transform_id,
+                side_input_id=tag,
+                window=window,
+                key=key))
+        worker_handler.state.append_raw(state_key, elements_data)
+
+  @staticmethod
+  def _collect_written_timers_and_add_to_deferred_inputs(context,
+      pipeline_components,
+      stage,
+      get_buffer_callable,
+      deferred_inputs):
+
+    for transform_id, timer_writes in stage.timer_pcollections:
+
+      # Queue any set timers as new inputs.
+      windowed_timer_coder_impl = context.coders[
+        pipeline_components.pcollections[timer_writes].coder_id].get_impl()
+      written_timers = get_buffer_callable(
+          create_buffer_id(timer_writes, kind='timers'))
+      if written_timers:
+        # Keep only the "last" timer set per key and window.
+        timers_by_key_and_window = {}
+        for elements_data in written_timers:
+          input_stream = create_InputStream(elements_data)
+          while input_stream.size() > 0:
+            windowed_key_timer = windowed_timer_coder_impl.decode_from_stream(
+                input_stream, True)
+            key, _ = windowed_key_timer.value
+            # TODO: Explode and merge windows.
+            assert len(windowed_key_timer.windows) == 1
+            timers_by_key_and_window[
+              key, windowed_key_timer.windows[0]] = windowed_key_timer
+        out = create_OutputStream()
+        for windowed_key_timer in timers_by_key_and_window.values():
+          windowed_timer_coder_impl.encode_to_stream(
+              windowed_key_timer, out, True)
+        deferred_inputs[transform_id] = _ListBuffer([out.get()])
+        written_timers[:] = []
+
+  @staticmethod
+  def _add_residuals_and_channel_splits_to_deferred_inputs(
+      process_bundle_descriptor, splits, get_input_coder_callable,
+      last_sent, deferred_inputs):
+    prev_stops = {}
+    for split in splits:
+      for delayed_application in split.residual_roots:
+
+        input_op_name = _FnApiRunnerExecution.get_input_operation_name(
+            process_bundle_descriptor,
+            delayed_application.application.transform_id,
+            delayed_application.application.input_id)
+
+        deferred_inputs[input_op_name].append(
+            delayed_application.application.element)
+      for channel_split in split.channel_splits:
+        coder_impl = get_input_coder_callable(channel_split.transform_id)
+        # TODO(SDF): This requires determanistic ordering of buffer iteration.
+        # TODO(SDF): The return split is in terms of indices.  Ideally,
+        # a runner could map these back to actual positions to effectively
+        # describe the two "halves" of the now-split range.  Even if we have
+        # to buffer each element we send (or at the very least a bit of
+        # metadata, like position, about each of them) this should be doable
+        # if they're already in memory and we are bounding the buffer size
+        # (e.g. to 10mb plus whatever is eagerly read from the SDK).  In the
+        # case of non-split-points, we can either immediately replay the
+        # "non-split-position" elements or record them as we do the other
+        # delayed applications.
+
+        # Decode and recode to split the encoded buffer by element index.
+        all_elements = list(coder_impl.decode_all(b''.join(last_sent[
+                                                             channel_split.transform_id])))
+        residual_elements = all_elements[
+                            channel_split.first_residual_element : prev_stops.get(
+                                channel_split.transform_id, len(all_elements)) + 1]
+        if residual_elements:
+          deferred_inputs[channel_split.transform_id].append(
+              coder_impl.encode_all(residual_elements))
+        prev_stops[
+          channel_split.transform_id] = channel_split.last_primary_element
+
+  @staticmethod
+  def _extract_stage_data_endpoints(
+      stage, pipeline_components, data_api_service_descriptor, pcoll_buffers):
+    # Returns maps of transform names to PCollection identifiers.
+    # Also mutates IO stages to point to the data ApiServiceDescriptor.
+    data_input = {}
+    data_side_input = {}
+    data_output = {}
+    for transform in stage.transforms:
+      if transform.spec.urn in (bundle_processor.DATA_INPUT_URN,
+                                bundle_processor.DATA_OUTPUT_URN):
+        pcoll_id = transform.spec.payload
+        if transform.spec.urn == bundle_processor.DATA_INPUT_URN:
+          target = transform.unique_name, only_element(transform.outputs)
+          if pcoll_id == fn_api_runner_transforms.IMPULSE_BUFFER:
+            data_input[target] = _ListBuffer([ENCODED_IMPULSE_VALUE])
+          else:
+            data_input[target] = pcoll_buffers[pcoll_id]
+          coder_id = pipeline_components.pcollections[
+            only_element(transform.outputs.values())].coder_id
+        elif transform.spec.urn == bundle_processor.DATA_OUTPUT_URN:
+          target = transform.unique_name, only_element(transform.inputs)
+          data_output[target] = pcoll_id
+          coder_id = pipeline_components.pcollections[
+            only_element(transform.inputs.values())].coder_id
+        else:
+          raise NotImplementedError
+        data_spec = beam_fn_api_pb2.RemoteGrpcPort(coder_id=coder_id)
+        if data_api_service_descriptor:
+          data_spec.api_service_descriptor.url = (
+              data_api_service_descriptor.url)
+        transform.spec.payload = data_spec.SerializeToString()
+      elif transform.spec.urn in fn_api_runner_transforms.PAR_DO_URNS:
+        payload = proto_utils.parse_Bytes(
+            transform.spec.payload, beam_runner_api_pb2.ParDoPayload)
+        for tag, si in payload.side_inputs.items():
+          data_side_input[transform.unique_name, tag] = (
+              create_buffer_id(transform.inputs[tag]), si.access_pattern)
+    return data_input, data_side_input, data_output
+
+
+class _ProcessingQueueManager(object):
+  """Manages the queues for ProcessBundle inputs.
+
+  There are three queues:
+   - ready_inputs_queue(collections.deque). This queue contains input data that
+       is ready to be processed. These are data such as timers past their
+       trigger time, and data to be processed.
+   - processing_time_queue(collections.deque). This queue contains input data
+       that is not yet ready to be processed, and is blocked on the processing
+       time advancing.
+   - event_time_queue(collections.deque). This queue contains input data that is
+       not yet ready to be processed, and is blocked on the watermark advancing.
+
+   # TODO(pabloem, MUST): Document what kind of elements each queue holds.
+  """
+  def __init__(self):
+    self.ready_inputs_queue = collections.deque()
+    self.processing_time_queue = collections.deque()
+    self.event_time_queue = collections.deque()
+
+  def __str__(self):
+    return '_ProcessingQueueManager(%s)' % self.__dict__
+
+
 class FnApiRunner(runner.PipelineRunner):
 
   def __init__(
@@ -325,7 +580,7 @@ class FnApiRunner(runner.PipelineRunner):
       bundle_repeat: replay every bundle this many extra times, for profiling
           and debugging
       use_state_iterables: Intentionally split gbk iterables over state API
-          (for testing)
+          (for testing).
       provision_info: provisioning info to make available to workers, or None
       progress_request_frequency: The frequency (in seconds) that the runner
           waits before requesting progress from the SDK.
@@ -446,6 +701,34 @@ class FnApiRunner(runner.PipelineRunner):
             common_urns.primitives.GROUP_BY_KEY.urn]),
         use_state_iterables=self._use_state_iterables)
 
+  @staticmethod
+  def _enqueue_all_initial_inputs(stages, input_queue_manager):
+    # type: (List[fn_api_runner_transforms.Stage], Dict[str, List[Bytes]], _ProcessingQueueManager) -> None
+    """Put all initial inputs to the pipeline in the input queue."""
+    for stage in stages:
+      data_inputs = {}
+      for transform in stage.transforms:
+        if (transform.spec.urn == bundle_processor.DATA_INPUT_URN and
+            transform.spec.payload == fn_api_runner_transforms.IMPULSE_BUFFER):
+          # If a transform is a DATA_INPUT or DATA_OUTPUT transform, it will
+          # receive data from / deliver data to the runner.
+          # For data input transforms, they only have one input.
+          # We map the transform name to a buffer containing the
+          # encoded input.
+          data_inputs[transform.unique_name] = _ListBuffer(
+              [ENCODED_IMPULSE_VALUE])
+        elif transform.spec.urn in fn_api_runner_transforms.PAR_DO_URNS:
+          payload = proto_utils.parse_Bytes(
+              transform.spec.payload, beam_runner_api_pb2.ParDoPayload)
+          if payload.side_inputs:
+            # If the stage needs side inputs, then it's not ready to be
+            # executed.
+            data_inputs = {}
+            break
+      if data_inputs:
+        # We push the data inputs, along with the name of the consuming stage.
+        input_queue_manager.ready_inputs_queue.append((stage.name, data_inputs))
+
   def run_stages(self, stage_context, stages):
     """Run a list of topologically-sorted stages in batch mode.
 
@@ -455,12 +738,17 @@ class FnApiRunner(runner.PipelineRunner):
     """
     worker_handler_manager = WorkerHandlerManager(
         stage_context.components.environments, self._provision_info)
+    input_queue_manager = _ProcessingQueueManager()
+    pcoll_buffers = collections.defaultdict(_ListBuffer)
     metrics_by_stage = {}
     monitoring_infos_by_stage = {}
 
+    # TODO(pabloem, MUST): Pipeline should work by processing successive inputs
+    # rather than by processing successive stages.
+    self._enqueue_all_initial_inputs(stages, input_queue_manager)
+
     try:
       with self.maybe_profile():
-        pcoll_buffers = collections.defaultdict(_ListBuffer)
         for stage in stages:
           stage_results = self._run_stage(
               worker_handler_manager.get_worker_handlers,
@@ -475,29 +763,6 @@ class FnApiRunner(runner.PipelineRunner):
       worker_handler_manager.close_all()
     return RunnerResult(
         runner.PipelineState.DONE, monitoring_infos_by_stage, metrics_by_stage)
-
-  def _store_side_inputs_in_state(self,
-                                  worker_handler,
-                                  context,
-                                  pipeline_components,
-                                  data_side_input,
-                                  pcoll_buffers,
-                                  safe_coders):
-    for (transform_id, tag), (buffer_id, si) in data_side_input.items():
-      _, pcoll_id = split_buffer_id(buffer_id)
-      value_coder = context.coders[safe_coders[
-          pipeline_components.pcollections[pcoll_id].coder_id]]
-      elements_by_window = _WindowGroupingBuffer(si, value_coder)
-      for element_data in pcoll_buffers[buffer_id]:
-        elements_by_window.append(element_data)
-      for key, window, elements_data in elements_by_window.encoded_items():
-        state_key = beam_fn_api_pb2.StateKey(
-            multimap_side_input=beam_fn_api_pb2.StateKey.MultimapSideInput(
-                transform_id=transform_id,
-                side_input_id=tag,
-                window=window,
-                key=key))
-        worker_handler.state.append_raw(state_key, elements_data)
 
   def _run_bundle_multiple_times_for_testing(
       self, worker_handler_list, process_bundle_descriptor, data_input,
@@ -519,117 +784,6 @@ class FnApiRunner(runner.PipelineRunner):
       finally:
         worker_handler.state.restore()
 
-  def _collect_written_timers_and_add_to_deferred_inputs(self,
-                                                         context,
-                                                         pipeline_components,
-                                                         stage,
-                                                         get_buffer_callable,
-                                                         deferred_inputs):
-
-    for transform_id, timer_writes in stage.timer_pcollections:
-
-      # Queue any set timers as new inputs.
-      windowed_timer_coder_impl = context.coders[
-          pipeline_components.pcollections[timer_writes].coder_id].get_impl()
-      written_timers = get_buffer_callable(
-          create_buffer_id(timer_writes, kind='timers'))
-      if written_timers:
-        # Keep only the "last" timer set per key and window.
-        timers_by_key_and_window = {}
-        for elements_data in written_timers:
-          input_stream = create_InputStream(elements_data)
-          while input_stream.size() > 0:
-            windowed_key_timer = windowed_timer_coder_impl.decode_from_stream(
-                input_stream, True)
-            key, _ = windowed_key_timer.value
-            # TODO: Explode and merge windows.
-            assert len(windowed_key_timer.windows) == 1
-            timers_by_key_and_window[
-                key, windowed_key_timer.windows[0]] = windowed_key_timer
-        out = create_OutputStream()
-        for windowed_key_timer in timers_by_key_and_window.values():
-          windowed_timer_coder_impl.encode_to_stream(
-              windowed_key_timer, out, True)
-        deferred_inputs[transform_id] = _ListBuffer([out.get()])
-        written_timers[:] = []
-
-  def _add_residuals_and_channel_splits_to_deferred_inputs(
-      self, splits, get_input_coder_callable,
-      input_for_callable, last_sent, deferred_inputs):
-    prev_stops = {}
-    for split in splits:
-      for delayed_application in split.residual_roots:
-        deferred_inputs[
-            input_for_callable(
-                delayed_application.application.transform_id,
-                delayed_application.application.input_id)
-        ].append(delayed_application.application.element)
-      for channel_split in split.channel_splits:
-        coder_impl = get_input_coder_callable(channel_split.transform_id)
-        # TODO(SDF): This requires determanistic ordering of buffer iteration.
-        # TODO(SDF): The return split is in terms of indices.  Ideally,
-        # a runner could map these back to actual positions to effectively
-        # describe the two "halves" of the now-split range.  Even if we have
-        # to buffer each element we send (or at the very least a bit of
-        # metadata, like position, about each of them) this should be doable
-        # if they're already in memory and we are bounding the buffer size
-        # (e.g. to 10mb plus whatever is eagerly read from the SDK).  In the
-        # case of non-split-points, we can either immediately replay the
-        # "non-split-position" elements or record them as we do the other
-        # delayed applications.
-
-        # Decode and recode to split the encoded buffer by element index.
-        all_elements = list(coder_impl.decode_all(b''.join(last_sent[
-            channel_split.transform_id])))
-        residual_elements = all_elements[
-            channel_split.first_residual_element : prev_stops.get(
-                channel_split.transform_id, len(all_elements)) + 1]
-        if residual_elements:
-          deferred_inputs[channel_split.transform_id].append(
-              coder_impl.encode_all(residual_elements))
-        prev_stops[
-            channel_split.transform_id] = channel_split.last_primary_element
-
-  @staticmethod
-  def _extract_stage_data_endpoints(
-      stage, pipeline_components, data_api_service_descriptor, pcoll_buffers):
-    # Returns maps of transform names to PCollection identifiers.
-    # Also mutates IO stages to point to the data ApiServiceDescriptor.
-    data_input = {}
-    data_side_input = {}
-    data_output = {}
-    for transform in stage.transforms:
-      if transform.spec.urn in (bundle_processor.DATA_INPUT_URN,
-                                bundle_processor.DATA_OUTPUT_URN):
-        pcoll_id = transform.spec.payload
-        if transform.spec.urn == bundle_processor.DATA_INPUT_URN:
-          target = transform.unique_name, only_element(transform.outputs)
-          if pcoll_id == fn_api_runner_transforms.IMPULSE_BUFFER:
-            data_input[target] = _ListBuffer([ENCODED_IMPULSE_VALUE])
-          else:
-            data_input[target] = pcoll_buffers[pcoll_id]
-          coder_id = pipeline_components.pcollections[
-              only_element(transform.outputs.values())].coder_id
-        elif transform.spec.urn == bundle_processor.DATA_OUTPUT_URN:
-          target = transform.unique_name, only_element(transform.inputs)
-          data_output[target] = pcoll_id
-          coder_id = pipeline_components.pcollections[
-              only_element(transform.inputs.values())].coder_id
-        else:
-          raise NotImplementedError
-        data_spec = beam_fn_api_pb2.RemoteGrpcPort(coder_id=coder_id)
-        if data_api_service_descriptor:
-          data_spec.api_service_descriptor.url = (
-              data_api_service_descriptor.url)
-        transform.spec.payload = data_spec.SerializeToString()
-      elif transform.spec.urn in fn_api_runner_transforms.PAR_DO_URNS:
-        payload = proto_utils.parse_Bytes(
-            transform.spec.payload, beam_runner_api_pb2.ParDoPayload)
-        for tag, si in payload.side_inputs.items():
-          data_side_input[transform.unique_name, tag] = (
-              create_buffer_id(transform.inputs[tag]), si.access_pattern)
-    return data_input, data_side_input, data_output
-
   def _run_stage(self,
                  worker_handler_factory,
                  pipeline_components,
@@ -646,32 +800,26 @@ class FnApiRunner(runner.PipelineRunner):
       pcoll_buffers (collections.defaultdict of str: list): Mapping of
         PCollection IDs to list that functions as buffer for the
         ``beam.PCollection``.
-      safe_coders (dict): TODO
+      safe_coders (dict): A map from coder URNs to the URN of a safe coder.
     """
-    def iterable_state_write(values, element_coder_impl):
-      token = unique_name(None, 'iter').encode('ascii')
-      out = create_OutputStream()
-      for element in values:
-        element_coder_impl.encode_to_stream(element, out, True)
-      worker_handler.state.append_raw(
-          beam_fn_api_pb2.StateKey(
-              runner=beam_fn_api_pb2.StateKey.Runner(key=token)),
-          out.get())
-      return token
-
     worker_handler_list = worker_handler_factory(
         stage.environment, self._num_workers)
 
     # All worker_handlers share the same grpc server, so we can read grpc server
     # info from any worker_handler and read from the first worker_handler.
     worker_handler = next(iter(worker_handler_list))
-    context = pipeline_context.PipelineContext(
-        pipeline_components, iterable_state_write=iterable_state_write)
+    pipeline_context = PipelineContext(
+        pipeline_components,
+        iterable_state_write=_FnApiRunnerExecution.make_iterable_state_write(
+            worker_handler))
     data_api_service_descriptor = worker_handler.data_api_service_descriptor()
 
     logging.info('Running %s', stage.name)
     data_input, data_side_input, data_output = self._extract_endpoints(
-        stage, pipeline_components, data_api_service_descriptor, pcoll_buffers)
+        stage,
+        pipeline_components,
+        data_api_service_descriptor,
+        pcoll_buffers)
 
     process_bundle_descriptor = beam_fn_api_pb2.ProcessBundleDescriptor(
         id=self._next_uid(),
@@ -689,99 +837,62 @@ class FnApiRunner(runner.PipelineRunner):
 
     # Store the required side inputs into state so it is accessible for the
     # worker when it runs this bundle.
-    self._store_side_inputs_in_state(worker_handler,
-                                     context,
-                                     pipeline_components,
-                                     data_side_input,
-                                     pcoll_buffers,
-                                     safe_coders)
-
-    def get_buffer(buffer_id):
-      """Returns the buffer for a given (operation_type, PCollection ID).
-
-      For grouping-typed operations, we produce a ``_GroupingBuffer``. For
-      others, we produce a ``_ListBuffer``.
-      """
-      kind, name = split_buffer_id(buffer_id)
-      if kind in ('materialize', 'timers'):
-        # If `buffer_id` is not a key in `pcoll_buffers`, it will be added by
-        # the `defaultdict`.
-        return pcoll_buffers[buffer_id]
-      elif kind == 'group':
-        # This is a grouping write, create a grouping buffer if needed.
-        if buffer_id not in pcoll_buffers:
-          original_gbk_transform = name
-          transform_proto = pipeline_components.transforms[
-              original_gbk_transform]
-          input_pcoll = only_element(list(transform_proto.inputs.values()))
-          output_pcoll = only_element(list(transform_proto.outputs.values()))
-          pre_gbk_coder = context.coders[safe_coders[
-              pipeline_components.pcollections[input_pcoll].coder_id]]
-          post_gbk_coder = context.coders[safe_coders[
-              pipeline_components.pcollections[output_pcoll].coder_id]]
-          windowing_strategy = context.windowing_strategies[
-              pipeline_components
-              .pcollections[output_pcoll].windowing_strategy_id]
-          pcoll_buffers[buffer_id] = _GroupingBuffer(
-              pre_gbk_coder, post_gbk_coder, windowing_strategy)
-      else:
-        # These should be the only two identifiers we produce for now,
-        # but special side input writes may go here.
-        raise NotImplementedError(buffer_id)
-      return pcoll_buffers[buffer_id]
-
-    def get_input_coder_impl(transform_id):
-      return context.coders[safe_coders[
-          beam_fn_api_pb2.RemoteGrpcPort.FromString(
-              process_bundle_descriptor.transforms[transform_id].spec.payload
-          ).coder_id
-      ]].get_impl()
+    _FnApiRunnerExecution._store_side_inputs_in_state(
+        worker_handler,
+        pipeline_context,
+        pipeline_components,
+        data_side_input,
+        pcoll_buffers,
+        safe_coders)
 
     # Change cache token across bundle repeats
     cache_token_generator = FnApiRunner.get_cache_token_generator(static=False)
 
     self._run_bundle_multiple_times_for_testing(
-        worker_handler_list, process_bundle_descriptor, data_input, data_output,
-        get_input_coder_impl, cache_token_generator=cache_token_generator)
+        worker_handler_list,
+        process_bundle_descriptor,
+        data_input,
+        data_output,
+        _FnApiRunnerExecution.make_input_coder_getter(pipeline_context,
+                                                      process_bundle_descriptor,
+                                                      safe_coders),
+        cache_token_generator=cache_token_generator)
 
     bundle_manager = ParallelBundleManager(
-        worker_handler_list, get_buffer, get_input_coder_impl,
-        process_bundle_descriptor, self._progress_frequency,
+        worker_handler_list,
+        _FnApiRunnerExecution.make_input_buffer_fetcher(pipeline_context,
+                                                        pcoll_buffers,
+                                                        pipeline_components,
+                                                        safe_coders),
+        _FnApiRunnerExecution.make_input_coder_getter(pipeline_context,
+                                                      process_bundle_descriptor,
+                                                      safe_coders),
+        process_bundle_descriptor,
+        self._progress_frequency,
         num_workers=self._num_workers,
         cache_token_generator=cache_token_generator)
 
+    print('Data input: ' + str(data_input))
+    print('Data output: ' + str(data_output))
     result, splits = bundle_manager.process_bundle(data_input, data_output)
-
-    def input_for(transform_id, input_id):
-      input_pcoll = process_bundle_descriptor.transforms[
-          transform_id].inputs[input_id]
-      for read_id, proto in process_bundle_descriptor.transforms.items():
-        if (proto.spec.urn == bundle_processor.DATA_INPUT_URN
-            and input_pcoll in proto.outputs.values()):
-          return read_id
-      raise RuntimeError(
-          'No IO transform feeds %s' % transform_id)
+    print('Result PRocessbundle residuals: ' + str(result.process_bundle.residual_roots))
+    print('Spluts: ' + str(splits))
 
     last_result = result
     last_sent = data_input
 
     while True:
-      deferred_inputs = collections.defaultdict(_ListBuffer)
 
-      self._collect_written_timers_and_add_to_deferred_inputs(
-          context, pipeline_components, stage, get_buffer, deferred_inputs)
-
-      # Queue any process-initiated delayed bundle applications.
-      for delayed_application in last_result.process_bundle.residual_roots:
-        deferred_inputs[
-            input_for(
-                delayed_application.application.transform_id,
-                delayed_application.application.input_id)
-        ].append(delayed_application.application.element)
-
-      # Queue any runner-initiated delayed bundle applications.
-      self._add_residuals_and_channel_splits_to_deferred_inputs(
-          splits, get_input_coder_impl, input_for, last_sent, deferred_inputs)
+      deferred_inputs = self._collect_deferred_inputs(
+          pipeline_context,
+          pipeline_components,
+          process_bundle_descriptor,
+          stage,
+          pcoll_buffers,
+          safe_coders,
+          last_result,
+          splits,
+          last_sent)
 
       if deferred_inputs:
         # The worker will be waiting on these inputs as well.
@@ -810,6 +921,46 @@ class FnApiRunner(runner.PipelineRunner):
     return result
 
   @staticmethod
+  def _collect_deferred_inputs(pipeline_context,
+                               pipeline_components,
+                               process_bundle_descriptor,
+                               stage,
+                               pcoll_buffers,
+                               safe_coders,
+                               last_result,
+                               splits,
+                               last_input):
+    deferred_inputs = collections.defaultdict(_ListBuffer)
+    _FnApiRunnerExecution._collect_written_timers_and_add_to_deferred_inputs(
+        pipeline_context, pipeline_components, stage,
+        _FnApiRunnerExecution.make_input_buffer_fetcher(pipeline_context,
+                                                        pcoll_buffers,
+                                                        pipeline_components,
+                                                        safe_coders),
+        deferred_inputs)
+
+    # Queue any process-initiated delayed bundle applications.
+    for delayed_application in last_result.process_bundle.residual_roots:
+      residual_root_op_name = _FnApiRunnerExecution.get_input_operation_name(
+          process_bundle_descriptor,
+          delayed_application.application.transform_id,
+          delayed_application.application.input_id)
+      deferred_inputs[residual_root_op_name].append(
+          delayed_application.application.element)
+
+    # Queue any runner-initiated delayed bundle applications.
+    _FnApiRunnerExecution._add_residuals_and_channel_splits_to_deferred_inputs(
+        process_bundle_descriptor,
+        splits,
+        _FnApiRunnerExecution.make_input_coder_getter(
+            pipeline_context,
+            process_bundle_descriptor,
+            safe_coders),
+        last_input,
+        deferred_inputs)
+    return deferred_inputs
+
+  @staticmethod
   def _extract_endpoints(stage,
                          pipeline_components,
                          data_api_service_descriptor,
@@ -828,8 +979,9 @@ class FnApiRunner(runner.PipelineRunner):
         elements.
     Returns:
       A tuple of (data_input, data_side_input, data_output) dictionaries.
-        `data_input` is a dictionary mapping (transform_name, output_name) to a
-        PCollection buffer; `data_output` is a dictionary mapping
+        `data_input` is a dictionary mapping (transform_name) to a
+           collection of encoded bytes representing the elements in a bundle.
+        `data_output` is a dictionary mapping
         (transform_name, output_name) to a PCollection ID.
     """
     data_input = {}
@@ -838,8 +990,13 @@ class FnApiRunner(runner.PipelineRunner):
     for transform in stage.transforms:
       if transform.spec.urn in (bundle_processor.DATA_INPUT_URN,
                                 bundle_processor.DATA_OUTPUT_URN):
+        # If a transform is a DATA_INPUT or DATA_OUTPUT transform, it will
+        # receive data from / deliver data to the runner.
         pcoll_id = transform.spec.payload
         if transform.spec.urn == bundle_processor.DATA_INPUT_URN:
+          # For data input transforms, they only have one input.
+          # We map the transform name to a buffer containing the
+          # encoded input.
           if pcoll_id == fn_api_runner_transforms.IMPULSE_BUFFER:
             data_input[transform.unique_name] = _ListBuffer(
                 [ENCODED_IMPULSE_VALUE])
@@ -848,6 +1005,8 @@ class FnApiRunner(runner.PipelineRunner):
           coder_id = pipeline_components.pcollections[
               only_element(transform.outputs.values())].coder_id
         elif transform.spec.urn == bundle_processor.DATA_OUTPUT_URN:
+          # For data output transforms, we map the transform name to the
+          # output PCollection name
           data_output[transform.unique_name] = pcoll_id
           coder_id = pipeline_components.pcollections[
               only_element(transform.inputs.values())].coder_id
@@ -859,6 +1018,9 @@ class FnApiRunner(runner.PipelineRunner):
               data_api_service_descriptor.url)
         transform.spec.payload = data_spec.SerializeToString()
       elif transform.spec.urn in fn_api_runner_transforms.PAR_DO_URNS:
+        # If a transform is a PARDO, then it may receive side inputs.
+        # For each side input in a PARDO we map PARDO.name + side input tag
+        # to a buffer id.
         payload = proto_utils.parse_Bytes(
             transform.spec.payload, beam_runner_api_pb2.ParDoPayload)
         for tag, si in payload.side_inputs.items():
@@ -1704,6 +1866,7 @@ class BundleManager(object):
     return split_results
 
   def process_bundle(self, inputs, expected_outputs):
+    # type: (Dict[str, Union[_ListBuffer, _GroupingBuffer], Dict[str, bytes]]) -> Tuple(beam_fn_api_pb2.ProcessBundleProgressResponse, List)
     # Unique id for the instruction processing this bundle.
     with BundleManager._lock:
       BundleManager._uid_counter += 1

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -229,12 +229,13 @@ class _GroupingBuffer(object):
           else windowed_key_value.with_value(value))
 
   def extend(self, input_buffer):
-    raise NotImplementedError(
-        'GroupingBuffer is not expected to merge with others')
+    # type: (_GroupingBuffer) -> None
+    for key, values in input_buffer._table.items():
+      self._table[key].extend(values)
 
   def partition(self, n):
     """ It is used to partition _GroupingBuffer to N parts. Once it is
-    partitioned, it would not be re-partitioned with diff N. Re-partition
+    partitioned, it would not be re-partitioned with different N. Re-partition
     is not supported now.
     """
     if not self._grouped_output:
@@ -615,8 +616,6 @@ class FnApiRunner(runner.PipelineRunner):
 
   def run_via_runner_api(self, pipeline_proto):
     stage_context, stages = self.create_stages(pipeline_proto)
-    # TODO(pabloem, BEAM-7514): Create a watermark manager (that has access to
-    #   the teststream (if any), and all the stages).
     return self.run_stages(stage_context, stages)
 
   @contextlib.contextmanager

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -1091,6 +1091,11 @@ class FnApiRunner(runner.PipelineRunner):
     last_result = result
     last_sent = input_bundle
 
+    # TODO(pabloem, MUST): THE PROBLEM CURRENTLY IS THAT WHEN THERE ARE DEFERRED
+    #  INPUTS, WE MUST HOLD BACK THE WATERMARK FOR A STAGE. We are not doing
+    #  that currently, and thus when we have deferred inputs, the watermark
+    #  still moves to +MAX_TS, and downstream operations are scheduled.
+    #  THIS BAD.
     while True:
       deferred_inputs = FnApiRunner._collect_deferred_inputs(
         pipeline_context,

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -407,6 +407,7 @@ class FnApiRunnerTest(unittest.TestCase):
       assert_that(actual, equal_to(expected))
 
   def test_pardo_state_timers(self):
+    logging.getLogger().setLevel(logging.DEBUG)
     self._run_pardo_state_timers(False)
 
   def test_windowed_pardo_state_timers(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -566,9 +566,10 @@ class FnApiRunnerTest(unittest.TestCase):
       res = (pcboth
              | beam.GroupByKey()
              | beam.Map(lambda k_vs: (k_vs[0], sorted(k_vs[1]))))
-      res | beam.Map(lambda x: print(x))
-      # TODO(pabloem, MUST): Uncomment assert
-      #assert_that(res, equal_to([('a', [1, 2]), ('b', [3])]))
+      assert_that(res, equal_to([('a', [1, 2]),
+                                 ('b', [3]),
+                                 ('c', [1, 2]),
+                                 ('d', [3])]))
 
   # Runners may special case the Reshuffle transform urn.
   def test_reshuffle(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -584,9 +584,9 @@ class FnApiRunnerTest(unittest.TestCase):
         additional = [ord('d')]
       else:
         additional = ['d']
-      res = (p | 'a' >> beam.Create(['a']) | 'ma' >> beam.Map(lambda x: x),
+      res = (p | 'a' >> beam.Create(['a']),
              p | 'bc' >> beam.Create(['b', 'c']),
-             p | 'd' >> beam.Create(additional) | 'md' >> beam.Map(lambda x: x)
+             p | 'd' >> beam.Create(additional)
             ) | beam.Flatten()
       assert_that(res, equal_to(['a', 'b', 'c'] + additional))
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -187,11 +187,9 @@ class FnApiRunnerTest(unittest.TestCase):
       main = p | 'main' >> beam.Create(['a', 'b', 'c'])
       side = p | 'side' >> beam.Create(['x', 'y'])
       res = main | beam.FlatMap(cross_product, beam.pvalue.AsList(side))
-      res | beam.Map(print)
-      # TODO(pabloem, MUST): Uncomment the assertion.
-      #assert_that(res,
-      #            equal_to([('a', 'x'), ('b', 'x'), ('c', 'x'),
-      #                      ('a', 'y'), ('b', 'y'), ('c', 'y')]))
+      assert_that(res,
+                  equal_to([('a', 'x'), ('b', 'x'), ('c', 'x'),
+                            ('a', 'y'), ('b', 'y'), ('c', 'y')]))
 
   def test_pardo_windowed_side_inputs(self):
     with self.create_pipeline() as p:

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -1598,6 +1598,9 @@ class FnApiRunnerSplitTestWithMultiWorkers(FnApiRunnerSplitTest):
     # TODO(BEAM-7514): Support checkpointing for SDF on multiple workers.
     raise unittest.SkipTest("This test is for a single worker only.")
 
+  def test_split_crazy_sdf(self, seed=None):
+    raise unittest.SkipTest("This test is for a single worker only.")
+
 
 class FnApiBasedLullLoggingTest(unittest.TestCase):
   def create_pipeline(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -581,10 +581,9 @@ class FnApiRunnerTest(unittest.TestCase):
         additional = ['d']
       res = (p | 'a' >> beam.Create(['a']) | 'ma' >> beam.Map(lambda x: x),
              p | 'bc' >> beam.Create(['b', 'c']) | 'mbc' >> beam.Map(lambda x: x),
-             p | 'd' >> beam.Create(additional) | 'md' >> beam.Map(lambda x: x)) | beam.Flatten()
-      res | beam.Map(lambda x: print(x))
-      # TODO(pabloem, MUST): Uncomment assert.
-      #assert_that(res, equal_to(['a', 'b', 'c'] + additional))
+             p | 'd' >> beam.Create(additional) | 'md' >> beam.Map(lambda x: x)
+             ) | beam.Flatten()
+      assert_that(res, equal_to(['a', 'b', 'c'] + additional))
 
   def test_combine_per_key(self):
     with self.create_pipeline() as p:

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -281,6 +281,10 @@ class FnApiRunnerTest(unittest.TestCase):
           pcoll | beam.FlatMap(cross_product, beam.pvalue.AsList(pcoll)),
           equal_to([('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')]))
 
+  def test_pardo_unfusable_by_gbk_side_inputs(self):
+    def cross_product(elem, sides):
+      for side in sides:
+        yield elem, side
     with self.create_pipeline() as p:
       pcoll = p | beam.Create(['a', 'b'])
       derived = ((pcoll,) | beam.Flatten()
@@ -439,7 +443,7 @@ class FnApiRunnerTest(unittest.TestCase):
     def is_buffered_correctly(actual):
       # Pickling self in the closure for asserts gives errors (only on jenkins).
       self = FnApiRunnerTest('__init__')
-      # Acutal should be a grouping of the inputs into batches of size
+      # Actual should be a grouping of the inputs into batches of size
       # at most buffer_size, but the actual batching is nondeterministic
       # based on ordering and trigger firing timing.
       self.assertEqual(sorted(sum((list(b) for b in actual), [])), elements)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -522,13 +522,14 @@ class FnApiRunnerTest(unittest.TestCase):
           | beam.Create(data)
           | beam.ParDo(ExpandStringsDoFn()))
 
+      actual | beam.Map(print)
       assert_that(actual, equal_to(list(''.join(data))))
 
     if isinstance(p.runner, fn_api_runner.FnApiRunner):
       res = p.runner._latest_run_result
-      counters = res.metrics().query(beam.metrics.MetricsFilter())['counters']
-      self.assertEqual(1, len(counters))
-      self.assertEqual(counters[0].committed, len(''.join(data)))
+      #counters = res.metrics().query(beam.metrics.MetricsFilter())['counters']
+      #self.assertEqual(1, len(counters))
+      #self.assertEqual(counters[0].committed, len(''.join(data)))
 
   def _run_sdf_wrapper_pipeline(self, source, expected_value):
     with self.create_pipeline() as p:

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -187,6 +187,7 @@ class FnApiRunnerTest(unittest.TestCase):
       main = p | 'main' >> beam.Create(['a', 'b', 'c'])
       side = p | 'side' >> beam.Create(['x', 'y'])
       res = main | beam.FlatMap(cross_product, beam.pvalue.AsList(side))
+      res | beam.Map(print)
       # TODO(pabloem, MUST): Uncomment the assertion.
       #assert_that(res,
       #            equal_to([('a', 'x'), ('b', 'x'), ('c', 'x'),

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -105,7 +105,7 @@ class FnApiRunnerTest(unittest.TestCase):
              | beam.Create(['a', 'bc'])
              | beam.Map(lambda e: e * 2)
              | beam.Map(lambda e: e + 'x'))
-      #assert_that(res, equal_to(['aax', 'bcbcx']))
+      assert_that(res, equal_to(['aax', 'bcbcx']))
 
   def test_pardo_metrics(self):
 
@@ -522,14 +522,13 @@ class FnApiRunnerTest(unittest.TestCase):
           | beam.Create(data)
           | beam.ParDo(ExpandStringsDoFn()))
 
-      actual | beam.Map(print)
       assert_that(actual, equal_to(list(''.join(data))))
 
     if isinstance(p.runner, fn_api_runner.FnApiRunner):
       res = p.runner._latest_run_result
-      #counters = res.metrics().query(beam.metrics.MetricsFilter())['counters']
-      #self.assertEqual(1, len(counters))
-      #self.assertEqual(counters[0].committed, len(''.join(data)))
+      counters = res.metrics().query(beam.metrics.MetricsFilter())['counters']
+      self.assertEqual(1, len(counters))
+      self.assertEqual(counters[0].committed, len(''.join(data)))
 
   def _run_sdf_wrapper_pipeline(self, source, expected_value):
     with self.create_pipeline() as p:
@@ -586,9 +585,9 @@ class FnApiRunnerTest(unittest.TestCase):
       else:
         additional = ['d']
       res = (p | 'a' >> beam.Create(['a']) | 'ma' >> beam.Map(lambda x: x),
-             p | 'bc' >> beam.Create(['b', 'c']) | 'mbc' >> beam.Map(lambda x: x),
+             p | 'bc' >> beam.Create(['b', 'c']),
              p | 'd' >> beam.Create(additional) | 'md' >> beam.Map(lambda x: x)
-             ) | beam.Flatten()
+            ) | beam.Flatten()
       assert_that(res, equal_to(['a', 'b', 'c'] + additional))
 
   def test_combine_per_key(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -1593,6 +1593,10 @@ class FnApiRunnerSplitTestWithMultiWorkers(FnApiRunnerSplitTest):
   def test_split_half(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
+  def test_checkpoint_sdf(self):
+    # TODO(BEAM-7514): Support checkpointing for SDF on multiple workers.
+    raise unittest.SkipTest("This test is for a single worker only.")
+
 
 class FnApiBasedLullLoggingTest(unittest.TestCase):
   def create_pipeline(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -80,9 +80,6 @@ class Stage(object):
     self.environment = environment
     self.forced_root = forced_root
 
-  def update_watermark(self):
-    pass
-
   def __repr__(self):
     must_follow = ', '.join(prev.name for prev in self.must_follow)
     if self.downstream_side_inputs is None:

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -344,7 +344,6 @@ class _WatermarkManager(object):
 
     def output_watermark(self):
       w = min(i.watermark() for i in self.inputs)
-      print('Watermark for stage %s' % self.name, 'is', w)
       return w
 
     def input_watermark(self):
@@ -353,7 +352,6 @@ class _WatermarkManager(object):
       if self.side_inputs:
         w = min(w,
                 min(i.upstream_watermark() for i in self.side_inputs))
-      print('INPUT Watermark for stage %s' % self.name, 'is', w)
       return w
 
   def __init__(self, stages, execution_context):
@@ -482,10 +480,13 @@ class PipelineExecutionContext(object):
 
   def update_pcoll_watermark(self, pcoll_name, watermark):
     # type: (str, timestamp.Timestamp) -> None
-    print('Watermark update: \n\t', pcoll_name, '\n\t', str(watermark))
+    logging.debug(
+      'Updating watermark to %s for PCollection: %s', watermark, pcoll_name)
     self.watermark_manager.set_watermark(pcoll_name, watermark)
     if watermark != self.watermark_manager.get_watermark(pcoll_name):
-      print('\n\tBecame: ', self.watermark_manager.get_watermark(pcoll_name))
+      logging.debug('Due to upstream holds, watermark could not be '
+                    'updated to value desired. Set to: %s',
+                    self.watermark_manager.get_watermark(pcoll_name))
 
   @staticmethod
   def _compute_pcoll_consumer_per_buffer_id(stages):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -364,30 +364,30 @@ class _WatermarkManager(object):
 
       data_input, data_output = execution_context.endpoints_per_stage[s.name]
 
-      for transform_name, buffer_id in data_input.items():
+      for _, buffer_id in data_input.items():
         if buffer_id == IMPULSE_BUFFER:
           pcoll_name = '%s%s' % (stage_name, IMPULSE_BUFFER)
         else:
           _, pcoll_name = split_buffer_id(buffer_id)
         if pcoll_name not in self._watermarks_by_name:
           self._watermarks_by_name[
-            pcoll_name] = _WatermarkManager.PCollectionNode(pcoll_name)
+              pcoll_name] = _WatermarkManager.PCollectionNode(pcoll_name)
 
         stage_node.inputs.add(self._watermarks_by_name[pcoll_name])
 
-      for transform_name, buffer_id in data_output.items():
+      for _, buffer_id in data_output.items():
         _, pcoll_name = split_buffer_id(buffer_id)
         if pcoll_name not in self._watermarks_by_name:
           self._watermarks_by_name[
-            pcoll_name] = _WatermarkManager.PCollectionNode(pcoll_name)
+              pcoll_name] = _WatermarkManager.PCollectionNode(pcoll_name)
         self._watermarks_by_name[pcoll_name].producers.add(stage_node)
 
       side_inputs = PipelineExecutionContext._get_data_side_input_per_pcoll_id(
-            s)
+          s)
       for si_name, _ in side_inputs:
         if si_name not in self._watermarks_by_name:
           self._watermarks_by_name[
-            si_name] = _WatermarkManager.PCollectionNode(si_name)
+              si_name] = _WatermarkManager.PCollectionNode(si_name)
         stage_node.side_inputs.add(self._watermarks_by_name[si_name])
 
   def get_node(self, name):
@@ -434,14 +434,14 @@ class PipelineExecutionContext(object):
     for s in self._stages:
       stage_name = ('_'.join([t.unique_name for t in [s.transforms[0],
                                                       s.transforms[1]]])
-                    .replace('(','_').replace(')', '_').replace('/', '_')
-                    .replace('<','_').replace('>','_').replace(',','_')
-                    .replace(' ','_').replace('.', '_').replace(':', '_'))
+                    .replace('(', '_').replace(')', '_').replace('/', '_')
+                    .replace('<', '_').replace('>', '_').replace(',', '_')
+                    .replace(' ', '_').replace('.', '_').replace(':', '_'))
       stage_name = 'STAGE_' + stage_name
       g.node(stage_name, shape='box')
       data_input, data_output = self.endpoints_per_stage[s.name]
 
-      for transform_name, buffer_id in data_input.items():
+      for _, buffer_id in data_input.items():
         if buffer_id == IMPULSE_BUFFER:
           pcoll_name = IMPULSE_BUFFER
         else:
@@ -450,7 +450,7 @@ class PipelineExecutionContext(object):
         g.node(pcoll_name)
         g.edge(pcoll_name, stage_name)
 
-      for transform_name, buffer_id in data_output.items():
+      for _, buffer_id in data_output.items():
         _, pcoll_name = split_buffer_id(buffer_id)
         pcoll_name = 'PCOLL_' + str(pcoll_name)
         g.node(pcoll_name)
@@ -481,7 +481,7 @@ class PipelineExecutionContext(object):
   def update_pcoll_watermark(self, pcoll_name, watermark):
     # type: (str, timestamp.Timestamp) -> None
     logging.debug(
-      'Updating watermark to %s for PCollection: %s', watermark, pcoll_name)
+        'Updating watermark to %s for PCollection: %s', watermark, pcoll_name)
     self.watermark_manager.set_watermark(pcoll_name, watermark)
     if watermark != self.watermark_manager.get_watermark(pcoll_name):
       logging.debug('Due to upstream holds, watermark could not be '
@@ -539,20 +539,22 @@ class PipelineExecutionContext(object):
     # type: (Stage) -> StageInfo
     result_inputs = set()
     result_outputs = set()
-    side_input_infos = PipelineExecutionContext._get_data_side_input_per_pcoll_id(stage)
-    main_inputs, outputs = PipelineExecutionContext._extract_stage_endpoints(stage)
+    side_input_infos = (PipelineExecutionContext
+                        ._get_data_side_input_per_pcoll_id(stage))
+    main_inputs, outputs = (PipelineExecutionContext
+                            ._extract_stage_endpoints(stage))
 
     for pcoll_id, unused_si_info in side_input_infos:
       result_inputs.add(pcoll_id)
 
-    for transform_name, buffer_id in main_inputs.items():
+    for _, buffer_id in main_inputs.items():
       if buffer_id == IMPULSE_BUFFER:
         pcoll_id = '%s%s' % (stage.name, IMPULSE_BUFFER)
       else:
         _, pcoll_id = split_buffer_id(buffer_id)
       result_inputs.add(pcoll_id)
 
-    for transform_name, buffer_id in outputs.items():
+    for _, buffer_id in outputs.items():
       _, pcoll_id = split_buffer_id(buffer_id)
       result_outputs.add(pcoll_id)
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -412,12 +412,12 @@ class PipelineExecutionContext(object):
     self.endpoints_per_stage = {
         s.name: self._extract_stage_endpoints(s) for s in stages}
 
-    self._consuming_stage_per_input_buffer_id = {
-        k: v[0]
+    self._consuming_stages_per_input_buffer_id = {
+        k: [subv[0] for subv in v]
         for k, v in self._compute_pcoll_consumer_per_buffer_id(stages).items()}
 
-    self._consuming_transform_per_input_buffer_id = {
-        k: v[1]
+    self._consuming_transforms_per_input_buffer_id = {
+        k: [subv[1] for subv in v]
         for k, v in self._compute_pcoll_consumer_per_buffer_id(stages).items()}
 
     self.pcoll_to_side_input_info = self._compute_side_input_to_consumer_map(
@@ -469,13 +469,13 @@ class PipelineExecutionContext(object):
     # type: (str) -> List[SideInputInfo]
     return self.pcoll_to_side_input_info.get(pcoll_name, [])
 
-  def get_consuming_stage(self, buffer_id):
-    # type: (str) -> Stage
-    return self._consuming_stage_per_input_buffer_id.get(buffer_id, None)
+  def get_consuming_stages(self, buffer_id):
+    # type: (str) -> List[Stage]
+    return self._consuming_stages_per_input_buffer_id.get(buffer_id, None)
 
-  def get_consuming_transform(self, buffer_id):
-    # type: (str) -> beam_runner_api_pb2.PTransform
-    return self._consuming_transform_per_input_buffer_id.get(
+  def get_consuming_transforms(self, buffer_id):
+    # type: (str) -> List[beam_runner_api_pb2.PTransform]
+    return self._consuming_transforms_per_input_buffer_id.get(
         buffer_id, None)
 
   def update_pcoll_watermark(self, pcoll_name, watermark):
@@ -490,27 +490,32 @@ class PipelineExecutionContext(object):
 
   @staticmethod
   def _compute_pcoll_consumer_per_buffer_id(stages):
+    # type: (List[Stage]) -> Dict[bytes, List[Tuple(Stage, beam_runner_api_pb2.PTransform)]]
     """Computes the stages that consume a PCollection as main input.
 
     This means either data-input operations, or timer pcollections. It does NOT
     include side input consumption."""
-    data_input_consumers = {
-        t.spec.payload: (s, t)
-        for s in stages
-        for t in s.transforms
-        if t.spec.urn == bundle_processor.DATA_INPUT_URN}
 
-    timer_pcoll_consumers = {}
+    result = collections.defaultdict(list)
+    known_consumers = collections.defaultdict(set)
+
+    for s in stages:
+      for t in s.transforms:
+        if t.spec.urn == bundle_processor.DATA_INPUT_URN:
+          consumer_pair = (s.name, t.unique_name)
+          if consumer_pair not in known_consumers[t.spec.payload]:
+            known_consumers[t.spec.payload].add(consumer_pair)
+            result[t.spec.payload].append((s, t))
+
     for s in stages:
       transforms_per_unique_name = {t.unique_name:t for t in s.transforms}
       for input_id, timer_pcoll in s.timer_pcollections:
+        # We do not need to review known_consumers for timer PCollections
+        # because they are always only consumed by a single transform.
+        # Specifically, the transform that outputs them.
         buffer_id = create_buffer_id(timer_pcoll, 'timers')
-        timer_pcoll_consumers[buffer_id] = (
-            s, transforms_per_unique_name[input_id])
+        result[buffer_id].append((s, transforms_per_unique_name[input_id]))
 
-    result = {}
-    result.update(timer_pcoll_consumers)
-    result.update(data_input_consumers)
     return result
 
   @staticmethod

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -32,6 +32,7 @@ from apache_beam import coders
 from apache_beam.portability import common_urns
 from apache_beam.portability import python_urns
 from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.portability.api.beam_runner_api_pb2 import PTransform
 from apache_beam.runners.worker import bundle_processor
 from apache_beam.utils import proto_utils
 from apache_beam.utils import timestamp
@@ -261,7 +262,7 @@ class Stage(object):
           user_states=user_states,
           timers=timers)
 
-      return beam_runner_api_pb2.PTransform(
+      return PTransform(
           unique_name=unique_name(None, self.name),
           spec=beam_runner_api_pb2.FunctionSpec(
               urn='beam:runner:executable_stage:v1',
@@ -489,8 +490,10 @@ class PipelineExecutionContext(object):
                     self.watermark_manager.get_watermark(pcoll_name))
 
   @staticmethod
-  def _compute_pcoll_consumer_per_buffer_id(stages):
-    # type: (List[Stage]) -> Dict[bytes, List[Tuple(Stage, beam_runner_api_pb2.PTransform)]]
+  def _compute_pcoll_consumer_per_buffer_id(
+      stages  # type: List[Stage]
+  ):
+    # type: (...) -> Dict[bytes, List[Tuple(Stage, PTransform)]]
     """Computes the stages that consume a PCollection as main input.
 
     This means either data-input operations, or timer pcollections. It does NOT

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -321,7 +321,10 @@ class _WatermarkManager(object):
       self._watermark = min(producer_wm, wm)
 
     def watermark(self):
-      return self._watermark
+      if self._watermark:
+        return self._watermark
+      else:
+        return min(p.watermark() for p in self.producers)
 
   class StageNode(WatermarkNode):
 
@@ -330,7 +333,7 @@ class _WatermarkManager(object):
       self.inputs = set()
 
     def set_watermark(self, wm):
-      raise NotImplementedError('WHY DIS')
+      raise NotImplementedError('Stages do not have a watermark')
 
     def watermark(self):
       return min(i.watermark() for i in self.inputs)
@@ -443,9 +446,8 @@ class PipelineExecutionContext(object):
         g.node(pcoll_name)
         g.edge(pcoll_name, stage_name)
 
-
-    g.render('/usr/local/google/home/pabloem/codes/streaming-runner/sdks/python/graph.png',
-             format='png')
+    #g.render('graph.png',
+    #         format='png')
 
 
   def get_watermark(self, name):

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -2388,6 +2388,9 @@ class Flatten(PTransform):
     return pvalueish, pvalueish
 
   def expand(self, pcolls):
+    if not pcolls:
+      raise ValueError('No input passed to Flatten PTransform')
+
     for pcoll in pcolls:
       self._check_pcollection(pcoll)
     is_bounded = all(pcoll.is_bounded for pcoll in pcolls)

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -523,9 +523,8 @@ class PTransformTest(unittest.TestCase):
     pipeline = TestPipeline()
     with self.assertRaises(ValueError):
       () | 'PipelineArgMissing' >> beam.Flatten()
-    result = () | 'Empty' >> beam.Flatten(pipeline=pipeline)
-    assert_that(result, equal_to([]))
-    pipeline.run()
+    with self.assertRaises(ValueError):
+      () | 'Empty' >> beam.Flatten(pipeline=pipeline)
 
   def test_flatten_same_pcollections(self):
     pipeline = TestPipeline()

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -551,6 +551,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
 
       @on_timer(EMIT_TIMER)
       def emit_values(self, set_state=beam.DoFn.StateParam(SET_STATE)):
+        print('emitin')
         yield sorted(set_state.read())
 
     print('start')
@@ -565,6 +566,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
                      | beam.WindowInto(window.FixedWindows(1))
                      | beam.ParDo(SetStateClearingStatefulDoFn()))
 
+    actual_values | 'printe' >> beam.Map(print)
     # TODO(pabloem, MUST): Remove this fixing.
     #assert_that(actual_values, equal_to([[100]]))
 

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -605,6 +605,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
                      | beam.ParDo(SetStateClearingStatefulDoFn())
                      | beam.GroupByKey())
 
+    assert_that(actual_values, equal_to([('key', [1, 2, 3, 4, 5])]))
     result = p.run()
     result.wait_until_finish()
 

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -551,7 +551,6 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
 
       @on_timer(EMIT_TIMER)
       def emit_values(self, set_state=beam.DoFn.StateParam(SET_STATE)):
-        print('emitin')
         yield sorted(set_state.read())
 
     p = TestPipeline()
@@ -565,9 +564,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
                      | beam.WindowInto(window.FixedWindows(1))
                      | beam.ParDo(SetStateClearingStatefulDoFn()))
 
-    actual_values | 'printe' >> beam.Map(print)
-    # TODO(pabloem, MUST): Remove this fixing.
-    #assert_that(actual_values, equal_to([[100]]))
+    assert_that(actual_values, equal_to([[100]]))
 
     result = p.run()
     result.wait_until_finish()

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -554,7 +554,6 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
         print('emitin')
         yield sorted(set_state.read())
 
-    print('start')
     p = TestPipeline()
     values = p | beam.Create([('key', 1),
                               ('key', 2),
@@ -572,7 +571,48 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
 
     result = p.run()
     result.wait_until_finish()
-    print('end')
+
+  def test_stateful_sum_then_gbk(self):
+
+    class SetStateClearingStatefulDoFn(beam.DoFn):
+
+      SET_STATE = SetStateSpec('buffer', VarIntCoder())
+      EMIT_TIMER = TimerSpec('emit_timer', TimeDomain.WATERMARK)
+
+      def process(self,
+          element,
+          set_state=beam.DoFn.StateParam(SET_STATE),
+          emit_timer=beam.DoFn.TimerParam(EMIT_TIMER)):
+        _, value = element
+        set_state.add(value)
+
+        all_elements = [element for element in set_state.read()]
+
+        if len(all_elements) == 5:
+          emit_timer.set(1)
+        yield element
+
+      @on_timer(EMIT_TIMER)
+      def emit_values(self, set_state=beam.DoFn.StateParam(SET_STATE)):
+        return [('key', i) for i in set_state.read()]
+
+    p = TestPipeline()
+    values = p | beam.Create([('key', 1),
+                              ('key', 2),
+                              ('key', 3),
+                              ('key', 4),
+                              ('key', 5)])
+    actual_values = (values
+                     | beam.Map(lambda t: window.TimestampedValue(t, 1))
+                     | beam.WindowInto(window.FixedWindows(1))
+                     | beam.ParDo(SetStateClearingStatefulDoFn())
+                     | beam.GroupByKey())
+
+    actual_values | 'printe' >> beam.Map(print)
+    # TODO(pabloem, MUST): Remove this fixing.
+
+    result = p.run()
+    result.wait_until_finish()
 
   def test_stateful_dofn_nonkeyed_input(self):
     p = TestPipeline()

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -605,7 +605,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
                      | beam.ParDo(SetStateClearingStatefulDoFn())
                      | beam.GroupByKey())
 
-    assert_that(actual_values, equal_to([('key', [1, 2, 3, 4, 5])]))
+    assert_that(actual_values, equal_to([('key', 2 * [1, 2, 3, 4, 5])]))
     result = p.run()
     result.wait_until_finish()
 

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -553,6 +553,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
       def emit_values(self, set_state=beam.DoFn.StateParam(SET_STATE)):
         yield sorted(set_state.read())
 
+    print('start')
     p = TestPipeline()
     values = p | beam.Create([('key', 1),
                               ('key', 2),
@@ -564,10 +565,12 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
                      | beam.WindowInto(window.FixedWindows(1))
                      | beam.ParDo(SetStateClearingStatefulDoFn()))
 
-    assert_that(actual_values, equal_to([[100]]))
+    # TODO(pabloem, MUST): Remove this fixing.
+    #assert_that(actual_values, equal_to([[100]]))
 
     result = p.run()
     result.wait_until_finish()
+    print('end')
 
   def test_stateful_dofn_nonkeyed_input(self):
     p = TestPipeline()

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -577,9 +577,9 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
       EMIT_TIMER = TimerSpec('emit_timer', TimeDomain.WATERMARK)
 
       def process(self,
-          element,
-          set_state=beam.DoFn.StateParam(SET_STATE),
-          emit_timer=beam.DoFn.TimerParam(EMIT_TIMER)):
+                  element,
+                  set_state=beam.DoFn.StateParam(SET_STATE),
+                  emit_timer=beam.DoFn.TimerParam(EMIT_TIMER)):
         _, value = element
         set_state.add(value)
 
@@ -604,9 +604,6 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
                      | beam.WindowInto(window.FixedWindows(1))
                      | beam.ParDo(SetStateClearingStatefulDoFn())
                      | beam.GroupByKey())
-
-    actual_values | 'printe' >> beam.Map(print)
-    # TODO(pabloem, MUST): Remove this fixing.
 
     result = p.run()
     result.wait_until_finish()

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -583,7 +583,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
         _, value = element
         set_state.add(value)
 
-        all_elements = [element for element in set_state.read()]
+        all_elements = [state_elm for state_elm in set_state.read()]
 
         if len(all_elements) == 5:
           emit_timer.set(1)


### PR DESCRIPTION
These changes to the FnApiRunner prepare it to work on the streaming case. Changes, in general are:

- Execution now is driven by executing available early work.
  - Before this change, execution was driven by fully executing each stage one by one.
- There is a primitive watermark manager that tracks the advancement of the watermark across the pipeline.

Next steps:
- Support for TestStream, to enable streaming-based testing of the FnApiRunner.
- Creating a first streaming source.

**Worth noting:**
- Note that commit https://github.com/apache/beam/pull/10067/commits/e9345afbae1e2219a199ef01c683d05e3d6fe207 changes the behavior of a particular corner case.
- Remaining flaky test: `FnApiRunnerSplitTestWithMultiWorkers.test_split_crazy_sdf`

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
