### PR TITLE
[BEAM-8659] RowJsonTest should test serialization independently

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/JsonMatcher.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/JsonMatcher.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import static org.hamcrest.Matchers.is;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Map;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher to compare a string or byte[] representing a JSON Object, independent of field order.
+ *
+ * <pre>
+ *   assertThat("{\"name\": \"person\", \"height\": 80}",
+ *              jsonStringLike("{\"height\": 80, \"name\": \"person\"}"));
+ * </pre>
+ */
+public abstract class JsonMatcher<T> extends TypeSafeMatcher<T> {
+  private Matcher<Map<String, Object>> mapMatcher;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private Map<String, Object> actualMap;
+
+  public JsonMatcher(Map<String, Object> expectedMap) {
+    this.mapMatcher = is(expectedMap);
+  }
+
+  protected abstract Map<String, Object> parse(T json) throws IOException;
+
+  public static Matcher<byte[]> jsonBytesLike(String json) throws IOException {
+    Map<String, Object> fields =
+        MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+    return jsonBytesLike(fields);
+  }
+
+  public static Matcher<byte[]> jsonBytesLike(Map<String, Object> fields) throws IOException {
+    return new JsonMatcher<byte[]>(fields) {
+      @Override
+      protected Map<String, Object> parse(byte[] json) throws IOException {
+        return MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+      }
+    };
+  }
+
+  public static Matcher<String> jsonStringLike(String json) throws IOException {
+    Map<String, Object> fields =
+        MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+    return jsonStringLike(fields);
+  }
+
+  public static Matcher<String> jsonStringLike(Map<String, Object> fields) throws IOException {
+    return new JsonMatcher<String>(fields) {
+      @Override
+      protected Map<String, Object> parse(String json) throws IOException {
+        return MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+      }
+    };
+  }
+
+  @Override
+  protected boolean matchesSafely(T actual) {
+    try {
+      actualMap = parse(actual);
+    } catch (IOException e) {
+      return false;
+    }
+    return mapMatcher.matches(actualMap);
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    mapMatcher.describeTo(description);
+  }
+
+  @Override
+  protected void describeMismatchSafely(T item, Description mismatchDescription) {
+    mapMatcher.describeMismatch(actualMap, mismatchDescription);
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
@@ -17,10 +17,12 @@
  */
 package org.apache.beam.sdk.util;
 
+import static org.apache.beam.sdk.testing.JsonMatcher.jsonStringLike;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.stringContainsInOrder;
-import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -239,18 +241,22 @@ public class RowJsonTest {
     public void testDeserialize() throws IOException {
       Row parsedRow = newObjectMapperFor(schema).readValue(serializedString, Row.class);
 
-      assertEquals(row, parsedRow);
+      assertThat(row, equalTo(parsedRow));
     }
 
-    // This serves to validate RowJsonSerializer. We don't have tests to check that the output
-    // string matches exactly what we expect, just that the string we produced can be deserialized
-    // again into an equal row.
+    @Test
+    public void testSerialize() throws IOException {
+      String str = newObjectMapperFor(schema).writeValueAsString(row);
+
+      assertThat(str, jsonStringLike(serializedString));
+    }
+
     @Test
     public void testRoundTrip() throws IOException {
       ObjectMapper objectMapper = newObjectMapperFor(schema);
       Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
 
-      assertEquals(row, parsedRow);
+      assertThat(row, equalTo(parsedRow));
     }
   }
 
@@ -416,7 +422,7 @@ public class RowJsonTest {
 
       Row parsedRow = jsonParser.readValue(jsonObjectWith(fieldName, jsonFieldValue), Row.class);
 
-      assertEquals(expectedRow, parsedRow);
+      assertThat(expectedRow, equalTo(parsedRow));
     }
 
     @Test


### PR DESCRIPTION
Adds `JsonMatcher` which can verify that strings represent equivalent JSON objects independent of field order. For example:

```java
assertThat("{\"foo\": 1, \"bar\": 2}", jsonStringLike("{\"bar\": 2, \"foo\": 1}));
```

This is used in `RowJsonTest` to verify serialization independently.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
