### PR TITLE
[BEAM-8619] Tear down the DoFns upon the control service termination …

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/CounterCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/CounterCell.java
@@ -51,6 +51,12 @@ public class CounterCell implements Counter, MetricCell<Long> {
     this.name = name;
   }
 
+  @Override
+  public void reset() {
+    dirty.afterModification();
+    value.set(0L);
+  }
+
   /**
    * Increment the counter by the given amount.
    *

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionCell.java
@@ -52,6 +52,12 @@ public class DistributionCell implements Distribution, MetricCell<DistributionDa
     this.name = name;
   }
 
+  @Override
+  public void reset() {
+    dirty.afterModification();
+    value.set(DistributionData.EMPTY);
+  }
+
   /** Increment the distribution by the given amount. */
   @Override
   public void update(long n) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateSampler.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateSampler.java
@@ -69,6 +69,11 @@ public class ExecutionStateSampler {
 
   @Nullable private Future<Void> executionSamplerFuture = null;
 
+  /** Reset the state sampler. */
+  public void reset() {
+    lastSampleTimeMillis = 0;
+  }
+
   /**
    * Called to start the ExecutionStateSampler. Until the returned {@link Closeable} is closed, the
    * state sampler will periodically sample the current state of all the threads it has been asked

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
@@ -137,6 +137,17 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
     this.sampler = sampler;
   }
 
+  /** Reset the execution status. */
+  public void reset() {
+    trackedThread = null;
+    currentState = null;
+    numTransitions = 0;
+    millisSinceLastTransition = 0;
+    transitionsAtLastSample = 0;
+    nextLullReportMs = LULL_REPORT_MS;
+    CURRENT_TRACKERS.entrySet().removeIf(entry -> entry.getValue() == this);
+  }
+
   @VisibleForTesting
   public static ExecutionStateTracker newForTest() {
     return new ExecutionStateTracker(ExecutionStateSampler.newForTest());
@@ -259,6 +270,16 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
   /** Return the time since the last transition. */
   public long getMillisSinceLastTransition() {
     return millisSinceLastTransition;
+  }
+
+  /** Return the number of transitions since the last sample. */
+  public long getTransitionsAtLastSample() {
+    return transitionsAtLastSample;
+  }
+
+  /** Return the time of the next lull report. */
+  public long getNextLullReportMs() {
+    return nextLullReportMs;
   }
 
   protected void takeSample(long millisSinceLastSample) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/GaugeCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/GaugeCell.java
@@ -50,6 +50,12 @@ public class GaugeCell implements Gauge, MetricCell<GaugeData> {
     this.name = name;
   }
 
+  @Override
+  public void reset() {
+    dirty.afterModification();
+    gaugeValue.set(GaugeData.empty());
+  }
+
   /** Set the gauge to the given value. */
   @Override
   public void set(long value) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricCell.java
@@ -36,4 +36,7 @@ public interface MetricCell<DataT> extends Serializable {
 
   /** Return the cumulative value of this metric. */
   DataT getCumulative();
+
+  /** Reset this metric. */
+  void reset();
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
@@ -79,6 +79,19 @@ public class MetricsContainerImpl implements Serializable, MetricsContainer {
     this.stepName = stepName;
   }
 
+  /** Reset the metrics. */
+  public void reset() {
+    reset(counters);
+    reset(distributions);
+    reset(gauges);
+  }
+
+  private void reset(MetricsMap<MetricName, ? extends MetricCell<?>> cells) {
+    for (MetricCell<?> cell : cells.values()) {
+      cell.reset();
+    }
+  }
+
   /**
    * Return a {@code CounterCell} named {@code metricName}. If it doesn't exist, create a {@code
    * Metric} with the specified name.

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
@@ -84,6 +84,14 @@ public class MetricsContainerStepMap implements Serializable {
     getContainer(step).update(container);
   }
 
+  /** Reset the metric containers. */
+  public void reset() {
+    for (MetricsContainerImpl metricsContainer : metricsContainers.values()) {
+      metricsContainer.reset();
+    }
+    unboundContainer.reset();
+  }
+
   @Override
   public boolean equals(Object object) {
     if (object instanceof MetricsContainerStepMap) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleExecutionState.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleExecutionState.java
@@ -69,6 +69,11 @@ public class SimpleExecutionState extends ExecutionState {
     }
   }
 
+  /** Reset the totalMillis spent in the state. */
+  public void reset() {
+    this.totalMillis = 0;
+  }
+
   public String getUrn() {
     return this.urn;
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleStateRegistry.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleStateRegistry.java
@@ -32,6 +32,13 @@ public class SimpleStateRegistry {
     this.executionStates.add(state);
   }
 
+  /** Reset the registered SimpleExecutionStates. */
+  public void reset() {
+    for (SimpleExecutionState state : executionStates) {
+      state.reset();
+    }
+  }
+
   /** @return Execution Time MonitoringInfos based on the tracked start or finish function. */
   public List<MonitoringInfo> getExecutionTimeMonitoringInfos() {
     List<MonitoringInfo> monitoringInfos = new ArrayList<MonitoringInfo>();

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/CounterCellTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/CounterCellTest.java
@@ -80,4 +80,15 @@ public class CounterCellTest {
     Assert.assertNotEquals(counterCell, differentName);
     Assert.assertNotEquals(counterCell.hashCode(), differentName.hashCode());
   }
+
+  @Test
+  public void testReset() {
+    CounterCell counterCell = new CounterCell(MetricName.named("namespace", "name"));
+    counterCell.inc(1);
+    assertThat(counterCell.getCumulative(), equalTo(1L));
+
+    counterCell.reset();
+    assertThat(counterCell.getCumulative(), equalTo(0L));
+    assertThat(counterCell.getDirty(), equalTo(new DirtyState()));
+  }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/DistributionCellTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/DistributionCellTest.java
@@ -81,4 +81,15 @@ public class DistributionCellTest {
     Assert.assertNotEquals(distributionCell, differentName);
     Assert.assertNotEquals(distributionCell.hashCode(), differentName.hashCode());
   }
+
+  @Test
+  public void testReset() {
+    DistributionCell distributionCell = new DistributionCell(MetricName.named("namespace", "name"));
+    distributionCell.update(2);
+    assertThat(distributionCell.getCumulative(), equalTo(DistributionData.create(2, 1, 2, 2)));
+
+    distributionCell.reset();
+    assertThat(distributionCell.getCumulative(), equalTo(DistributionData.EMPTY));
+    assertThat(distributionCell.getDirty(), equalTo(new DirtyState()));
+  }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/ExecutionStateSamplerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/ExecutionStateSamplerTest.java
@@ -123,6 +123,13 @@ public class ExecutionStateSamplerTest {
     assertThat(step1act1.lullReported, equalTo(true));
   }
 
+  @Test
+  public void testReset() throws Exception {
+    sampler.lastSampleTimeMillis = 100L;
+    sampler.reset();
+    assertThat(sampler.lastSampleTimeMillis, equalTo(0L));
+  }
+
   private ExecutionStateTracker createTracker() {
     return new ExecutionStateTracker(sampler);
   }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/ExecutionStateTrackerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/ExecutionStateTrackerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.metrics;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.runners.core.metrics.ExecutionStateTracker.ExecutionState;
+import org.joda.time.DateTimeUtils.MillisProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link ExecutionStateTracker}. */
+public class ExecutionStateTrackerTest {
+
+  private MillisProvider clock;
+  private ExecutionStateSampler sampler;
+
+  @Before
+  public void setUp() {
+    clock = mock(MillisProvider.class);
+    sampler = ExecutionStateSampler.newForTest(clock);
+  }
+
+  private static class TestExecutionState extends ExecutionState {
+
+    private long totalMillis = 0;
+
+    public TestExecutionState(String stateName) {
+      super(stateName);
+    }
+
+    @Override
+    public void takeSample(long millisSinceLastSample) {
+      totalMillis += millisSinceLastSample;
+    }
+
+    @Override
+    public void reportLull(Thread trackedThread, long millis) {}
+  }
+
+  private final TestExecutionState testExecutionState = new TestExecutionState("activity");
+
+  @Test
+  public void testReset() throws Exception {
+    ExecutionStateTracker tracker = createTracker();
+    try (Closeable c1 = tracker.activate(new Thread())) {
+      try (Closeable c2 = tracker.enterState(testExecutionState)) {
+        sampler.doSampling(400);
+        assertThat(testExecutionState.totalMillis, equalTo(400L));
+      }
+    }
+
+    tracker.reset();
+    assertThat(tracker.getTrackedThread(), equalTo(null));
+    assertThat(tracker.getCurrentState(), equalTo(null));
+    assertThat(tracker.getNumTransitions(), equalTo(0L));
+    assertThat(tracker.getMillisSinceLastTransition(), equalTo(0L));
+    assertThat(tracker.getTransitionsAtLastSample(), equalTo(0L));
+    assertThat(tracker.getNextLullReportMs(), equalTo(TimeUnit.MINUTES.toMillis(5)));
+  }
+
+  private ExecutionStateTracker createTracker() {
+    return new ExecutionStateTracker(sampler);
+  }
+}

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/GaugeCellTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/GaugeCellTest.java
@@ -74,4 +74,15 @@ public class GaugeCellTest {
     Assert.assertNotEquals(gaugeCell, differentName);
     Assert.assertNotEquals(gaugeCell.hashCode(), differentName.hashCode());
   }
+
+  @Test
+  public void testReset() {
+    GaugeCell gaugeCell = new GaugeCell(MetricName.named("namespace", "name"));
+    gaugeCell.set(2);
+    assertThat(gaugeCell.getCumulative().value(), equalTo(GaugeData.create(2).value()));
+
+    gaugeCell.reset();
+    assertThat(gaugeCell.getCumulative(), equalTo(GaugeData.empty()));
+    assertThat(gaugeCell.getDirty(), equalTo(new DirtyState()));
+  }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMapTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMapTest.java
@@ -328,6 +328,50 @@ public class MetricsContainerStepMapTest {
         metricsContainerStepMap.hashCode(), differentUnboundedContainer.hashCode());
   }
 
+  @Test
+  public void testReset() {
+    MetricsContainerStepMap attemptedMetrics = new MetricsContainerStepMap();
+    attemptedMetrics.update(STEP1, metricsContainer);
+    attemptedMetrics.update(STEP2, metricsContainer);
+    attemptedMetrics.update(STEP2, metricsContainer);
+
+    MetricResults metricResults = asAttemptedOnlyMetricResults(attemptedMetrics);
+    MetricQueryResults allres = metricResults.allMetrics();
+    assertCounter(COUNTER_NAME, allres, STEP1, VALUE, false);
+    assertDistribution(
+        DISTRIBUTION_NAME,
+        allres,
+        STEP1,
+        DistributionResult.create(VALUE * 3, 2, VALUE, VALUE * 2),
+        false);
+    assertGauge(GAUGE_NAME, allres, STEP1, GaugeResult.create(VALUE, Instant.now()), false);
+
+    assertCounter(COUNTER_NAME, allres, STEP2, VALUE * 2, false);
+    assertDistribution(
+        DISTRIBUTION_NAME,
+        allres,
+        STEP2,
+        DistributionResult.create(VALUE * 6, 4, VALUE, VALUE * 2),
+        false);
+    assertGauge(GAUGE_NAME, allres, STEP2, GaugeResult.create(VALUE, Instant.now()), false);
+
+    attemptedMetrics.reset();
+    metricResults = asAttemptedOnlyMetricResults(attemptedMetrics);
+    allres = metricResults.allMetrics();
+
+    // Check that the metrics container for STEP1 is reset
+    assertCounter(COUNTER_NAME, allres, STEP1, 0L, false);
+    assertDistribution(
+        DISTRIBUTION_NAME, allres, STEP1, DistributionResult.IDENTITY_ELEMENT, false);
+    assertGauge(GAUGE_NAME, allres, STEP1, GaugeResult.empty(), false);
+
+    // Check that the metrics container for STEP2 is reset
+    assertCounter(COUNTER_NAME, allres, STEP2, 0L, false);
+    assertDistribution(
+        DISTRIBUTION_NAME, allres, STEP2, DistributionResult.IDENTITY_ELEMENT, false);
+    assertGauge(GAUGE_NAME, allres, STEP2, GaugeResult.empty(), false);
+  }
+
   private <T> void assertIterableSize(Iterable<T> iterable, int size) {
     assertThat(iterable, IsIterableWithSize.iterableWithSize(size));
   }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/SimpleExecutionStateTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/SimpleExecutionStateTest.java
@@ -54,6 +54,9 @@ public class SimpleExecutionStateTest {
     assertEquals(10, testObject.getTotalMillis());
     testObject.takeSample(5);
     assertEquals(15, testObject.getTotalMillis());
+
+    testObject.reset();
+    assertEquals(0, testObject.getTotalMillis());
   }
 
   @Test

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/SimpleStateRegistryTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/SimpleStateRegistryTest.java
@@ -18,6 +18,9 @@
 package org.apache.beam.runners.core.metrics;
 
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -80,5 +83,19 @@ public class SimpleStateRegistryTest {
     for (Matcher<MonitoringInfo> matcher : matchers) {
       assertThat(testOutput, Matchers.hasItem(matcher));
     }
+  }
+
+  @Test
+  public void testResetRegistry() {
+    SimpleExecutionState state1 = mock(SimpleExecutionState.class);
+    SimpleExecutionState state2 = mock(SimpleExecutionState.class);
+
+    SimpleStateRegistry testObject = new SimpleStateRegistry();
+    testObject.register(state1);
+    testObject.register(state2);
+
+    testObject.reset();
+    verify(state1, times(1)).reset();
+    verify(state2, times(1)).reset();
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DeltaCounterCell.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DeltaCounterCell.java
@@ -38,6 +38,11 @@ public class DeltaCounterCell implements Counter, MetricCell<Long> {
   }
 
   @Override
+  public void reset() {
+    value.set(0L);
+  }
+
+  @Override
   public void inc(long n) {
     value.addAndGet(n);
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DeltaDistributionCell.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DeltaDistributionCell.java
@@ -53,6 +53,11 @@ public class DeltaDistributionCell implements Distribution, MetricCell<Distribut
   }
 
   @Override
+  public void reset() {
+    value.set(DistributionData.EMPTY);
+  }
+
+  @Override
   public void update(long sum, long count, long min, long max) {
     update(DistributionData.create(sum, count, min, max));
   }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataReadRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataReadRunner.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.I
 import com.google.auto.service.AutoService;
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
@@ -42,6 +43,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.data.InboundDataClient;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
 import org.apache.beam.sdk.fn.data.RemoteGrpcPortRead;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
@@ -86,6 +88,7 @@ public class BeamFnDataReadRunner<OutputT> {
         PCollectionConsumerRegistry pCollectionConsumerRegistry,
         PTransformFunctionRegistry startFunctionRegistry,
         PTransformFunctionRegistry finishFunctionRegistry,
+        Consumer<ThrowingRunnable> tearDownFunctions,
         BundleSplitListener splitListener)
         throws IOException {
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataWriteRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataWriteRunner.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.I
 import com.google.auto.service.AutoService;
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
@@ -42,6 +43,7 @@ import org.apache.beam.sdk.fn.data.CloseableFnDataReceiver;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
 import org.apache.beam.sdk.fn.data.RemoteGrpcPortWrite;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
@@ -86,6 +88,7 @@ public class BeamFnDataWriteRunner<InputT> {
         PCollectionConsumerRegistry pCollectionConsumerRegistry,
         PTransformFunctionRegistry startFunctionRegistry,
         PTransformFunctionRegistry finishFunctionRegistry,
+        Consumer<ThrowingRunnable> tearDownFunctions,
         BundleSplitListener splitListener)
         throws IOException {
       RunnerApi.Coder coderSpec;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BoundedSourceRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BoundedSourceRunner.java
@@ -21,6 +21,7 @@ import com.google.auto.service.AutoService;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.control.ProcessBundleHandler;
@@ -36,6 +37,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.ReadPayload;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.ReadTranslation;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.Source.Reader;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -80,6 +82,7 @@ public class BoundedSourceRunner<InputT extends BoundedSource<OutputT>, OutputT>
         PCollectionConsumerRegistry pCollectionConsumerRegistry,
         PTransformFunctionRegistry startFunctionRegistry,
         PTransformFunctionRegistry finishFunctionRegistry,
+        Consumer<ThrowingRunnable> tearDownFunctions,
         BundleSplitListener splitListener) {
       ImmutableList.Builder<FnDataReceiver<WindowedValue<?>>> consumers = ImmutableList.builder();
       for (String pCollectionId : pTransform.getOutputsMap().values()) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
@@ -20,6 +20,7 @@ package org.apache.beam.fn.harness;
 import com.google.auto.service.AutoService;
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
@@ -37,6 +38,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.function.ThrowingFunction;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.util.SerializableUtils;
@@ -125,6 +127,7 @@ public class CombineRunners {
         PCollectionConsumerRegistry pCollectionConsumerRegistry,
         PTransformFunctionRegistry startFunctionRegistry,
         PTransformFunctionRegistry finishFunctionRegistry,
+        Consumer<ThrowingRunnable> tearDownFunctions,
         BundleSplitListener splitListener)
         throws IOException {
       // Get objects needed to create the runner.

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.I
 import com.google.auto.service.AutoService;
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
@@ -33,6 +34,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
@@ -65,6 +67,7 @@ public class FlattenRunner<InputT> {
         PCollectionConsumerRegistry pCollectionConsumerRegistry,
         PTransformFunctionRegistry startFunctionRegistry,
         PTransformFunctionRegistry finishFunctionRegistry,
+        Consumer<ThrowingRunnable> tearDownFunctions,
         BundleSplitListener splitListener)
         throws IOException {
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -225,6 +225,11 @@ public class FnApiDoFnRunner<InputT, OutputT>
     this.stateAccessor = null;
   }
 
+  @Override
+  public void tearDown() {
+    doFnInvoker.invokeTeardown();
+  }
+
   /** Outputs the given element to the specified set of consumers wrapping any exceptions. */
   private <T> void outputTo(
       Collection<FnDataReceiver<WindowedValue<T>>> consumers, WindowedValue<T> output) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -206,6 +206,7 @@ public class FnHarness {
 
       LOG.info("Entering instruction processing loop");
       control.processInstructionRequests(executorService);
+      processBundleHandler.shutdown();
     } finally {
       System.out.println("Shutting SDK harness down.");
       executorService.shutdown();

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/MapFnRunners.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/MapFnRunners.java
@@ -21,6 +21,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.I
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
@@ -32,6 +33,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.function.ThrowingFunction;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
@@ -107,6 +109,7 @@ public abstract class MapFnRunners {
         PCollectionConsumerRegistry pCollectionConsumerRegistry,
         PTransformFunctionRegistry startFunctionRegistry,
         PTransformFunctionRegistry finishFunctionRegistry,
+        Consumer<ThrowingRunnable> tearDownFunctions,
         BundleSplitListener splitListener)
         throws IOException {
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PTransformRunnerFactory.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PTransformRunnerFactory.java
@@ -19,6 +19,7 @@ package org.apache.beam.fn.harness;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
@@ -29,6 +30,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptions;
 
 /** A factory able to instantiate an appropriate handler for a given PTransform. */
@@ -55,6 +57,7 @@ public interface PTransformRunnerFactory<T> {
    *     registered within this multimap.
    * @param startFunctionRegistry A class to register a start bundle handler with.
    * @param finishFunctionRegistry A class to register a finish bundle handler with.
+   * @param addTearDownFunction A consumer to register a tear down handler with.
    * @param splitListener A listener to be invoked when the PTransform splits itself.
    */
   T createRunnerForPTransform(
@@ -70,6 +73,7 @@ public interface PTransformRunnerFactory<T> {
       PCollectionConsumerRegistry pCollectionConsumerRegistry,
       PTransformFunctionRegistry startFunctionRegistry,
       PTransformFunctionRegistry finishFunctionRegistry,
+      Consumer<ThrowingRunnable> addTearDownFunction,
       BundleSplitListener splitListener)
       throws IOException;
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableProcessElementsRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableProcessElementsRunner.java
@@ -265,6 +265,11 @@ public class SplittableProcessElementsRunner<InputT, RestrictionT, OutputT>
     doFnInvoker.invokeFinishBundle(finishBundleContext);
   }
 
+  @Override
+  public void tearDown() {
+    doFnInvoker.invokeTeardown();
+  }
+
   /** Outputs the given element to the specified set of consumers wrapping any exceptions. */
   private <T> void outputTo(
       Collection<FnDataReceiver<WindowedValue<T>>> consumers, WindowedValue<T> output) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PCollectionConsumerRegistry.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PCollectionConsumerRegistry.java
@@ -109,6 +109,11 @@ public class PCollectionConsumerRegistry {
     pCollectionIdsToConsumers.put(pCollectionId, (FnDataReceiver) wrapAndEnableMetricContainer);
   }
 
+  /** Reset the execution states of the registered functions. */
+  public void reset() {
+    executionStates.reset();
+  }
+
   /** @return the list of pcollection ids. */
   public Set<String> keySet() {
     return pCollectionIdsToConsumers.keySet();

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PTransformFunctionRegistry.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PTransformFunctionRegistry.java
@@ -112,6 +112,11 @@ public class PTransformFunctionRegistry {
     runnables.add(wrapped);
   }
 
+  /** Reset the execution states of the registered functions. */
+  public void reset() {
+    executionStates.reset();
+  }
+
   /** @return Execution Time MonitoringInfos based on the tracked start or finish function. */
   public List<MonitoringInfo> getExecutionTimeMonitoringInfos() {
     return executionStates.getExecutionTimeMonitoringInfos();

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
@@ -205,6 +205,7 @@ public class AssignWindowsRunnerTest implements Serializable {
             pCollectionConsumerRegistry,
             null /* startFunctionRegistry */,
             null, /* finishFunctionRegistry */
+            null, /* tearDownRegistry */
             null /* splitListener */);
 
     WindowedValue<Integer> value =

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.fn.harness;
 import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -59,6 +60,7 @@ import org.apache.beam.sdk.fn.data.LogicalEndpoint;
 import org.apache.beam.sdk.fn.data.RemoteGrpcPortRead;
 import org.apache.beam.sdk.fn.test.TestExecutors;
 import org.apache.beam.sdk.fn.test.TestExecutors.TestExecutorService;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -144,6 +146,7 @@ public class BeamFnDataReadRunnerTest {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     RunnerApi.PTransform pTransform =
         RemoteGrpcPortRead.readFromPort(PORT_SPEC, localOutputId).toPTransform();
@@ -164,7 +167,10 @@ public class BeamFnDataReadRunnerTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
+
+    assertThat(teardownFunctions, empty());
 
     verifyZeroInteractions(mockBeamFnDataClient);
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataWriteRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataWriteRunnerTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.fn.harness;
 import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -54,6 +55,7 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.fn.data.CloseableFnDataReceiver;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
 import org.apache.beam.sdk.fn.data.RemoteGrpcPortWrite;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -125,6 +127,7 @@ public class BeamFnDataWriteRunnerTest {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     String localInputId = "inputPC";
     RunnerApi.PTransform pTransform =
@@ -145,7 +148,10 @@ public class BeamFnDataWriteRunnerTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
+
+    assertThat(teardownFunctions, empty());
 
     verifyZeroInteractions(mockBeamFnDataClient);
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BoundedSourceRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BoundedSourceRunnerTest.java
@@ -38,6 +38,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -141,6 +142,7 @@ public class BoundedSourceRunnerTest {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     RunnerApi.FunctionSpec functionSpec =
         RunnerApi.FunctionSpec.newBuilder()
@@ -170,6 +172,7 @@ public class BoundedSourceRunnerTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     // This is testing a deprecated way of running sources and should be removed
@@ -188,6 +191,7 @@ public class BoundedSourceRunnerTest {
     assertThat(outputValues, contains(valueInGlobalWindow(0L), valueInGlobalWindow(1L)));
 
     assertThat(finishFunctionRegistry.getFunctions(), Matchers.empty());
+    assertThat(teardownFunctions, Matchers.empty());
   }
 
   @Test

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/CombineRunnersTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/CombineRunnersTest.java
@@ -156,6 +156,7 @@ public class CombineRunnersTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            null,
             null);
 
     Iterables.getOnlyElement(startFunctionRegistry.getFunctions()).run();
@@ -230,6 +231,7 @@ public class CombineRunnersTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            null,
             null);
 
     assertThat(startFunctionRegistry.getFunctions(), empty());
@@ -292,6 +294,7 @@ public class CombineRunnersTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            null,
             null);
 
     assertThat(startFunctionRegistry.getFunctions(), empty());
@@ -354,6 +357,7 @@ public class CombineRunnersTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            null,
             null);
 
     assertThat(startFunctionRegistry.getFunctions(), empty());

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
@@ -91,6 +91,7 @@ public class FlattenRunnerTest {
             consumers,
             null /* startFunctionRegistry */,
             null, /* finishFunctionRegistry */
+            null, /* tearDownRegistry */
             null /* splitListener */);
 
     mainOutputValues.clear();
@@ -158,6 +159,7 @@ public class FlattenRunnerTest {
             consumers,
             null /* startFunctionRegistry */,
             null, /* finishFunctionRegistry */
+            null, /* tearDownRegistry */
             null /* splitListener */);
 
     mainOutputValues.clear();

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -53,6 +53,7 @@ import org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
@@ -211,6 +212,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     new FnApiDoFnRunner.Factory<>()
         .createRunnerForPTransform(
@@ -226,6 +228,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     Iterables.getOnlyElement(startFunctionRegistry.getFunctions()).run();
@@ -259,6 +262,9 @@ public class FnApiDoFnRunnerTest implements Serializable {
     mainOutputValues.clear();
 
     Iterables.getOnlyElement(finishFunctionRegistry.getFunctions()).run();
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
     assertThat(mainOutputValues, empty());
 
     assertEquals(
@@ -382,6 +388,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     new FnApiDoFnRunner.Factory<>()
         .createRunnerForPTransform(
@@ -397,6 +404,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     Iterables.getOnlyElement(startFunctionRegistry.getFunctions()).run();
@@ -431,6 +439,9 @@ public class FnApiDoFnRunnerTest implements Serializable {
     mainOutputValues.clear();
 
     Iterables.getOnlyElement(finishFunctionRegistry.getFunctions()).run();
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
     assertThat(mainOutputValues, empty());
 
     // Assert that state data did not change
@@ -516,6 +527,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     new FnApiDoFnRunner.Factory<>()
         .createRunnerForPTransform(
@@ -531,6 +543,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     Iterables.getOnlyElement(startFunctionRegistry.getFunctions()).run();
@@ -551,6 +564,13 @@ public class FnApiDoFnRunnerTest implements Serializable {
     assertThat(
         mainOutputValues.get(1).getValue(),
         contains("iterableValue1B", "iterableValue2B", "iterableValue3B"));
+    mainOutputValues.clear();
+
+    Iterables.getOnlyElement(finishFunctionRegistry.getFunctions()).run();
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
+    assertThat(mainOutputValues, empty());
 
     // Assert that state data did not change
     assertEquals(stateData, fakeClient.getData());
@@ -622,6 +642,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     new FnApiDoFnRunner.Factory<>()
         .createRunnerForPTransform(
@@ -637,6 +658,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     Iterables.getOnlyElement(startFunctionRegistry.getFunctions()).run();
@@ -650,6 +672,13 @@ public class FnApiDoFnRunnerTest implements Serializable {
         consumers.getMultiplexingConsumer(inputPCollectionId);
     mainInput.accept(valueInWindow("X", windowA));
     mainInput.accept(valueInWindow("Y", windowB));
+    mainOutputValues.clear();
+
+    Iterables.getOnlyElement(finishFunctionRegistry.getFunctions()).run();
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
+    assertThat(mainOutputValues, empty());
 
     MetricsContainer mc = MetricsEnvironment.getCurrentContainer();
 
@@ -810,6 +839,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     new FnApiDoFnRunner.Factory<>()
         .createRunnerForPTransform(
@@ -837,6 +867,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     Iterables.getOnlyElement(startFunctionRegistry.getFunctions()).run();
@@ -912,6 +943,9 @@ public class FnApiDoFnRunnerTest implements Serializable {
     mainOutputValues.clear();
 
     Iterables.getOnlyElement(finishFunctionRegistry.getFunctions()).run();
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
     assertThat(mainOutputValues, empty());
 
     assertEquals(

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/MapFnRunnersTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/MapFnRunnersTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.sdk.function.ThrowingFunction;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
@@ -74,6 +75,7 @@ public class MapFnRunnersTest {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             metricsContainerRegistry, mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     ValueMapFnFactory<String, String> factory = (ptId, pt) -> String::toUpperCase;
     MapFnRunners.forValueMapFnFactory(factory)
@@ -90,10 +92,12 @@ public class MapFnRunnersTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     assertThat(startFunctionRegistry.getFunctions(), empty());
     assertThat(finishFunctionRegistry.getFunctions(), empty());
+    assertThat(teardownFunctions, empty());
 
     assertThat(consumers.keySet(), containsInAnyOrder("inputPC", "outputPC"));
 
@@ -117,6 +121,7 @@ public class MapFnRunnersTest {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             metricsContainerRegistry, mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     MapFnRunners.forWindowedValueMapFnFactory(this::createMapFunctionForPTransform)
         .createRunnerForPTransform(
@@ -132,10 +137,12 @@ public class MapFnRunnersTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     assertThat(startFunctionRegistry.getFunctions(), empty());
     assertThat(finishFunctionRegistry.getFunctions(), empty());
+    assertThat(teardownFunctions, empty());
 
     assertThat(consumers.keySet(), containsInAnyOrder("inputPC", "outputPC"));
 
@@ -158,6 +165,7 @@ public class MapFnRunnersTest {
     PTransformFunctionRegistry finishFunctionRegistry =
         new PTransformFunctionRegistry(
             mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
 
     MapFnRunners.forWindowedValueMapFnFactory(this::createMapFunctionForPTransform)
         .createRunnerForPTransform(
@@ -173,10 +181,12 @@ public class MapFnRunnersTest {
             consumers,
             startFunctionRegistry,
             finishFunctionRegistry,
+            teardownFunctions::add,
             null /* splitListener */);
 
     assertThat(startFunctionRegistry.getFunctions(), empty());
     assertThat(finishFunctionRegistry.getFunctions(), empty());
+    assertThat(teardownFunctions, empty());
 
     assertThat(consumers.keySet(), containsInAnyOrder("inputPC", "outputPC"));
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -131,6 +131,13 @@ public class ProcessBundleHandlerTest {
       orderOfOperations.add("setUp");
     }
 
+    @Teardown
+    public void tearDown() {
+      checkState(!TestDoFn.State.TEAR_DOWN.equals(state), "Unexpected state: %s", state);
+      state = TestDoFn.State.TEAR_DOWN;
+      orderOfOperations.add("tearDown");
+    }
+
     @StartBundle
     public void startBundle() {
       state = TestDoFn.State.START_BUNDLE;
@@ -416,11 +423,14 @@ public class ProcessBundleHandlerTest {
                 BeamFnApi.ProcessBundleRequest.newBuilder().setProcessBundleDescriptorId("1L"))
             .build());
 
+    handler.shutdown();
+
     // setup and teardown should occur only once when processing multiple bundles for the same
     // descriptor
     assertThat(
         TestDoFn.orderOfOperations,
-        contains("setUp", "startBundle", "finishBundle", "startBundle", "finishBundle"));
+        contains(
+            "setUp", "startBundle", "finishBundle", "startBundle", "finishBundle", "tearDown"));
   }
 
   @Test

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -17,16 +17,22 @@
  */
 package org.apache.beam.fn.harness.control;
 
+import static org.apache.beam.fn.harness.control.ProcessBundleHandler.REGISTERED_RUNNER_FACTORIES;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -34,9 +40,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.PTransformRunnerFactory;
+import org.apache.beam.fn.harness.control.ProcessBundleHandler.BundleProcessor;
+import org.apache.beam.fn.harness.control.ProcessBundleHandler.BundleProcessorCache;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
 import org.apache.beam.fn.harness.data.PCollectionConsumerRegistry;
 import org.apache.beam.fn.harness.data.PTransformFunctionRegistry;
+import org.apache.beam.fn.harness.data.QueueingBeamFnDataClient;
 import org.apache.beam.fn.harness.state.BeamFnStateClient;
 import org.apache.beam.fn.harness.state.BeamFnStateGrpcClientCache;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
@@ -48,13 +57,29 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.model.pipeline.v1.RunnerApi.WindowingStrategy;
+import org.apache.beam.runners.core.construction.CoderTranslation;
+import org.apache.beam.runners.core.construction.ModelCoders;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.core.construction.ParDoTranslation;
+import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
+import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.function.ThrowingConsumer;
 import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.util.DoFnWithExecutionInformation;
+import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.Message;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Multimap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Before;
 import org.junit.Rule;
@@ -82,6 +107,117 @@ public class ProcessBundleHandlerTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+  }
+
+  private static class TestDoFn extends DoFn<String, String> {
+    private static final TupleTag<String> mainOutput = new TupleTag<>("mainOutput");
+
+    static List<String> orderOfOperations = new ArrayList<>();
+
+    private enum State {
+      NOT_SET_UP,
+      SET_UP,
+      START_BUNDLE,
+      FINISH_BUNDLE,
+      TEAR_DOWN
+    }
+
+    private TestDoFn.State state = TestDoFn.State.NOT_SET_UP;
+
+    @Setup
+    public void setUp() {
+      checkState(TestDoFn.State.NOT_SET_UP.equals(state), "Unexpected state: %s", state);
+      state = TestDoFn.State.SET_UP;
+      orderOfOperations.add("setUp");
+    }
+
+    @StartBundle
+    public void startBundle() {
+      state = TestDoFn.State.START_BUNDLE;
+      orderOfOperations.add("startBundle");
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context, BoundedWindow window) {
+      checkState(TestDoFn.State.START_BUNDLE.equals(state), "Unexpected state: %s", state);
+    }
+
+    @FinishBundle
+    public void finishBundle(FinishBundleContext context) {
+      checkState(TestDoFn.State.START_BUNDLE.equals(state), "Unexpected state: %s", state);
+      state = TestDoFn.State.FINISH_BUNDLE;
+      orderOfOperations.add("finishBundle");
+    }
+  }
+
+  private static class TestBundleProcessor extends BundleProcessor {
+    static int resetCnt = 0;
+
+    private BundleProcessor wrappedBundleProcessor;
+
+    TestBundleProcessor(BundleProcessor wrappedBundleProcessor) {
+      this.wrappedBundleProcessor = wrappedBundleProcessor;
+    }
+
+    @Override
+    PTransformFunctionRegistry getStartFunctionRegistry() {
+      return wrappedBundleProcessor.getStartFunctionRegistry();
+    }
+
+    @Override
+    PTransformFunctionRegistry getFinishFunctionRegistry() {
+      return wrappedBundleProcessor.getFinishFunctionRegistry();
+    }
+
+    @Override
+    List<ThrowingRunnable> getTearDownFunctions() {
+      return wrappedBundleProcessor.getTearDownFunctions();
+    }
+
+    @Override
+    Multimap<String, BeamFnApi.DelayedBundleApplication> getAllResiduals() {
+      return wrappedBundleProcessor.getAllResiduals();
+    }
+
+    @Override
+    PCollectionConsumerRegistry getpCollectionConsumerRegistry() {
+      return wrappedBundleProcessor.getpCollectionConsumerRegistry();
+    }
+
+    @Override
+    MetricsContainerStepMap getMetricsContainerRegistry() {
+      return wrappedBundleProcessor.getMetricsContainerRegistry();
+    }
+
+    @Override
+    ExecutionStateTracker getStateTracker() {
+      return wrappedBundleProcessor.getStateTracker();
+    }
+
+    @Override
+    ProcessBundleHandler.HandleStateCallsForBundle getBeamFnStateClient() {
+      return wrappedBundleProcessor.getBeamFnStateClient();
+    }
+
+    @Override
+    QueueingBeamFnDataClient getQueueingClient() {
+      return wrappedBundleProcessor.getQueueingClient();
+    }
+
+    @Override
+    void reset() {
+      resetCnt++;
+      wrappedBundleProcessor.reset();
+    }
+  }
+
+  private static class TestBundleProcessorCache extends BundleProcessorCache {
+
+    @Override
+    BundleProcessor get(
+        String bundleDescriptorId, Supplier<BundleProcessor> bundleProcessorSupplier) {
+      return new TestBundleProcessor(super.get(bundleDescriptorId, bundleProcessorSupplier));
+    }
   }
 
   @Test
@@ -122,13 +258,19 @@ public class ProcessBundleHandlerTest {
             finishFunctionRegistry,
             addTearDownFunction,
             splitListener) -> {
-          assertThat(processBundleInstructionId.get(), equalTo("999L"));
-
           transformsProcessed.add(pTransform);
           startFunctionRegistry.register(
-              pTransformId, () -> orderOfOperations.add("Start" + pTransformId));
+              pTransformId,
+              () -> {
+                assertThat(processBundleInstructionId.get(), equalTo("999L"));
+                orderOfOperations.add("Start" + pTransformId);
+              });
           finishFunctionRegistry.register(
-              pTransformId, () -> orderOfOperations.add("Finish" + pTransformId));
+              pTransformId,
+              () -> {
+                assertThat(processBundleInstructionId.get(), equalTo("999L"));
+                orderOfOperations.add("Finish" + pTransformId);
+              });
           return null;
         };
 
@@ -140,7 +282,8 @@ public class ProcessBundleHandlerTest {
             null /* beamFnStateClient */,
             ImmutableMap.of(
                 DATA_INPUT_URN, startFinishRecorder,
-                DATA_OUTPUT_URN, startFinishRecorder));
+                DATA_OUTPUT_URN, startFinishRecorder),
+            new BundleProcessorCache());
 
     handler.processBundle(
         BeamFnApi.InstructionRequest.newBuilder()
@@ -157,6 +300,214 @@ public class ProcessBundleHandlerTest {
             processBundleDescriptor.getTransformsMap().get("2L")));
     // Start should occur in reverse order while finish calls should occur in forward order
     assertThat(orderOfOperations, contains("Start3L", "Start2L", "Finish2L", "Finish3L"));
+  }
+
+  @Test
+  public void testOrderOfSetupTeardownCalls() throws Exception {
+    DoFnWithExecutionInformation doFnWithExecutionInformation =
+        DoFnWithExecutionInformation.of(
+            new TestDoFn(),
+            TestDoFn.mainOutput,
+            Collections.emptyMap(),
+            DoFnSchemaInformation.create());
+    RunnerApi.FunctionSpec functionSpec =
+        RunnerApi.FunctionSpec.newBuilder()
+            .setUrn(ParDoTranslation.CUSTOM_JAVA_DO_FN_URN)
+            .setPayload(
+                ByteString.copyFrom(
+                    SerializableUtils.serializeToByteArray(doFnWithExecutionInformation)))
+            .build();
+    RunnerApi.ParDoPayload parDoPayload =
+        RunnerApi.ParDoPayload.newBuilder()
+            .setDoFn(RunnerApi.SdkFunctionSpec.newBuilder().setSpec(functionSpec))
+            .build();
+    BeamFnApi.ProcessBundleDescriptor processBundleDescriptor =
+        BeamFnApi.ProcessBundleDescriptor.newBuilder()
+            .putTransforms(
+                "2L",
+                PTransform.newBuilder()
+                    .setSpec(RunnerApi.FunctionSpec.newBuilder().setUrn(DATA_INPUT_URN).build())
+                    .putOutputs("2L-output", "2L-output-pc")
+                    .build())
+            .putTransforms(
+                "3L",
+                PTransform.newBuilder()
+                    .setSpec(
+                        RunnerApi.FunctionSpec.newBuilder()
+                            .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                            .setPayload(parDoPayload.toByteString()))
+                    .putInputs("3L-input", "2L-output-pc")
+                    .build())
+            .putPcollections(
+                "2L-output-pc",
+                PCollection.newBuilder()
+                    .setWindowingStrategyId("window-strategy")
+                    .setCoderId("2L-output-coder")
+                    .build())
+            .putWindowingStrategies(
+                "window-strategy",
+                WindowingStrategy.newBuilder()
+                    .setWindowCoderId("window-strategy-coder")
+                    .setWindowFn(
+                        RunnerApi.SdkFunctionSpec.newBuilder()
+                            .setSpec(
+                                RunnerApi.FunctionSpec.newBuilder()
+                                    .setUrn("beam:windowfn:global_windows:v0.1"))
+                            .build())
+                    .setOutputTime(RunnerApi.OutputTime.Enum.END_OF_WINDOW)
+                    .setAccumulationMode(RunnerApi.AccumulationMode.Enum.ACCUMULATING)
+                    .setTrigger(
+                        RunnerApi.Trigger.newBuilder()
+                            .setAlways(RunnerApi.Trigger.Always.getDefaultInstance()))
+                    .setClosingBehavior(RunnerApi.ClosingBehavior.Enum.EMIT_ALWAYS)
+                    .setOnTimeBehavior(RunnerApi.OnTimeBehavior.Enum.FIRE_ALWAYS)
+                    .build())
+            .putCoders("2L-output-coder", CoderTranslation.toProto(StringUtf8Coder.of()).getCoder())
+            .putCoders(
+                "window-strategy-coder",
+                Coder.newBuilder()
+                    .setSpec(
+                        RunnerApi.FunctionSpec.newBuilder()
+                            .setUrn(ModelCoders.GLOBAL_WINDOW_CODER_URN)
+                            .build())
+                    .build())
+            .build();
+    Map<String, Message> fnApiRegistry = ImmutableMap.of("1L", processBundleDescriptor);
+
+    Map<String, PTransformRunnerFactory> urnToPTransformRunnerFactoryMap =
+        Maps.newHashMap(REGISTERED_RUNNER_FACTORIES);
+    urnToPTransformRunnerFactoryMap.put(
+        DATA_INPUT_URN,
+        (pipelineOptions,
+            beamFnDataClient,
+            beamFnStateClient,
+            pTransformId,
+            pTransform,
+            processBundleInstructionId,
+            pCollections,
+            coders,
+            windowingStrategies,
+            pCollectionConsumerRegistry,
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            addTearDownFunction,
+            splitListener) -> null);
+
+    ProcessBundleHandler handler =
+        new ProcessBundleHandler(
+            PipelineOptionsFactory.create(),
+            fnApiRegistry::get,
+            beamFnDataClient,
+            null /* beamFnStateClient */,
+            urnToPTransformRunnerFactoryMap,
+            new BundleProcessorCache());
+
+    handler.processBundle(
+        BeamFnApi.InstructionRequest.newBuilder()
+            .setInstructionId("998L")
+            .setProcessBundle(
+                BeamFnApi.ProcessBundleRequest.newBuilder().setProcessBundleDescriptorId("1L"))
+            .build());
+
+    handler.processBundle(
+        BeamFnApi.InstructionRequest.newBuilder()
+            .setInstructionId("999L")
+            .setProcessBundle(
+                BeamFnApi.ProcessBundleRequest.newBuilder().setProcessBundleDescriptorId("1L"))
+            .build());
+
+    // setup and teardown should occur only once when processing multiple bundles for the same
+    // descriptor
+    assertThat(
+        TestDoFn.orderOfOperations,
+        contains("setUp", "startBundle", "finishBundle", "startBundle", "finishBundle"));
+  }
+
+  @Test
+  public void testBundleProcessorIsResetWhenAddedBackToCache() throws Exception {
+    BeamFnApi.ProcessBundleDescriptor processBundleDescriptor =
+        BeamFnApi.ProcessBundleDescriptor.newBuilder()
+            .putTransforms(
+                "2L",
+                RunnerApi.PTransform.newBuilder()
+                    .setSpec(RunnerApi.FunctionSpec.newBuilder().setUrn(DATA_INPUT_URN).build())
+                    .build())
+            .build();
+    Map<String, Message> fnApiRegistry = ImmutableMap.of("1L", processBundleDescriptor);
+
+    ProcessBundleHandler handler =
+        new ProcessBundleHandler(
+            PipelineOptionsFactory.create(),
+            fnApiRegistry::get,
+            beamFnDataClient,
+            null /* beamFnStateGrpcClientCache */,
+            ImmutableMap.of(
+                DATA_INPUT_URN,
+                (pipelineOptions,
+                    beamFnDataClient,
+                    beamFnStateClient,
+                    pTransformId,
+                    pTransform,
+                    processBundleInstructionId,
+                    pCollections,
+                    coders,
+                    windowingStrategies,
+                    pCollectionConsumerRegistry,
+                    startFunctionRegistry,
+                    finishFunctionRegistry,
+                    addTearDownFunction,
+                    splitListener) -> null),
+            new TestBundleProcessorCache());
+
+    assertThat(TestBundleProcessor.resetCnt, equalTo(0));
+
+    handler.processBundle(
+        BeamFnApi.InstructionRequest.newBuilder()
+            .setInstructionId("998L")
+            .setProcessBundle(
+                BeamFnApi.ProcessBundleRequest.newBuilder().setProcessBundleDescriptorId("1L"))
+            .build());
+
+    // Check that BundleProcessor is reset when added back to the cache
+    assertThat(TestBundleProcessor.resetCnt, equalTo(1));
+
+    // BundleProcessor is added back to the BundleProcessorCache
+    assertThat(handler.bundleProcessorCache.getCachedBundleProcessors().size(), equalTo(1));
+    assertThat(
+        handler.bundleProcessorCache.getCachedBundleProcessors().get("1L").size(), equalTo(1));
+  }
+
+  @Test
+  public void testBundleProcessorReset() {
+    PTransformFunctionRegistry startFunctionRegistry = mock(PTransformFunctionRegistry.class);
+    PTransformFunctionRegistry finishFunctionRegistry = mock(PTransformFunctionRegistry.class);
+    Multimap<String, BeamFnApi.DelayedBundleApplication> allResiduals = mock(Multimap.class);
+    PCollectionConsumerRegistry pCollectionConsumerRegistry =
+        mock(PCollectionConsumerRegistry.class);
+    MetricsContainerStepMap metricsContainerRegistry = mock(MetricsContainerStepMap.class);
+    ExecutionStateTracker stateTracker = mock(ExecutionStateTracker.class);
+    ProcessBundleHandler.HandleStateCallsForBundle beamFnStateClient =
+        mock(ProcessBundleHandler.HandleStateCallsForBundle.class);
+    QueueingBeamFnDataClient queueingClient = mock(QueueingBeamFnDataClient.class);
+    BundleProcessor bundleProcessor =
+        BundleProcessor.create(
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            new ArrayList<>(),
+            allResiduals,
+            pCollectionConsumerRegistry,
+            metricsContainerRegistry,
+            stateTracker,
+            beamFnStateClient,
+            queueingClient);
+
+    bundleProcessor.reset();
+    verify(startFunctionRegistry, times(1)).reset();
+    verify(finishFunctionRegistry, times(1)).reset();
+    verify(allResiduals, times(1)).clear();
+    verify(pCollectionConsumerRegistry, times(1)).reset();
+    verify(metricsContainerRegistry, times(1)).reset();
+    verify(stateTracker, times(1)).reset();
   }
 
   @Test
@@ -196,7 +547,8 @@ public class ProcessBundleHandlerTest {
                   thrown.expect(IllegalStateException.class);
                   thrown.expectMessage("TestException");
                   throw new IllegalStateException("TestException");
-                }));
+                }),
+            new BundleProcessorCache());
     handler.processBundle(
         BeamFnApi.InstructionRequest.newBuilder()
             .setProcessBundle(
@@ -244,12 +596,18 @@ public class ProcessBundleHandlerTest {
                       startFunctionRegistry.register(
                           pTransformId, ProcessBundleHandlerTest::throwException);
                       return null;
-                    }));
+                    }),
+            new BundleProcessorCache());
     handler.processBundle(
         BeamFnApi.InstructionRequest.newBuilder()
             .setProcessBundle(
                 BeamFnApi.ProcessBundleRequest.newBuilder().setProcessBundleDescriptorId("1L"))
             .build());
+
+    // BundleProcessor is not re-added back to the BundleProcessorCache in case of an exception
+    // during bundle processing
+    assertThat(
+        handler.bundleProcessorCache.getCachedBundleProcessors(), equalTo(Collections.EMPTY_MAP));
   }
 
   @Test
@@ -292,12 +650,18 @@ public class ProcessBundleHandlerTest {
                       finishFunctionRegistry.register(
                           pTransformId, ProcessBundleHandlerTest::throwException);
                       return null;
-                    }));
+                    }),
+            new BundleProcessorCache());
     handler.processBundle(
         BeamFnApi.InstructionRequest.newBuilder()
             .setProcessBundle(
                 BeamFnApi.ProcessBundleRequest.newBuilder().setProcessBundleDescriptorId("1L"))
             .build());
+
+    // BundleProcessor is not re-added back to the BundleProcessorCache in case of an exception
+    // during bundle processing
+    assertThat(
+        handler.bundleProcessorCache.getCachedBundleProcessors(), equalTo(Collections.EMPTY_MAP));
   }
 
   @Test
@@ -385,7 +749,8 @@ public class ProcessBundleHandlerTest {
                     beamFnStateClient.handle(
                         StateRequest.newBuilder().setInstructionId("FAIL"), unsuccessfulResponse);
                   }
-                }));
+                }),
+            new BundleProcessorCache());
     handler.processBundle(
         BeamFnApi.InstructionRequest.newBuilder()
             .setProcessBundle(
@@ -446,7 +811,8 @@ public class ProcessBundleHandlerTest {
                         StateRequest.newBuilder().setInstructionId("SUCCESS"),
                         new CompletableFuture<>());
                   }
-                }));
+                }),
+            new BundleProcessorCache());
     handler.processBundle(
         BeamFnApi.InstructionRequest.newBuilder()
             .setProcessBundle(

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.PTransformRunnerFactory;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
@@ -48,6 +49,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.model.pipeline.v1.RunnerApi.WindowingStrategy;
 import org.apache.beam.sdk.function.ThrowingConsumer;
+import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -118,6 +120,7 @@ public class ProcessBundleHandlerTest {
             pCollectionConsumerRegistry,
             startFunctionRegistry,
             finishFunctionRegistry,
+            addTearDownFunction,
             splitListener) -> {
           assertThat(processBundleInstructionId.get(), equalTo("999L"));
 
@@ -188,6 +191,7 @@ public class ProcessBundleHandlerTest {
                     pCollectionConsumerRegistry,
                     startFunctionRegistry,
                     finishFunctionRegistry,
+                    addTearDownFunction,
                     splitListener) -> {
                   thrown.expect(IllegalStateException.class);
                   thrown.expectMessage("TestException");
@@ -233,6 +237,7 @@ public class ProcessBundleHandlerTest {
                         pCollectionConsumerRegistry,
                         startFunctionRegistry,
                         finishFunctionRegistry,
+                        addTearDownFunction,
                         splitListener) -> {
                       thrown.expect(IllegalStateException.class);
                       thrown.expectMessage("TestException");
@@ -280,6 +285,7 @@ public class ProcessBundleHandlerTest {
                         pCollectionConsumerRegistry,
                         startFunctionRegistry,
                         finishFunctionRegistry,
+                        addTearDownFunction,
                         splitListener) -> {
                       thrown.expect(IllegalStateException.class);
                       thrown.expectMessage("TestException");
@@ -365,6 +371,7 @@ public class ProcessBundleHandlerTest {
                       PCollectionConsumerRegistry pCollectionConsumerRegistry,
                       PTransformFunctionRegistry startFunctionRegistry,
                       PTransformFunctionRegistry finishFunctionRegistry,
+                      Consumer<ThrowingRunnable> addTearDownFunction,
                       BundleSplitListener splitListener)
                       throws IOException {
                     startFunctionRegistry.register(
@@ -424,6 +431,7 @@ public class ProcessBundleHandlerTest {
                       PCollectionConsumerRegistry pCollectionConsumerRegistry,
                       PTransformFunctionRegistry startFunctionRegistry,
                       PTransformFunctionRegistry finishFunctionRegistry,
+                      Consumer<ThrowingRunnable> addTearDownFunction,
                       BundleSplitListener splitListener)
                       throws IOException {
                     startFunctionRegistry.register(


### PR DESCRIPTION
Motivation:
This PR is to add support to teardown the DoFns upon the control service termination for Java SDK harness. The detail of discussion can be found here: https://lists.apache.org/thread.html/0c4a4cf83cf2e35c3dfeb9d906e26cd82d3820968ba6f862f91739e4@%3Cdev.beam.apache.org%3E

Changes:
- Cache the informations which could be reused between bundles for the same bundle descriptor. It is a prerequisite to teardown the DoFns upon the control service termination. Besides, it also solves the problem that currently the setup of DoFn is called each time a process bundle request is processed in the Java SDK harness.
- Teardown the DoFns upon the control service termination for Java SDK harness
Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
