### PR TITLE
[BEAM-8737] Incorporate TRIAGE NEEDED status in beam_Dependency_Check

### DIFF
--- a/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
+++ b/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
@@ -140,8 +140,7 @@ def prioritize_dependencies(deps, sdk_type):
           compare_dependency_release_dates(curr_release_date, latest_release_date)):
         # Create a new issue or update on the existing issue
         jira_issue = jira_manager.run(dep_name, curr_ver, latest_ver, sdk_type, group_id = group_id)
-        if (jira_issue.fields.status.name == 'Open' or
-            jira_issue.fields.status.name == 'Reopened'):
+        if (jira_issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED'):
           dep_info += "<td><a href=\'{0}\'>{1}</a></td></tr>".format(
             ReportGeneratorConfig.BEAM_JIRA_HOST+"browse/"+ jira_issue.key,
             jira_issue.key)

--- a/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
+++ b/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
@@ -140,7 +140,7 @@ def prioritize_dependencies(deps, sdk_type):
           compare_dependency_release_dates(curr_release_date, latest_release_date)):
         # Create a new issue or update on the existing issue
         jira_issue = jira_manager.run(dep_name, curr_ver, latest_ver, sdk_type, group_id = group_id)
-        if (jira_issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED'):
+        if (jira_issue and jira_issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED'):
           dep_info += "<td><a href=\'{0}\'>{1}</a></td></tr>".format(
             ReportGeneratorConfig.BEAM_JIRA_HOST+"browse/"+ jira_issue.key,
             jira_issue.key)

--- a/.test-infra/jenkins/jira_utils/jira_manager.py
+++ b/.test-infra/jenkins/jira_utils/jira_manager.py
@@ -83,9 +83,9 @@ class JiraManager:
               Stop handling the JIRA issue for {1}, {2}""".format(group_id, dep_name, dep_latest_version))
             return
         # Reopen the existing parent issue if it was closed
-        elif (parent_issue.fields.status.name != 'Open' and
-          parent_issue.fields.status.name != 'Reopened'):
-          logging.info("""The parent issue {0} is not opening. Attempt reopening the issue""".format(parent_issue.key))
+        elif parent_issue.fields.status.name not in ['Open', 'Reopened', 'TRIAGE NEEDED']:
+          logging.info("""The parent issue {0} is not opening (status: {1}). Attempt reopening the issue""".format(
+            parent_issue.key, parent_issue.fields.status.name))
           try:
             self.jira.reopen_issue(parent_issue)
           except:
@@ -111,7 +111,7 @@ class JiraManager:
           issue = self._create_issue(dep_name, dep_current_version, dep_latest_version)
         logging.info('Created a new issue {0} of {1} {2}'.format(issue.key, dep_name, dep_latest_version))
       # Add descriptions in to the opening issue.
-      elif issue.fields.status.name == 'Open' or issue.fields.status.name == 'Reopened':
+      elif issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED']:
         self._append_descriptions(issue, dep_name, dep_current_version, dep_latest_version)
         logging.info('Updated the existing issue {0} of {1} {2}'.format(issue.key, dep_name, dep_latest_version))
       # Check if we need reopen the issue if it was closed. If so, reopen it then add descriptions.


### PR DESCRIPTION
https://issues.apache.org/jira/projects/BEAM/issues/BEAM-8737
As of now weekly beam_Dependency_Check job throws exception for JIRA tickets marked as "TRIAGE NEEDED", failing to include corresponding dependencies into email. This PR fixes this.


Example log: https://builds.apache.org/job/beam_Dependency_Check/237/

```
15:43:02 Start processing:  - com.google.cloud.bigtable:bigtable-client-core [1.8.0 -> 1.12.1]
15:43:02 
15:43:02 INFO:root:Finding release date of com.google.cloud.bigtable:bigtable-client-core 1.8.0 from the Maven Central
15:43:02 INFO:root:Finding release date of com.google.cloud.bigtable:bigtable-client-core 1.12.1 from the Maven Central
15:43:03 INFO:root:Start handling the JIRA issues for Java dependency: com.google.cloud.bigtable:bigtable-client-core 1.12.1
15:43:04 INFO:root:The parent issue BEAM-8690 is not opening. Attempt reopening the issue
15:43:04 Traceback (most recent call last):
15:43:04   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/.test-infra/jenkins/jira_utils/jira_manager.py", line 90, in run
15:43:04     self.jira.reopen_issue(parent_issue)
15:43:04   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/.test-infra/jenkins/jira_utils/jira_client.py", line 130, in reopen_issue
15:43:04     self.jira.transition_issue(issue.key, 3)
15:43:04   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/dependency/check/lib/python3.5/site-packages/jira/client.py", line 126, in wrapper
15:43:04     result = func(*arg_list, **kwargs)
15:43:04   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/dependency/check/lib/python3.5/site-packages/jira/client.py", line 1578, in transition_issue
15:43:04     url, data=json.dumps(data))
15:43:04   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/dependency/check/lib/python3.5/site-packages/jira/resilientsession.py", line 154, in post
15:43:04     return self.__verb('POST', url, **kwargs)
15:43:04   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/dependency/check/lib/python3.5/site-packages/jira/resilientsession.py", line 147, in __verb
15:43:04     raise_on_error(response, verb=verb, **kwargs)
15:43:04   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/dependency/check/lib/python3.5/site-packages/jira/resilientsession.py", line 57, in raise_on_error
15:43:04     r.status_code, error, r.url, request=request, response=r, **kwargs)
15:43:04 jira.exceptions.JIRAError: JiraError HTTP 400 url: https://issues.apache.org/jira/rest/api/2/issue/BEAM-8690/transitions
15:43:04 	text: It seems that you have tried to perform a workflow operation (Reopen Issue) that is not valid for the current state of this issue (BEAM-8690). The likely cause is that somebody has changed the issue recently, please look at the issue history for details.
15:43:04 	
15:43:04 	response headers = {'X-AREQUESTID': '1243x60347388x3', 'Date': 'Mon, 18 Nov 2019 20:43:04 GMT', 'X-AUSERNAME': ****, 'Cache-Control': 'no-cache, no-store, no-transform', 'Server': 'Apache', 'Connection': 'close', 'X-XSS-Protection': '1; mode=block', 'Content-Type': 'application/json;charset=UTF-8', 'Content-Security-Policy': "frame-ancestors 'self'", 'Transfer-Encoding': 'chunked', 'X-Frame-Options': 'SAMEORIGIN', 'X-ASEN': 'SEN-2062203', 'X-Seraph-LoginReason': 'OK', 'X-Content-Type-Options': 'nosniff', 'X-ASESSIONID': '877oha'}
15:43:04 	response text = {"errorMessages":["It seems that you have tried to perform a workflow operation (Reopen Issue) that is not valid for the current state of this issue (BEAM-8690). The likely cause is that somebody has changed the issue recently, please look at the issue history for details."],"errors":{}}
15:43:04 ERROR:root:Failed reopening the parent issue BEAM-8690.
15:43:04               Stop handling the JIRA issue for com.google.cloud.bigtable:bigtable-client-core, 1.12.1
15:43:04 Traceback (most recent call last):
15:43:04   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py", line 143, in prioritize_dependencies
15:43:04     if (jira_issue.fields.status.name == 'Open' or
15:43:04 AttributeError: 'NoneType' object has no attribute 'fields'
```

The ticket it tried to reopen was https://issues.apache.org/jira/projects/BEAM/issues/BEAM-8690, which has "TRIAGE NEEDED" status.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
