### PR TITLE
[BEAM-7390] Add code snippet for Latest

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/transforms/aggregation/latest.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/aggregation/latest.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+
+def latest_globally(test=None):
+  # [START latest_globally]
+  import apache_beam as beam
+
+  with beam.Pipeline() as pipeline:
+    latest_element = (
+        pipeline
+        | 'Create produce' >> beam.Create([
+            '🍓 Strawberry',
+            '🥕 Carrot',
+            '🍆 Eggplant',
+            '🍅 Tomato',
+            '🌽 Corn',
+        ])
+        | 'Get latest element' >> beam.combiners.Latest.Globally()
+        | beam.Map(print)
+    )
+    # [END latest_globally]
+    if test:
+      test(latest_element)
+
+
+def latest_per_key(test=None):
+  # [START latest_per_key]
+  import apache_beam as beam
+
+  with beam.Pipeline() as pipeline:
+    latest_elements_per_key = (
+        pipeline
+        | 'Create produce' >> beam.Create([
+            ('spring', '🍓'),
+            ('spring', '🥕'),
+            ('spring', '🍆'),
+            ('spring', '🍅'),
+            ('summer', '🥕'),
+            ('summer', '🍅'),
+            ('summer', '🌽'),
+            ('fall', '🥕'),
+            ('fall', '🍅'),
+            ('winter', '🍆'),
+        ])
+        | 'Get latest elements per key' >> beam.combiners.Latest.PerKey()
+        | beam.Map(print)
+    )
+    # [END latest_per_key]
+    if test:
+      test(latest_elements_per_key)

--- a/sdks/python/apache_beam/examples/snippets/transforms/aggregation/latest.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/aggregation/latest.py
@@ -23,17 +23,24 @@ from __future__ import print_function
 def latest_globally(test=None):
   # [START latest_globally]
   import apache_beam as beam
+  import time
+
+  def to_unix_time(time_str, format='%Y-%m-%d %H:%M:%S'):
+    return time.mktime(time.strptime(time_str, format))
 
   with beam.Pipeline() as pipeline:
     latest_element = (
         pipeline
-        | 'Create produce' >> beam.Create([
-            '🍓 Strawberry',
-            '🥕 Carrot',
-            '🍆 Eggplant',
-            '🍅 Tomato',
-            '🌽 Corn',
+        | 'Create crops' >> beam.Create([
+            {'item': '🥬', 'harvest': '2020-02-24 00:00:00'},
+            {'item': '🍓', 'harvest': '2020-06-16 00:00:00'},
+            {'item': '🥕', 'harvest': '2020-07-17 00:00:00'},
+            {'item': '🍆', 'harvest': '2020-10-26 00:00:00'},
+            {'item': '🍅', 'harvest': '2020-10-01 00:00:00'},
         ])
+        | 'With timestamps' >> beam.Map(
+            lambda crop: beam.window.TimestampedValue(
+                crop['item'], to_unix_time(crop['harvest'])))
         | 'Get latest element' >> beam.combiners.Latest.Globally()
         | beam.Map(print)
     )
@@ -45,22 +52,30 @@ def latest_globally(test=None):
 def latest_per_key(test=None):
   # [START latest_per_key]
   import apache_beam as beam
+  import time
+
+  def to_unix_time(time_str, format='%Y-%m-%d %H:%M:%S'):
+    return time.mktime(time.strptime(time_str, format))
 
   with beam.Pipeline() as pipeline:
     latest_elements_per_key = (
         pipeline
-        | 'Create produce' >> beam.Create([
-            ('spring', '🍓'),
-            ('spring', '🥕'),
-            ('spring', '🍆'),
-            ('spring', '🍅'),
-            ('summer', '🥕'),
-            ('summer', '🍅'),
-            ('summer', '🌽'),
-            ('fall', '🥕'),
-            ('fall', '🍅'),
-            ('winter', '🍆'),
+        | 'Create crops' >> beam.Create([
+            ('spring', {'item': '🥕', 'harvest': '2020-06-28 00:00:00'}),
+            ('spring', {'item': '🍓', 'harvest': '2020-06-16 00:00:00'}),
+            ('summer', {'item': '🥕', 'harvest': '2020-07-17 00:00:00'}),
+            ('summer', {'item': '🍓', 'harvest': '2020-08-26 00:00:00'}),
+            ('summer', {'item': '🍆', 'harvest': '2020-09-04 00:00:00'}),
+            ('summer', {'item': '🥬', 'harvest': '2020-09-18 00:00:00'}),
+            ('summer', {'item': '🍅', 'harvest': '2020-09-22 00:00:00'}),
+            ('autumn', {'item': '🍅', 'harvest': '2020-10-01 00:00:00'}),
+            ('autumn', {'item': '🥬', 'harvest': '2020-10-20 00:00:00'}),
+            ('autumn', {'item': '🍆', 'harvest': '2020-10-26 00:00:00'}),
+            ('winter', {'item': '🥬', 'harvest': '2020-02-24 00:00:00'}),
         ])
+        | 'With timestamps' >> beam.Map(
+            lambda pair: beam.window.TimestampedValue(
+                (pair[0], pair[1]['item']), to_unix_time(pair[1]['harvest'])))
         | 'Get latest elements per key' >> beam.combiners.Latest.PerKey()
         | beam.Map(print)
     )

--- a/sdks/python/apache_beam/examples/snippets/transforms/aggregation/latest_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/aggregation/latest_test.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import unittest
+
+import mock
+
+from apache_beam.examples.snippets.util import assert_matches_stdout
+from apache_beam.testing.test_pipeline import TestPipeline
+
+from . import latest
+
+
+def check_latest_element(actual):
+  expected = '''[START latest_element]
+🌽 Corn
+[END latest_element]'''.splitlines()[1:-1]
+  assert_matches_stdout(actual, expected)
+
+
+def check_latest_elements_per_key(actual):
+  expected = '''[START latest_elements_per_key]
+('spring', '🍅')
+('summer', '🌽')
+('fall', '🍅')
+('winter', '🍆')
+[END latest_elements_per_key]'''.splitlines()[1:-1]
+  # The value from the key-value pair is non-deterministic since there are no
+  # timestamps attached, so get rid of it and check the keys only.
+  assert_matches_stdout(actual, expected, lambda pair: pair[0])
+
+
+@mock.patch('apache_beam.Pipeline', TestPipeline)
+@mock.patch(
+    'apache_beam.examples.snippets.transforms.aggregation.latest.print', str)
+class LatestTest(unittest.TestCase):
+  def test_latest_globally(self):
+    latest.latest_globally(check_latest_element)
+
+  def test_latest_per_key(self):
+    latest.latest_per_key(check_latest_elements_per_key)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/examples/snippets/transforms/aggregation/latest_test.py
+++ b/sdks/python/apache_beam/examples/snippets/transforms/aggregation/latest_test.py
@@ -31,21 +31,19 @@ from . import latest
 
 def check_latest_element(actual):
   expected = '''[START latest_element]
-🌽 Corn
+🍆
 [END latest_element]'''.splitlines()[1:-1]
   assert_matches_stdout(actual, expected)
 
 
 def check_latest_elements_per_key(actual):
   expected = '''[START latest_elements_per_key]
-('spring', '🍅')
-('summer', '🌽')
-('fall', '🍅')
-('winter', '🍆')
+('spring', '🥕')
+('summer', '🍅')
+('autumn', '🍆')
+('winter', '🥬')
 [END latest_elements_per_key]'''.splitlines()[1:-1]
-  # The value from the key-value pair is non-deterministic since there are no
-  # timestamps attached, so get rid of it and check the keys only.
-  assert_matches_stdout(actual, expected, lambda pair: pair[0])
+  assert_matches_stdout(actual, expected)
 
 
 @mock.patch('apache_beam.Pipeline', TestPipeline)


### PR DESCRIPTION
Adding the code snippets for `Latest`.

R: @chamikaramj 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
