### PR TITLE
[BEAM-8575] Added two unit tests to CombineTest class to test that Co…

### DIFF
--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -75,13 +75,14 @@ class SortedConcatWithCounters(beam.CombineFn):
     self.word_lengths_dist.update(len(element))
     self.last_word_len.set(len(element))
 
-    # ''.join() converts the list to a string.
-    return ''.join(acc + element)
+    return acc + element
 
   def merge_accumulators(self, accs):
     return ''.join(accs)
 
   def extract_output(self, acc):
+    # The sorted acc became a list of characters
+    # and has to be converted back to a string using join.
     return ''.join(sorted(acc))
 
 
@@ -539,9 +540,6 @@ class CombineTest(unittest.TestCase):
     # The (key, concatenated_string) pairs for all keys.
     concat_per_key = (input
                       | beam.CombinePerKey(SortedConcatWithCounters()))
-
-    result = p.run()
-    result.wait_until_finish()
 
     # Verify the concatenated strings are correct.
     expected_concat_per_key = [('key1', 'aaabbc'), ('key2', 'uuvvxxyyz')]

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -434,7 +434,6 @@ class CombineTest(unittest.TestCase):
           | beam.CombineGlobally(combine.MeanCombineFn()).with_fanout(11))
       assert_that(result, equal_to([49.5]))
 
-<<<<<<< HEAD
   def test_MeanCombineFn_combine(self):
     with TestPipeline() as p:
       input = (p
@@ -519,11 +518,8 @@ class CombineTest(unittest.TestCase):
                   equal_to([('c', 3), ('c', 10), ('d', 5), ('d', 17)]),
                   label='sum per key')
 
-  # Test that three different counters work with the customized CombineFn.
-=======
   # Test that three different kinds of metrics work with a customized
   # CounterIncrememtingCombineFn.
->>>>>>> b70d276ffe... Fixed Lint errors.
   def test_simple_combine(self):
     p = TestPipeline()
     input = (p

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -531,10 +531,10 @@ class CombineTest(unittest.TestCase):
     # The result of concatenating all values regardless of key.
     global_concat = (input
                      | beam.Values()
-                     | beam.CombineGlobally(ConcatIntCombineFn()))
+                     | beam.CombineGlobally(CounterIncrememtingCombineFn()))
 
     # The (key, concatenated_int_to_string) pairs for all keys.
-    concat_per_key = (input | beam.CombinePerKey(ConcatIntCombineFn()))
+    concat_per_key = (input | beam.CombinePerKey(CounterIncrememtingCombineFn()))
 
     result = p.run()
     result.wait_until_finish()
@@ -577,10 +577,10 @@ class CombineTest(unittest.TestCase):
     # The result of concatenating all values regardless of key.
     global_concat = (input
                      | beam.Values()
-                     | beam.CombineGlobally(ConcatIntCombineFn()))
+                     | beam.CombineGlobally(CounterIncrememtingCombineFn()))
 
     # The (key, concatenated_int_to_string) pairs for all keys.
-    concat_per_key = (input | beam.CombinePerKey(ConcatIntCombineFn()))
+    concat_per_key = (input | beam.CombinePerKey(CounterIncrememtingCombineFn()))
 
     result = p.run()
     result.wait_until_finish()

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -783,14 +783,14 @@ class TimestampCombinerTest(unittest.TestCase):
           label='assert per window')
 
 def _sort_lists(result):
-    if isinstance(result, list):
-      return sorted(result)
-    elif isinstance(result, tuple):
-      return tuple(_sort_lists(e) for e in result)
-    elif isinstance(result, dict):
-      return {k: _sort_lists(v) for k, v in result.items()}
-    else:
-      return result
+  if isinstance(result, list):
+    return sorted(result)
+  elif isinstance(result, tuple):
+    return tuple(_sort_lists(e) for e in result)
+  elif isinstance(result, dict):
+    return {k: _sort_lists(v) for k, v in result.items()}
+  else:
+    return result
 
 _SortLists = beam.Map(_sort_lists)
 

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -538,7 +538,7 @@ class CombineTest(unittest.TestCase):
 
     # The (key, concatenated_string) pairs for all keys.
     concat_per_key = (input | beam.CombinePerKey(
-                      CounterIncrememtingCombineFn()))
+        CounterIncrememtingCombineFn()))
 
     result = p.run()
     result.wait_until_finish()
@@ -588,7 +588,7 @@ class CombineTest(unittest.TestCase):
 
     # The (key, concatenated_string) pairs for all keys.
     concat_per_key = (input | beam.CombinePerKey(
-                      CounterIncrememtingCombineFn()))
+        CounterIncrememtingCombineFn()))
 
     result = p.run()
     result.wait_until_finish()

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -620,9 +620,9 @@ class CombineTest(unittest.TestCase):
 
     last_word_len_filter = MetricsFilter().with_name('last_word_len')
     query_result = result.metrics().query(last_word_len_filter)
-    if query_result['gauges']:
-      last_word_len = query_result['gauges'][0]
-      self.assertIn(last_word_len.result.value, [0])
+
+    # No element has ever been recorded.
+    self.assertFalse(query_result['gauges'])
 
 
 class LatestTest(unittest.TestCase):

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -32,6 +32,8 @@ from nose.plugins.attrib import attr
 
 import apache_beam as beam
 import apache_beam.transforms.combiners as combine
+from apache_beam.metrics import Metrics
+from apache_beam.metrics import MetricsFilter
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.test_stream import TestStream

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -564,9 +564,9 @@ class CombineTest(unittest.TestCase):
 
     last_word_len_filter = MetricsFilter().with_name('last_word_len')
     query_result = result.metrics().query(last_word_len_filter)
-    if query_result['counters']:
-      last_word_len = query_result['counters'][0]
-      self.assertEqual(last_word_len.result, 5)
+    if query_result['gauges']:
+      last_word_len = query_result['gauges'][0]
+      self.assertEqual(last_word_len.result.value, 6)
 
   # Test that three different counters work with the customized CombineFn
   # when the PCollection is empty.
@@ -608,9 +608,9 @@ class CombineTest(unittest.TestCase):
 
     last_word_len_filter = MetricsFilter().with_name('last_word_len')
     query_result = result.metrics().query(last_word_len_filter)
-    if query_result['counters']:
-      last_word_len = query_result['counters'][0]
-      self.assertEqual(last_word_len.result, 0)
+    if query_result['gauges']:
+      last_word_len = query_result['gauges'][0]
+      self.assertEqual(last_word_len.result.value, 0)
 
 class LatestTest(unittest.TestCase):
 

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -83,22 +83,6 @@ class CounterIncrememtingCombineFn(beam.CombineFn):
     return acc
 
 
-class ConcatIntCombineFn(beam.CombineFn):
-  """ CombineFn for concatenating string representations of integers. """
-
-  def create_accumulator(self):
-    return ''
-
-  def add_input(self, acc, element):
-    return acc + str(element)
-
-  def merge_accumulators(self, accs):
-    return ''.join(accs)
-
-  def extract_output(self, acc):
-    return acc
-
-
 class CombineTest(unittest.TestCase):
 
   def test_builtin_combines(self):
@@ -547,10 +531,10 @@ class CombineTest(unittest.TestCase):
     # The result of concatenating all values regardless of key.
     global_concat = (input
                      | beam.Values()
-                     | beam.CombineGlobally(CounterIncrememtingCombineFn()))
+                     | beam.CombineGlobally(ConcatIntCombineFn()))
 
     # The (key, concatenated_int_to_string) pairs for all keys.
-    concat_per_key = (input | beam.CombinePerKey(CounterIncrememtingCombineFn()))
+    concat_per_key = (input | beam.CombinePerKey(ConcatIntCombineFn()))
 
     result = p.run()
     result.wait_until_finish()
@@ -593,10 +577,10 @@ class CombineTest(unittest.TestCase):
     # The result of concatenating all values regardless of key.
     global_concat = (input
                      | beam.Values()
-                     | beam.CombineGlobally(CounterIncrememtingCombineFn()))
+                     | beam.CombineGlobally(ConcatIntCombineFn()))
 
     # The (key, concatenated_int_to_string) pairs for all keys.
-    concat_per_key = (input | beam.CombinePerKey(CounterIncrememtingCombineFn()))
+    concat_per_key = (input | beam.CombinePerKey(ConcatIntCombineFn()))
 
     result = p.run()
     result.wait_until_finish()

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -538,9 +538,9 @@ class CombineTest(unittest.TestCase):
                      | "sort global result" >> _SortLists)
 
     # The (key, concatenated_string) pairs for all keys.
-    concat_per_key = (input | beam.CombinePerKey(
-        CounterIncrememtingCombineFn())
-        | "sort per key result" >> _SortLists)
+    concat_per_key = (input
+                      | beam.CombinePerKey(CounterIncrememtingCombineFn())
+                      | "sort per key result" >> _SortLists)
 
     result = p.run()
     result.wait_until_finish()

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -83,6 +83,22 @@ class CounterIncrememtingCombineFn(beam.CombineFn):
     return acc
 
 
+class ConcatIntCombineFn(beam.CombineFn):
+  """ CombineFn for concatenating string representations of integers. """
+
+  def create_accumulator(self):
+    return ''
+
+  def add_input(self, acc, element):
+    return acc + str(element)
+
+  def merge_accumulators(self, accs):
+    return ''.join(accs)
+
+  def extract_output(self, acc):
+    return acc
+
+
 class CombineTest(unittest.TestCase):
 
   def test_builtin_combines(self):
@@ -611,6 +627,7 @@ class CombineTest(unittest.TestCase):
     if query_result['gauges']:
       last_word_len = query_result['gauges'][0]
       self.assertEqual(last_word_len.result.value, 0)
+
 
 class LatestTest(unittest.TestCase):
 


### PR DESCRIPTION
…mbinePerKey works with a simple customized CombineFn.

Added two unit tests to CombineTest class to test that CombinePerKey works with a simple customized CombineFn, namely ConcatIntCombineFn.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
