### PR TITLE
[BEAM-7116] Remove use of KV in Schema transforms

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/CoGroup.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/CoGroup.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.schemas.transforms;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -56,24 +57,26 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
  *
  * <p>This transform has similarities to {@link CoGroupByKey}, however works on PCollections that
  * have schemas. This allows users of the transform to simply specify schema fields to join on. The
- * output type of the transform is a {@code KV<Row, Row>} where the value contains one field for
- * every input PCollection and the key represents the fields that were joined on. By default the
- * cross product is not expanded, so all fields in the output row are array fields.
+ * output type of the transform is {@code Row} that contains one row field for the key and an ITERABLE
+ * field for each input containing the rows that joined on that key; by default the cross product is
+ * not expanded, but the cross product can be optionally expanded. By default the key field is named
+ * "key" (the name can be overridden using withKeyField) and has index 0. The tags in the
+ * PCollectionTuple control the names of the value fields in the Row.
  *
  * <p>For example, the following demonstrates joining three PCollections on the "user" and "country"
  * fields:
  *
- * <pre>{@code PCollection<KV<Row, Row>> joined =
+ * <pre>{@code PCollection<Row> joined =
  *   PCollectionTuple.of("input1", input1, "input2", input2, "input3", input3)
  *     .apply(CoGroup.join(By.fieldNames("user", "country")));
  * }</pre>
  *
  * <p>In the above case, the key schema will contain the two string fields "user" and "country"; in
  * this case, the schemas for Input1, Input2, Input3 must all have fields named "user" and
- * "country". The value schema will contain three array of Row fields named "input1" "input2" and
- * "input3". The value Row contains all inputs that came in on any of the inputs for that key.
+ * "country". The remainder of the Row will contain three iterable of Row fields named "input1"
+ * "input2" and "input3". This contains all inputs that came in on any of the inputs for that key.
  * Standard join types (inner join, outer join, etc.) can be accomplished by expanding the cross
- * product of these arrays in various ways.
+ * product of these iterables in various ways.
  *
  * <p>To put it in other words, the key schema is convertible to the following POJO:
  *
@@ -81,34 +84,34 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
  * public class JoinedKey {
  *   public String user;
  *   public String country;
- * }
+ * }</pre>
  *
- * PCollection<JoinedKey> keys = joined
- *     .apply(Keys.create())
+ *  <p>The value schema is convertible to the following POJO:
+ *
+ *  <pre>{@code @DefaultSchema(JavaFieldSchema.class)
+ *  public class JoinedValue {
+ *    public JoinedKey key;
+ *    // The below lists contain all values from each of the three inputs that match on the given
+ *    // key.
+ *    public Iterable<Input1Type> input1;
+ *    public Iterable<Input2Type> input2;
+ *    public Iterable<Input3Type> input3;
+ *  }
+ *
+ * PCollection<JoinedValue> values = joined.apply(Convert.to(JoinedValue.class));
+ *
+ * PCollection<JoinedKey> keys = values
+ *     .apply(Select.fieldNames("key"))
  *     .apply(Convert.to(JoinedKey.class));
  * }</pre>
  *
- * <p>The value schema is convertible to the following POJO:
  *
- * <pre>{@code @DefaultSchema(JavaFieldSchema.class)
- * public class JoinedValue {
- *   // The below lists contain all values from each of the three inputs that match on the given
- *   // key.
- *   public List<Input1Type> input1;
- *   public List<Input2Type> input2;
- *   public List<Input3Type> input3;
- * }
- *
- * PCollection<JoinedValue> values = joined
- *     .apply(Values.create())
- *     .apply(Convert.to(JoinedValue.class));
- * }</pre>
  *
  * <p>It's also possible to join between different fields in two inputs, as long as the types of
  * those fields match. In this case, fields must be specified for every input PCollection. For
  * example:
  *
- * <pre>{@code PCollection<KV<Row, Row>> joined
+ * <pre>{@code PCollection<Row> joined
  *      = PCollectionTuple.of("input1Tag", input1, "input2Tag", input2)
  *   .apply(CoGroup
  *     .join("input1Tag", By.fieldNames("referringUser")))
@@ -191,7 +194,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
  * {@link CoGroup} transform supports any number of inputs, and optional participation can be
  * specified on any subset of them.
  *
- * <p>Do note that cross-product joins while simpler and easier to program, can cause
+ * <p>Do note that cross-product joins while simpler and easier to program, can cause performance problems.
  */
 @Experimental(Experimental.Kind.SCHEMAS)
 public class CoGroup {
@@ -423,15 +426,25 @@ public class CoGroup {
   }
 
   /** The implementing PTransform. */
-  public static class Impl extends PTransform<PCollectionTuple, PCollection<KV<Row, Row>>> {
+  public static class Impl extends PTransform<PCollectionTuple, PCollection<Row>> {
     private final JoinArguments joinArgs;
+    private final String keyFieldName;
 
     private Impl() {
       this(new JoinArguments(Collections.emptyMap()));
     }
 
     private Impl(JoinArguments joinArgs) {
+      this(joinArgs, "key");
+    }
+
+    private Impl(JoinArguments joinArgs, String keyFieldName) {
       this.joinArgs = joinArgs;
+      this.keyFieldName = keyFieldName;
+    }
+
+    public Impl withKeyField(String keyFieldName) {
+      return new Impl(joinArgs, keyFieldName);
     }
 
     /**
@@ -443,7 +456,7 @@ public class CoGroup {
       if (joinArgs.allInputsJoinArgs != null) {
         throw new IllegalStateException("Cannot set both a global and per-tag fields.");
       }
-      return new Impl(joinArgs.with(tag, clause));
+      return new Impl(joinArgs.with(tag, clause), keyFieldName);
     }
 
     /** Expand the join into individual rows, similar to SQL joins. */
@@ -451,77 +464,84 @@ public class CoGroup {
       return new ExpandCrossProduct(joinArgs);
     }
 
-    private Schema getOutputSchema(JoinInformation joinInformation) {
-      // Construct the output schema. It contains one field for each input PCollection, of type
-      // ARRAY[ROW].
-      Schema.Builder joinedSchemaBuilder = Schema.builder();
-      for (Map.Entry<String, Schema> entry : joinInformation.componentSchemas.entrySet()) {
-        joinedSchemaBuilder.addArrayField(entry.getKey(), FieldType.row(entry.getValue()));
-      }
-      return joinedSchemaBuilder.build();
-    }
-
     @Override
-    public PCollection<KV<Row, Row>> expand(PCollectionTuple input) {
+    public PCollection<Row> expand(PCollectionTuple input) {
       verify(input, joinArgs);
 
       JoinInformation joinInformation =
           JoinInformation.from(input, joinArgs::getFieldAccessDescriptor);
-
-      Schema joinedSchema = getOutputSchema(joinInformation);
-
+      ConvertToRow convertToRow = new ConvertToRow(joinInformation, keyFieldName);
       return joinInformation
           .keyedPCollectionTuple
           .apply("CoGroupByKey", CoGroupByKey.create())
-          .apply(
-              "ConvertToRow",
-              ParDo.of(
-                  new ConvertToRow(
-                      joinInformation.sortedTags,
-                      joinInformation.toRows,
-                      joinedSchema,
-                      joinInformation.tagToKeyedTag)))
-          .setCoder(
-              KvCoder.of(SchemaCoder.of(joinInformation.keySchema), SchemaCoder.of(joinedSchema)));
+          .apply("ConvertToRow", ParDo.of(convertToRow))
+          .setRowSchema(convertToRow.getOutputSchema());
     }
 
     // Used by the unexpanded join to create the output rows.
-    private static class ConvertToRow extends DoFn<KV<Row, CoGbkResult>, KV<Row, Row>> {
+    private static class ConvertToRow extends DoFn<KV<Row, CoGbkResult>, Row> {
       private final List<String> sortedTags;
-      private final Map<Integer, SerializableFunction<Object, Row>> toRows;
       private final Map<Integer, String> tagToKeyedTag;
-      private final Schema joinedSchema;
+      private final Map<Integer, SerializableFunction<Object, Row>> toRows;
 
-      ConvertToRow(
-          List<String> sortedTags,
-          Map<Integer, SerializableFunction<Object, Row>> toRows,
-          Schema joinedSchema,
-          Map<Integer, String> tagToKeyedTag) {
-        this.sortedTags = sortedTags;
-        this.toRows = toRows;
-        this.joinedSchema = joinedSchema;
-        this.tagToKeyedTag = tagToKeyedTag;
+      private final Schema outputSchema;
+
+      ConvertToRow(JoinInformation joinInformation, String keyFieldName) {
+        this.sortedTags = joinInformation.sortedTags;
+        this.tagToKeyedTag = joinInformation.tagToKeyedTag;
+        this.toRows = joinInformation.toRows;
+        Schema.Builder schemaBuilder =
+            Schema.builder().addRowField(keyFieldName, joinInformation.keySchema);
+        for (Map.Entry<String, Schema> entry : joinInformation.componentSchemas.entrySet()) {
+          schemaBuilder.addIterableField(entry.getKey(), FieldType.row(entry.getValue()));
+        }
+        outputSchema = schemaBuilder.build();
+      }
+
+      Schema getOutputSchema() {
+        return outputSchema;
+      }
+
+      /** Lazy iterable that wraps the result returned from CoGroupByKey. */
+      static final class Result implements Iterable<Row> {
+        private Iterable<Row> coGbkIterable;
+        private SerializableFunction<Object, Row> toRow;
+
+        Result(Iterable<Row> coGbkIterable, SerializableFunction<Object, Row> toRow) {
+          this.coGbkIterable = coGbkIterable;
+          this.toRow = toRow;
+        }
+
+        @Override
+        public Iterator<Row> iterator() {
+          return new Iterator<Row>() {
+            private Iterator<Row> coGbkIterator = coGbkIterable.iterator();
+
+            @Override
+            public boolean hasNext() {
+              return coGbkIterator.hasNext();
+            }
+
+            @Override
+            public Row next() {
+              return toRow.apply(coGbkIterator.next());
+            }
+          };
+        }
       }
 
       @ProcessElement
-      public void process(@Element KV<Row, CoGbkResult> kv, OutputReceiver<KV<Row, Row>> o) {
+      public void process(@Element KV<Row, CoGbkResult> kv, OutputReceiver<Row> o) {
         Row key = kv.getKey();
         CoGbkResult result = kv.getValue();
         List<Object> fields = Lists.newArrayListWithCapacity(sortedTags.size());
         for (int i = 0; i < sortedTags.size(); ++i) {
-          String tag = sortedTags.get(i);
-          // TODO: This forces the entire join to materialize in memory. We should create a
-          // lazy Row interface on top of the iterable returned by CoGbkResult. This will
-          // allow the data to be streamed in. Tracked in [BEAM-6756].
-          SerializableFunction<Object, Row> toRow = toRows.get(i);
           String tupleTag = tagToKeyedTag.get(i);
-          List<Row> joined = Lists.newArrayList();
-          for (Object item : result.getAll(tupleTag)) {
-            joined.add(toRow.apply(item));
-          }
-          fields.add(joined);
+          SerializableFunction<Object, Row> toRow = toRows.get(i);
+          fields.add(new Result(result.getAll(tupleTag), toRow));
         }
-        o.output(KV.of(key, Row.withSchema(joinedSchema).addValues(fields).build()));
+        Row row = Row.withSchema(outputSchema).addValue(key).addValues(fields).build();
+        o.output(row);
       }
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Group.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Group.java
@@ -17,14 +17,15 @@
  */
 package org.apache.beam.sdk.schemas.transforms;
 
+import com.google.auto.value.AutoValue;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.schemas.utils.SelectHelpers;
 import org.apache.beam.sdk.transforms.Combine;
@@ -38,6 +39,7 @@ import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptors;
 
 /**
  * A generic grouping transform for schema {@link PCollection}s.
@@ -60,8 +62,7 @@ import org.apache.beam.sdk.values.Row;
  * <p>You can group all purchases by user and country as follows:
  *
  * <pre>{@code @DefaultSchema(JavaFieldSchema.class)
- * PCollection<KV<Row, Iterable<UserPurchase>> byUser =
- *   purchases.apply(Group.byFieldNames("userId', "country"));
+ * PCollection<Row> byUser = purchases.apply(Group.byFieldNames("userId', "country"));
  * }</pre>
  *
  * <p>However often an aggregation of some form is desired. The builder methods inside the Group
@@ -69,7 +70,7 @@ import org.apache.beam.sdk.values.Row;
  * schema, and generating an output schema based on these aggregations. For example:
  *
  * <pre>{@code
- * PCollection<KV<Row, Row>> aggregated = purchases
+ * PCollection<Row> aggregated = purchases
  *      .apply(Group.byFieldNames("userId', "country")
  *          .aggregateField("cost", Sum.ofLongs(), "total_cost")
  *          .aggregateField("cost", Top.<Long>largestLongsFn(10), "top_purchases")
@@ -79,7 +80,8 @@ import org.apache.beam.sdk.values.Row;
  *
  * <p>The result will be a new row schema containing the fields total_cost, top_purchases, and
  * transactionDurations, containing the sum of all purchases costs (for that user and country), the
- * top ten purchases, and a histogram of transaction durations.
+ * top ten purchases, and a histogram of transaction durations. The schema will als contain a key
+ * field, which will be a row containing userId and country.
  *
  * <p>Note that usually the field type can be automatically inferred from the {@link CombineFn}
  * passed in. However sometimes it cannot be inferred, due to Java type erasure, in which case a
@@ -103,37 +105,39 @@ public class Group {
    * methods to control how the grouping is done.
    */
   public static <T> ByFields<T> byFieldNames(String... fieldNames) {
-    return new ByFields<>(FieldAccessDescriptor.withFieldNames(fieldNames));
+    return ByFields.of(FieldAccessDescriptor.withFieldNames(fieldNames));
   }
 
   /** Same as {@link #byFieldNames(String...)}. */
   public static <T> ByFields<T> byFieldNames(Iterable<String> fieldNames) {
-    return new ByFields<>(FieldAccessDescriptor.withFieldNames(fieldNames));
+    return ByFields.of(FieldAccessDescriptor.withFieldNames(fieldNames));
   }
 
   /**
    * Returns a transform that groups all elements in the input {@link PCollection} keyed by the list
-   * of fields specified. The output of this transform will be a {@link KV} keyed by a {@link Row}
+   * of fields specified. The output of this transform will have a key field of type {@link Row}
+   * containing the specified extracted fields. It will also have a value field of type {@link Row}
    * containing the specified extracted fields. The returned transform contains further builder
    * methods to control how the grouping is done.
    */
   public static <T> ByFields<T> byFieldIds(Integer... fieldIds) {
-    return new ByFields<>(FieldAccessDescriptor.withFieldIds(fieldIds));
+    return ByFields.of(FieldAccessDescriptor.withFieldIds(fieldIds));
   }
 
   /** Same as {@link #byFieldIds(Integer...)}. */
   public static <T> ByFields<T> byFieldIds(Iterable<Integer> fieldIds) {
-    return new ByFields<>(FieldAccessDescriptor.withFieldIds(fieldIds));
+    return ByFields.of(FieldAccessDescriptor.withFieldIds(fieldIds));
   }
 
   /**
    * Returns a transform that groups all elements in the input {@link PCollection} keyed by the
-   * fields specified. The output of this transform will be a {@link KV} keyed by a {@link Row}
+   * fields specified. The output of this transform will have a key field of type {@link Row}
+   * containing the specified extracted fields. It will also have a value field of type {@link Row}
    * containing the specified extracted fields. The returned transform contains further builder
    * methods to control how the grouping is done.
    */
   public static <T> ByFields<T> byFieldAccessDescriptor(FieldAccessDescriptor fieldAccess) {
-    return new ByFields<>(fieldAccess);
+    return ByFields.of(fieldAccess);
   }
 
   /** A {@link PTransform} for doing global aggregations on schema PCollections. */
@@ -159,7 +163,7 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
       return new CombineFieldsGlobally<>(
-          SchemaAggregateFn.<InputT>create()
+          SchemaAggregateFn.create()
               .aggregateFields(
                   FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName));
     }
@@ -170,7 +174,7 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
       return new CombineFieldsGlobally<>(
-          SchemaAggregateFn.<InputT>create()
+          SchemaAggregateFn.create()
               .aggregateFields(
                   FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName));
     }
@@ -186,7 +190,7 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
       return new CombineFieldsGlobally<>(
-          SchemaAggregateFn.<InputT>create()
+          SchemaAggregateFn.create()
               .aggregateFields(
                   FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField));
     }
@@ -195,7 +199,7 @@ public class Group {
     public <CombineInputT, AccumT, CombineOutputT> CombineFieldsGlobally<InputT> aggregateField(
         int inputFielId, CombineFn<CombineInputT, AccumT, CombineOutputT> fn, Field outputField) {
       return new CombineFieldsGlobally<>(
-          SchemaAggregateFn.<InputT>create()
+          SchemaAggregateFn.create()
               .aggregateFields(FieldAccessDescriptor.withFieldIds(inputFielId), fn, outputField));
     }
 
@@ -242,8 +246,7 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
       return new CombineFieldsGlobally<>(
-          SchemaAggregateFn.<InputT>create()
-              .aggregateFields(fieldsToAggregate, fn, outputFieldName));
+          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, fn, outputFieldName));
     }
 
     /**
@@ -279,7 +282,7 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
       return new CombineFieldsGlobally<>(
-          SchemaAggregateFn.<InputT>create().aggregateFields(fieldsToAggregate, fn, outputField));
+          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, fn, outputField));
     }
 
     @Override
@@ -313,9 +316,9 @@ public class Group {
    */
   public static class CombineFieldsGlobally<InputT>
       extends PTransform<PCollection<InputT>, PCollection<Row>> {
-    private final SchemaAggregateFn.Inner<InputT> schemaAggregateFn;
+    private final SchemaAggregateFn.Inner schemaAggregateFn;
 
-    CombineFieldsGlobally(SchemaAggregateFn.Inner<InputT> schemaAggregateFn) {
+    CombineFieldsGlobally(SchemaAggregateFn.Inner schemaAggregateFn) {
       this.schemaAggregateFn = schemaAggregateFn;
     }
 
@@ -452,38 +455,80 @@ public class Group {
 
     @Override
     public PCollection<Row> expand(PCollection<InputT> input) {
-      SchemaAggregateFn.Inner<InputT> fn =
-          schemaAggregateFn.withSchema(input.getSchema(), input.getToRowFunction());
-      return input.apply(Combine.globally(fn)).setRowSchema(fn.getOutputSchema());
+      SchemaAggregateFn.Inner fn = schemaAggregateFn.withSchema(input.getSchema());
+      return input
+          .apply(Convert.toRows())
+          .apply(Combine.globally(fn))
+          .setRowSchema(fn.getOutputSchema());
     }
   }
 
   /**
    * a {@link PTransform} that groups schema elements based on the given fields.
    *
-   * <p>The output of this transform is a {@link KV} where the key type is a {@link Row} containing
-   * the extracted fields.
+   * <p>The output of this transform will have a key field of type {@link Row} containing the
+   * specified extracted fields. It will also have a value field of type {@link Row} containing the
+   * specified extracted fields.
    */
-  public static class ByFields<InputT>
-      extends PTransform<PCollection<InputT>, PCollection<KV<Row, Iterable<InputT>>>> {
-    private final FieldAccessDescriptor fieldAccessDescriptor;
-    @Nullable private Schema keySchema = null;
+  @AutoValue
+  public abstract static class ByFields<InputT>
+      extends PTransform<PCollection<InputT>, PCollection<Row>> {
+    abstract FieldAccessDescriptor getFieldAccessDescriptor();
 
-    private ByFields(FieldAccessDescriptor fieldAccessDescriptor) {
-      this.fieldAccessDescriptor = fieldAccessDescriptor;
+    abstract String getKeyField();
+
+    abstract String getValueField();
+
+    abstract Builder<InputT> toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder<InputT> {
+      abstract Builder<InputT> setFieldAccessDescriptor(
+          FieldAccessDescriptor fieldAccessDescriptor);
+
+      abstract Builder<InputT> setKeyField(String keyField);
+
+      abstract Builder<InputT> setValueField(String valueField);
+
+      abstract ByFields<InputT> build();
     }
 
-    Schema getKeySchema() {
-      return keySchema;
+    class ToKv extends PTransform<PCollection<InputT>, PCollection<KV<Row, Iterable<Row>>>> {
+      @Override
+      public PCollection<KV<Row, Iterable<Row>>> expand(PCollection<InputT> input) {
+        Schema schema = input.getSchema();
+        FieldAccessDescriptor resolved = getFieldAccessDescriptor().resolve(schema);
+        Schema keySchema = getKeySchema(schema);
+
+        return input
+            .apply("toRow", Convert.toRows())
+            .apply(
+                "selectKeys",
+                WithKeys.of((Row e) -> SelectHelpers.selectRow(e, resolved, schema, keySchema))
+                    .withKeyType(TypeDescriptors.rows()))
+            .setCoder(KvCoder.of(SchemaCoder.of(keySchema), SchemaCoder.of(schema)))
+            .apply(GroupByKey.create());
+      }
     }
 
-    /**
-     * Aggregate the grouped data using the specified {@link CombineFn}. The resulting {@link
-     * PCollection} will have type {@code PCollection<KV<Row, OutputT>>}.
-     */
-    public <OutputT> CombineByFields<InputT, OutputT> aggregate(
-        CombineFn<InputT, ?, OutputT> combineFn) {
-      return new CombineByFields<>(this, combineFn);
+    ToKv getToKvs() {
+      return new ToKv();
+    }
+
+    private static <InputT> ByFields<InputT> of(FieldAccessDescriptor fieldAccessDescriptor) {
+      return new AutoValue_Group_ByFields.Builder<InputT>()
+          .setFieldAccessDescriptor(fieldAccessDescriptor)
+          .setKeyField("key")
+          .setValueField("value")
+          .build();
+    }
+
+    public ByFields<InputT> withKeyField(String keyField) {
+      return toBuilder().setKeyField(keyField).build();
+    }
+
+    public ByFields<InputT> withValueField(String valueField) {
+      return toBuilder().setValueField(valueField).build();
     }
 
     /**
@@ -500,22 +545,26 @@ public class Group {
         String inputFieldName,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
-      return new CombineFieldsByFields<>(
+      return CombineFieldsByFields.of(
           this,
-          SchemaAggregateFn.<InputT>create()
+          SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName));
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName),
+          getKeyField(),
+          getValueField());
     }
 
     public <CombineInputT, AccumT, CombineOutputT> CombineFieldsByFields<InputT> aggregateField(
         int inputFieldId,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
-      return new CombineFieldsByFields<>(
+      return CombineFieldsByFields.of(
           this,
-          SchemaAggregateFn.<InputT>create()
+          SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName));
+                  FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName),
+          getKeyField(),
+          getValueField());
     }
 
     /**
@@ -528,19 +577,23 @@ public class Group {
         String inputFieldName,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
-      return new CombineFieldsByFields<>(
+      return CombineFieldsByFields.of(
           this,
-          SchemaAggregateFn.<InputT>create()
+          SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField));
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField),
+          getKeyField(),
+          getValueField());
     }
 
     public <CombineInputT, AccumT, CombineOutputT> CombineFieldsByFields<InputT> aggregateField(
         int inputFieldId, CombineFn<CombineInputT, AccumT, CombineOutputT> fn, Field outputField) {
-      return new CombineFieldsByFields<>(
+      return CombineFieldsByFields.of(
           this,
-          SchemaAggregateFn.<InputT>create()
-              .aggregateFields(FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputField));
+          SchemaAggregateFn.create()
+              .aggregateFields(FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputField),
+          getKeyField(),
+          getValueField());
     }
 
     /**
@@ -584,10 +637,11 @@ public class Group {
         FieldAccessDescriptor fieldsToAggregate,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
-      return new CombineFieldsByFields<>(
+      return CombineFieldsByFields.of(
           this,
-          SchemaAggregateFn.<InputT>create()
-              .aggregateFields(fieldsToAggregate, fn, outputFieldName));
+          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, fn, outputFieldName),
+          getKeyField(),
+          getValueField());
     }
 
     /**
@@ -622,55 +676,43 @@ public class Group {
         FieldAccessDescriptor fieldsToAggregate,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
-      return new CombineFieldsByFields<>(
+      return CombineFieldsByFields.of(
           this,
-          SchemaAggregateFn.<InputT>create().aggregateFields(fieldsToAggregate, fn, outputField));
+          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, fn, outputField),
+          getKeyField(),
+          getValueField());
+    }
+
+    Schema getKeySchema(Schema inputSchema) {
+      FieldAccessDescriptor resolved = getFieldAccessDescriptor().resolve(inputSchema);
+      return SelectHelpers.getOutputSchema(inputSchema, resolved);
     }
 
     @Override
-    public PCollection<KV<Row, Iterable<InputT>>> expand(PCollection<InputT> input) {
+    public PCollection<Row> expand(PCollection<InputT> input) {
       Schema schema = input.getSchema();
-      FieldAccessDescriptor resolved = fieldAccessDescriptor.resolve(schema);
-      keySchema = SelectHelpers.getOutputSchema(schema, resolved);
+      Schema keySchema = getKeySchema(schema);
+      Schema outputSchema =
+          Schema.builder()
+              .addRowField(getKeyField(), keySchema)
+              .addIterableField(getValueField(), FieldType.row(schema))
+              .build();
+
       return input
+          .apply(getToKvs())
           .apply(
-              "Group by fields",
               ParDo.of(
-                  new DoFn<InputT, KV<Row, InputT>>() {
+                  new DoFn<KV<Row, Iterable<Row>>, Row>() {
                     @ProcessElement
-                    public void process(
-                        @Element InputT element,
-                        @Element Row row,
-                        OutputReceiver<KV<Row, InputT>> o) {
+                    public void process(@Element KV<Row, Iterable<Row>> e, OutputReceiver<Row> o) {
                       o.output(
-                          KV.of(
-                              SelectHelpers.selectRow(row, resolved, schema, keySchema), element));
+                          Row.withSchema(outputSchema)
+                              .addValue(e.getKey())
+                              .addIterable(e.getValue())
+                              .build());
                     }
                   }))
-          .setCoder(KvCoder.of(SchemaCoder.of(keySchema), input.getCoder()))
-          .apply(GroupByKey.create());
-    }
-  }
-
-  /**
-   * a {@link PTransform} that does a per0-key combine using a specified {@link CombineFn}.
-   *
-   * <p>The output of this transform is a {@code <KV<Row, OutputT>>} where the key type is a {@link
-   * Row} containing the extracted fields.
-   */
-  public static class CombineByFields<InputT, OutputT>
-      extends PTransform<PCollection<InputT>, PCollection<KV<Row, OutputT>>> {
-    private final ByFields<InputT> byFields;
-    private final CombineFn<InputT, ?, OutputT> combineFn;
-
-    CombineByFields(ByFields<InputT> byFields, CombineFn<InputT, ?, OutputT> combineFn) {
-      this.byFields = byFields;
-      this.combineFn = combineFn;
-    }
-
-    @Override
-    public PCollection<KV<Row, OutputT>> expand(PCollection<InputT> input) {
-      return input.apply(byFields).apply(Combine.groupedValues(combineFn));
+          .setRowSchema(outputSchema);
     }
   }
 
@@ -679,15 +721,53 @@ public class Group {
    * aggregateField and aggregateFields. The output of this transform will have a schema that is
    * determined by the output types of all the composed combiners.
    */
-  public static class CombineFieldsByFields<InputT>
-      extends PTransform<PCollection<InputT>, PCollection<KV<Row, Row>>> {
-    private final ByFields<InputT> byFields;
-    private final SchemaAggregateFn.Inner<InputT> schemaAggregateFn;
+  @AutoValue
+  public abstract static class CombineFieldsByFields<InputT>
+      extends PTransform<PCollection<InputT>, PCollection<Row>> {
+    abstract ByFields<InputT> getByFields();
 
-    CombineFieldsByFields(
-        ByFields<InputT> byFields, SchemaAggregateFn.Inner<InputT> schemaAggregateFn) {
-      this.byFields = byFields;
-      this.schemaAggregateFn = schemaAggregateFn;
+    abstract SchemaAggregateFn.Inner getSchemaAggregateFn();
+
+    abstract String getKeyField();
+
+    abstract String getValueField();
+
+    abstract Builder<InputT> toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder<InputT> {
+      abstract Builder<InputT> setByFields(ByFields<InputT> byFields);
+
+      abstract Builder<InputT> setSchemaAggregateFn(SchemaAggregateFn.Inner schemaAggregateFn);
+
+      abstract Builder<InputT> setKeyField(String keyField);
+
+      abstract Builder<InputT> setValueField(String valueField);
+
+      abstract CombineFieldsByFields<InputT> build();
+    }
+
+    static <InputT> CombineFieldsByFields<InputT> of(
+        ByFields<InputT> byFields,
+        SchemaAggregateFn.Inner schemaAggregateFn,
+        String keyField,
+        String valueField) {
+      return new AutoValue_Group_CombineFieldsByFields.Builder<InputT>()
+          .setByFields(byFields)
+          .setSchemaAggregateFn(schemaAggregateFn)
+          .setKeyField(keyField)
+          .setValueField(valueField)
+          .build();
+    }
+
+    /** Set the name of the key field in the resulting schema. */
+    public CombineFieldsByFields<InputT> withKeyField(String keyField) {
+      return toBuilder().setKeyField(keyField).build();
+    }
+
+    /** Set the name of the value field in the resulting schema. */
+    public CombineFieldsByFields<InputT> witValueField(String valueField) {
+      return toBuilder().setValueField(valueField).build();
     }
 
     /**
@@ -704,20 +784,24 @@ public class Group {
         String inputFieldName,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
-      return new CombineFieldsByFields<>(
-          byFields,
-          schemaAggregateFn.aggregateFields(
-              FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName));
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn()
+                  .aggregateFields(
+                      FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName))
+          .build();
     }
 
     public <CombineInputT, AccumT, CombineOutputT> CombineFieldsByFields<InputT> aggregateField(
         int inputFieldId,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
-      return new CombineFieldsByFields<>(
-          byFields,
-          schemaAggregateFn.aggregateFields(
-              FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName));
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn()
+                  .aggregateFields(
+                      FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName))
+          .build();
     }
 
     /**
@@ -730,18 +814,22 @@ public class Group {
         String inputFieldName,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
-      return new CombineFieldsByFields<>(
-          byFields,
-          schemaAggregateFn.aggregateFields(
-              FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField));
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn()
+                  .aggregateFields(
+                      FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField))
+          .build();
     }
 
     public <CombineInputT, AccumT, CombineOutputT> CombineFieldsByFields<InputT> aggregateField(
         int inputFieldId, CombineFn<CombineInputT, AccumT, CombineOutputT> fn, Field outputField) {
-      return new CombineFieldsByFields<>(
-          byFields,
-          schemaAggregateFn.aggregateFields(
-              FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputField));
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn()
+                  .aggregateFields(
+                      FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputField))
+          .build();
     }
 
     /**
@@ -776,8 +864,10 @@ public class Group {
         FieldAccessDescriptor fieldsToAggregate,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
-      return new CombineFieldsByFields<>(
-          byFields, schemaAggregateFn.aggregateFields(fieldsToAggregate, fn, outputFieldName));
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn().aggregateFields(fieldsToAggregate, fn, outputFieldName))
+          .build();
     }
 
     /**
@@ -812,15 +902,38 @@ public class Group {
         FieldAccessDescriptor fieldsToAggregate,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
-      return new CombineFieldsByFields<>(
-          byFields, schemaAggregateFn.aggregateFields(fieldsToAggregate, fn, outputField));
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn().aggregateFields(fieldsToAggregate, fn, outputField))
+          .build();
     }
 
     @Override
-    public PCollection<KV<Row, Row>> expand(PCollection<InputT> input) {
-      SchemaAggregateFn.Inner<InputT> fn =
-          schemaAggregateFn.withSchema(input.getSchema(), input.getToRowFunction());
-      return input.apply(byFields).apply(Combine.groupedValues(fn));
+    public PCollection<Row> expand(PCollection<InputT> input) {
+      SchemaAggregateFn.Inner fn = getSchemaAggregateFn().withSchema(input.getSchema());
+
+      Schema keySchema = getByFields().getKeySchema(input.getSchema());
+      Schema outputSchema =
+          Schema.builder()
+              .addRowField(getKeyField(), keySchema)
+              .addRowField(getValueField(), getSchemaAggregateFn().getOutputSchema())
+              .build();
+
+      return input
+          .apply(getByFields().getToKvs())
+          .apply(Combine.groupedValues(fn))
+          .apply(
+              ParDo.of(
+                  new DoFn<KV<Row, Row>, Row>() {
+                    @ProcessElement
+                    public void process(@Element KV<Row, Row> element, OutputReceiver<Row> o) {
+                      o.output(
+                          Row.withSchema(outputSchema)
+                              .addValues(element.getKey(), element.getValue())
+                              .build());
+                    }
+                  }))
+          .setRowSchema(outputSchema);
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/SchemaAggregateFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/SchemaAggregateFn.java
@@ -37,7 +37,6 @@ import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.CombineFns;
 import org.apache.beam.sdk.transforms.CombineFns.CoCombineResult;
 import org.apache.beam.sdk.transforms.CombineFns.ComposedCombineFn;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
@@ -46,15 +45,15 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 /** This is the builder used by {@link Group} to build up a composed {@link CombineFn}. */
 @Experimental(Kind.SCHEMAS)
 class SchemaAggregateFn {
-  static <T> Inner<T> create() {
-    return new AutoValue_SchemaAggregateFn_Inner.Builder<T>()
+  static Inner create() {
+    return new AutoValue_SchemaAggregateFn_Inner.Builder()
         .setFieldAggregations(Lists.newArrayList())
         .build();
   }
 
   /** Implementation of {@link #create}. */
   @AutoValue
-  abstract static class Inner<T> extends CombineFn<T, Object[], Row> {
+  abstract static class Inner extends CombineFn<Row, Object[], Row> {
     // Represents an aggregation of one or more fields.
     static class FieldAggregation<FieldT, AccumT, OutputT> implements Serializable {
       FieldAccessDescriptor fieldsToAggregate;
@@ -118,48 +117,48 @@ class SchemaAggregateFn {
       }
     }
 
-    abstract Builder<T> toBuilder();
+    abstract Builder toBuilder();
 
     @AutoValue.Builder
-    abstract static class Builder<T> {
-      abstract Builder<T> setInputSchema(@Nullable Schema inputSchema);
+    abstract static class Builder {
+      abstract Builder setInputSchema(@Nullable Schema inputSchema);
 
-      abstract Builder<T> setOutputSchema(@Nullable Schema outputSchema);
+      abstract Builder setOutputSchema(@Nullable Schema outputSchema);
 
-      abstract Builder<T> setComposedCombineFn(@Nullable ComposedCombineFn<T> composedCombineFn);
+      abstract Builder setComposedCombineFn(@Nullable ComposedCombineFn composedCombineFn);
 
-      abstract Builder<T> setFieldAggregations(List<FieldAggregation> fieldAggregations);
+      abstract Builder setFieldAggregations(List<FieldAggregation> fieldAggregations);
 
-      abstract Inner<T> build();
+      abstract Inner build();
     }
 
     abstract @Nullable Schema getInputSchema();
 
     abstract @Nullable Schema getOutputSchema();
 
-    abstract @Nullable ComposedCombineFn<T> getComposedCombineFn();
+    abstract @Nullable ComposedCombineFn getComposedCombineFn();
 
     abstract List<FieldAggregation> getFieldAggregations();
 
     /** Once the schema is known, this function is called by the {@link Group} transform. */
-    Inner<T> withSchema(Schema inputSchema, SerializableFunction<T, Row> toRowFunction) {
+    Inner withSchema(Schema inputSchema) {
       List<FieldAggregation> fieldAggregations =
           getFieldAggregations().stream()
               .map(f -> f.resolve(inputSchema))
               .collect(Collectors.toList());
 
-      ComposedCombineFn<T> composedCombineFn = null;
+      ComposedCombineFn composedCombineFn = null;
       for (int i = 0; i < fieldAggregations.size(); ++i) {
         FieldAggregation fieldAggregation = fieldAggregations.get(i);
-        SimpleFunction<T, ?> extractFunction;
+        SimpleFunction<Row, ?> extractFunction;
         Coder extractOutputCoder;
-        if (fieldAggregation.unnestedInputSubSchema.getFieldCount() == 1) {
-          extractFunction = new ExtractSingleFieldFunction<>(fieldAggregation, toRowFunction);
+        if (fieldAggregation.fieldsToAggregate.referencesSingleField()) {
+          extractFunction = new ExtractSingleFieldFunction(fieldAggregation);
           extractOutputCoder =
               SchemaCoder.coderForFieldType(
                   fieldAggregation.unnestedInputSubSchema.getField(0).getType());
         } else {
-          extractFunction = new ExtractFieldsFunction<>(fieldAggregation, toRowFunction);
+          extractFunction = new ExtractFieldsFunction(fieldAggregation);
           extractOutputCoder = SchemaCoder.of(fieldAggregation.inputSubSchema);
         }
         if (i == 0) {
@@ -188,7 +187,7 @@ class SchemaAggregateFn {
     }
 
     /** Aggregate all values of a set of fields into an output field. */
-    <CombineInputT, AccumT, CombineOutputT> Inner<T> aggregateFields(
+    <CombineInputT, AccumT, CombineOutputT> Inner aggregateFields(
         FieldAccessDescriptor fieldsToAggregate,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
@@ -199,7 +198,7 @@ class SchemaAggregateFn {
     }
 
     /** Aggregate all values of a set of fields into an output field. */
-    <CombineInputT, AccumT, CombineOutputT> Inner<T> aggregateFields(
+    <CombineInputT, AccumT, CombineOutputT> Inner aggregateFields(
         FieldAccessDescriptor fieldsToAggregate,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
@@ -224,20 +223,15 @@ class SchemaAggregateFn {
     }
 
     /** Extract a single field from an input {@link Row}. */
-    private static class ExtractSingleFieldFunction<InputT, OutputT>
-        extends SimpleFunction<InputT, OutputT> {
+    private static class ExtractSingleFieldFunction<OutputT> extends SimpleFunction<Row, OutputT> {
       private final FieldAggregation fieldAggregation;
-      private final SerializableFunction<InputT, Row> toRowFunction;
 
-      private ExtractSingleFieldFunction(
-          FieldAggregation fieldAggregation, SerializableFunction<InputT, Row> toRowFunction) {
+      private ExtractSingleFieldFunction(FieldAggregation fieldAggregation) {
         this.fieldAggregation = fieldAggregation;
-        this.toRowFunction = toRowFunction;
       }
 
       @Override
-      public OutputT apply(InputT input) {
-        Row row = toRowFunction.apply(input);
+      public OutputT apply(Row row) {
         Row selected =
             SelectHelpers.selectRow(
                 row,
@@ -252,19 +246,15 @@ class SchemaAggregateFn {
     }
 
     /** Extract multiple fields from an input {@link Row}. */
-    private static class ExtractFieldsFunction<T> extends SimpleFunction<T, Row> {
+    private static class ExtractFieldsFunction extends SimpleFunction<Row, Row> {
       private FieldAggregation fieldAggregation;
-      private SerializableFunction<T, Row> toRowFunction;
 
-      private ExtractFieldsFunction(
-          FieldAggregation fieldAggregation, SerializableFunction<T, Row> toRowFunction) {
+      private ExtractFieldsFunction(FieldAggregation fieldAggregation) {
         this.fieldAggregation = fieldAggregation;
-        this.toRowFunction = toRowFunction;
       }
 
       @Override
-      public Row apply(T input) {
-        Row row = toRowFunction.apply(input);
+      public Row apply(Row row) {
         return SelectHelpers.selectRow(
             row,
             fieldAggregation.fieldsToAggregate,
@@ -279,7 +269,7 @@ class SchemaAggregateFn {
     }
 
     @Override
-    public Object[] addInput(Object[] accumulator, T input) {
+    public Object[] addInput(Object[] accumulator, Row input) {
       return getComposedCombineFn().addInput(accumulator, input);
     }
 
@@ -289,13 +279,13 @@ class SchemaAggregateFn {
     }
 
     @Override
-    public Coder<Object[]> getAccumulatorCoder(CoderRegistry registry, Coder<T> inputCoder)
+    public Coder<Object[]> getAccumulatorCoder(CoderRegistry registry, Coder<Row> inputCoder)
         throws CannotProvideCoderException {
       return getComposedCombineFn().getAccumulatorCoder(registry, inputCoder);
     }
 
     @Override
-    public Coder<Row> getDefaultOutputCoder(CoderRegistry registry, Coder<T> inputCoder) {
+    public Coder<Row> getDefaultOutputCoder(CoderRegistry registry, Coder<Row> inputCoder) {
       return SchemaCoder.of(getOutputSchema());
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -512,7 +512,6 @@ public abstract class Row implements Serializable {
       if (a == b) {
         return true;
       }
-
       Iterator<Object> bIter = b.iterator();
       for (Object currentA : a) {
         if (!bIter.hasNext()) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
@@ -31,7 +31,6 @@ import org.apache.avro.reflect.AvroIgnore;
 import org.apache.avro.reflect.AvroName;
 import org.apache.avro.reflect.AvroSchema;
 import org.apache.avro.util.Utf8;
-import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
@@ -43,7 +42,6 @@ import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.util.SerializableUtils;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -481,14 +479,19 @@ public class AvroSchemaTest {
   public void testAvroPipelineGroupBy() {
     PCollection<Row> input = pipeline.apply(Create.of(ROW_FOR_POJO)).setRowSchema(POJO_SCHEMA);
 
-    PCollection<KV<Row, Iterable<Row>>> output = input.apply(Group.byFieldNames("string"));
+    PCollection<Row> output = input.apply(Group.byFieldNames("string"));
+    Schema keySchema = Schema.builder().addStringField("string").build();
+    Schema outputSchema =
+        Schema.builder()
+            .addRowField("key", keySchema)
+            .addIterableField("value", FieldType.row(POJO_SCHEMA))
+            .build();
     PAssert.that(output)
         .containsInAnyOrder(
-            KV.of(
-                Row.withSchema(Schema.of(Field.of("string", FieldType.STRING)))
-                    .addValue("mystring")
-                    .build(),
-                ImmutableList.of(ROW_FOR_POJO)));
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValue("mystring").build())
+                .addIterable(ImmutableList.of(ROW_FOR_POJO))
+                .build());
 
     pipeline.run();
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
@@ -19,30 +19,25 @@ package org.apache.beam.sdk.schemas.transforms;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
-import java.util.Collection;
 import java.util.List;
-import org.apache.beam.sdk.TestUtils.KvMatcher;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.schemas.transforms.CoGroup.By;
+import org.apache.beam.sdk.schemas.utils.SchemaTestUtils.RowFieldMatcherIterableFieldAnyOrder;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,16 +62,11 @@ public class CoGroupTest {
 
   private static final Schema SIMPLE_CG_KEY_SCHEMA =
       Schema.builder().addStringField("user").addStringField("country").build();
-  private static final Schema SIMPLE_CG_OUTPUT_SCHEMA =
-      Schema.builder()
-          .addArrayField("pc1", FieldType.row(CG_SCHEMA_1))
-          .addArrayField("pc2", FieldType.row(CG_SCHEMA_1))
-          .addArrayField("pc3", FieldType.row(CG_SCHEMA_1))
-          .build();
 
   @Test
   @Category(NeedsRunner.class)
   public void testCoGroupByFieldNames() {
+    // Input
     PCollection<Row> pc1 =
         pipeline
             .apply(
@@ -120,83 +110,87 @@ public class CoGroupTest {
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 24, "ar").build()))
             .setRowSchema(CG_SCHEMA_1);
 
-    Row key1 = Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user1", "us").build();
+    // Output
+    Schema expectedSchema =
+        Schema.builder()
+            .addRowField("key", SIMPLE_CG_KEY_SCHEMA)
+            .addIterableField("pc1", FieldType.row(CG_SCHEMA_1))
+            .addIterableField("pc2", FieldType.row(CG_SCHEMA_1))
+            .addIterableField("pc3", FieldType.row(CG_SCHEMA_1))
+            .build();
+
     Row key1Joined =
-        Row.withSchema(SIMPLE_CG_OUTPUT_SCHEMA)
-            .addValue(
+        Row.withSchema(expectedSchema)
+            .addValue(Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user1", "us").build())
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 1, "us").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 2, "us").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 9, "us").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 10, "us").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 17, "us").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 18, "us").build()))
             .build();
 
-    Row key2 = Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user1", "il").build();
     Row key2Joined =
-        Row.withSchema(SIMPLE_CG_OUTPUT_SCHEMA)
-            .addValue(
+        Row.withSchema(expectedSchema)
+            .addValue(Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user1", "il").build())
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 3, "il").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 4, "il").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 11, "il").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 12, "il").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 19, "il").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 20, "il").build()))
             .build();
 
-    Row key3 = Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user2", "fr").build();
     Row key3Joined =
-        Row.withSchema(SIMPLE_CG_OUTPUT_SCHEMA)
-            .addValue(
+        Row.withSchema(expectedSchema)
+            .addValue(Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user2", "fr").build())
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 5, "fr").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 6, "fr").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 13, "fr").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 14, "fr").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 21, "fr").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 22, "fr").build()))
             .build();
 
-    Row key4 = Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user2", "ar").build();
     Row key4Joined =
-        Row.withSchema(SIMPLE_CG_OUTPUT_SCHEMA)
-            .addValue(
+        Row.withSchema(expectedSchema)
+            .addValue(Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user2", "ar").build())
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 7, "ar").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 8, "ar").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 15, "ar").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 16, "ar").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 23, "ar").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 24, "ar").build()))
             .build();
 
-    PCollection<KV<Row, Row>> joined =
+    PCollection<Row> joined =
         PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
             .apply("CoGroup", CoGroup.join(By.fieldNames("user", "country")));
-    List<KV<Row, Row>> expected =
-        ImmutableList.of(
-            KV.of(key1, key1Joined),
-            KV.of(key2, key2Joined),
-            KV.of(key3, key3Joined),
-            KV.of(key4, key4Joined));
+    List<Row> expected = ImmutableList.of(key1Joined, key2Joined, key3Joined, key4Joined);
     PAssert.that(joined).satisfies(actual -> containsJoinedFields(expected, actual));
     pipeline.run();
   }
@@ -218,6 +212,7 @@ public class CoGroupTest {
   @Test
   @Category(NeedsRunner.class)
   public void testCoGroupByDifferentFields() {
+    // Inputs.
     PCollection<Row> pc1 =
         pipeline
             .apply(
@@ -261,75 +256,83 @@ public class CoGroupTest {
                     Row.withSchema(CG_SCHEMA_3).addValues("user2", 24, "ar").build()))
             .setRowSchema(CG_SCHEMA_3);
 
-    Row key1 = Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user1", "us").build();
+    // Expected outputs
+    Schema expectedSchema =
+        Schema.builder()
+            .addRowField("key", SIMPLE_CG_KEY_SCHEMA)
+            .addIterableField("pc1", FieldType.row(CG_SCHEMA_1))
+            .addIterableField("pc2", FieldType.row(CG_SCHEMA_2))
+            .addIterableField("pc3", FieldType.row(CG_SCHEMA_3))
+            .build();
     Row key1Joined =
-        Row.withSchema(SIMPLE_CG_OUTPUT_SCHEMA)
-            .addValue(
+        Row.withSchema(expectedSchema)
+            .addValue(Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user1", "us").build())
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 1, "us").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 2, "us").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_2).addValues("user1", 9, "us").build(),
                     Row.withSchema(CG_SCHEMA_2).addValues("user1", 10, "us").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_3).addValues("user1", 17, "us").build(),
                     Row.withSchema(CG_SCHEMA_3).addValues("user1", 18, "us").build()))
             .build();
 
-    Row key2 = Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user1", "il").build();
     Row key2Joined =
-        Row.withSchema(SIMPLE_CG_OUTPUT_SCHEMA)
-            .addValue(
+        Row.withSchema(expectedSchema)
+            .addValue(Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user1", "il").build())
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 3, "il").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user1", 4, "il").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_2).addValues("user1", 11, "il").build(),
                     Row.withSchema(CG_SCHEMA_2).addValues("user1", 12, "il").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_3).addValues("user1", 19, "il").build(),
                     Row.withSchema(CG_SCHEMA_3).addValues("user1", 20, "il").build()))
             .build();
 
-    Row key3 = Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user2", "fr").build();
     Row key3Joined =
-        Row.withSchema(SIMPLE_CG_OUTPUT_SCHEMA)
-            .addValue(
+        Row.withSchema(expectedSchema)
+            .addValue(Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user2", "fr").build())
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 5, "fr").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 6, "fr").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_2).addValues("user2", 13, "fr").build(),
                     Row.withSchema(CG_SCHEMA_2).addValues("user2", 14, "fr").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_3).addValues("user2", 21, "fr").build(),
                     Row.withSchema(CG_SCHEMA_3).addValues("user2", 22, "fr").build()))
             .build();
 
-    Row key4 = Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user2", "ar").build();
     Row key4Joined =
-        Row.withSchema(SIMPLE_CG_OUTPUT_SCHEMA)
-            .addValue(
+        Row.withSchema(expectedSchema)
+            .addValue(Row.withSchema(SIMPLE_CG_KEY_SCHEMA).addValues("user2", "ar").build())
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 7, "ar").build(),
                     Row.withSchema(CG_SCHEMA_1).addValues("user2", 8, "ar").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_2).addValues("user2", 15, "ar").build(),
                     Row.withSchema(CG_SCHEMA_2).addValues("user2", 16, "ar").build()))
-            .addValue(
+            .addIterable(
                 Lists.newArrayList(
                     Row.withSchema(CG_SCHEMA_3).addValues("user2", 23, "ar").build(),
                     Row.withSchema(CG_SCHEMA_3).addValues("user2", 24, "ar").build()))
             .build();
 
-    PCollection<KV<Row, Row>> joined =
+    PCollection<Row> joined =
         PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
             .apply(
                 "CoGroup",
@@ -337,12 +340,8 @@ public class CoGroupTest {
                     .join("pc2", By.fieldNames("user2", "country2"))
                     .join("pc3", By.fieldNames("user3", "country3")));
 
-    List<KV<Row, Row>> expected =
-        ImmutableList.of(
-            KV.of(key1, key1Joined),
-            KV.of(key2, key2Joined),
-            KV.of(key3, key3Joined),
-            KV.of(key4, key4Joined));
+    List<Row> expected = ImmutableList.of(key1Joined, key2Joined, key3Joined, key4Joined);
+
     PAssert.that(joined).satisfies(actual -> containsJoinedFields(expected, actual));
     pipeline.run();
   }
@@ -367,7 +366,7 @@ public class CoGroupTest {
             "Create3", Create.of(Row.withSchema(CG_SCHEMA_3).addValues("user1", 17, "us").build()));
 
     thrown.expect(IllegalArgumentException.class);
-    PCollection<KV<Row, Row>> joined =
+    PCollection<Row> joined =
         PCollectionTuple.of("pc1", pc1, "pc2", pc2, "pc3", pc3)
             .apply(
                 "CoGroup",
@@ -393,7 +392,7 @@ public class CoGroupTest {
             .setRowSchema(CG_SCHEMA_1);
 
     thrown.expect(IllegalStateException.class);
-    PCollection<KV<Row, Row>> joined =
+    PCollection<Row> joined =
         PCollectionTuple.of("pc1", pc1, "pc2", pc2)
             .apply(
                 "CoGroup",
@@ -683,46 +682,21 @@ public class CoGroupTest {
     pipeline.run();
   }
 
-  private static Void containsJoinedFields(
-      List<KV<Row, Row>> expected, Iterable<KV<Row, Row>> actual) {
-    List<Matcher<? super KV<Row, Row>>> matchers = Lists.newArrayList();
-    for (KV<Row, Row> row : expected) {
+  private static Void containsJoinedFields(List<Row> expected, Iterable<Row> actual) {
+    List<Matcher<? super Row>> matchers = Lists.newArrayList();
+    for (Row row : expected) {
       List<Matcher> fieldMatchers = Lists.newArrayList();
-      Row value = row.getValue();
-      Schema valueSchema = value.getSchema();
-      for (int i = 0; i < valueSchema.getFieldCount(); ++i) {
-        assertEquals(TypeName.ARRAY, valueSchema.getField(i).getType().getTypeName());
-        fieldMatchers.add(new ArrayFieldMatchesAnyOrder(i, (List) value.getArray(i)));
+      Schema schema = row.getSchema();
+      fieldMatchers.add(
+          new RowFieldMatcherIterableFieldAnyOrder(row.getSchema(), 0, row.getRow(0)));
+      for (int i = 1; i < schema.getFieldCount(); ++i) {
+        assertEquals(TypeName.ITERABLE, schema.getField(i).getType().getTypeName());
+        fieldMatchers.add(
+            new RowFieldMatcherIterableFieldAnyOrder(row.getSchema(), i, row.getIterable(i)));
       }
-      matchers.add(
-          KvMatcher.isKv(equalTo(row.getKey()), allOf(fieldMatchers.toArray(new Matcher[0]))));
+      matchers.add(allOf(fieldMatchers.toArray(new Matcher[0])));
     }
     assertThat(actual, containsInAnyOrder(matchers.toArray(new Matcher[0])));
     return null;
-  }
-
-  static class ArrayFieldMatchesAnyOrder extends BaseMatcher<Row> {
-    int fieldIndex;
-    Row[] expected;
-
-    ArrayFieldMatchesAnyOrder(int fieldIndex, List<Row> expected) {
-      this.fieldIndex = fieldIndex;
-      this.expected = expected.toArray(new Row[0]);
-    }
-
-    @Override
-    public boolean matches(Object item) {
-      if (!(item instanceof Row)) {
-        return false;
-      }
-      Row row = (Row) item;
-      Collection<Row> actual = row.getArray(fieldIndex);
-      return containsInAnyOrder(expected).matches(actual);
-    }
-
-    @Override
-    public void describeTo(Description description) {
-      description.appendText("arrayFieldMatchesAnyOrder");
-    }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/GroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/GroupTest.java
@@ -17,7 +17,8 @@
  */
 package org.apache.beam.sdk.schemas.transforms;
 
-import static org.apache.beam.sdk.TestUtils.KvMatcher.isKv;
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -30,9 +31,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import org.apache.beam.sdk.schemas.JavaFieldSchema;
+import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.schemas.utils.SchemaTestUtils.RowFieldMatcherIterableFieldAnyOrder;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -40,17 +44,16 @@ import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.Flatten;
-import org.apache.beam.sdk.transforms.Keys;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.Top;
-import org.apache.beam.sdk.transforms.Values;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -121,8 +124,8 @@ public class GroupTest implements Serializable {
 
   @Test
   @Category(NeedsRunner.class)
-  public void testGroupByOneField() {
-    PCollection<KV<Row, Iterable<POJO>>> grouped =
+  public void testGroupByOneField() throws NoSuchSchemaException {
+    PCollection<Row> grouped =
         pipeline
             .apply(
                 Create.of(
@@ -133,14 +136,31 @@ public class GroupTest implements Serializable {
             .apply(Group.byFieldNames("field1"));
 
     Schema keySchema = Schema.builder().addStringField("field1").build();
-    List<KV<Row, Collection<POJO>>> expected =
+    Schema outputSchema =
+        Schema.builder()
+            .addRowField("key", keySchema)
+            .addIterableField("value", FieldType.row(POJO_SCHEMA))
+            .build();
+
+    SerializableFunction<POJO, Row> toRow =
+        pipeline.getSchemaRegistry().getToRowFunction(POJO.class);
+
+    List<Row> expected =
         ImmutableList.of(
-            KV.of(
-                Row.withSchema(keySchema).addValue("key1").build(),
-                ImmutableList.of(new POJO("key1", 1L, "value1"), new POJO("key1", 2L, "value2"))),
-            KV.of(
-                Row.withSchema(keySchema).addValue("key2").build(),
-                ImmutableList.of(new POJO("key2", 3L, "value3"), new POJO("key2", 4L, "value4"))));
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValue("key1").build())
+                .addIterable(
+                    ImmutableList.of(
+                        toRow.apply(new POJO("key1", 1L, "value1")),
+                        toRow.apply(new POJO("key1", 2L, "value2"))))
+                .build(),
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValue("key2").build())
+                .addIterable(
+                    ImmutableList.of(
+                        toRow.apply(new POJO("key2", 3L, "value3")),
+                        toRow.apply(new POJO("key2", 4L, "value4"))))
+                .build());
 
     PAssert.that(grouped).satisfies(actual -> containsKIterableVs(expected, actual, new POJO[0]));
     pipeline.run();
@@ -148,8 +168,8 @@ public class GroupTest implements Serializable {
 
   @Test
   @Category(NeedsRunner.class)
-  public void testGroupByMultiple() {
-    PCollection<KV<Row, Iterable<POJO>>> grouped =
+  public void testGroupByMultiple() throws NoSuchSchemaException {
+    PCollection<Row> grouped =
         pipeline
             .apply(
                 Create.of(
@@ -160,14 +180,30 @@ public class GroupTest implements Serializable {
             .apply(Group.byFieldNames("field1", "field2"));
 
     Schema keySchema = Schema.builder().addStringField("field1").addInt64Field("field2").build();
-    List<KV<Row, Collection<POJO>>> expected =
+    Schema outputSchema =
+        Schema.builder()
+            .addRowField("key", keySchema)
+            .addIterableField("value", FieldType.row(POJO_SCHEMA))
+            .build();
+    SerializableFunction<POJO, Row> toRow =
+        pipeline.getSchemaRegistry().getToRowFunction(POJO.class);
+
+    List<Row> expected =
         ImmutableList.of(
-            KV.of(
-                Row.withSchema(keySchema).addValues("key1", 1L).build(),
-                ImmutableList.of(new POJO("key1", 1L, "value1"), new POJO("key1", 1L, "value2"))),
-            KV.of(
-                Row.withSchema(keySchema).addValues("key2", 2L).build(),
-                ImmutableList.of(new POJO("key2", 2L, "value3"), new POJO("key2", 2L, "value4"))));
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValues("key1", 1L).build())
+                .addIterable(
+                    ImmutableList.of(
+                        toRow.apply(new POJO("key1", 1L, "value1")),
+                        toRow.apply(new POJO("key1", 1L, "value2"))))
+                .build(),
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValues("key2", 2L).build())
+                .addIterable(
+                    ImmutableList.of(
+                        toRow.apply(new POJO("key2", 2L, "value3")),
+                        toRow.apply(new POJO("key2", 2L, "value4"))))
+                .build());
 
     PAssert.that(grouped).satisfies(actual -> containsKIterableVs(expected, actual, new POJO[0]));
     pipeline.run();
@@ -207,11 +243,14 @@ public class GroupTest implements Serializable {
     }
   }
 
+  private static final Schema OUTER_POJO_SCHEMA =
+      Schema.builder().addRowField("inner", POJO_SCHEMA).build();
+
   /** Test grouping by a set of fields that are nested. */
   @Test
   @Category(NeedsRunner.class)
-  public void testGroupByNestedKey() {
-    PCollection<KV<Row, Iterable<OuterPOJO>>> grouped =
+  public void testGroupByNestedKey() throws NoSuchSchemaException {
+    PCollection<Row> grouped =
         pipeline
             .apply(
                 Create.of(
@@ -222,18 +261,31 @@ public class GroupTest implements Serializable {
             .apply(Group.byFieldNames("inner.field1", "inner.field2"));
 
     Schema keySchema = Schema.builder().addStringField("field1").addInt64Field("field2").build();
-    List<KV<Row, Collection<OuterPOJO>>> expected =
+    Schema outputSchema =
+        Schema.builder()
+            .addRowField("key", keySchema)
+            .addIterableField("value", FieldType.row(OUTER_POJO_SCHEMA))
+            .build();
+
+    SerializableFunction<OuterPOJO, Row> toRow =
+        pipeline.getSchemaRegistry().getToRowFunction(OuterPOJO.class);
+
+    List<Row> expected =
         ImmutableList.of(
-            KV.of(
-                Row.withSchema(keySchema).addValues("key1", 1L).build(),
-                ImmutableList.of(
-                    new OuterPOJO(new POJO("key1", 1L, "value1")),
-                    new OuterPOJO(new POJO("key1", 1L, "value2")))),
-            KV.of(
-                Row.withSchema(keySchema).addValues("key2", 2L).build(),
-                ImmutableList.of(
-                    new OuterPOJO(new POJO("key2", 2L, "value3")),
-                    new OuterPOJO(new POJO("key2", 2L, "value4")))));
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValues("key1", 1L).build())
+                .addIterable(
+                    ImmutableList.of(
+                        toRow.apply(new OuterPOJO(new POJO("key1", 1L, "value1"))),
+                        toRow.apply(new OuterPOJO(new POJO("key1", 1L, "value2")))))
+                .build(),
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValues("key2", 2L).build())
+                .addIterable(
+                    ImmutableList.of(
+                        toRow.apply(new OuterPOJO(new POJO("key2", 2L, "value3"))),
+                        toRow.apply(new OuterPOJO(new POJO("key2", 2L, "value4")))))
+                .build());
 
     PAssert.that(grouped)
         .satisfies(actual -> containsKIterableVs(expected, actual, new OuterPOJO[0]));
@@ -276,47 +328,21 @@ public class GroupTest implements Serializable {
 
   @Test
   @Category(NeedsRunner.class)
-  public void testPerKeyAggregation() {
-    Collection<POJO> elements =
-        ImmutableList.of(
-            new POJO("key1", 1, "value1"),
-            new POJO("key1", 1, "value2"),
-            new POJO("key2", 2, "value3"),
-            new POJO("key2", 2, "value4"),
-            new POJO("key2", 2, "value4"));
-    PCollection<KV<Row, Long>> count =
-        pipeline
-            .apply(Create.of(elements))
-            .apply(Group.<POJO>byFieldNames("field1").aggregate(Count.combineFn()));
-
-    Schema keySchema = Schema.builder().addStringField("field1").build();
-
-    Collection<KV<Row, Long>> expectedCounts =
-        ImmutableList.of(
-            KV.of(Row.withSchema(keySchema).addValue("key1").build(), 2L),
-            KV.of(Row.withSchema(keySchema).addValue("key2").build(), 3L));
-    PAssert.that(count).containsInAnyOrder(expectedCounts);
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
   public void testOutputCoders() {
     Schema keySchema = Schema.builder().addStringField("field1").build();
+    Schema outputSchema =
+        Schema.builder()
+            .addRowField("key", keySchema)
+            .addIterableField("value", FieldType.row(POJO_SCHEMA))
+            .build();
 
-    PCollection<KV<Row, Iterable<POJO>>> grouped =
+    PCollection<Row> grouped =
         pipeline
             .apply(Create.of(new POJO("key1", 1, "value1")))
             .apply(Group.byFieldNames("field1"));
 
-    // Make sure that the key has the right schema.
-    PCollection<Row> keys = grouped.apply(Keys.create());
-    assertTrue(keys.getSchema().equivalent(keySchema));
+    assertTrue(grouped.getSchema().equivalent(outputSchema));
 
-    // Make sure that the value has the right schema.
-    PCollection<POJO> values = grouped.apply(Values.create()).apply(Flatten.iterables());
-    assertTrue(values.getSchema().equivalent(POJO_SCHEMA));
     pipeline.run();
   }
 
@@ -363,7 +389,7 @@ public class GroupTest implements Serializable {
             new AggregatePojos(3, 2, 4),
             new AggregatePojos(4, 2, 5));
 
-    PCollection<KV<Row, Row>> aggregations =
+    PCollection<Row> aggregations =
         pipeline
             .apply(Create.of(elements))
             .apply(
@@ -379,16 +405,20 @@ public class GroupTest implements Serializable {
             .addInt32Field("field3_sum")
             .addArrayField("field1_top", FieldType.INT64)
             .build();
+    Schema outputSchema =
+        Schema.builder().addRowField("key", keySchema).addRowField("value", valueSchema).build();
 
-    List<KV<Row, Row>> expected =
+    List<Row> expected =
         ImmutableList.of(
-            KV.of(
-                Row.withSchema(keySchema).addValue(1L).build(),
-                Row.withSchema(valueSchema).addValue(3L).addValue(5).addArray(2L).build()),
-            KV.of(
-                Row.withSchema(keySchema).addValue(2L).build(),
-                Row.withSchema(valueSchema).addValue(7L).addValue(9).addArray(4L).build()));
-    PAssert.that(aggregations).satisfies(actual -> containsKvs(expected, actual));
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValue(1L).build())
+                .addValue(Row.withSchema(valueSchema).addValue(3L).addValue(5).addArray(2L).build())
+                .build(),
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValue(2L).build())
+                .addValue(Row.withSchema(valueSchema).addValue(7L).addValue(9).addArray(4L).build())
+                .build());
+    PAssert.that(aggregations).satisfies(actual -> containsKvRows(expected, actual));
 
     pipeline.run();
   }
@@ -526,7 +556,7 @@ public class GroupTest implements Serializable {
             new OuterAggregate(new AggregatePojos(3, 2, 4)),
             new OuterAggregate(new AggregatePojos(4, 2, 5)));
 
-    PCollection<KV<Row, Row>> aggregations =
+    PCollection<Row> aggregations =
         pipeline
             .apply(Create.of(elements))
             .apply(
@@ -542,16 +572,20 @@ public class GroupTest implements Serializable {
             .addInt32Field("field3_sum")
             .addArrayField("field1_top", FieldType.INT64)
             .build();
+    Schema outputSchema =
+        Schema.builder().addRowField("key", keySchema).addRowField("value", valueSchema).build();
 
-    List<KV<Row, Row>> expected =
+    List<Row> expected =
         ImmutableList.of(
-            KV.of(
-                Row.withSchema(keySchema).addValue(1L).build(),
-                Row.withSchema(valueSchema).addValue(3L).addValue(5).addArray(2L).build()),
-            KV.of(
-                Row.withSchema(keySchema).addValue(2L).build(),
-                Row.withSchema(valueSchema).addValue(7L).addValue(9).addArray(4L).build()));
-    PAssert.that(aggregations).satisfies(actual -> containsKvs(expected, actual));
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValue(1L).build())
+                .addValue(Row.withSchema(valueSchema).addValue(3L).addValue(5).addArray(2L).build())
+                .build(),
+            Row.withSchema(outputSchema)
+                .addValue(Row.withSchema(keySchema).addValue(2L).build())
+                .addValue(Row.withSchema(valueSchema).addValue(7L).addValue(9).addArray(4L).build())
+                .build());
+    PAssert.that(aggregations).satisfies(actual -> containsKvRows(expected, actual));
 
     pipeline.run();
   }
@@ -587,27 +621,55 @@ public class GroupTest implements Serializable {
   }
 
   private static <T> Void containsKIterableVs(
-      List<KV<Row, Collection<T>>> expectedKvs,
-      Iterable<KV<Row, Iterable<T>>> actualKvs,
-      T[] emptyArray) {
-    List<KV<Row, Iterable<T>>> list = Lists.newArrayList(actualKvs);
-    List<Matcher<? super KV<Row, Iterable<POJO>>>> matchers = new ArrayList<>();
-    for (KV<Row, Collection<T>> expected : expectedKvs) {
-      T[] values = expected.getValue().toArray(emptyArray);
-      matchers.add(isKv(equalTo(expected.getKey()), containsInAnyOrder(values)));
+      List<Row> expectedKvs, Iterable<Row> actualKvs, T[] emptyArray) {
+    List<Row> list = Lists.newArrayList(actualKvs);
+    List<Matcher<? super Row>> matchers = new ArrayList<>();
+    for (Row expected : expectedKvs) {
+      List<Matcher> fieldMatchers = Lists.newArrayList();
+      fieldMatchers.add(
+          new RowFieldMatcherIterableFieldAnyOrder(expected.getSchema(), 0, expected.getRow(0)));
+      assertEquals(TypeName.ITERABLE, expected.getSchema().getField(1).getType().getTypeName());
+      fieldMatchers.add(
+          new RowFieldMatcherIterableFieldAnyOrder(
+              expected.getSchema(), 1, expected.getIterable(1)));
+      matchers.add(allOf(fieldMatchers.toArray(new Matcher[0])));
     }
     assertThat(actualKvs, containsInAnyOrder(matchers.toArray(new Matcher[0])));
     return null;
   }
 
-  private static <T> Void containsKvs(
-      List<KV<Row, Row>> expectedKvs, Iterable<KV<Row, Row>> actualKvs) {
-    List<Matcher<? super KV<Row, Iterable<POJO>>>> matchers = new ArrayList<>();
-    for (KV<Row, Row> expected : expectedKvs) {
-      matchers.add(isKv(equalTo(expected.getKey()), equalTo(expected.getValue())));
+  private static <T> Void containsKvRows(List<Row> expectedKvs, Iterable<Row> actualKvs) {
+    List<Matcher<? super Row>> matchers = new ArrayList<>();
+    for (Row expected : expectedKvs) {
+      matchers.add(new KvRowMatcher(equalTo(expected.getRow(0)), equalTo(expected.getRow(1))));
     }
     assertThat(actualKvs, containsInAnyOrder(matchers.toArray(new Matcher[0])));
     return null;
+  }
+
+  public static class KvRowMatcher extends TypeSafeMatcher<Row> {
+    final Matcher<? super Row> keyMatcher;
+    final Matcher<? super Row> valueMatcher;
+
+    public KvRowMatcher(Matcher<? super Row> keyMatcher, Matcher<? super Row> valueMatcher) {
+      this.keyMatcher = keyMatcher;
+      this.valueMatcher = valueMatcher;
+    }
+
+    @Override
+    public boolean matchesSafely(Row kvRow) {
+      return keyMatcher.matches(kvRow.getRow(0)) && valueMatcher.matches(kvRow.getRow(1));
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description
+          .appendText("a KVRow(")
+          .appendValue(keyMatcher)
+          .appendText(", ")
+          .appendValue(valueMatcher)
+          .appendText(")");
+    }
   }
 
   private static Void containsSingleIterable(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaTestUtils.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaTestUtils.java
@@ -17,9 +17,18 @@
  */
 package org.apache.beam.sdk.schemas.utils;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 
 /** Utilities for testing schemas. */
 public class SchemaTestUtils {
@@ -27,5 +36,58 @@ public class SchemaTestUtils {
   // (recursively) contain the same fields with the same names, but possibly different orders.
   public static void assertSchemaEquivalent(Schema expected, Schema actual) {
     assertTrue("Expected: " + expected + "  Got: " + actual, actual.equivalent(expected));
+  }
+
+  public static class RowFieldMatcherIterableFieldAnyOrder extends BaseMatcher<Row> {
+    private final int fieldIndex;
+    private final Object expected;
+    private final FieldType fieldType;
+
+    public RowFieldMatcherIterableFieldAnyOrder(Schema schema, int fieldIndex, Object expected) {
+      this.fieldIndex = fieldIndex;
+      this.expected = expected;
+      this.fieldType = schema.getField(fieldIndex).getType();
+    }
+
+    public RowFieldMatcherIterableFieldAnyOrder(Schema schema, String fieldName, Object expected) {
+      this.fieldIndex = schema.indexOf(fieldName);
+      this.expected = expected;
+      this.fieldType = schema.getField(fieldIndex).getType();
+    }
+
+    @Override
+    public boolean matches(Object item) {
+      if (!(item instanceof Row)) {
+        return false;
+      }
+      Row row = (Row) item;
+      switch (fieldType.getTypeName()) {
+        case ROW:
+          if (!row.getSchema().getField(fieldIndex).getType().getTypeName().isCompositeType()) {
+            return false;
+          }
+          Row actualRow = row.getRow(fieldIndex);
+          return equalTo((Row) expected).matches(actualRow);
+        case ARRAY:
+          Row[] expectedArray = ((List<Row>) expected).toArray(new Row[0]);
+
+          return containsInAnyOrder(expectedArray).matches(row.getArray(fieldIndex));
+        case ITERABLE:
+          Row[] expectedIterable = Iterables.toArray((Iterable<Row>) expected, Row.class);
+          List<Row> actualIterable = Lists.newArrayList(row.getIterable(fieldIndex));
+          return containsInAnyOrder(expectedIterable).matches(actualIterable);
+        case MAP:
+          throw new RuntimeException("Not yet implemented for maps");
+        default:
+          return equalTo(expected).matches(row.getValue(fieldIndex));
+      }
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("rowFieldMatcher: ");
+      description.appendText("FieldType: " + fieldType.getTypeName());
+      description.appendText(expected.toString());
+    }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.extensions.sql.impl.transform.agg.AggregationCombineF
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
@@ -45,7 +46,6 @@ import org.apache.beam.sdk.transforms.windowing.Sessions;
 import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.Row;
@@ -261,18 +261,26 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
         }
       }
 
-      PTransform<PCollection<Row>, PCollection<KV<Row, Row>>> combiner = combined;
+      PTransform<PCollection<Row>, PCollection<Row>> combiner = combined;
+      boolean ignoreValues = false;
       if (combiner == null) {
         // If no field aggregations were specified, we run a constant combiner that always returns
         // a single empty row for each key. This is used by the SELECT DISTINCT query plan - in this
         // case a group by is generated to determine unique keys, and a constant null combiner is
         // used.
-        combiner = byFields.aggregate(AggregationCombineFnAdapter.createConstantCombineFn());
+        combiner =
+            byFields.aggregateField(
+                "*",
+                AggregationCombineFnAdapter.createConstantCombineFn(),
+                Field.of(
+                    "e",
+                    FieldType.row(AggregationCombineFnAdapter.EMPTY_SCHEMA).withNullable(true)));
+        ignoreValues = true;
       }
 
       return windowedStream
           .apply(combiner)
-          .apply("mergeRecord", ParDo.of(mergeRecord(outputSchema, windowFieldIndex)))
+          .apply("mergeRecord", ParDo.of(mergeRecord(outputSchema, windowFieldIndex, ignoreValues)))
           .setRowSchema(outputSchema);
     }
 
@@ -313,17 +321,20 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
       }
     }
 
-    static DoFn<KV<Row, Row>, Row> mergeRecord(Schema outputSchema, int windowStartFieldIndex) {
-      return new DoFn<KV<Row, Row>, Row>() {
+    static DoFn<Row, Row> mergeRecord(
+        Schema outputSchema, int windowStartFieldIndex, boolean ignoreValues) {
+      return new DoFn<Row, Row>() {
         @ProcessElement
         public void processElement(
-            @Element KV<Row, Row> kvRow, BoundedWindow window, OutputReceiver<Row> o) {
+            @Element Row kvRow, BoundedWindow window, OutputReceiver<Row> o) {
           List<Object> fieldValues =
               Lists.newArrayListWithCapacity(
-                  kvRow.getKey().getValues().size() + kvRow.getValue().getValues().size());
+                  kvRow.getRow(0).getValues().size() + kvRow.getRow(1).getValues().size());
 
-          fieldValues.addAll(kvRow.getKey().getValues());
-          fieldValues.addAll(kvRow.getValue().getValues());
+          fieldValues.addAll(kvRow.getRow(0).getValues());
+          if (!ignoreValues) {
+            fieldValues.addAll(kvRow.getRow(1).getValues());
+          }
 
           if (windowStartFieldIndex != -1) {
             fieldValues.add(windowStartFieldIndex, ((IntervalWindow) window).start());

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/AggregationCombineFnAdapter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/AggregationCombineFnAdapter.java
@@ -99,10 +99,10 @@ public class AggregationCombineFnAdapter<T> {
     }
   }
 
-  private static class ConstantEmpty extends CombineFn<Row, Row, Row> {
-    private static final Schema EMPTY_SCHEMA = Schema.builder().build();
-    private static final Row EMPTY_ROW = Row.withSchema(EMPTY_SCHEMA).build();
+  public static final Schema EMPTY_SCHEMA = Schema.builder().build();
+  public static final Row EMPTY_ROW = Row.withSchema(EMPTY_SCHEMA).build();
 
+  private static class ConstantEmpty extends CombineFn<Row, Row, Row> {
     public static final ConstantEmpty INSTANCE = new ConstantEmpty();
 
     @Override


### PR DESCRIPTION
Beam's KV type has no schema and due to special casing of KvCoder in Beam it is difficult to give it one. Here we modify the Beam schema transforms that return PCollection<KV> to instead return PCollection<Row> where the Row contains key and value fields. This is possible now that we support large iterables in schemas.