### PR TITLE
[BEAM-8819] Fix AvroCoder serialisation by introduction of AvroGenericCoder specialisation

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/AvroGenericCoderRegistrar.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/AvroGenericCoderRegistrar.java
@@ -19,22 +19,22 @@ package org.apache.beam.runners.core.construction;
 
 import com.google.auto.service.AutoService;
 import java.util.Map;
-import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.AvroGenericCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 
-/** Coder registrar for AvroCoder. */
+/** Coder registrar for AvroGenericCoder. */
 @AutoService(CoderTranslatorRegistrar.class)
-public class AvroCoderRegistrar implements CoderTranslatorRegistrar {
-  public static final String AVRO_CODER_URN = "beam:coder:avro:v1";
+public class AvroGenericCoderRegistrar implements CoderTranslatorRegistrar {
+  public static final String AVRO_CODER_URN = "beam:coder:avro:generic:v1";
 
   @Override
   public Map<Class<? extends Coder>, String> getCoderURNs() {
-    return ImmutableMap.of(AvroCoder.class, AVRO_CODER_URN);
+    return ImmutableMap.of(AvroGenericCoder.class, AVRO_CODER_URN);
   }
 
   @Override
   public Map<Class<? extends Coder>, CoderTranslator<? extends Coder>> getCoderTranslators() {
-    return ImmutableMap.of(AvroCoder.class, new AvroCoderTranslator());
+    return ImmutableMap.of(AvroGenericCoder.class, new AvroGenericCoderTranslator());
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/AvroGenericCoderTranslator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/AvroGenericCoderTranslator.java
@@ -20,25 +20,25 @@ package org.apache.beam.runners.core.construction;
 import java.util.Collections;
 import java.util.List;
 import org.apache.avro.Schema;
-import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.AvroGenericCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Charsets;
 
-/** Coder translator for AvroCoder. */
-public class AvroCoderTranslator implements CoderTranslator<AvroCoder<?>> {
+/** Coder translator for AvroGenericCoder. */
+public class AvroGenericCoderTranslator implements CoderTranslator<AvroGenericCoder> {
   @Override
-  public List<? extends Coder<?>> getComponents(AvroCoder from) {
+  public List<? extends Coder<?>> getComponents(AvroGenericCoder from) {
     return Collections.emptyList();
   }
 
   @Override
-  public byte[] getPayload(AvroCoder from) {
+  public byte[] getPayload(AvroGenericCoder from) {
     return from.getSchema().toString().getBytes(Charsets.UTF_8);
   }
 
   @Override
-  public AvroCoder fromComponents(List<Coder<?>> components, byte[] payload) {
+  public AvroGenericCoder fromComponents(List<Coder<?>> components, byte[] payload) {
     Schema schema = new Schema.Parser().parse(new String(payload, Charsets.UTF_8));
-    return AvroCoder.of(schema);
+    return AvroGenericCoder.of(schema);
   }
 }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CoderTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CoderTranslationTest.java
@@ -143,6 +143,11 @@ public class CoderTranslationTest {
               KvCoder.of(
                   new RecordCoder(),
                   AvroCoder.of(SchemaBuilder.record("record").fields().endRecord())))
+          .add(
+              StringUtf8Coder.of(),
+              SerializableCoder.of(Record.class),
+              new RecordCoder(),
+              KvCoder.of(new RecordCoder(), AvroCoder.of(Record.class)))
           .build();
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -122,10 +122,10 @@ public class AvroCoder<T> extends CustomCoder<T> {
   }
 
   /**
-   * Returns an {@code AvroCoder} instance for the Avro schema. The implicit type is GenericRecord.
+   * Returns an {@code AvroGenericCoder} instance for the Avro schema. The implicit type is GenericRecord.
    */
-  public static AvroCoder<GenericRecord> of(Schema schema) {
-    return new AvroCoder<>(GenericRecord.class, schema);
+  public static AvroGenericCoder of(Schema schema) {
+    return AvroGenericCoder.of(schema);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -122,7 +122,8 @@ public class AvroCoder<T> extends CustomCoder<T> {
   }
 
   /**
-   * Returns an {@code AvroGenericCoder} instance for the Avro schema. The implicit type is GenericRecord.
+   * Returns an {@code AvroGenericCoder} instance for the Avro schema. The implicit type is
+   * GenericRecord.
    */
   public static AvroGenericCoder of(Schema schema) {
     return AvroGenericCoder.of(schema);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroGenericCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroGenericCoder.java
@@ -20,7 +20,7 @@ package org.apache.beam.sdk.coders;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
-/** AvroCoder specialisation for GenericRecord */
+/** AvroCoder specialisation for GenericRecord. */
 public class AvroGenericCoder extends AvroCoder<GenericRecord> {
   AvroGenericCoder(Schema schema) {
     super(GenericRecord.class, schema);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroGenericCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroGenericCoder.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.sdk.coders;
 
 import org.apache.avro.Schema;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroGenericCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroGenericCoder.java
@@ -1,0 +1,15 @@
+package org.apache.beam.sdk.coders;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+/** AvroCoder specialisation for GenericRecord */
+public class AvroGenericCoder extends AvroCoder<GenericRecord> {
+  AvroGenericCoder(Schema schema) {
+    super(GenericRecord.class, schema);
+  }
+
+  public static AvroGenericCoder of(Schema schema) {
+    return new AvroGenericCoder(schema);
+  }
+}

--- a/sdks/python/apache_beam/coders/avro_record.py
+++ b/sdks/python/apache_beam/coders/avro_record.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-"""AvroRecord for AvroCoder."""
+"""AvroRecord for AvroGenericCoder."""
 
 from __future__ import absolute_import
 

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -60,7 +60,7 @@ except ImportError:
 
 __all__ = [
     'Coder',
-    'AvroCoder', 'BooleanCoder', 'BytesCoder', 'DillCoder',
+    'AvroGenericCoder', 'BooleanCoder', 'BytesCoder', 'DillCoder',
     'FastPrimitivesCoder', 'FloatCoder', 'IterableCoder', 'PickleCoder',
     'ProtoCoder', 'SingletonCoder', 'StrUtf8Coder', 'TimestampCoder',
     'TupleCoder', 'TupleSequenceCoder', 'VarIntCoder',
@@ -819,10 +819,10 @@ class DeterministicProtoCoder(ProtoCoder):
     return self
 
 
-AVRO_CODER_URN = "beam:coder:avro:v1"
+AVRO_GENERIC_CODER_URN = "beam:coder:avro:generic:v1"
 
 
-class AvroCoder(FastCoder):
+class AvroGenericCoder(FastCoder):
   """A coder used for AvroRecord values."""
 
   def __init__(self, schema):
@@ -846,11 +846,11 @@ class AvroCoder(FastCoder):
     return AvroRecord
 
   def to_runner_api_parameter(self, context):
-    return AVRO_CODER_URN, self.schema, ()
+    return AVRO_GENERIC_CODER_URN, self.schema, ()
 
-  @Coder.register_urn(AVRO_CODER_URN, bytes)
+  @Coder.register_urn(AVRO_GENERIC_CODER_URN, bytes)
   def from_runner_api_parameter(payload, unused_components, unused_context):
-    return AvroCoder(payload)
+    return AvroGenericCoder(payload)
 
 
 class TupleCoder(FastCoder):

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -113,7 +113,7 @@ class DeterministicProtoCoderTest(unittest.TestCase):
       self.assertEqual(coder.encode(mm_forward), coder.encode(mm_reverse))
 
 
-class AvroTestCoder(coders.AvroCoder):
+class AvroTestCoder(coders.AvroGenericCoder):
   SCHEMA = """
   {
     "type": "record", "name": "testrecord",

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -72,7 +72,7 @@ class CodersTest(unittest.TestCase):
                    if isinstance(c, type) and issubclass(c, coders.Coder) and
                    'Base' not in c.__name__)
     standard -= set([coders.Coder,
-                     coders.AvroCoder,
+                     coders.AvroGenericCoder,
                      coders.DeterministicProtoCoder,
                      coders.FastCoder,
                      coders.ProtoCoder,

--- a/sdks/python/apache_beam/io/external/xlang_parquetio_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_parquetio_test.py
@@ -69,7 +69,7 @@ class XlangParquetIOTest(unittest.TestCase):
         raise e
 
 
-class AvroTestCoder(coders.AvroCoder):
+class AvroTestCoder(coders.AvroGenericCoder):
   SCHEMA = """
   {
     "type": "record", "name": "testrecord",


### PR DESCRIPTION
Introduction of AvroCoderRegistrar and AvroCoderTranslator in #8342 broke AvroCoder behaviour for avro specific records - they are now always decoded as GenericRecord.

With this change the new entity is created - AvroGenericCoder with corresponding *Registrar and *Translator to be used for GenericRecord coding/decoding.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
