### PR TITLE
[BEAM-8743] Add support for flat schemas in pubsub

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOJsonTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOJsonTable.java
@@ -20,14 +20,13 @@ package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
 import static org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubMessageToRow.DLQ_TAG;
 import static org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubMessageToRow.MAIN_TAG;
 
-import com.google.auto.value.AutoValue;
 import java.io.Serializable;
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.impl.BeamTableStatistics;
 import org.apache.beam.sdk.extensions.sql.meta.BaseBeamTable;
 import org.apache.beam.sdk.extensions.sql.meta.BeamSqlTable;
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubJsonTableProvider.PubsubIOTableConfiguration;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -65,7 +64,7 @@ import org.apache.beam.sdk.values.TupleTagList;
  *  }
  * </pre>
  *
- * <p>Then SQL statements to declare and query such topic will look like this:
+ * <p>Then SQL statements to declare and query such a topic will look like this:
  *
  * <pre>
  *  CREATE TABLE topic_table (
@@ -85,49 +84,54 @@ import org.apache.beam.sdk.values.TupleTagList;
  * the value of that attribute. If it is not specified, then message publish time will be used as
  * event timestamp. 'attributes' map contains Pubsub message attributes map unchanged and can be
  * referenced in the queries as well.
+ *
+ * <p>Alternatively, one can use a flattened schema to model the pubsub messages (meaning {@link
+ * PubsubIOTableConfiguration#getUseFlatSchema()} is set).
+ *
+ * <p>In this configuration, only {@code event_timestamp} is required to be specified in the table
+ * schema. All other fields are assumed to be part of the message payload. SQL statements to declare
+ * and query the same topic as above will look like this:
+ *
+ * <pre>
+ *  CREATE TABLE topic_table (
+ *        event_timestamp TIMESTAMP,
+ *        name VARCHAR,
+ *        age INTEGER
+ *     )
+ *     TYPE 'pubsub'
+ *     LOCATION projects/&lt;GCP project id&gt;/topics/&lt;topic name&gt;
+ *     TBLPROPERTIES '{ \"timestampAttributeKey\" : &lt;timestamp attribute&gt; }';
+ *
+ *  SELECT event_timestamp, name FROM topic_table;
+ * </pre>
+ *
+ * <p>If 'timestampAttributeKey' is specified in TBLPROPERTIES then 'event_timestamp' will be set to
+ * the value of that attribute. If it is not specified, then message publish time will be used as
+ * event timestamp.
+ *
+ * <p>In order to write to the same table you can use an INSERT statement like this:
+ *
+ * <pre>
+ *   INSERT INTO topic_table VALUES (TIMESTAMP '2019-11-13 10:14:14', 'Brian', 30)
+ * </pre>
+ *
+ * <p>Note that when writing, the value for {@code event_timestamp} is ignored by default, since the
+ * Pubsub-managed publish time will be used to populate {@code event_timestamp} on read. In order to
+ * ensure the {@code event_timestamp} you specified is used, you should specify
+ * 'timestampAttributeKey' in TBLPROPERTIES.
  */
-@AutoValue
 @Internal
 @Experimental
-abstract class PubsubIOJsonTable extends BaseBeamTable implements Serializable {
+class PubsubIOJsonTable extends BaseBeamTable implements Serializable {
 
-  /**
-   * Optional attribute key of the Pubsub message from which to extract the event timestamp.
-   *
-   * <p>This attribute has to conform to the same requirements as in {@link
-   * PubsubIO.Read.Builder#withTimestampAttribute}.
-   *
-   * <p>Short version: it has to be either millis since epoch or string in RFC 3339 format.
-   *
-   * <p>If the attribute is specified then event timestamps will be extracted from the specified
-   * attribute. If it is not specified then message publish timestamp will be used.
-   */
-  @Nullable
-  abstract String getTimestampAttribute();
+  protected final PubsubIOTableConfiguration config;
 
-  /**
-   * Optional topic path which will be used as a dead letter queue.
-   *
-   * <p>Messages that cannot be processed will be sent to this topic. If it is not specified then
-   * exception will be thrown for errors during processing causing the pipeline to crash.
-   */
-  @Nullable
-  abstract String getDeadLetterQueue();
-
-  private boolean useDlq() {
-    return getDeadLetterQueue() != null;
+  private PubsubIOJsonTable(PubsubIOTableConfiguration config) {
+    this.config = config;
   }
 
-  /**
-   * Pubsub topic name.
-   *
-   * <p>Topic is the only way to specify the Pubsub source. Explicitly specifying the subscription
-   * is not supported at the moment. Subscriptions are automatically created (but not deleted).
-   */
-  abstract String getTopic();
-
-  static Builder builder() {
-    return new AutoValue_PubsubIOJsonTable.Builder();
+  static PubsubIOJsonTable withConfiguration(PubsubIOTableConfiguration config) {
+    return new PubsubIOJsonTable(config);
   }
 
   @Override
@@ -135,14 +139,10 @@ abstract class PubsubIOJsonTable extends BaseBeamTable implements Serializable {
     return PCollection.IsBounded.UNBOUNDED;
   }
 
-  /**
-   * Table schema, describes Pubsub message schema.
-   *
-   * <p>Includes fields 'event_timestamp', 'attributes, and 'payload'. See {@link
-   * PubsubMessageToRow}.
-   */
   @Override
-  public abstract Schema getSchema();
+  public Schema getSchema() {
+    return config.getSchema();
+  }
 
   @Override
   public PCollection<Row> buildIOReader(PBegin begin) {
@@ -152,7 +152,7 @@ abstract class PubsubIOJsonTable extends BaseBeamTable implements Serializable {
             .apply("parseMessageToRow", createParserParDo());
     rowsWithDlq.get(MAIN_TAG).setRowSchema(getSchema());
 
-    if (useDlq()) {
+    if (config.useDlq()) {
       rowsWithDlq.get(DLQ_TAG).apply(writeMessagesToDlq());
     }
 
@@ -163,47 +163,52 @@ abstract class PubsubIOJsonTable extends BaseBeamTable implements Serializable {
     return ParDo.of(
             PubsubMessageToRow.builder()
                 .messageSchema(getSchema())
-                .useDlq(getDeadLetterQueue() != null)
+                .useDlq(config.useDlq())
+                .useFlatSchema(config.getUseFlatSchema())
                 .build())
-        .withOutputTags(MAIN_TAG, useDlq() ? TupleTagList.of(DLQ_TAG) : TupleTagList.empty());
+        .withOutputTags(
+            MAIN_TAG, config.useDlq() ? TupleTagList.of(DLQ_TAG) : TupleTagList.empty());
   }
 
   private PubsubIO.Read<PubsubMessage> readMessagesWithAttributes() {
-    PubsubIO.Read<PubsubMessage> read = PubsubIO.readMessagesWithAttributes().fromTopic(getTopic());
+    PubsubIO.Read<PubsubMessage> read =
+        PubsubIO.readMessagesWithAttributes().fromTopic(config.getTopic());
 
-    return (getTimestampAttribute() == null)
-        ? read
-        : read.withTimestampAttribute(getTimestampAttribute());
+    return config.useTimestampAttribute()
+        ? read.withTimestampAttribute(config.getTimestampAttribute())
+        : read;
   }
 
   private PubsubIO.Write<PubsubMessage> writeMessagesToDlq() {
-    PubsubIO.Write<PubsubMessage> write = PubsubIO.writeMessages().to(getDeadLetterQueue());
+    PubsubIO.Write<PubsubMessage> write = PubsubIO.writeMessages().to(config.getDeadLetterQueue());
 
-    return (getTimestampAttribute() == null)
-        ? write
-        : write.withTimestampAttribute(getTimestampAttribute());
+    return config.useTimestampAttribute()
+        ? write.withTimestampAttribute(config.getTimestampAttribute())
+        : write;
   }
 
   @Override
   public POutput buildIOWriter(PCollection<Row> input) {
-    throw new UnsupportedOperationException("Writing to a Pubsub topic is not supported");
+    if (!config.getUseFlatSchema()) {
+      throw new UnsupportedOperationException(
+          "Writing to a Pubsub topic is only supported for flattened schemas");
+    }
+
+    return input
+        .apply(RowToPubsubMessage.fromTableConfig(config))
+        .apply(createPubsubMessageWrite());
+  }
+
+  private PubsubIO.Write<PubsubMessage> createPubsubMessageWrite() {
+    PubsubIO.Write<PubsubMessage> write = PubsubIO.writeMessages().to(config.getTopic());
+    if (config.useTimestampAttribute()) {
+      write = write.withTimestampAttribute(config.getTimestampAttribute());
+    }
+    return write;
   }
 
   @Override
   public BeamTableStatistics getTableStatistics(PipelineOptions options) {
     return BeamTableStatistics.UNBOUNDED_UNKNOWN;
-  }
-
-  @AutoValue.Builder
-  abstract static class Builder {
-    abstract Builder setSchema(Schema schema);
-
-    abstract Builder setTimestampAttribute(String timestampAttribute);
-
-    abstract Builder setDeadLetterQueue(String deadLetterQueue);
-
-    abstract Builder setTopic(String topic);
-
-    abstract PubsubIOJsonTable build();
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProvider.java
@@ -26,6 +26,9 @@ import static org.apache.beam.sdk.schemas.Schema.TypeName.ROW;
 
 import com.alibaba.fastjson.JSONObject;
 import com.google.auto.service.AutoService;
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.meta.BeamSqlTable;
@@ -51,38 +54,40 @@ public class PubsubJsonTableProvider extends InMemoryMetaTableProvider {
 
   @Override
   public BeamSqlTable buildBeamSqlTable(Table tableDefintion) {
-    validatePubsubMessageSchema(tableDefintion);
-
     JSONObject tableProperties = tableDefintion.getProperties();
     String timestampAttributeKey = tableProperties.getString("timestampAttributeKey");
     String deadLetterQueue = tableProperties.getString("deadLetterQueue");
     validateDlq(deadLetterQueue);
 
-    return PubsubIOJsonTable.builder()
-        .setSchema(tableDefintion.getSchema())
-        .setTimestampAttribute(timestampAttributeKey)
-        .setDeadLetterQueue(deadLetterQueue)
-        .setTopic(tableDefintion.getLocation())
-        .build();
+    Schema schema = tableDefintion.getSchema();
+    validateEventTimestamp(schema);
+
+    PubsubIOTableConfiguration config =
+        PubsubIOTableConfiguration.builder()
+            .setSchema(schema)
+            .setTimestampAttribute(timestampAttributeKey)
+            .setDeadLetterQueue(deadLetterQueue)
+            .setTopic(tableDefintion.getLocation())
+            .setUseFlatSchema(!definesAttributeAndPayload(schema))
+            .build();
+
+    return PubsubIOJsonTable.withConfiguration(config);
   }
 
-  private void validatePubsubMessageSchema(Table tableDefinition) {
-    Schema schema = tableDefinition.getSchema();
-
-    if (schema.getFieldCount() != 3
-        || !fieldPresent(schema, TIMESTAMP_FIELD, TIMESTAMP)
-        || !fieldPresent(
-            schema, ATTRIBUTES_FIELD, Schema.FieldType.map(VARCHAR.withNullable(false), VARCHAR))
-        || !(schema.hasField(PAYLOAD_FIELD)
-            && ROW.equals(schema.getField(PAYLOAD_FIELD).getType().getTypeName()))) {
-
+  private void validateEventTimestamp(Schema schema) {
+    if (!fieldPresent(schema, TIMESTAMP_FIELD, TIMESTAMP)) {
       throw new IllegalArgumentException(
-          "Unsupported schema specified for Pubsub source in CREATE TABLE. "
-              + "CREATE TABLE for Pubsub topic should define exactly the following fields: "
-              + "'event_timestamp' field of type 'TIMESTAMP', 'attributes' field of type "
-              + "MAP<VARCHAR, VARCHAR>, and 'payload' field of type 'ROW<...>' which matches the "
-              + "payload JSON format.");
+          "Unsupported schema specified for Pubsub source in CREATE TABLE."
+              + "CREATE TABLE for Pubsub topic must include at least 'event_timestamp' field of "
+              + "type 'TIMESTAMP'");
     }
+  }
+
+  private boolean definesAttributeAndPayload(Schema schema) {
+    return fieldPresent(
+            schema, ATTRIBUTES_FIELD, Schema.FieldType.map(VARCHAR.withNullable(false), VARCHAR))
+        && (schema.hasField(PAYLOAD_FIELD)
+            && ROW.equals(schema.getField(PAYLOAD_FIELD).getType().getTypeName()));
   }
 
   private boolean fieldPresent(Schema schema, String field, Schema.FieldType expectedType) {
@@ -94,6 +99,79 @@ public class PubsubJsonTableProvider extends InMemoryMetaTableProvider {
   private void validateDlq(String deadLetterQueue) {
     if (deadLetterQueue != null && deadLetterQueue.isEmpty()) {
       throw new IllegalArgumentException("Dead letter queue topic name is not specified");
+    }
+  }
+
+  @AutoValue
+  public abstract static class PubsubIOTableConfiguration implements Serializable {
+    public boolean useDlq() {
+      return getDeadLetterQueue() != null;
+    }
+
+    public boolean useTimestampAttribute() {
+      return getTimestampAttribute() != null;
+    }
+
+    /** Determines whether or not the messages should be represented with a flattened schema. */
+    abstract boolean getUseFlatSchema();
+
+    /**
+     * Optional attribute key of the Pubsub message from which to extract the event timestamp.
+     *
+     * <p>This attribute has to conform to the same requirements as in {@link
+     * PubsubIO.Read.Builder#withTimestampAttribute}.
+     *
+     * <p>Short version: it has to be either millis since epoch or string in RFC 3339 format.
+     *
+     * <p>If the attribute is specified then event timestamps will be extracted from the specified
+     * attribute. If it is not specified then message publish timestamp will be used.
+     */
+    @Nullable
+    abstract String getTimestampAttribute();
+
+    /**
+     * Optional topic path which will be used as a dead letter queue.
+     *
+     * <p>Messages that cannot be processed will be sent to this topic. If it is not specified then
+     * exception will be thrown for errors during processing causing the pipeline to crash.
+     */
+    @Nullable
+    abstract String getDeadLetterQueue();
+
+    /**
+     * Pubsub topic name.
+     *
+     * <p>Topic is the only way to specify the Pubsub source. Explicitly specifying the subscription
+     * is not supported at the moment. Subscriptions are automatically created (but not deleted).
+     */
+    abstract String getTopic();
+
+    /**
+     * Table schema, describes Pubsub message schema.
+     *
+     * <p>If {@link #getUseFlatSchema()} is not set, schema must contain exactly fields
+     * 'event_timestamp', 'attributes, and 'payload'. Else, it must contain just 'event_timestamp'.
+     * See {@linkA PubsubMessageToRow} for details.
+     */
+    public abstract Schema getSchema();
+
+    static Builder builder() {
+      return new AutoValue_PubsubJsonTableProvider_PubsubIOTableConfiguration.Builder();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setUseFlatSchema(boolean useFlatSchema);
+
+      abstract Builder setSchema(Schema schema);
+
+      abstract Builder setTimestampAttribute(String timestampAttribute);
+
+      abstract Builder setDeadLetterQueue(String deadLetterQueue);
+
+      abstract Builder setTopic(String topic);
+
+      abstract PubsubIOTableConfiguration build();
     }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRow.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRow.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.value.AutoValue;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Internal;
@@ -54,10 +56,12 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
   /**
    * Schema of the Pubsub message.
    *
-   * <p>Required to have exactly 3 top level fields at the moment:
+   * <p>Required to have at least 'event_timestamp' field of type {@link Schema.FieldType#DATETIME}.
+   *
+   * <p>If {@code useFlatSchema()} is set every other field is assumed to be part of the payload.
+   * Otherwise, the schema must contain exactly:
    *
    * <ul>
-   *   <li>'event_timestamp' of type {@link Schema.FieldType#DATETIME}
    *   <li>'attributes' of type {@link TypeName#MAP MAP&lt;VARCHAR,VARCHAR&gt;}
    *   <li>'payload' of type {@link TypeName#ROW ROW&lt;...&gt;}
    * </ul>
@@ -68,8 +72,18 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
 
   public abstract boolean useDlq();
 
+  public abstract boolean useFlatSchema();
+
   private Schema payloadSchema() {
-    return messageSchema().getField(PAYLOAD_FIELD).getType().getRowSchema();
+    if (!useFlatSchema()) {
+      return messageSchema().getField(PAYLOAD_FIELD).getType().getRowSchema();
+    } else {
+      // The payload contains every field in the schema except event_timestamp
+      return new Schema(
+          messageSchema().getFields().stream()
+              .filter(f -> !f.getName().equals(TIMESTAMP_FIELD))
+              .collect(Collectors.toList()));
+    }
   }
 
   public static Builder builder() {
@@ -95,28 +109,40 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
    * payload, and attributes.
    */
   private List<Object> getFieldValues(ProcessContext context) {
+    Row payload = parsePayloadJsonRow(context.element());
     return messageSchema().getFields().stream()
-        .map(field -> getValueForField(field, context.timestamp(), context.element()))
+        .map(
+            field ->
+                getValueForField(
+                    field, context.timestamp(), context.element().getAttributeMap(), payload))
         .collect(toList());
   }
 
   private Object getValueForField(
-      Schema.Field field, Instant timestamp, PubsubMessage pubsubMessage) {
-
-    switch (field.getName()) {
-      case TIMESTAMP_FIELD:
+      Schema.Field field, Instant timestamp, Map<String, String> attributeMap, Row payload) {
+    // TODO(BEAM-8801): do this check once at construction time, rather than for every element.
+    if (useFlatSchema()) {
+      if (field.getName().equals(TIMESTAMP_FIELD)) {
         return timestamp;
-      case ATTRIBUTES_FIELD:
-        return pubsubMessage.getAttributeMap();
-      case PAYLOAD_FIELD:
-        return parsePayloadJsonRow(pubsubMessage);
-      default:
-        throw new IllegalArgumentException(
-            "Unexpected field '"
-                + field.getName()
-                + "' in top level schema"
-                + " for Pubsub message. Top level schema should only contain "
-                + "'timestamp', 'attributes', and 'payload' fields");
+      } else {
+        return payload.getValue(field.getName());
+      }
+    } else {
+      switch (field.getName()) {
+        case TIMESTAMP_FIELD:
+          return timestamp;
+        case ATTRIBUTES_FIELD:
+          return attributeMap;
+        case PAYLOAD_FIELD:
+          return payload;
+        default:
+          throw new IllegalArgumentException(
+              "Unexpected field '"
+                  + field.getName()
+                  + "' in top level schema"
+                  + " for Pubsub message. Top level schema should only contain "
+                  + "'timestamp', 'attributes', and 'payload' fields");
+      }
     }
   }
 
@@ -135,6 +161,8 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
     public abstract Builder messageSchema(Schema messageSchema);
 
     public abstract Builder useDlq(boolean useDlq);
+
+    public abstract Builder useFlatSchema(boolean useFlatSchema);
 
     public abstract PubsubMessageToRow build();
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/RowToPubsubMessage.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/RowToPubsubMessage.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.transforms.DropFields;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ToJson;
+import org.apache.beam.sdk.transforms.WithTimestamps;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+
+/**
+ * A {@link PTransform} to convert {@link Row} to {@link PubsubMessage} with JSON payload.
+ *
+ * <p>Currently only supports writing a flat schema into a JSON payload. This means that all Row
+ * field values are written to the {@link PubsubMessage} JSON payload, except for {@code
+ * event_timestamp}, which is either ignored or written to the message attributes, depending on
+ * whether {@link PubsubJsonTableProvider.PubsubIOTableConfiguration#getTimestampAttribute()} is
+ * set.
+ */
+@Experimental
+public class RowToPubsubMessage extends PTransform<PCollection<Row>, PCollection<PubsubMessage>> {
+  private final PubsubJsonTableProvider.PubsubIOTableConfiguration config;
+
+  private RowToPubsubMessage(PubsubJsonTableProvider.PubsubIOTableConfiguration config) {
+    checkArgument(
+        config.getUseFlatSchema(), "RowToPubsubMessage is only supported for flattened schemas.");
+
+    this.config = config;
+  }
+
+  public static RowToPubsubMessage fromTableConfig(
+      PubsubJsonTableProvider.PubsubIOTableConfiguration config) {
+    return new RowToPubsubMessage(config);
+  }
+
+  @Override
+  public PCollection<PubsubMessage> expand(PCollection<Row> input) {
+    PCollection<Row> withTimestamp =
+        (config.useTimestampAttribute())
+            ? input.apply(
+                WithTimestamps.of((row) -> row.getDateTime("event_timestamp").toInstant()))
+            : input;
+
+    return withTimestamp
+        .apply(DropFields.fields("event_timestamp"))
+        .apply(ToJson.of())
+        .apply(
+            MapElements.into(TypeDescriptor.of(PubsubMessage.class))
+                .via(
+                    (String json) ->
+                        new PubsubMessage(
+                            json.getBytes(StandardCharsets.ISO_8859_1), ImmutableMap.of())));
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProviderTest.java
@@ -75,53 +75,30 @@ public class PubsubJsonTableProviderTest {
   }
 
   @Test
-  public void testThrowsIfAttributesFieldNotProvided() {
+  public void testCreatesTableWithJustTimestamp() {
     PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
-    Schema messageSchema =
-        Schema.builder()
-            .addDateTimeField("event_timestamp")
-            .addRowField("payload", Schema.builder().build())
-            .build();
+    Schema messageSchema = Schema.builder().addDateTimeField("event_timestamp").build();
 
     Table tableDefinition = tableDefinition().schema(messageSchema).build();
 
-    thrown.expectMessage("Unsupported");
-    thrown.expectMessage("'attributes'");
-    provider.buildBeamSqlTable(tableDefinition);
+    BeamSqlTable pubsubTable = provider.buildBeamSqlTable(tableDefinition);
+
+    assertNotNull(pubsubTable);
+    assertEquals(messageSchema, pubsubTable.getSchema());
   }
 
   @Test
-  public void testThrowsIfPayloadFieldNotProvided() {
+  public void testCreatesFlatTable() {
     PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
     Schema messageSchema =
-        Schema.builder()
-            .addDateTimeField("event_timestamp")
-            .addMapField("attributes", VARCHAR, VARCHAR)
-            .build();
+        Schema.builder().addDateTimeField("event_timestamp").addStringField("someField").build();
 
     Table tableDefinition = tableDefinition().schema(messageSchema).build();
 
-    thrown.expectMessage("Unsupported");
-    thrown.expectMessage("'payload'");
-    provider.buildBeamSqlTable(tableDefinition);
-  }
+    BeamSqlTable pubsubTable = provider.buildBeamSqlTable(tableDefinition);
 
-  @Test
-  public void testThrowsIfExtraFieldsExist() {
-    PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
-    Schema messageSchema =
-        Schema.builder()
-            .addDateTimeField("event_timestamp")
-            .addMapField("attributes", VARCHAR, VARCHAR)
-            .addStringField("someField")
-            .addRowField("payload", Schema.builder().build())
-            .build();
-
-    Table tableDefinition = tableDefinition().schema(messageSchema).build();
-
-    thrown.expectMessage("Unsupported");
-    thrown.expectMessage("'event_timestamp'");
-    provider.buildBeamSqlTable(tableDefinition);
+    assertNotNull(pubsubTable);
+    assertEquals(messageSchema, pubsubTable.getSchema());
   }
 
   private static Table.Builder tableDefinition() {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
@@ -85,6 +85,7 @@ public class PubsubMessageToRowTest implements Serializable {
                     PubsubMessageToRow.builder()
                         .messageSchema(messageSchema)
                         .useDlq(false)
+                        .useFlatSchema(false)
                         .build()));
 
     PAssert.that(rows)
@@ -134,6 +135,7 @@ public class PubsubMessageToRowTest implements Serializable {
                         PubsubMessageToRow.builder()
                             .messageSchema(messageSchema)
                             .useDlq(true)
+                            .useFlatSchema(false)
                             .build())
                     .withOutputTags(MAIN_TAG, TupleTagList.of(DLQ_TAG)));
 
@@ -161,6 +163,113 @@ public class PubsubMessageToRowTest implements Serializable {
                 .build(),
             Row.withSchema(messageSchema)
                 .addValues(ts(4), map("bttr", "vbl"), row(payloadSchema, 5, "baz"))
+                .build());
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testConvertsMessagesToFlatRow() {
+    Schema messageSchema =
+        Schema.builder()
+            .addDateTimeField("event_timestamp")
+            .addNullableField("id", FieldType.INT32)
+            .addNullableField("name", FieldType.STRING)
+            .build();
+
+    PCollection<Row> rows =
+        pipeline
+            .apply(
+                "create",
+                Create.timestamped(
+                    message(1, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
+                    message(2, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }"),
+                    message(3, map("cttr", "vcl"), "{ \"id\" : 7, \"name\" : \"bar\" }"),
+                    message(4, map("dttr", "vdl"), "{ \"name\" : \"qaz\", \"id\" : 8 }"),
+                    message(4, map("dttr", "vdl"), "{ \"name\" : null, \"id\" : null }")))
+            .apply(
+                "convert",
+                ParDo.of(
+                    PubsubMessageToRow.builder()
+                        .messageSchema(messageSchema)
+                        .useDlq(false)
+                        .useFlatSchema(true)
+                        .build()));
+
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            Row.withSchema(messageSchema)
+                .addValues(ts(1), /* map("attr", "val"), */ 3, "foo")
+                .build(),
+            Row.withSchema(messageSchema)
+                .addValues(ts(2), /* map("bttr", "vbl"), */ 5, "baz")
+                .build(),
+            Row.withSchema(messageSchema)
+                .addValues(ts(3), /* map("cttr", "vcl"), */ 7, "bar")
+                .build(),
+            Row.withSchema(messageSchema)
+                .addValues(ts(4), /* map("dttr", "vdl"), */ 8, "qaz")
+                .build(),
+            Row.withSchema(messageSchema)
+                .addValues(ts(4), /* map("dttr", "vdl"), */ null, null)
+                .build());
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testSendsFlatRowInvalidToDLQ() {
+    Schema messageSchema =
+        Schema.builder()
+            .addDateTimeField("event_timestamp")
+            .addInt32Field("id")
+            .addStringField("name")
+            .build();
+
+    PCollectionTuple outputs =
+        pipeline
+            .apply(
+                "create",
+                Create.timestamped(
+                    message(1, map("attr1", "val1"), "{ \"invalid1\" : \"sdfsd\" }"),
+                    message(2, map("attr2", "val2"), "{ \"invalid2"),
+                    message(3, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
+                    message(4, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }")))
+            .apply(
+                "convert",
+                ParDo.of(
+                        PubsubMessageToRow.builder()
+                            .messageSchema(messageSchema)
+                            .useDlq(true)
+                            .useFlatSchema(true)
+                            .build())
+                    .withOutputTags(
+                        PubsubMessageToRow.MAIN_TAG, TupleTagList.of(PubsubMessageToRow.DLQ_TAG)));
+
+    PCollection<Row> rows = outputs.get(PubsubMessageToRow.MAIN_TAG);
+    PCollection<PubsubMessage> dlqMessages = outputs.get(PubsubMessageToRow.DLQ_TAG);
+
+    PAssert.that(dlqMessages)
+        .satisfies(
+            messages -> {
+              assertEquals(2, size(messages));
+              assertEquals(
+                  ImmutableSet.of(map("attr1", "val1"), map("attr2", "val2")),
+                  convertToSet(messages, m -> m.getAttributeMap()));
+
+              assertEquals(
+                  ImmutableSet.of("{ \"invalid1\" : \"sdfsd\" }", "{ \"invalid2"),
+                  convertToSet(messages, m -> new String(m.getPayload(), UTF_8)));
+              return null;
+            });
+
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            Row.withSchema(messageSchema)
+                .addValues(ts(3), /* map("attr", "val"), */ 3, "foo")
+                .build(),
+            Row.withSchema(messageSchema)
+                .addValues(ts(4), /* map("bttr", "vbl"), */ 5, "baz")
                 .build());
 
     pipeline.run();


### PR DESCRIPTION
This PR adds support for flat schemas in pubsub topics as discussed in this [mailing list thread](https://lists.apache.org/thread.html/bf4c37f21bda194d7f8c40f6e7b9a776262415755cc1658412af3c76@%3Cdev.beam.apache.org%3E). With this change the following SQL query, which filters messages from one pubsub topic and writes the result to another, is possible:

```sql
CREATE TABLE people (
    event_timestamp TIMESTAMP,
    name VARCHAR,
    age INTEGER
  )
  TYPE 'pubsub'
  LOCATION 'projects/my-project/topics/my-topic'

CREATE TABLE eligible_voters ...

INSERT INTO eligible_voters (
  SELECT
    name
    FROM people
    WHERE age >= 18
)
```

The change maintains support for the original `event_timestamp, payload, attributes` style of table definition, but if a definition has a schema that doesn't follow that pattern exactly, the new flattened approach is used.

A summary of the changes:
- Separated out the AutoValue-based configuration out of `PubsubIOJsonTable` into `PubsubJsonTableProvider.PubsubIOTableConfiguration`. This configuration is now referenced throughout the affected classes.
- Modified `PubsubMessageToRow` so it can read a flat schema.
- Add `RowToPubsubMessage` which (currently) only supports flat schemas. Used in `PubsubIOJsonTable#buildIOWriter`.

The changes rely on the `JsonMatcher` added in #10094 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
