### PR TITLE
[BEAM-8335] Add timestamp and duration to/from protos to Python SDK

### DIFF
--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -30,6 +30,7 @@ from builtins import object
 
 import dateutil.parser
 import pytz
+from google.protobuf import timestamp_pb2
 from past.builtins import long
 
 from apache_beam.portability import common_urns
@@ -139,6 +140,23 @@ class Timestamp(object):
   def to_rfc3339(self):
     # Append 'Z' for UTC timezone.
     return self.to_utc_datetime().isoformat() + 'Z'
+
+  def to_proto(self):
+    """Returns the `google.protobuf.timestamp_pb2` representation."""
+    secs = self.micros // 1000000
+    nanos = (self.micros - (secs * 1000000)) * 1000
+    return timestamp_pb2.Timestamp(seconds=secs, nanos=nanos)
+
+  @staticmethod
+  def from_proto(timestamp_proto):
+    """Creates a Timestamp from a `google.protobuf.timestamp_pb2`.
+
+    Note that the google has a sub-second resolution of nanoseconds whereas this
+    class has a resolution of microsends. This class will truncate the
+    nanosecond resolution down to the microsecond.
+    """
+    return Timestamp(seconds=timestamp_proto.seconds,
+                     micros=timestamp_proto.nanos // 1000)
 
   def __float__(self):
     # Note that the returned value may have lost precision.

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -280,7 +280,7 @@ class Duration(object):
                        "See [BEAM-8738] for more information.")
 
     return Duration(seconds=duration_proto.seconds,
-                     micros=duration_proto.nanos // 1000)
+                    micros=duration_proto.nanos // 1000)
 
   def __repr__(self):
     micros = self.micros

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -30,6 +30,7 @@ from builtins import object
 
 import dateutil.parser
 import pytz
+from google.protobuf import duration_pb2
 from google.protobuf import timestamp_pb2
 from past.builtins import long
 
@@ -144,7 +145,7 @@ class Timestamp(object):
   def to_proto(self):
     """Returns the `google.protobuf.timestamp_pb2` representation."""
     secs = self.micros // 1000000
-    nanos = (self.micros - (secs * 1000000)) * 1000
+    nanos = (self.micros % 1000000) * 1000
     return timestamp_pb2.Timestamp(seconds=secs, nanos=nanos)
 
   @staticmethod
@@ -155,6 +156,15 @@ class Timestamp(object):
     class has a resolution of microsends. This class will truncate the
     nanosecond resolution down to the microsecond.
     """
+
+    if timestamp_proto.nanos % 1000 != 0:
+      # TODO(BEAM-8738): Better define timestamps.
+      raise ValueError("Cannot convert from nanoseconds to microseconds " +
+                       "because this loses precision. Please make sure that " +
+                       "this is the correct behavior you want and manually " +
+                       "truncate the precision to the nearest microseconds. " +
+                       "See [BEAM-8738] for more information.")
+
     return Timestamp(seconds=timestamp_proto.seconds,
                      micros=timestamp_proto.nanos // 1000)
 
@@ -245,6 +255,32 @@ class Duration(object):
     if isinstance(seconds, Duration):
       return seconds
     return Duration(seconds)
+
+  def to_proto(self):
+    """Returns the `google.protobuf.duration_pb2` representation."""
+    secs = self.micros // 1000000
+    nanos = (self.micros % 1000000) * 1000
+    return duration_pb2.Duration(seconds=secs, nanos=nanos)
+
+  @staticmethod
+  def from_proto(duration_proto):
+    """Creates a Duration from a `google.protobuf.duration_pb2`.
+
+    Note that the google has a sub-second resolution of nanoseconds whereas this
+    class has a resolution of microsends. This class will truncate the
+    nanosecond resolution down to the microsecond.
+    """
+
+    if duration_proto.nanos % 1000 != 0:
+      # TODO(BEAM-8738): Better define durations.
+      raise ValueError("Cannot convert from nanoseconds to microseconds " +
+                       "because this loses precision. Please make sure that " +
+                       "this is the correct behavior you want and manually " +
+                       "truncate the precision to the nearest microseconds. " +
+                       "See [BEAM-8738] for more information.")
+
+    return Duration(seconds=duration_proto.seconds,
+                     micros=duration_proto.nanos // 1000)
 
   def __repr__(self):
     micros = self.micros

--- a/sdks/python/apache_beam/utils/timestamp_test.py
+++ b/sdks/python/apache_beam/utils/timestamp_test.py
@@ -176,8 +176,7 @@ class TimestampTest(unittest.TestCase):
   def test_from_proto_fails_with_truncation(self):
     # TODO(BEAM-8738): Better define timestamps.
     with self.assertRaises(ValueError):
-      ts_proto = timestamp_pb2.Timestamp(seconds=1234, nanos=56789)
-      actual_ts = Timestamp.from_proto(ts_proto)
+      Timestamp.from_proto(timestamp_pb2.Timestamp(seconds=1234, nanos=56789))
 
   def test_to_proto(self):
     ts = Timestamp(seconds=1234, micros=56)

--- a/sdks/python/apache_beam/utils/timestamp_test.py
+++ b/sdks/python/apache_beam/utils/timestamp_test.py
@@ -25,10 +25,10 @@ import unittest
 # patches unittest.TestCase to be python3 compatible
 import future.tests.base  # pylint: disable=unused-import
 import pytz
+from google.protobuf import timestamp_pb2
 
 from apache_beam.utils.timestamp import Duration
 from apache_beam.utils.timestamp import Timestamp
-from google.protobuf import timestamp_pb2
 
 
 class TimestampTest(unittest.TestCase):

--- a/sdks/python/apache_beam/utils/timestamp_test.py
+++ b/sdks/python/apache_beam/utils/timestamp_test.py
@@ -28,6 +28,7 @@ import pytz
 
 from apache_beam.utils.timestamp import Duration
 from apache_beam.utils.timestamp import Timestamp
+from google.protobuf import timestamp_pb2
 
 
 class TimestampTest(unittest.TestCase):
@@ -164,6 +165,21 @@ class TimestampTest(unittest.TestCase):
   def test_now(self):
     now = Timestamp.now()
     self.assertTrue(isinstance(now, Timestamp))
+
+  def test_from_proto(self):
+    ts_proto = timestamp_pb2.Timestamp(seconds=1234, nanos=56789)
+    actual_ts = Timestamp.from_proto(ts_proto)
+
+    # Micros is 56 instead of 56.789 because we use an integer representation
+    # that truncates extra precision.
+    expected_ts = Timestamp(seconds=1234, micros=56)
+    self.assertEqual(actual_ts, expected_ts)
+
+  def test_to_proto(self):
+    ts = Timestamp(seconds=1234, micros=56)
+    actual_ts_proto = Timestamp.to_proto(ts)
+    expected_ts_proto = timestamp_pb2.Timestamp(seconds=1234, nanos=56000)
+    self.assertEqual(actual_ts_proto, expected_ts_proto)
 
 
 class DurationTest(unittest.TestCase):


### PR DESCRIPTION
Adds extra utility in the Python SDK Timestamp object to convert between it and the well-known google.protobuf.timestamp.Timestamp object.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
