### PR TITLE
[BEAM-7949] Add time-based cache threshold support in the data service of the Python SDK harness

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -126,6 +126,9 @@ ENCODED_IMPULSE_VALUE = beam.coders.WindowedValueCoder(
 # The cache is disabled in production for other runners.
 STATE_CACHE_SIZE = 100
 
+# Time-based flush is enabled in the fn_api_runner by default.
+DATA_BUFFER_TIME_LIMIT_MS = 1000
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -1442,7 +1445,8 @@ class GrpcServer(object):
       beam_artifact_api_pb2_grpc.add_ArtifactRetrievalServiceServicer_to_server(
           service, self.control_server)
 
-    self.data_plane_handler = data_plane.BeamFnDataServicer()
+    self.data_plane_handler = data_plane.BeamFnDataServicer(
+        DATA_BUFFER_TIME_LIMIT_MS)
     beam_fn_api_pb2_grpc.add_BeamFnDataServicer_to_server(
         self.data_plane_handler, self.data_server)
 
@@ -1580,16 +1584,20 @@ class EmbeddedGrpcWorkerHandler(GrpcWorkerHandler):
     # type: (...) -> None
     super(EmbeddedGrpcWorkerHandler, self).__init__(state, provision_info,
                                                     grpc_server)
-    if payload:
-      state_cache_size = payload.decode('ascii')
-      self._state_cache_size = int(state_cache_size)
-    else:
-      self._state_cache_size = STATE_CACHE_SIZE
+
+    from apache_beam.transforms.environments import EmbeddedPythonGrpcEnvironment
+    config = EmbeddedPythonGrpcEnvironment.parse_config(
+        payload.decode('utf-8'))
+    self._state_cache_size = config.get('state_cache_size') or STATE_CACHE_SIZE
+    self._data_buffer_time_limit_ms = \
+        config.get('data_buffer_time_limit_ms') or DATA_BUFFER_TIME_LIMIT_MS
 
   def start_worker(self):
     # type: () -> None
     self.worker = sdk_worker.SdkHarness(
-        self.control_address, state_cache_size=self._state_cache_size,
+        self.control_address,
+        state_cache_size=self._state_cache_size,
+        data_buffer_time_limit_ms=self._data_buffer_time_limit_ms,
         worker_id=self.worker_id)
     self.worker_thread = threading.Thread(
         name='run_worker', target=self.worker.run)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -597,7 +597,8 @@ class FnApiRunnerTest(unittest.TestCase):
     with self.create_pipeline() as p:
       big = (p
              | beam.Create(['a', 'a', 'b'])
-             | beam.Map(lambda x: (x, x * data_plane._DEFAULT_FLUSH_THRESHOLD)))
+             | beam.Map(lambda x: (
+                 x, x * data_plane._DEFAULT_SIZE_FLUSH_THRESHOLD)))
 
       side_input_res = (
           big
@@ -1153,7 +1154,8 @@ class FnApiRunnerTestWithDisabledCaching(FnApiRunnerTest):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
             default_environment=environments.EmbeddedPythonGrpcEnvironment(
-                state_cache_size=0)))
+                state_cache_size=0,
+                data_buffer_time_limit_ms=0)))
 
 
 class FnApiRunnerTestWithMultiWorkers(FnApiRunnerTest):

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -151,6 +151,8 @@ class PortableRunner(runner.PipelineRunner):
       portable_options.environment_config, server = (
           worker_pool_main.BeamFnExternalWorkerPoolServicer.start(
               state_cache_size=sdk_worker_main._get_state_cache_size(options),
+              data_buffer_time_limit_ms=
+              sdk_worker_main._get_data_buffer_time_limit_ms(options),
               use_process=use_loopback_process_worker))
       cleanup_callbacks = [functools.partial(server.stop, 1)]
     else:

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -185,6 +185,9 @@ class PortableRunnerTest(fn_api_runner_test.FnApiRunnerTest):
         python_urns.EMBEDDED_PYTHON)
     # Enable caching (disabled by default)
     options.view_as(DebugOptions).add_experiment('state_cache_size=100')
+    # Enable time-based data buffer (disabled by default)
+    options.view_as(DebugOptions).add_experiment(
+        'data_buffer_time_limit_ms=1000')
     return options
 
   def create_pipeline(self):
@@ -240,6 +243,8 @@ class PortableRunnerOptimized(PortableRunnerTest):
     options = super(PortableRunnerOptimized, self).create_options()
     options.view_as(DebugOptions).add_experiment('pre_optimize=all')
     options.view_as(DebugOptions).add_experiment('state_cache_size=100')
+    options.view_as(DebugOptions).add_experiment(
+        'data_buffer_time_limit_ms=1000')
     return options
 
 
@@ -249,7 +254,7 @@ class PortableRunnerTestWithExternalEnv(PortableRunnerTest):
   def setUpClass(cls):
     cls._worker_address, cls._worker_server = (
         worker_pool_main.BeamFnExternalWorkerPoolServicer.start(
-            state_cache_size=100))
+            state_cache_size=100, data_buffer_time_limit_ms=1000))
 
   @classmethod
   def tearDownClass(cls):
@@ -274,6 +279,9 @@ class PortableRunnerTestWithSubprocesses(PortableRunnerTest):
         sys.executable.encode('ascii')).decode('utf-8')
     # Enable caching (disabled by default)
     options.view_as(DebugOptions).add_experiment('state_cache_size=100')
+    # Enable time-based data buffer (disabled by default)
+    options.view_as(DebugOptions).add_experiment(
+        'data_buffer_time_limit_ms=1000')
     return options
 
   @classmethod

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -56,7 +56,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-_DEFAULT_FLUSH_THRESHOLD = 10 << 20  # 10MB
+_DEFAULT_SIZE_FLUSH_THRESHOLD = 10 << 20  # 10MB
+_DEFAULT_TIME_FLUSH_THRESHOLD_MS = 0  # disable time-based flush by default
 
 
 if TYPE_CHECKING:
@@ -69,24 +70,90 @@ else:
 class ClosableOutputStream(OutputStream):
   """A Outputstream for use with CoderImpls that has a close() method."""
 
-  def __init__(self,
-               close_callback=None,  # type: Optional[Callable[[bytes], None]]
-               flush_callback=None,  # type: Optional[Callable[[bytes], None]]
-               flush_threshold=_DEFAULT_FLUSH_THRESHOLD):
+  def __init__(self, close_callback=None):
     super(ClosableOutputStream, self).__init__()
     self._close_callback = close_callback
-    self._flush_callback = flush_callback
-    self._flush_threshold = flush_threshold
-
-  # This must be called explicitly to avoid flushing partial elements.
-  def maybe_flush(self):
-    if self._flush_callback and self.size() > self._flush_threshold:
-      self._flush_callback(self.get())
-      self._clear()
 
   def close(self):
     if self._close_callback:
       self._close_callback(self.get())
+
+  @staticmethod
+  def create(close_callback,
+             flush_callback,
+             data_buffer_time_limit_ms):
+    if data_buffer_time_limit_ms > 0:
+      return TimeBasedBufferingClosableOutputStream(
+          close_callback,
+          flush_callback=flush_callback,
+          time_flush_threshold_ms=data_buffer_time_limit_ms)
+    else:
+      return SizeBasedBufferingClosableOutputStream(
+          close_callback, flush_callback=flush_callback)
+
+
+class SizeBasedBufferingClosableOutputStream(ClosableOutputStream):
+  """A size-based buffering OutputStream."""
+
+  def __init__(self,
+               close_callback=None,  # type: Optional[Callable[[bytes], None]]
+               flush_callback=None,  # type: Optional[Callable[[bytes], None]]
+               size_flush_threshold=_DEFAULT_SIZE_FLUSH_THRESHOLD):
+    super(SizeBasedBufferingClosableOutputStream, self).__init__(close_callback)
+    self._flush_callback = flush_callback
+    self._size_flush_threshold = size_flush_threshold
+
+  # This must be called explicitly to avoid flushing partial elements.
+  def maybe_flush(self):
+    if self.size() > self._size_flush_threshold:
+      self.flush()
+
+  def flush(self):
+    if self._flush_callback:
+      self._flush_callback(self.get())
+      self._clear()
+
+
+class TimeBasedBufferingClosableOutputStream(
+    SizeBasedBufferingClosableOutputStream):
+  """A buffering OutputStream with both time-based and size-based."""
+
+  def __init__(self,
+               close_callback=None,
+               flush_callback=None,
+               size_flush_threshold=_DEFAULT_SIZE_FLUSH_THRESHOLD,
+               time_flush_threshold_ms=_DEFAULT_TIME_FLUSH_THRESHOLD_MS):
+    super(TimeBasedBufferingClosableOutputStream, self).__init__(
+        close_callback, flush_callback, size_flush_threshold)
+    assert time_flush_threshold_ms > 0
+    self._time_flush_threshold_ms = time_flush_threshold_ms
+    self._flush_lock = threading.Lock()
+    self._schedule_lock = threading.Lock()
+    self._closed = False
+    self._schedule_periodic_flush()
+
+  def flush(self):
+    with self._flush_lock:
+      super(TimeBasedBufferingClosableOutputStream, self).flush()
+
+  def close(self):
+    with self._schedule_lock:
+      self._closed = True
+      if self._flush_timer:
+        self._flush_timer.cancel()
+        self._flush_timer = None
+    super(TimeBasedBufferingClosableOutputStream, self).close()
+
+  def _schedule_periodic_flush(self):
+    def _periodic_flush():
+      with self._schedule_lock:
+        if not self._closed:
+          self.flush()
+          self._schedule_periodic_flush()
+
+    self._flush_timer = threading.Timer(
+        self._time_flush_threshold_ms / 1000.0, _periodic_flush)
+    self._flush_timer.start()
 
 
 class DataChannel(with_metaclass(abc.ABCMeta, object)):  # type: ignore[misc]
@@ -163,10 +230,12 @@ class InMemoryDataChannel(DataChannel):
   The inverse() method returns the other side of a instance.
   """
 
-  def __init__(self, inverse=None):
-    # type: (Optional[InMemoryDataChannel]) -> None
+  def __init__(self, inverse=None, data_buffer_time_limit_ms=0):
+    # type: (Optional[InMemoryDataChannel], Optional[int]) -> None
     self._inputs = []  # type: List[beam_fn_api_pb2.Elements.Data]
-    self._inverse = inverse or InMemoryDataChannel(self)
+    self._data_buffer_time_limit_ms = data_buffer_time_limit_ms
+    self._inverse = inverse or InMemoryDataChannel(
+        self, data_buffer_time_limit_ms=data_buffer_time_limit_ms)
 
   def inverse(self):
     # type: () -> InMemoryDataChannel
@@ -195,8 +264,10 @@ class InMemoryDataChannel(DataChannel):
               instruction_id=instruction_id,
               transform_id=transform_id,
               data=data))
-    return ClosableOutputStream(
-        add_to_inverse_output, flush_callback=add_to_inverse_output)
+    return ClosableOutputStream.create(
+        add_to_inverse_output,
+        add_to_inverse_output,
+        self._data_buffer_time_limit_ms)
 
   def close(self):
     pass
@@ -207,7 +278,9 @@ class _GrpcDataChannel(DataChannel):
 
   _WRITES_FINISHED = object()
 
-  def __init__(self):
+  def __init__(self, data_buffer_time_limit_ms=0):
+    # type: (Optional[int]) -> None
+    self._data_buffer_time_limit_ms = data_buffer_time_limit_ms
     self._to_send = queue.Queue()  # type: queue.Queue[beam_fn_api_pb2.Elements.Data]
     self._received = collections.defaultdict(lambda: queue.Queue(maxsize=5))  # type: DefaultDict[str, queue.Queue[beam_fn_api_pb2.Elements.Data]]
     self._receive_lock = threading.Lock()
@@ -292,8 +365,11 @@ class _GrpcDataChannel(DataChannel):
               instruction_id=instruction_id,
               transform_id=transform_id,
               data=b''))
-    return ClosableOutputStream(
-        close_callback, flush_callback=add_to_send_queue)
+
+    return ClosableOutputStream.create(
+        close_callback,
+        add_to_send_queue,
+        self._data_buffer_time_limit_ms)
 
   def _write_outputs(self):
     # type: () -> Iterator[beam_fn_api_pb2.Elements]
@@ -340,20 +416,23 @@ class GrpcClientDataChannel(_GrpcDataChannel):
   """A DataChannel wrapping the client side of a BeamFnData connection."""
 
   def __init__(self,
-               data_stub  # type: beam_fn_api_pb2_grpc.BeamFnDataStub
-              ):
+               data_stub,  # type: beam_fn_api_pb2_grpc.BeamFnDataStub
+               data_buffer_time_limit_ms=0  # type: Optional[int]
+               ):
     # type: (...) -> None
-    super(GrpcClientDataChannel, self).__init__()
+    super(GrpcClientDataChannel, self).__init__(data_buffer_time_limit_ms)
     self.set_inputs(data_stub.Data(self._write_outputs()))
 
 
 class BeamFnDataServicer(beam_fn_api_pb2_grpc.BeamFnDataServicer):
   """Implementation of BeamFnDataServicer for any number of clients"""
 
-  def __init__(self):
+  def __init__(self,
+               data_buffer_time_limit_ms=0  # type: Optional[int]
+               ):
     self._lock = threading.Lock()
     self._connections_by_worker_id = collections.defaultdict(
-        _GrpcDataChannel)  # type: DefaultDict[str, _GrpcDataChannel]
+        lambda: _GrpcDataChannel(data_buffer_time_limit_ms))  # type: DefaultDict[str, _GrpcDataChannel]
 
   def get_conn_by_worker_id(self, worker_id):
     # type: (str) -> _GrpcDataChannel
@@ -396,13 +475,15 @@ class GrpcClientDataChannelFactory(DataChannelFactory):
 
   def __init__(self,
                credentials=None,
-               worker_id=None  # type: Optional[str]
-              ):
+               worker_id=None,  # type: Optional[str]
+               data_buffer_time_limit_ms=0  # type: Optional[int]
+               ):
     # type: (...) -> None
     self._data_channel_cache = {}  # type: Dict[str, GrpcClientDataChannel]
     self._lock = threading.Lock()
     self._credentials = None
     self._worker_id = worker_id
+    self._data_buffer_time_limit_ms = data_buffer_time_limit_ms
     if credentials is not None:
       _LOGGER.info('Using secure channel creds.')
       self._credentials = credentials
@@ -430,7 +511,8 @@ class GrpcClientDataChannelFactory(DataChannelFactory):
           grpc_channel = grpc.intercept_channel(
               grpc_channel, WorkerIdInterceptor(self._worker_id))
           self._data_channel_cache[url] = GrpcClientDataChannel(
-              beam_fn_api_pb2_grpc.BeamFnDataStub(grpc_channel))
+              beam_fn_api_pb2_grpc.BeamFnDataStub(grpc_channel),
+              self._data_buffer_time_limit_ms)
 
     return self._data_channel_cache[url]
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -74,8 +74,10 @@ class SdkHarness(object):
                worker_id=None,  # type: Optional[str]
                # Caching is disabled by default
                state_cache_size=0,
+               # time-based data buffering is disabled by default
+               data_buffer_time_limit_ms=0,
                profiler_factory=None  # type: Optional[Callable[..., Profile]]
-              ):
+               ):
     self._alive = True
     self._worker_index = 0
     self._worker_id = worker_id
@@ -94,7 +96,7 @@ class SdkHarness(object):
     self._control_channel = grpc.intercept_channel(
         self._control_channel, WorkerIdInterceptor(self._worker_id))
     self._data_channel_factory = data_plane.GrpcClientDataChannelFactory(
-        credentials, self._worker_id)
+        credentials, self._worker_id, data_buffer_time_limit_ms)
     self._state_handler_factory = GrpcStateHandlerFactory(self._state_cache,
                                                           credentials)
     self._profiler_factory = profiler_factory

--- a/sdks/python/apache_beam/transforms/environments_test.py
+++ b/sdks/python/apache_beam/transforms/environments_test.py
@@ -46,7 +46,8 @@ class RunnerApiTest(unittest.TestCase):
         ExternalEnvironment('localhost:8080', params={'k1': 'v1'}),
         EmbeddedPythonEnvironment(),
         EmbeddedPythonGrpcEnvironment(),
-        EmbeddedPythonGrpcEnvironment(state_cache_size=0),
+        EmbeddedPythonGrpcEnvironment(
+            state_cache_size=0, data_buffer_time_limit_ms=0),
         SubprocessSDKEnvironment(command_string=u'foö')):
       context = pipeline_context.PipelineContext()
       self.assertEqual(


### PR DESCRIPTION
Currently only size-based cache threshold is supported in the data service of Python SDK harness. This PR adds support of time-based cache threshold support in the Python SDK harness. This is especially useful for streaming jobs which are sensitive to the latency.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
