### PR TITLE
[BEAM-8744] Fix error in Beam Dependency Check Report

### DIFF
--- a/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
+++ b/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
@@ -32,6 +32,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 
+
 logging.getLogger().setLevel(logging.INFO)
 
 class InvalidFormatError(Exception):
@@ -75,7 +76,6 @@ def extract_single_dep(dep):
   if match is None:
     raise InvalidFormatError("Failed to extract the dependency information: {}".format(dep))
   return match.group(1).strip(), match.group(2).strip(), match.group(3).strip()
-
 
 def prioritize_dependencies(deps, sdk_type):
   """

--- a/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
+++ b/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
@@ -142,7 +142,7 @@ def prioritize_dependencies(deps, sdk_type):
           compare_dependency_release_dates(curr_release_date, latest_release_date)):
         # Create a new issue or update on the existing issue
         jira_issue = jira_manager.run(dep_name, curr_ver, latest_ver, sdk_type, group_id = group_id)
-        if (jira_issue and jira_issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED'):
+        if (jira_issue and jira_issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED']):
           dep_info += "<td><a href=\'{0}\'>{1}</a></td></tr>".format(
             ReportGeneratorConfig.BEAM_JIRA_HOST+"browse/"+ jira_issue.key,
             jira_issue.key)

--- a/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
+++ b/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
@@ -76,6 +76,7 @@ def extract_single_dep(dep):
     raise InvalidFormatError("Failed to extract the dependency information: {}".format(dep))
   return match.group(1).strip(), match.group(2).strip(), match.group(3).strip()
 
+
 def prioritize_dependencies(deps, sdk_type):
   """
   Extracts and analyze dependency versions and release dates.

--- a/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
+++ b/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
@@ -32,7 +32,6 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 
-
 logging.getLogger().setLevel(logging.INFO)
 
 class InvalidFormatError(Exception):

--- a/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
+++ b/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py
@@ -142,7 +142,7 @@ def prioritize_dependencies(deps, sdk_type):
           compare_dependency_release_dates(curr_release_date, latest_release_date)):
         # Create a new issue or update on the existing issue
         jira_issue = jira_manager.run(dep_name, curr_ver, latest_ver, sdk_type, group_id = group_id)
-        if (jira_issue and jira_issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED']):
+        if (jira_issue and jira_issue.fields.status.name in ['Open', 'Reopened', 'Triage Needed']):
           dep_info += "<td><a href=\'{0}\'>{1}</a></td></tr>".format(
             ReportGeneratorConfig.BEAM_JIRA_HOST+"browse/"+ jira_issue.key,
             jira_issue.key)

--- a/.test-infra/jenkins/jira_utils/jira_manager.py
+++ b/.test-infra/jenkins/jira_utils/jira_manager.py
@@ -83,7 +83,7 @@ class JiraManager:
               Stop handling the JIRA issue for {1}, {2}""".format(group_id, dep_name, dep_latest_version))
             return
         # Reopen the existing parent issue if it was closed
-        elif parent_issue.fields.status.name not in ['Open', 'Reopened', 'TRIAGE NEEDED']:
+        elif parent_issue.fields.status.name not in ['Open', 'Reopened', 'Triage Needed']:
           logging.info("""The parent issue {0} is not opening (status: {1}). Attempt reopening the issue""".format(
             parent_issue.key, parent_issue.fields.status.name))
           try:
@@ -111,7 +111,7 @@ class JiraManager:
           issue = self._create_issue(dep_name, dep_current_version, dep_latest_version)
         logging.info('Created a new issue {0} of {1} {2}'.format(issue.key, dep_name, dep_latest_version))
       # Add descriptions in to the opening issue.
-      elif issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED']:
+      elif issue.fields.status.name in ['Open', 'Reopened', 'Triage Needed']:
         self._append_descriptions(issue, dep_name, dep_current_version, dep_latest_version)
         logging.info('Updated the existing issue {0} of {1} {2}'.format(issue.key, dep_name, dep_latest_version))
       # Check if we need reopen the issue if it was closed. If so, reopen it then add descriptions.

--- a/.test-infra/jenkins/job_Dependency_Check.groovy
+++ b/.test-infra/jenkins/job_Dependency_Check.groovy
@@ -58,7 +58,7 @@ job('beam_Dependency_Check') {
     extendedEmail {
       triggers {
         always {
-          recipientList('dev@beam.apache.org')
+          recipientList('suztomo@google.com') // TODO: Revert this
           contentType('text/html')
           subject("Beam Dependency Check Report (${date})")
           content('''${FILE, path="src/build/dependencyUpdates/beam-dependency-check-report.html"}''')

--- a/.test-infra/jenkins/job_Dependency_Check.groovy
+++ b/.test-infra/jenkins/job_Dependency_Check.groovy
@@ -58,7 +58,7 @@ job('beam_Dependency_Check') {
     extendedEmail {
       triggers {
         always {
-          recipientList('suztomo@google.com') // TODO: Revert this
+          recipientList('dev@beam.apache.org')
           contentType('text/html')
           subject("Beam Dependency Check Report (${date})")
           content('''${FILE, path="src/build/dependencyUpdates/beam-dependency-check-report.html"}''')


### PR DESCRIPTION
https://issues.apache.org/jira/projects/BEAM/issues/BEAM-8744
The latest changes had a bug.

https://builds.apache.org/job/beam_Dependency_Check/238/console

```
12:41:11 python -m dependency_check.dependency_check_report_generator_test
12:41:11 Traceback (most recent call last):
12:41:11   File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
12:41:11     "__main__", mod_spec)
12:41:11   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
12:41:11     exec(code, run_globals)
12:41:11   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/.test-infra/jenkins/dependency_check/dependency_check_report_generator_test.py", line 26, in <module>
12:41:11     from .dependency_check_report_generator import prioritize_dependencies
12:41:11   File "/home/jenkins/jenkins-slave/workspace/beam_Dependency_Check/src/.test-infra/jenkins/dependency_check/dependency_check_report_generator.py", line 146
12:41:11     if (jira_issue and jira_issue.fields.status.name in ['Open', 'Reopened', 'TRIAGE NEEDED'):
12:41:11                                                                                             ^
12:41:11 SyntaxError: invalid syntax
```

Also the value of 'triage needed' status is "Triage Needed":

```
INFO:root:The parent issue BEAM-8690 is not opening (status: Triage Needed). Attempt reopening the issue
```
as per https://builds.apache.org/job/beam_Dependency_Check/239/consoleFull



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
