### PR TITLE
[GoSDK] Handle data write errors & stream recreate

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr_test.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"strings"
 	"testing"
 
 	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
@@ -28,11 +29,14 @@ import (
 
 const extraData = 2
 
+// fakeClient attempts to mimic the semantics of a GRPC stream
+// and also permit configurability.
 type fakeClient struct {
-	t     *testing.T
-	done  chan bool
-	calls int
-	err   error
+	t              *testing.T
+	done           chan bool
+	calls          int
+	err            error
+	skipFirstError bool
 }
 
 func (f *fakeClient) Recv() (*pb.Elements, error) {
@@ -73,10 +77,20 @@ func (f *fakeClient) Recv() (*pb.Elements, error) {
 }
 
 func (f *fakeClient) Send(*pb.Elements) error {
+	// We skip errors on the first call to test that  errors can be returned
+	// on the sentinel value send in dataWriter.Close
+	// Otherwise, we return an io.EOF similar to semantics documented
+	// in https://godoc.org/google.golang.org/grpc#ClientConn.NewStream
+	if f.skipFirstError && f.err != nil {
+		f.skipFirstError = false
+		return nil
+	} else if f.err != nil {
+		return io.EOF
+	}
 	return nil
 }
 
-func TestDataChannelTerminate(t *testing.T) {
+func TestDataChannelTerminate_dataReader(t *testing.T) {
 	// The logging of channels closed is quite noisy for this test
 	log.SetOutput(ioutil.Discard)
 
@@ -141,9 +155,72 @@ func TestDataChannelTerminate(t *testing.T) {
 			if got, want := err, test.expectedError; got != want {
 				t.Errorf("Unexpected error from read %d: got %v, want %v", i, got, want)
 			}
-			// Verify that new readers return the same their reads after client.Recv is done.
+			// Verify that new readers return the same error on their reads after client.Recv is done.
 			if n, err := c.OpenRead(context.Background(), "ptr", "inst_ref").Read(make([]byte, 4)); err != test.expectedError {
 				t.Errorf("Unexpected error from read: got %v, want, %v read %d bytes.", err, test.expectedError, n)
+			}
+		})
+	}
+
+}
+
+func TestDataChannelTerminate_Writes(t *testing.T) {
+	// The logging of channels closed is quite noisy for this test
+	log.SetOutput(ioutil.Discard)
+
+	expectedError := fmt.Errorf("EXPECTED ERROR")
+
+	tests := []struct {
+		name   string
+		caseFn func(t *testing.T, w io.WriteCloser, client *fakeClient) error
+	}{
+		{
+			name: "onClose_Flush",
+			caseFn: func(t *testing.T, w io.WriteCloser, client *fakeClient) error {
+				return w.Close()
+			},
+		}, {
+			name: "onClose_Sentinel",
+			caseFn: func(t *testing.T, w io.WriteCloser, client *fakeClient) error {
+				client.skipFirstError = true
+				return w.Close()
+			},
+		}, {
+			name: "onWrite",
+			caseFn: func(t *testing.T, w io.WriteCloser, client *fakeClient) error {
+				_, err := w.Write([]byte{'d', 'o', 'n', 'e'})
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			done := make(chan bool, 1)
+			client := &fakeClient{t: t, done: done, err: expectedError}
+			c := makeDataChannel(context.Background(), "id", client)
+
+			w := c.OpenWrite(context.Background(), "ptr", "inst_ref")
+
+			msg := []byte{'b', 'y', 't', 'e'}
+			var bufSize int
+			for bufSize+len(msg) <= chunkSize {
+				bufSize += len(msg)
+				n, err := w.Write(msg)
+				if err != nil {
+					t.Errorf("Unexpected error from write: %v, wrote %d bytes, after %d total bytes", err, n, bufSize)
+				}
+			}
+
+			err := test.caseFn(t, w, client)
+
+			if got, want := err, expectedError; err == nil || !strings.Contains(err.Error(), expectedError.Error()) {
+				t.Errorf("Unexpected error: got %v, want %v", got, want)
+			}
+			// Verify that new readers return the same error for writes after stream termination.
+			// TODO(lostluck) 2019.11.26: use the the go 1.13 errors package to check this rather
+			// than a strings.Contains check once testing infrastructure can use go 1.13.
+			if n, err := c.OpenWrite(context.Background(), "ptr", "inst_ref").Write(msg); err != nil && !strings.Contains(err.Error(), expectedError.Error()) {
+				t.Errorf("Unexpected error from write: got %v, want, %v read %d bytes.", err, expectedError, n)
 			}
 		})
 	}


### PR DESCRIPTION
This resolves a longstanding TODO around errors when writing data to a runner. 
1. This adds handling for failing stream Sends per https://godoc.org/google.golang.org/grpc#ClientConn.NewStream which was only discovered by looking at all the generated GRPC code.
In particular, this documentation clarifies that when Send fails with an io.EOF, the caller must drain Recv until a non-nil error occurs, which further causes stream resource cleanup on the SDK side. This surfaces the "root" error for why the write failed.
2. This (along with previous similar fixes) promotes errors to bundle failures, which should be a sufficient signal to the runner to terminate attention to Sends from the SDK, allowing runner side resources to be cleaned up.
3. This fixes previously broken cases where the now-broken DataChannel wasn't being cleaned up. That is, the data manager would persist in using the broken channel as directed by the runner, but that particular stream was broken. If a channel is broken, it now returns errors for why, which should cause users to clean up, but further, the DataManager is now able to re-use that stream id for a new DataChannel for subsequent bundles.
4. Allow the writer to cancel the reader goroutine incase the reader is blocked in GRPC's receive, via the context. 
5. Unit tests for the above.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
