### PR TITLE
[BEAM-7473] Pack RangeTracker into restriction

### DIFF
--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1442,10 +1442,10 @@ class _SDFBoundedSourceWrapper(ptransform.PTransform):
       stop_pos = self._delegate_range_tracker.stop_position()
       return _SDFBoundedSourceWrapper._SDFBoundedSourceRestriction(
           SourceBundle(
-            self._weight,
-            self._source,
-            start_pos,
-            stop_pos), self._delegate_range_tracker)
+              self._weight,
+              self._source,
+              start_pos,
+              stop_pos), self._delegate_range_tracker)
 
     def start_pos(self):
       return self._delegate_range_tracker.start_position()

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1440,7 +1440,7 @@ class _SDFBoundedSourceWrapper(ptransform.PTransform):
         split_pos, split_fraction = split_result
         primary_weight = self._source_bundle.weight * split_fraction
         residual_weight = self._source_bundle.weight - primary_weight
-        # Update self._weight to primary weight
+        # Update self to primary weight and end position.
         self._source_bundle = SourceBundle(primary_weight,
                                            self._source_bundle.source,
                                            self._source_bundle.start_position,

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -50,12 +50,13 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
 
   def test_initial_restriction(self):
     unused_element = None
-    restriction = (
+    source_bundle, range_tracker = (
         self.sdf_restriction_provider.initial_restriction(unused_element))
-    self.assertTrue(isinstance(restriction, SourceBundle))
-    self.assertEqual(self.initial_range_start, restriction.start_position)
-    self.assertEqual(self.initial_range_stop, restriction.stop_position)
-    self.assertTrue(isinstance(restriction.source, RangeSource))
+    self.assertTrue(isinstance(source_bundle, SourceBundle))
+    self.assertEqual(self.initial_range_start, source_bundle.start_position)
+    self.assertEqual(self.initial_range_stop, source_bundle.stop_position)
+    self.assertTrue(isinstance(source_bundle.source, RangeSource))
+    self.assertEqual(range_tracker, None)
 
   def test_create_tracker(self):
     expected_start = 1
@@ -65,7 +66,7 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
                                expected_start,
                                expected_stop)
     restriction_tracker = (
-        self.sdf_restriction_provider.create_tracker(restriction))
+        self.sdf_restriction_provider.create_tracker((restriction, None)))
     self.assertTrue(isinstance(restriction_tracker,
                                iobase.
                                _SDFBoundedSourceWrapper.
@@ -75,16 +76,16 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
 
   def test_simple_source_split(self):
     unused_element = None
-    restriction = (
+    restriction, _ = (
         self.sdf_restriction_provider.initial_restriction(unused_element))
     expect_splits = [(0, 2), (2, 4)]
     split_bundles = list(self.sdf_restriction_provider.split(unused_element,
                                                              restriction))
-    self.assertTrue(
-        all([isinstance(bundle, SourceBundle) for bundle in split_bundles]))
+    self.assertTrue(all(
+        [isinstance(bundle, SourceBundle) for (bundle, _) in split_bundles]))
 
     splits = ([(bundle.start_position,
-                bundle.stop_position) for bundle in split_bundles])
+                bundle.stop_position) for (bundle, _) in split_bundles])
     self.assertEqual(expect_splits, list(splits))
 
   def test_concat_source_split(self):
@@ -94,20 +95,20 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
         iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionProvider(
             initial_concat_source,
             desired_chunk_size=2))
-    restriction = (
+    restriction, _ = (
         self.sdf_restriction_provider.initial_restriction(unused_element))
     expect_splits = [(0, 2), (2, 4)]
     split_bundles = list(sdf_concat_restriction_provider.split(unused_element,
                                                                restriction))
-    self.assertTrue(
-        all([isinstance(bundle, SourceBundle) for bundle in split_bundles]))
+    self.assertTrue(all(
+        [isinstance(bundle, SourceBundle) for (bundle, _) in split_bundles]))
     splits = ([(bundle.start_position,
-                bundle.stop_position) for bundle in split_bundles])
+                bundle.stop_position) for (bundle, _) in split_bundles])
     self.assertEqual(expect_splits, list(splits))
 
   def test_restriction_size(self):
     unused_element = None
-    restriction = (
+    restriction, _ = (
         self.sdf_restriction_provider.initial_restriction(unused_element))
     split_1, split_2 = self.sdf_restriction_provider.split(unused_element,
                                                            restriction)
@@ -131,21 +132,27 @@ class SDFBoundedSourceRestrictionTrackerTest(unittest.TestCase):
         self.initial_stop_pos)
     self.sdf_restriction_tracker = (
         iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionTracker(
-            source_bundle))
+            (source_bundle, None)))
 
   def test_current_restriction_before_split(self):
-    _, _, actual_start, actual_stop = (
+    source_bundle, range_tracker = (
         self.sdf_restriction_tracker.current_restriction())
-    self.assertEqual(self.initial_start_pos, actual_start)
-    self.assertEqual(self.initial_stop_pos, actual_stop)
+    self.assertEqual(self.initial_start_pos, source_bundle.start_position)
+    self.assertEqual(self.initial_stop_pos, source_bundle.stop_position)
+    self.assertEqual(self.initial_start_pos, range_tracker.start_position())
+    self.assertEqual(self.initial_stop_pos, range_tracker.stop_position())
 
   def test_current_restriction_after_split(self):
     fraction_of_remainder = 0.5
     self.sdf_restriction_tracker.try_claim(1)
     expected_restriction, _ = (
         self.sdf_restriction_tracker.try_split(fraction_of_remainder))
-    self.assertEqual(expected_restriction,
-                     self.sdf_restriction_tracker.current_restriction())
+    expect_source_bundle, expect_range_tracker = expected_restriction
+    actual_source_bundle, actual_range_tracker = (
+        self.sdf_restriction_tracker.current_restriction())
+    self.assertEqual(expect_source_bundle, actual_source_bundle)
+    self.assertEqual(expect_range_tracker, None)
+    self.assertTrue(actual_range_tracker)
 
   def test_try_split_at_remainder(self):
     fraction_of_remainder = 0.4
@@ -154,13 +161,15 @@ class SDFBoundedSourceRestrictionTrackerTest(unittest.TestCase):
     self.sdf_restriction_tracker.try_claim(0)
     actual_primary, actual_residual = (
         self.sdf_restriction_tracker.try_split(fraction_of_remainder))
-    self.assertEqual(expected_primary, (actual_primary.start_position,
-                                        actual_primary.stop_position,
-                                        actual_primary.weight))
-    self.assertEqual(expected_residual, (actual_residual.start_position,
-                                         actual_residual.stop_position,
-                                         actual_residual.weight))
-    self.assertEqual(actual_primary.weight,
+    primary_source_bundle, _ = actual_primary
+    residual_source_bundle, _ = actual_residual
+    self.assertEqual(expected_primary, (primary_source_bundle.start_position,
+                                        primary_source_bundle.stop_position,
+                                        primary_source_bundle.weight))
+    self.assertEqual(expected_residual, (residual_source_bundle.start_position,
+                                         residual_source_bundle.stop_position,
+                                         residual_source_bundle.weight))
+    self.assertEqual(primary_source_bundle.weight,
                      self.sdf_restriction_tracker._weight)
 
 

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -68,9 +68,9 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     expected_start = 1
     expected_stop = 3
     source_bundle = SourceBundle(expected_stop - expected_start,
-                               RangeSource(1, 3),
-                               expected_start,
-                               expected_stop)
+                                 RangeSource(1, 3),
+                                 expected_start,
+                                 expected_stop)
     restriction_tracker = (
         self.sdf_restriction_provider.create_tracker(
             iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestriction(

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -56,13 +56,13 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
         isinstance(
             restriction,
             iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestriction))
-    self.assertTrue(isinstance(restriction.source_bundle, SourceBundle))
+    self.assertTrue(isinstance(restriction._source_bundle, SourceBundle))
     self.assertEqual(self.initial_range_start,
-                     restriction.source_bundle.start_position)
+                     restriction._source_bundle.start_position)
     self.assertEqual(self.initial_range_stop,
-                     restriction.source_bundle.stop_position)
-    self.assertTrue(isinstance(restriction.source_bundle.source, RangeSource))
-    self.assertEqual(restriction.range_tracker, None)
+                     restriction._source_bundle.stop_position)
+    self.assertTrue(isinstance(restriction._source_bundle.source, RangeSource))
+    self.assertEqual(restriction._range_tracker, None)
 
   def test_create_tracker(self):
     expected_start = 1
@@ -92,11 +92,11 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
                                                              restriction))
     self.assertTrue(all(
         [isinstance(
-            bundle.source_bundle, SourceBundle) for bundle in split_bundles]))
+            bundle._source_bundle, SourceBundle) for bundle in split_bundles]))
 
     splits = (
-        [(bundle.source_bundle.start_position,
-          bundle.source_bundle.stop_position) for bundle in split_bundles])
+        [(bundle._source_bundle.start_position,
+          bundle._source_bundle.stop_position) for bundle in split_bundles])
     self.assertEqual(expect_splits, list(splits))
 
   def test_concat_source_split(self):
@@ -113,11 +113,11 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
                                                                restriction))
     self.assertTrue(
         all(
-            [isinstance(bundle.source_bundle,
+            [isinstance(bundle._source_bundle,
                         SourceBundle) for bundle in split_bundles]))
     splits = ([(
-        bundle.source_bundle.start_position,
-        bundle.source_bundle.stop_position) for bundle in split_bundles])
+        bundle._source_bundle.start_position,
+        bundle._source_bundle.stop_position) for bundle in split_bundles])
     self.assertEqual(expect_splits, list(splits))
 
   def test_restriction_size(self):
@@ -153,13 +153,13 @@ class SDFBoundedSourceRestrictionTrackerTest(unittest.TestCase):
     current_restriction = (
         self.sdf_restriction_tracker.current_restriction())
     self.assertEqual(self.initial_start_pos,
-                     current_restriction.source_bundle.start_position)
+                     current_restriction._source_bundle.start_position)
     self.assertEqual(self.initial_stop_pos,
-                     current_restriction.source_bundle.stop_position)
+                     current_restriction._source_bundle.stop_position)
     self.assertEqual(self.initial_start_pos,
-                     current_restriction.range_tracker.start_position())
+                     current_restriction._range_tracker.start_position())
     self.assertEqual(self.initial_stop_pos,
-                     current_restriction.range_tracker.stop_position())
+                     current_restriction._range_tracker.stop_position())
 
   def test_current_restriction_after_split(self):
     fraction_of_remainder = 0.5
@@ -167,10 +167,9 @@ class SDFBoundedSourceRestrictionTrackerTest(unittest.TestCase):
     expected_restriction, _ = (
         self.sdf_restriction_tracker.try_split(fraction_of_remainder))
     current_restriction = self.sdf_restriction_tracker.current_restriction()
-    self.assertEqual(expected_restriction.source_bundle,
-                     current_restriction.source_bundle)
-    self.assertEqual(expected_restriction.range_tracker, None)
-    self.assertTrue(current_restriction.range_tracker)
+    self.assertEqual(expected_restriction._source_bundle,
+                     current_restriction._source_bundle)
+    self.assertTrue(current_restriction._range_tracker)
 
   def test_try_split_at_remainder(self):
     fraction_of_remainder = 0.4
@@ -180,15 +179,16 @@ class SDFBoundedSourceRestrictionTrackerTest(unittest.TestCase):
     actual_primary, actual_residual = (
         self.sdf_restriction_tracker.try_split(fraction_of_remainder))
     self.assertEqual(expected_primary,
-                     (actual_primary.source_bundle.start_position,
-                      actual_primary.source_bundle.stop_position,
-                      actual_primary.source_bundle.weight))
+                     (actual_primary._source_bundle.start_position,
+                      actual_primary._source_bundle.stop_position,
+                      actual_primary._source_bundle.weight))
     self.assertEqual(expected_residual,
-                     (actual_residual.source_bundle.start_position,
-                      actual_residual.source_bundle.stop_position,
-                      actual_residual.source_bundle.weight))
-    self.assertEqual(actual_primary.source_bundle.weight,
-                     self.sdf_restriction_tracker._weight)
+                     (actual_residual._source_bundle.start_position,
+                      actual_residual._source_bundle.stop_position,
+                      actual_residual._source_bundle.weight))
+    self.assertEqual(
+        actual_primary._source_bundle.weight,
+        self.sdf_restriction_tracker.current_restriction().weight())
 
 
 class UseSdfBoundedSourcesTests(unittest.TestCase):


### PR DESCRIPTION
Use (SourceBundle, RangeTracker) as restriction for SDFBoundedSourceWrapper. 

This PR fixes the issue that the system and SDF.process don't use the same instance of RangeTracker, which causes splitting failed.

R: @robertwb 
cc: @chamikaramj 