### PR TITLE
[BEAM-3865] Stronger trigger tests.

### DIFF
--- a/sdks/python/apache_beam/testing/data/trigger_transcripts.yaml
+++ b/sdks/python/apache_beam/testing/data/trigger_transcripts.yaml
@@ -55,24 +55,6 @@ transcript:
       - {window: [20, 29], values: [25], timestamp: 25, late: false}
 
 ---
-name: timestamp_combiner_earliest_separate_bundles
-window_fn: FixedWindows(10)
-trigger_fn: Default
-timestamp_combiner: OUTPUT_AT_EARLIEST
-transcript:
-  - input: [1]
-  - input: [2]
-  - input: [3]
-  - input: [10]
-  - input: [11]
-  - input: [25]
-  - watermark: 100
-  - expect:
-      - {window: [0, 9], values: [1, 2, 3], timestamp: 1, final: false}
-      - {window: [10, 19], values: [10, 11], timestamp: 10}
-      - {window: [20, 29], values: [25], timestamp: 25, late: false}
-
----
 name: timestamp_combiner_latest
 window_fn: FixedWindows(10)
 trigger_fn: Default

--- a/sdks/python/apache_beam/transforms/trigger_test.py
+++ b/sdks/python/apache_beam/transforms/trigger_test.py
@@ -23,6 +23,7 @@ import collections
 import json
 import os.path
 import pickle
+import random
 import unittest
 from builtins import range
 from builtins import zip
@@ -644,7 +645,9 @@ def _windowed_value_info_map_fn(
           vs, windows=[window], timestamp=t, pane_info=p)))
 
 
-def _windowed_value_info_check(actual, expected):
+def _windowed_value_info_check(actual, expected, key=None):
+
+  key_string = 'for %s' % key if key else ''
 
   def format(panes):
     return '\n[%s]\n' % '\n '.join(str(pane) for pane in sorted(
@@ -652,12 +655,12 @@ def _windowed_value_info_check(actual, expected):
 
   if len(actual) > len(expected):
     raise AssertionError(
-        'Unexpected output: expected %s but got %s' % (
-            format(expected), format(actual)))
+        'Unexpected output%s: expected %s but got %s' % (
+            key_string, format(expected), format(actual)))
   elif len(expected) > len(actual):
     raise AssertionError(
-        'Unmatched output: expected %s but got %s' % (
-            format(expected), format(actual)))
+        'Unmatched output%s: expected %s but got %s' % (
+            key_string, format(expected), format(actual)))
   else:
 
     def diff(actual, expected):
@@ -670,8 +673,8 @@ def _windowed_value_info_check(actual, expected):
       diffs = [diff(output, pane) for pane in expected]
       if all(diffs):
         raise AssertionError(
-            'Unmatched output: %s not found in %s (diffs in %s)' % (
-                output, format(expected), diffs))
+            'Unmatched output%s: %s not found in %s (diffs in %s)' % (
+                key_string, output, format(expected), diffs))
 
 
 class _ConcatCombineFn(beam.CombineFn):
@@ -757,6 +760,19 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
     if runner_name in spec.get('broken_on', ()):
       self.skipTest('Known to be broken on %s' % runner_name)
 
+    is_order_agnostic = (
+        isinstance(trigger_fn, DefaultTrigger)
+        and accumulation_mode == AccumulationMode.ACCUMULATING)
+
+    if is_order_agnostic:
+      reshuffle_seed = random.randrange(1 << 20)
+      keys = [
+          'original', 'reversed', 'reshuffled(%s)' % reshuffle_seed,
+          'one-element-bundles', 'one-element-bundles-reversed',
+          'two-element-bundles']
+    else:
+      keys = ['key1', 'key2']
+
     # Elements are encoded as a json strings to allow other languages to
     # decode elements while executing the test stream.
     # TODO(BEAM-8600): Eliminate these gymnastics.
@@ -767,7 +783,28 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
       else:
         test_stream.add_elements([json.dumps(('expect', []))])
         if action == 'input':
-          test_stream.add_elements([json.dumps(('input', e)) for e in params])
+          def keyed(key, values):
+            return [json.dumps(('input', (key, v))) for v in values]
+          if is_order_agnostic:
+            # Must match keys above.
+            test_stream.add_elements(keyed('original', params))
+            test_stream.add_elements(keyed('reversed', reversed(params)))
+            r = random.Random(reshuffle_seed)
+            reshuffled = list(params)
+            r.shuffle(reshuffled)
+            test_stream.add_elements(keyed(
+                'reshuffled(%s)' % reshuffle_seed, reshuffled))
+            for v in params:
+              test_stream.add_elements(keyed('one-element-bundles', [v]))
+            for v in reversed(params):
+              test_stream.add_elements(
+                  keyed('one-element-bundles-reversed', [v]))
+            for ix in range(0, len(params), 2):
+              test_stream.add_elements(
+                  keyed('two-element-bundles', params[ix:ix+2]))
+          else:
+            for key in keys:
+              test_stream.add_elements(keyed(key, params))
         elif action == 'watermark':
           test_stream.advance_watermark_to(params)
         elif action == 'clock':
@@ -806,7 +843,7 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
               beam.transforms.userstate.BagStateSpec(
                   'expected',
                   beam.coders.FastPrimitivesCoder()))):
-        _, (action, data) = element
+        key, (action, data) = element
 
         if self.allow_out_of_order:
           if action == 'expect' and not list(seen.read()):
@@ -831,7 +868,7 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
         elif action == 'expect':
           actual = list(seen.read())
           seen.clear()
-          _windowed_value_info_check(actual, data)
+          _windowed_value_info_check(actual, data, key)
 
         else:
           raise ValueError('Unexpected action: %s' % action)
@@ -842,11 +879,9 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
       # a branch of expected results.
       inputs, expected = (
           inputs_and_expected
-          | beam.FlatMapTuple(
-              lambda tag, value: [
-                  beam.pvalue.TaggedOutput(tag, ('key1', value)),
-                  beam.pvalue.TaggedOutput(tag, ('key2', value)),
-              ]).with_outputs('input', 'expect'))
+          | beam.MapTuple(
+              lambda tag, value: beam.pvalue.TaggedOutput(tag, value),
+              ).with_outputs('input', 'expect'))
 
       # Process the inputs with the given windowing to produce actual outputs.
       outputs = (
@@ -865,7 +900,8 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
           | 'Global' >> beam.WindowInto(beam.transforms.window.GlobalWindows()))
       # Feed both the expected and actual outputs to Check() for comparison.
       tagged_expected = (
-          expected | beam.MapTuple(lambda key, value: (key, ('expect', value))))
+          expected | beam.FlatMap(
+              lambda value: [(key, ('expect', value)) for key in keys]))
       tagged_outputs = (
           outputs | beam.MapTuple(lambda key, value: (key, ('actual', value))))
       # pylint: disable=expression-not-assigned

--- a/sdks/python/apache_beam/transforms/trigger_test.py
+++ b/sdks/python/apache_beam/transforms/trigger_test.py
@@ -647,7 +647,7 @@ def _windowed_value_info_map_fn(
 
 def _windowed_value_info_check(actual, expected, key=None):
 
-  key_string = 'for %s' % key if key else ''
+  key_string = ' for %s' % key if key else ''
 
   def format(panes):
     return '\n[%s]\n' % '\n '.join(str(pane) for pane in sorted(
@@ -767,11 +767,11 @@ class BaseTestStreamTranscriptTest(TranscriptTest):
     if is_order_agnostic:
       reshuffle_seed = random.randrange(1 << 20)
       keys = [
-          'original', 'reversed', 'reshuffled(%s)' % reshuffle_seed,
-          'one-element-bundles', 'one-element-bundles-reversed',
-          'two-element-bundles']
+          u'original', u'reversed', u'reshuffled(%s)' % reshuffle_seed,
+          u'one-element-bundles', u'one-element-bundles-reversed',
+          u'two-element-bundles']
     else:
-      keys = ['key1', 'key2']
+      keys = [u'key1', u'key2']
 
     # Elements are encoded as a json strings to allow other languages to
     # decode elements while executing the test stream.


### PR DESCRIPTION
When possible, runs trigger fns over various permutations and bundling of the inputs (using different keys), ensuring the results are still correct. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
