### PR TITLE
[BEAM-8651] Guard pickling operations with a lock to prevent race condition in module imports.

### DIFF
--- a/sdks/python/apache_beam/internal/pickler.py
+++ b/sdks/python/apache_beam/internal/pickler.py
@@ -33,12 +33,16 @@ from __future__ import absolute_import
 import base64
 import logging
 import sys
+import threading
 import traceback
 import types
 import zlib
 
 import dill
 
+# Pickling, especially unpickling, can cause broken module imports
+# if executed concurrently, see: BEAM-8651.
+pickle_lock = threading.Lock()
 # Dill 0.28.0 renamed dill.dill to dill._dill:
 # https://github.com/uqfoundation/dill/commit/f0972ecc7a41d0b8acada6042d557068cac69baa
 # TODO: Remove this once Beam depends on dill >= 0.2.8
@@ -228,17 +232,17 @@ logging.getLogger('dill').setLevel(logging.WARN)
 # encoding.  This should be cleaned up.
 def dumps(o, enable_trace=True):
   """For internal use only; no backwards-compatibility guarantees."""
-
-  try:
-    s = dill.dumps(o)
-  except Exception:      # pylint: disable=broad-except
-    if enable_trace:
-      dill.dill._trace(True)  # pylint: disable=protected-access
+  with pickle_lock:
+    try:
       s = dill.dumps(o)
-    else:
-      raise
-  finally:
-    dill.dill._trace(False)  # pylint: disable=protected-access
+    except Exception:      # pylint: disable=broad-except
+      if enable_trace:
+        dill.dill._trace(True)  # pylint: disable=protected-access
+        s = dill.dumps(o)
+      else:
+        raise
+    finally:
+      dill.dill._trace(False)  # pylint: disable=protected-access
 
   # Compress as compactly as possible to decrease peak memory usage (of multiple
   # in-memory copies) and free up some possibly large and no-longer-needed
@@ -257,16 +261,17 @@ def loads(encoded, enable_trace=True):
   s = zlib.decompress(c)
   del c  # Free up some possibly large and no-longer-needed memory.
 
-  try:
-    return dill.loads(s)
-  except Exception:          # pylint: disable=broad-except
-    if enable_trace:
-      dill.dill._trace(True)   # pylint: disable=protected-access
+  with pickle_lock:
+    try:
       return dill.loads(s)
-    else:
-      raise
-  finally:
-    dill.dill._trace(False)  # pylint: disable=protected-access
+    except Exception:          # pylint: disable=broad-except
+      if enable_trace:
+        dill.dill._trace(True)   # pylint: disable=protected-access
+        return dill.loads(s)
+      else:
+        raise
+    finally:
+      dill.dill._trace(False)  # pylint: disable=protected-access
 
 
 def dump_session(file_path):
@@ -278,10 +283,12 @@ def dump_session(file_path):
   create and load the dump twice to have consistent results in the worker and
   the running session. Check: https://github.com/uqfoundation/dill/issues/195
   """
-  dill.dump_session(file_path)
-  dill.load_session(file_path)
-  return dill.dump_session(file_path)
+  with pickle_lock:
+    dill.dump_session(file_path)
+    dill.load_session(file_path)
+    return dill.dump_session(file_path)
 
 
 def load_session(file_path):
-  return dill.load_session(file_path)
+  with pickle_lock:
+    return dill.load_session(file_path)


### PR DESCRIPTION
Portable pipeline execution assumes an execution model where Python SDK workers can launch multiple threads that can process the work delegated by the runner. Up to 2.17.0 the model assumed [12 worker threads by default](https://github.com/apache/beam/blob/a5118faff0a3de63b9b31a8862aa937b1c6bd8e1/sdks/python/apache_beam/runners/worker/sdk_worker_main.py#L206), possibly customized by pipeline options. As of 2.18.0, we will scale these threads dynamically, see: https://issues.apache.org/jira/browse/BEAM-8151  

Part of work execution involves unserializing (unpicking) payloads, such as serialized DoFns. Pickling   depends on a pickler library (`dill`), and Python pickling mechanisms (`pickle` module). As a part of unpickling, python interpreter will dynamically load some modules referenced in users' code.  

It appears that concurrent unpickling of data causes races during module imports, which causes deadlocks and/or corrupted imports, see: BEAM-8651. The error is very common on Python 3.x, including latest releases of Python 3.7. 

This PR guards picking operations with a lock to mitigate these errors in Beam. 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
