### PR TITLE
[BEAM-8658] [BEAM-8781] Optionally set jar and artifact staging port …

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -919,6 +919,31 @@ class PortableOptions(PipelineOptions):
               'the pipeline.'))
 
 
+class FlinkRunnerOptions(PipelineOptions):
+
+  PUBLISHED_FLINK_VERSIONS = ['1.7', '1.8', '1.9']
+
+  @classmethod
+  def _add_argparse_args(cls, parser):
+    parser.add_argument('--flink_master',
+                        default='[auto]',
+                        help='Flink master address (http://host:port)'
+                             ' Use "[local]" to start a local cluster'
+                             ' for the execution. Use "[auto]" if you'
+                             ' plan to either execute locally or let the'
+                             ' Flink job server infer the cluster address.')
+    parser.add_argument('--flink_version',
+                        default=cls.PUBLISHED_FLINK_VERSIONS[-1],
+                        choices=cls.PUBLISHED_FLINK_VERSIONS,
+                        help='Flink version to use.')
+    parser.add_argument('--flink_job_server_jar',
+                        help='Path or URL to a flink jobserver jar.')
+    parser.add_argument('--artifacts_dir', default=None)
+    parser.add_argument('--artifact_port', default=0,
+                        help='Port to use for artifact staging. 0 to use a '
+                             'dynamic port.')
+
+
 class TestOptions(PipelineOptions):
 
   @classmethod

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -919,6 +919,27 @@ class PortableOptions(PipelineOptions):
               'the pipeline.'))
 
 
+class JobServerOptions(PipelineOptions):
+  """Options for starting a Beam job server. Roughly corresponds to
+  JobServerDriver.ServerConfiguration in Java.
+  """
+  @classmethod
+  def _add_argparse_args(cls, parser):
+    parser.add_argument('--artifacts_dir', default=None,
+                        help='The location to store staged artifact files. '
+                             'Any Beam-supported file system is allowed. '
+                             'If unset, the local temp dir will be used.')
+    parser.add_argument('--job_port', default=0,
+                        help='Port to use for the job service. 0 to use a '
+                             'dynamic port.')
+    parser.add_argument('--artifact_port', default=0,
+                        help='Port to use for artifact staging. 0 to use a '
+                             'dynamic port.')
+    parser.add_argument('--expansion_port', default=0,
+                        help='Port to use for artifact staging. 0 to use a '
+                             'dynamic port.')
+
+
 class FlinkRunnerOptions(PipelineOptions):
 
   PUBLISHED_FLINK_VERSIONS = ['1.7', '1.8', '1.9']
@@ -938,10 +959,6 @@ class FlinkRunnerOptions(PipelineOptions):
                         help='Flink version to use.')
     parser.add_argument('--flink_job_server_jar',
                         help='Path or URL to a flink jobserver jar.')
-    parser.add_argument('--artifacts_dir', default=None)
-    parser.add_argument('--artifact_port', default=0,
-                        help='Port to use for artifact staging. 0 to use a '
-                             'dynamic port.')
 
 
 class TestOptions(PipelineOptions):

--- a/sdks/python/apache_beam/runners/portability/flink_runner.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner.py
@@ -73,13 +73,11 @@ class FlinkRunner(portable_runner.PortableRunner):
 
 class FlinkJarJobServer(job_server.JavaJarJobServer):
   def __init__(self, options):
-    super(FlinkJarJobServer, self).__init__()
+    super(FlinkJarJobServer, self).__init__(options)
     options = options.view_as(pipeline_options.FlinkRunnerOptions)
     self._jar = options.flink_job_server_jar
     self._master_url = options.flink_master
     self._flink_version = options.flink_version
-    self._artifacts_dir = options.artifacts_dir
-    self._artifact_port = options.artifact_port
 
   def path_to_jar(self):
     if self._jar:
@@ -88,12 +86,12 @@ class FlinkJarJobServer(job_server.JavaJarJobServer):
       return self.path_to_beam_jar(
           'runners:flink:%s:job-server:shadowJar' % self._flink_version)
 
-  def java_arguments(self, job_port, artifacts_dir):
+  def java_arguments(
+      self, job_port, artifact_port, expansion_port, artifacts_dir):
     return [
         '--flink-master', self._master_url,
-        '--artifacts-dir', (self._artifacts_dir
-                            if self._artifacts_dir else artifacts_dir),
+        '--artifacts-dir', artifacts_dir,
         '--job-port', job_port,
-        '--artifact-port', self._artifact_port,
-        '--expansion-port', 0
+        '--artifact-port', artifact_port,
+        '--expansion-port', expansion_port
     ]

--- a/sdks/python/apache_beam/runners/portability/flink_runner.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner.py
@@ -101,6 +101,7 @@ class FlinkJarJobServer(job_server.JavaJarJobServer):
     self._master_url = options.flink_master
     self._flink_version = options.flink_version
     self._artifacts_dir = options.artifacts_dir
+    self._artifact_port = options.artifact_port
 
   def path_to_jar(self):
     if self._jar:
@@ -115,6 +116,6 @@ class FlinkJarJobServer(job_server.JavaJarJobServer):
         '--artifacts-dir', (self._artifacts_dir
                             if self._artifacts_dir else artifacts_dir),
         '--job-port', job_port,
-        '--artifact-port', 0,
+        '--artifact-port', self._artifact_port,
         '--expansion-port', 0
     ]

--- a/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py
+++ b/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py
@@ -54,9 +54,10 @@ class FlinkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
   def __init__(self, master_url, options):
     super(FlinkUberJarJobServer, self).__init__()
     self._master_url = master_url
-    flink_options = options.view_as(pipeline_options.FlinkRunnerOptions)
-    self._executable_jar = flink_options.flink_job_server_jar
-    self._artifact_port = flink_options.artifact_port
+    self._executable_jar = (options.view_as(pipeline_options.FlinkRunnerOptions)
+                            .flink_job_server_jar)
+    self._artifact_port = (options.view_as(pipeline_options.JobServerOptions)
+                           .artifact_port)
     self._temp_dir = tempfile.mkdtemp(prefix='apache-beam-flink')
 
   def start(self):

--- a/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py
+++ b/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py
@@ -33,12 +33,12 @@ import grpc
 import requests
 from google.protobuf import json_format
 
+from apache_beam.options import pipeline_options
 from apache_beam.portability.api import beam_artifact_api_pb2_grpc
 from apache_beam.portability.api import beam_job_api_pb2
 from apache_beam.portability.api import endpoints_pb2
 from apache_beam.runners.portability import abstract_job_service
 from apache_beam.runners.portability import artifact_service
-from apache_beam.runners.portability import flink_runner
 from apache_beam.runners.portability import job_server
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class FlinkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
   def __init__(self, master_url, options):
     super(FlinkUberJarJobServer, self).__init__()
     self._master_url = master_url
-    flink_options = options.view_as(flink_runner.FlinkRunnerOptions)
+    flink_options = options.view_as(pipeline_options.FlinkRunnerOptions)
     self._executable_jar = flink_options.flink_job_server_jar
     self._artifact_port = flink_options.artifact_port
     self._temp_dir = tempfile.mkdtemp(prefix='apache-beam-flink')

--- a/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py
+++ b/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py
@@ -38,6 +38,7 @@ from apache_beam.portability.api import beam_job_api_pb2
 from apache_beam.portability.api import endpoints_pb2
 from apache_beam.runners.portability import abstract_job_service
 from apache_beam.runners.portability import artifact_service
+from apache_beam.runners.portability import flink_runner
 from apache_beam.runners.portability import job_server
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,10 +51,12 @@ class FlinkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
   the pipeline artifacts.
   """
 
-  def __init__(self, master_url, executable_jar=None):
+  def __init__(self, master_url, options):
     super(FlinkUberJarJobServer, self).__init__()
     self._master_url = master_url
-    self._executable_jar = executable_jar
+    flink_options = options.view_as(flink_runner.FlinkRunnerOptions)
+    self._executable_jar = flink_options.flink_job_server_jar
+    self._artifact_port = flink_options.artifact_port
     self._temp_dir = tempfile.mkdtemp(prefix='apache-beam-flink')
 
   def start(self):
@@ -63,9 +66,10 @@ class FlinkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
     pass
 
   def executable_jar(self):
-    return self._executable_jar or job_server.JavaJarJobServer.local_jar(
-        job_server.JavaJarJobServer.path_to_beam_jar(
-            'runners:flink:%s:job-server:shadowJar' % self.flink_version()))
+    url = (self._executable_jar or
+           job_server.JavaJarJobServer.path_to_beam_jar(
+               'runners:flink:%s:job-server:shadowJar' % self.flink_version()))
+    return job_server.JavaJarJobServer.local_jar(url)
 
   def flink_version(self):
     full_version = requests.get(
@@ -80,7 +84,8 @@ class FlinkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
         job_id,
         job_name,
         pipeline,
-        options)
+        options,
+        artifact_port=self._artifact_port)
 
 
 class FlinkBeamJob(abstract_job_service.AbstractBeamJob):
@@ -101,11 +106,13 @@ class FlinkBeamJob(abstract_job_service.AbstractBeamJob):
       [PIPELINE_FOLDER, PIPELINE_NAME, 'artifact-manifest.json'])
 
   def __init__(
-      self, master_url, executable_jar, job_id, job_name, pipeline, options):
+      self, master_url, executable_jar, job_id, job_name, pipeline, options,
+      artifact_port=0):
     super(FlinkBeamJob, self).__init__(job_id, job_name, pipeline, options)
     self._master_url = master_url
     self._executable_jar = executable_jar
     self._jar_uploaded = False
+    self._artifact_port = artifact_port
 
   def prepare(self):
     # Copy the executable jar, injecting the pipeline and options as resources.
@@ -122,13 +129,14 @@ class FlinkBeamJob(abstract_job_service.AbstractBeamJob):
       with z.open(self.PIPELINE_MANIFEST, 'w') as fout:
         fout.write(json.dumps(
             {'defaultJobName': self.PIPELINE_NAME}).encode('utf-8'))
-    self._start_artifact_service(self._jar)
+    self._start_artifact_service(self._jar, self._artifact_port)
 
-  def _start_artifact_service(self, jar):
+  def _start_artifact_service(self, jar, requested_port):
     self._artifact_staging_service = artifact_service.ZipFileArtifactService(
         jar)
     self._artifact_staging_server = grpc.server(futures.ThreadPoolExecutor())
-    port = self._artifact_staging_server.add_insecure_port('[::]:0')
+    port = self._artifact_staging_server.add_insecure_port(
+        '[::]:%s' % requested_port)
     beam_artifact_api_pb2_grpc.add_ArtifactStagingServiceServicer_to_server(
         self._artifact_staging_service, self._artifact_staging_server)
     self._artifact_staging_endpoint = endpoints_pb2.ApiServiceDescriptor(

--- a/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server_test.py
@@ -32,6 +32,7 @@ from apache_beam.portability.api import beam_artifact_api_pb2
 from apache_beam.portability.api import beam_artifact_api_pb2_grpc
 from apache_beam.portability.api import beam_job_api_pb2
 from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.runners.portability import flink_runner
 from apache_beam.runners.portability import flink_uber_jar_job_server
 
 
@@ -51,7 +52,7 @@ class FlinkUberJarJobServerTest(unittest.TestCase):
   def test_flink_version(self, http_mock):
     http_mock.get('http://flink/v1/config', json={'flink-version': '3.1.4.1'})
     job_server = flink_uber_jar_job_server.FlinkUberJarJobServer(
-        'http://flink', None)
+        'http://flink', flink_runner.FlinkRunnerOptions())
     self.assertEqual(job_server.flink_version(), "3.1")
 
   @requests_mock.mock()
@@ -62,8 +63,10 @@ class FlinkUberJarJobServerTest(unittest.TestCase):
         with zip.open('FakeClass.class', 'w') as fout:
           fout.write(b'[original_contents]')
 
+      options = flink_runner.FlinkRunnerOptions()
+      options.flink_job_server_jar = fake_jar
       job_server = flink_uber_jar_job_server.FlinkUberJarJobServer(
-          'http://flink', fake_jar)
+          'http://flink', options)
 
       # Prepare the job.
       prepare_response = job_server.Prepare(

--- a/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server_test.py
@@ -28,11 +28,11 @@ import zipfile
 import grpc
 import requests_mock
 
+from apache_beam.options import pipeline_options
 from apache_beam.portability.api import beam_artifact_api_pb2
 from apache_beam.portability.api import beam_artifact_api_pb2_grpc
 from apache_beam.portability.api import beam_job_api_pb2
 from apache_beam.portability.api import beam_runner_api_pb2
-from apache_beam.runners.portability import flink_runner
 from apache_beam.runners.portability import flink_uber_jar_job_server
 
 
@@ -52,7 +52,7 @@ class FlinkUberJarJobServerTest(unittest.TestCase):
   def test_flink_version(self, http_mock):
     http_mock.get('http://flink/v1/config', json={'flink-version': '3.1.4.1'})
     job_server = flink_uber_jar_job_server.FlinkUberJarJobServer(
-        'http://flink', flink_runner.FlinkRunnerOptions())
+        'http://flink', pipeline_options.FlinkRunnerOptions())
     self.assertEqual(job_server.flink_version(), "3.1")
 
   @requests_mock.mock()
@@ -63,7 +63,7 @@ class FlinkUberJarJobServerTest(unittest.TestCase):
         with zip.open('FakeClass.class', 'w') as fout:
           fout.write(b'[original_contents]')
 
-      options = flink_runner.FlinkRunnerOptions()
+      options = pipeline_options.FlinkRunnerOptions()
       options.flink_job_server_jar = fake_jar
       job_server = flink_uber_jar_job_server.FlinkUberJarJobServer(
           'http://flink', options)

--- a/sdks/python/apache_beam/runners/portability/job_server.py
+++ b/sdks/python/apache_beam/runners/portability/job_server.py
@@ -28,6 +28,7 @@ import threading
 
 import grpc
 
+from apache_beam.options import pipeline_options
 from apache_beam.portability.api import beam_job_api_pb2_grpc
 from apache_beam.runners.portability import local_job_service
 from apache_beam.utils import subprocess_server
@@ -124,7 +125,16 @@ class JavaJarJobServer(SubprocessJobServer):
   MAVEN_REPOSITORY = 'https://repo.maven.apache.org/maven2/org/apache/beam'
   JAR_CACHE = os.path.expanduser("~/.apache_beam/cache")
 
-  def java_arguments(self, job_port, artifacts_dir):
+  def __init__(self, options):
+    super(JavaJarJobServer, self).__init__()
+    options = options.view_as(pipeline_options.JobServerOptions)
+    self._job_port = options.job_port
+    self._artifact_port = options.artifact_port
+    self._expansion_port = options.expansion_port
+    self._artifacts_dir = options.artifacts_dir
+
+  def java_arguments(
+      self, job_port, artifact_port, expansion_port, artifacts_dir):
     raise NotImplementedError(type(self))
 
   def path_to_jar(self):
@@ -140,11 +150,15 @@ class JavaJarJobServer(SubprocessJobServer):
 
   def subprocess_cmd_and_endpoint(self):
     jar_path = self.local_jar(self.path_to_jar())
-    artifacts_dir = self.local_temp_dir(prefix='artifacts')
-    job_port, = subprocess_server.pick_port(None)
+    artifacts_dir = (self._artifacts_dir if self._artifacts_dir
+                     else self.local_temp_dir(prefix='artifacts'))
+    job_port, = subprocess_server.pick_port(self._job_port)
     return (
         ['java', '-jar', jar_path] + list(
-            self.java_arguments(job_port, artifacts_dir)),
+            self.java_arguments(job_port,
+                                self._artifact_port,
+                                self._expansion_port,
+                                artifacts_dir)),
         'localhost:%s' % job_port)
 
 

--- a/sdks/python/apache_beam/runners/portability/spark_runner.py
+++ b/sdks/python/apache_beam/runners/portability/spark_runner.py
@@ -56,16 +56,14 @@ class SparkRunnerOptions(pipeline_options.PipelineOptions):
                              'the execution.')
     parser.add_argument('--spark_job_server_jar',
                         help='Path or URL to a Beam Spark jobserver jar.')
-    parser.add_argument('--artifacts_dir', default=None)
 
 
 class SparkJarJobServer(job_server.JavaJarJobServer):
   def __init__(self, options):
-    super(SparkJarJobServer, self).__init__()
+    super(SparkJarJobServer, self).__init__(options)
     options = options.view_as(SparkRunnerOptions)
     self._jar = options.spark_job_server_jar
     self._master_url = options.spark_master_url
-    self._artifacts_dir = options.artifacts_dir
 
   def path_to_jar(self):
     if self._jar:
@@ -73,12 +71,12 @@ class SparkJarJobServer(job_server.JavaJarJobServer):
     else:
       return self.path_to_beam_jar('runners:spark:job-server:shadowJar')
 
-  def java_arguments(self, job_port, artifacts_dir):
+  def java_arguments(
+      self, job_port, artifact_port, expansion_port, artifacts_dir):
     return [
         '--spark-master-url', self._master_url,
-        '--artifacts-dir', (self._artifacts_dir
-                            if self._artifacts_dir else artifacts_dir),
+        '--artifacts-dir', artifacts_dir,
         '--job-port', job_port,
-        '--artifact-port', 0,
-        '--expansion-port', 0
+        '--artifact-port', artifact_port,
+        '--expansion-port', expansion_port
     ]


### PR DESCRIPTION
…in FlinkUberJarJobServer

Pass around options to fix:

- BEAM-8658: add an `artifact_port` option. We need this because we need to expose a static port to use for artifact staging on Kubernetes (AFAIK gRPC does not support in-process mode on Python).
- BEAM-8781: respect the existing `flink_job_server_jar` option. I wanted this so I could download the released job server jar from Maven instead of having to build it locally. This allows me to override the default behavior for .dev, which is to fail: https://github.com/apache/beam/blob/0b415fd7e9dd5c80034ca237e08c3959ec78ffe3/sdks/python/apache_beam/utils/subprocess_server.py#L176-L181
We could consider changing that behavior (as indicated in the TODO), but it matters less if you can get around it if you really want to.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
