### PR TITLE
[BEAM-7274] Add type conversions factory

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.beam.sdk.schemas.utils.AutoValueUtils;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.FieldValueTypeSupplier;
 import org.apache.beam.sdk.schemas.utils.JavaBeanUtils;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils;
@@ -61,7 +62,7 @@ public class AutoValueSchema extends GetterBasedSchemaProvider {
 
   @Override
   public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
-    return JavaBeanUtils.getGetters(targetClass, schema, AbstractGetterTypeSupplier.INSTANCE);
+    return JavaBeanUtils.getGetters(targetClass, schema, AbstractGetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
   }
 
   @Override
@@ -76,7 +77,7 @@ public class AutoValueSchema extends GetterBasedSchemaProvider {
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {
       return JavaBeanUtils.getStaticCreator(
-          targetClass, annotated, schema, AbstractGetterTypeSupplier.INSTANCE);
+          targetClass, annotated, schema, AbstractGetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     }
 
     // Try to find a generated builder class. If one exists, use that to generate a

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
@@ -62,7 +62,11 @@ public class AutoValueSchema extends GetterBasedSchemaProvider {
 
   @Override
   public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
-    return JavaBeanUtils.getGetters(targetClass, schema, AbstractGetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+    return JavaBeanUtils.getGetters(
+        targetClass,
+        schema,
+        AbstractGetterTypeSupplier.INSTANCE,
+        new DefaultTypeConversionsFactory());
   }
 
   @Override
@@ -77,7 +81,11 @@ public class AutoValueSchema extends GetterBasedSchemaProvider {
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {
       return JavaBeanUtils.getStaticCreator(
-          targetClass, annotated, schema, AbstractGetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+          targetClass,
+          annotated,
+          schema,
+          AbstractGetterTypeSupplier.INSTANCE,
+          new DefaultTypeConversionsFactory());
     }
 
     // Try to find a generated builder class. If one exists, use that to generate a

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
@@ -60,17 +60,18 @@ public class AutoValueSchema extends GetterBasedSchemaProvider {
   }
 
   @Override
-  List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
+  public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
     return JavaBeanUtils.getGetters(targetClass, schema, AbstractGetterTypeSupplier.INSTANCE);
   }
 
   @Override
-  List<FieldValueTypeInformation> fieldValueTypeInformations(Class<?> targetClass, Schema schema) {
+  public List<FieldValueTypeInformation> fieldValueTypeInformations(
+      Class<?> targetClass, Schema schema) {
     return JavaBeanUtils.getFieldTypes(targetClass, schema, AbstractGetterTypeSupplier.INSTANCE);
   }
 
   @Override
-  SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema) {
+  public SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema) {
     // If a static method is marked with @SchemaCreate, use that.
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroRecordSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AvroRecordSchema.java
@@ -38,17 +38,18 @@ public class AvroRecordSchema extends GetterBasedSchemaProvider {
   }
 
   @Override
-  List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
+  public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
     return AvroUtils.getGetters(targetClass, schema);
   }
 
   @Override
-  List<FieldValueTypeInformation> fieldValueTypeInformations(Class<?> targetClass, Schema schema) {
+  public List<FieldValueTypeInformation> fieldValueTypeInformations(
+      Class<?> targetClass, Schema schema) {
     return AvroUtils.getFieldTypes(targetClass, schema);
   }
 
   @Override
-  SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema) {
+  public SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema) {
     return AvroUtils.getCreator(targetClass, schema);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
@@ -32,14 +32,14 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 @Experimental(Kind.SCHEMAS)
 public abstract class GetterBasedSchemaProvider implements SchemaProvider {
   /** Implementing class should override to return FieldValueGetters. */
-  abstract List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema);
+  public abstract List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema);
 
   /** Implementing class should override to return a list of type-informations. */
-  abstract List<FieldValueTypeInformation> fieldValueTypeInformations(
+  public abstract List<FieldValueTypeInformation> fieldValueTypeInformations(
       Class<?> targetClass, Schema schema);
 
   /** Implementing class should override to return a constructor. */
-  abstract SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema);
+  public abstract SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema);
 
   private class ToRowWithValueGetters<T> implements SerializableFunction<T, Row> {
     private final Schema schema;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.FieldValueTypeSupplier;
 import org.apache.beam.sdk.schemas.utils.JavaBeanUtils;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils;
@@ -120,7 +121,7 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
 
   @Override
   public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
-    return JavaBeanUtils.getGetters(targetClass, schema, GetterTypeSupplier.INSTANCE);
+    return JavaBeanUtils.getGetters(targetClass, schema, GetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
   }
 
   @Override
@@ -135,14 +136,14 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {
       return JavaBeanUtils.getStaticCreator(
-          targetClass, annotated, schema, GetterTypeSupplier.INSTANCE);
+          targetClass, annotated, schema, GetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     }
 
     // If a Constructor was tagged with @SchemaCreate, invoke that constructor.
     Constructor<?> constructor = ReflectUtils.getAnnotatedConstructor(targetClass);
     if (constructor != null) {
       return JavaBeanUtils.getConstructorCreator(
-          targetClass, constructor, schema, GetterTypeSupplier.INSTANCE);
+          targetClass, constructor, schema, GetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     }
 
     // Else try to make a setter-based creator
@@ -155,7 +156,7 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
   public static class JavaBeanSetterFactory implements FieldValueSetterFactory {
     @Override
     public List<FieldValueSetter> create(Class<?> targetClass, Schema schema) {
-      return JavaBeanUtils.getSetters(targetClass, schema, SetterTypeSupplier.INSTANCE);
+      return JavaBeanUtils.getSetters(targetClass, schema, SetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -121,7 +121,8 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
 
   @Override
   public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
-    return JavaBeanUtils.getGetters(targetClass, schema, GetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+    return JavaBeanUtils.getGetters(
+        targetClass, schema, GetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
   }
 
   @Override
@@ -136,14 +137,22 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {
       return JavaBeanUtils.getStaticCreator(
-          targetClass, annotated, schema, GetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+          targetClass,
+          annotated,
+          schema,
+          GetterTypeSupplier.INSTANCE,
+          new DefaultTypeConversionsFactory());
     }
 
     // If a Constructor was tagged with @SchemaCreate, invoke that constructor.
     Constructor<?> constructor = ReflectUtils.getAnnotatedConstructor(targetClass);
     if (constructor != null) {
       return JavaBeanUtils.getConstructorCreator(
-          targetClass, constructor, schema, GetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+          targetClass,
+          constructor,
+          schema,
+          GetterTypeSupplier.INSTANCE,
+          new DefaultTypeConversionsFactory());
     }
 
     // Else try to make a setter-based creator
@@ -156,7 +165,8 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
   public static class JavaBeanSetterFactory implements FieldValueSetterFactory {
     @Override
     public List<FieldValueSetter> create(Class<?> targetClass, Schema schema) {
-      return JavaBeanUtils.getSetters(targetClass, schema, SetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+      return JavaBeanUtils.getSetters(
+          targetClass, schema, SetterTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -119,17 +119,18 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
   }
 
   @Override
-  List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
+  public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
     return JavaBeanUtils.getGetters(targetClass, schema, GetterTypeSupplier.INSTANCE);
   }
 
   @Override
-  List<FieldValueTypeInformation> fieldValueTypeInformations(Class<?> targetClass, Schema schema) {
+  public List<FieldValueTypeInformation> fieldValueTypeInformations(
+      Class<?> targetClass, Schema schema) {
     return JavaBeanUtils.getFieldTypes(targetClass, schema, GetterTypeSupplier.INSTANCE);
   }
 
   @Override
-  SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema) {
+  public SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema) {
     // If a static method is marked with @SchemaCreate, use that.
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
@@ -98,7 +98,8 @@ public class JavaFieldSchema extends GetterBasedSchemaProvider {
 
   @Override
   public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
-    return POJOUtils.getGetters(targetClass, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+    return POJOUtils.getGetters(
+        targetClass, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
   }
 
   @Override
@@ -113,16 +114,25 @@ public class JavaFieldSchema extends GetterBasedSchemaProvider {
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {
       return POJOUtils.getStaticCreator(
-          targetClass, annotated, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+          targetClass,
+          annotated,
+          schema,
+          JavaFieldTypeSupplier.INSTANCE,
+          new DefaultTypeConversionsFactory());
     }
 
     // If a Constructor was tagged with @SchemaCreate, invoke that constructor.
     Constructor<?> constructor = ReflectUtils.getAnnotatedConstructor(targetClass);
     if (constructor != null) {
       return POJOUtils.getConstructorCreator(
-          targetClass, constructor, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+          targetClass,
+          constructor,
+          schema,
+          JavaFieldTypeSupplier.INSTANCE,
+          new DefaultTypeConversionsFactory());
     }
 
-    return POJOUtils.getSetFieldCreator(targetClass, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+    return POJOUtils.getSetFieldCreator(
+        targetClass, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.FieldValueTypeSupplier;
 import org.apache.beam.sdk.schemas.utils.POJOUtils;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils;
@@ -97,7 +98,7 @@ public class JavaFieldSchema extends GetterBasedSchemaProvider {
 
   @Override
   public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
-    return POJOUtils.getGetters(targetClass, schema, JavaFieldTypeSupplier.INSTANCE);
+    return POJOUtils.getGetters(targetClass, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
   }
 
   @Override
@@ -112,16 +113,16 @@ public class JavaFieldSchema extends GetterBasedSchemaProvider {
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {
       return POJOUtils.getStaticCreator(
-          targetClass, annotated, schema, JavaFieldTypeSupplier.INSTANCE);
+          targetClass, annotated, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     }
 
     // If a Constructor was tagged with @SchemaCreate, invoke that constructor.
     Constructor<?> constructor = ReflectUtils.getAnnotatedConstructor(targetClass);
     if (constructor != null) {
       return POJOUtils.getConstructorCreator(
-          targetClass, constructor, schema, JavaFieldTypeSupplier.INSTANCE);
+          targetClass, constructor, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     }
 
-    return POJOUtils.getSetFieldCreator(targetClass, schema, JavaFieldTypeSupplier.INSTANCE);
+    return POJOUtils.getSetFieldCreator(targetClass, schema, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
@@ -96,17 +96,18 @@ public class JavaFieldSchema extends GetterBasedSchemaProvider {
   }
 
   @Override
-  List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
+  public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
     return POJOUtils.getGetters(targetClass, schema, JavaFieldTypeSupplier.INSTANCE);
   }
 
   @Override
-  List<FieldValueTypeInformation> fieldValueTypeInformations(Class<?> targetClass, Schema schema) {
+  public List<FieldValueTypeInformation> fieldValueTypeInformations(
+      Class<?> targetClass, Schema schema) {
     return POJOUtils.getFieldTypes(targetClass, schema, JavaFieldTypeSupplier.INSTANCE);
   }
 
   @Override
-  SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema) {
+  public SchemaUserTypeCreator schemaTypeCreator(Class<?> targetClass, Schema schema) {
     // If a static method is marked with @SchemaCreate, use that.
     Method annotated = ReflectUtils.getAnnotatedCreateMethod(targetClass);
     if (annotated != null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.SchemaRegistry;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ConvertHelpers;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -150,7 +151,8 @@ public class Convert {
                 converted.outputSchemaCoder.getFromRowFunction());
       } else {
         SerializableFunction<?, OutputT> convertPrimitive =
-            ConvertHelpers.getConvertPrimitive(converted.unboxedType, outputTypeDescriptor);
+            ConvertHelpers.getConvertPrimitive(
+                converted.unboxedType, outputTypeDescriptor, new DefaultTypeConversionsFactory());
         output =
             input.apply(
                 ParDo.of(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -34,9 +35,10 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
-import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertType;
-import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertValueForSetter;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.InjectPackageStrategy;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversion;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversionsFactory;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.ByteBuddy;
@@ -236,6 +238,7 @@ public class AutoValueUtils {
 
     @Override
     public ByteCodeAppender appender(final Target implementationTarget) {
+      TypeConversionsFactory typeConversionsFactory = new DefaultTypeConversionsFactory();
       ForLoadedType loadedBuilder = new ForLoadedType(builderClass);
       return (methodVisitor, implementationContext, instrumentedMethod) -> {
         // this + method parameters.
@@ -252,13 +255,13 @@ public class AutoValueUtils {
                             ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
                         .getOnly()));
 
-        ConvertType convertType = new ConvertType(true);
+        TypeConversion<Type> convertType = typeConversionsFactory.createTypeConversion(true);
         for (int i = 0; i < setters.size(); ++i) {
           Method setterMethod = checkNotNull(setters.get(i).getMethod());
           Parameter parameter = setterMethod.getParameters()[0];
           ForLoadedType convertedType =
               new ForLoadedType(
-                  (Class) convertType.convert(TypeDescriptor.of(parameter.getType())));
+                  (Class) convertType.convert(TypeDescriptor.of(parameter.getParameterizedType())));
 
           StackManipulation readParameter =
               new StackManipulation.Compound(
@@ -271,7 +274,8 @@ public class AutoValueUtils {
               new StackManipulation.Compound(
                   stackManipulation,
                   Duplication.SINGLE,
-                  new ConvertValueForSetter(readParameter)
+                  typeConversionsFactory
+                      .createSetterConversions(readParameter)
                       .convert(TypeDescriptor.of(parameter.getType())),
                   MethodInvocation.invoke(new ForLoadedMethod(setterMethod)),
                   Removal.SINGLE);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
@@ -116,7 +116,7 @@ public class AutoValueUtils {
         .map(
             c ->
                 JavaBeanUtils.getConstructorCreator(
-                    generatedClass, c, schema, fieldValueTypeSupplier))
+                    generatedClass, c, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory()))
         .orElse(null);
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
@@ -116,7 +116,11 @@ public class AutoValueUtils {
         .map(
             c ->
                 JavaBeanUtils.getConstructorCreator(
-                    generatedClass, c, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory()))
+                    generatedClass,
+                    c,
+                    schema,
+                    fieldValueTypeSupplier,
+                    new DefaultTypeConversionsFactory()))
         .orElse(null);
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroByteBuddyUtils.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
-import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
+import org.apache.beam.sdk.schemas.utils.AvroUtils.AvroTypeConversionFactory;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.InjectPackageStrategy;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversion;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversionsFactory;
@@ -104,7 +104,7 @@ class AvroByteBuddyUtils {
 
   private static StackManipulation readAndConvertParameter(
       Class<?> constructorParameterType, int index) {
-    TypeConversionsFactory typeConversionsFactory = new DefaultTypeConversionsFactory();
+    TypeConversionsFactory typeConversionsFactory = new AvroTypeConversionFactory();
 
     // The types in the AVRO-generated constructor might be the types returned by Beam's Row class,
     // so we have to convert the types used by Beam's Row class.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroByteBuddyUtils.java
@@ -19,12 +19,15 @@ package org.apache.beam.sdk.schemas.utils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
 import java.util.Map;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
-import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertType;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.InjectPackageStrategy;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversion;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils.ClassWithSchema;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -101,11 +104,13 @@ class AvroByteBuddyUtils {
 
   private static StackManipulation readAndConvertParameter(
       Class<?> constructorParameterType, int index) {
+    TypeConversionsFactory typeConversionsFactory = new DefaultTypeConversionsFactory();
+
     // The types in the AVRO-generated constructor might be the types returned by Beam's Row class,
     // so we have to convert the types used by Beam's Row class.
     // We know that AVRO generates constructor parameters in the same order as fields
     // in the schema, so we can just add the parameters sequentially.
-    ConvertType convertType = new ConvertType(true);
+    TypeConversion<Type> convertType = typeConversionsFactory.createTypeConversion(true);
 
     // Map the AVRO-generated type to the one Beam will use.
     ForLoadedType convertedType =
@@ -121,7 +126,8 @@ class AvroByteBuddyUtils {
             TypeCasting.to(convertedType));
 
     // Convert to the parameter accepted by the SpecificRecord constructor.
-    return new ByteBuddyUtils.ConvertValueForSetter(readParameter)
+    return typeConversionsFactory
+        .createSetterConversions(readParameter)
         .convert(TypeDescriptor.of(constructorParameterType));
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -182,7 +182,7 @@ public class AvroUtils {
   }
 
   public static class AvroConvertType extends ConvertType {
-    public  AvroConvertType(boolean returnRawType) {
+    public AvroConvertType(boolean returnRawType) {
       super(returnRawType);
     }
 
@@ -212,20 +212,20 @@ public class AvroUtils {
         // Generate the following code:
         // return value.bytes();
         return new Compound(
-                readValue,
-                MethodInvocation.invoke(
-                        new ForLoadedType(GenericFixed.class)
-                                .getDeclaredMethods()
-                                .filter(
-                                        ElementMatchers.named("bytes")
-                                                .and(ElementMatchers.returns(new ForLoadedType(byte[].class))))
-                                .getOnly()));
+            readValue,
+            MethodInvocation.invoke(
+                new ForLoadedType(GenericFixed.class)
+                    .getDeclaredMethods()
+                    .filter(
+                        ElementMatchers.named("bytes")
+                            .and(ElementMatchers.returns(new ForLoadedType(byte[].class))))
+                    .getOnly()));
       }
       return super.convertDefault(type);
     }
   }
 
-  public static class AvroConvertValueForSetter extends ConvertValueForSetter  {
+  public static class AvroConvertValueForSetter extends ConvertValueForSetter {
     AvroConvertValueForSetter(StackManipulation readValue) {
       super(readValue);
     }
@@ -243,19 +243,19 @@ public class AvroUtils {
         // return new T((byte[]) value);
         ForLoadedType loadedType = new ForLoadedType(type.getRawType());
         return new Compound(
-                TypeCreation.of(loadedType),
-                Duplication.SINGLE,
-                // Load the parameter and cast it to a byte[].
-                readValue,
-                TypeCasting.to(byteArrayType),
-                // Create a new instance that wraps this byte[].
-                MethodInvocation.invoke(
-                        loadedType
-                                .getDeclaredMethods()
-                                .filter(
-                                        ElementMatchers.isConstructor()
-                                                .and(ElementMatchers.takesArguments(byteArrayType)))
-                                .getOnly()));
+            TypeCreation.of(loadedType),
+            Duplication.SINGLE,
+            // Load the parameter and cast it to a byte[].
+            readValue,
+            TypeCasting.to(byteArrayType),
+            // Create a new instance that wraps this byte[].
+            MethodInvocation.invoke(
+                loadedType
+                    .getDeclaredMethods()
+                    .filter(
+                        ElementMatchers.isConstructor()
+                            .and(ElementMatchers.takesArguments(byteArrayType)))
+                    .getOnly()));
       }
       return super.convertDefault(type);
     }
@@ -567,9 +567,13 @@ public class AvroUtils {
   public static <T> List<FieldValueGetter> getGetters(Class<T> clazz, Schema schema) {
     if (TypeDescriptor.of(clazz).isSubtypeOf(TypeDescriptor.of(SpecificRecord.class))) {
       return JavaBeanUtils.getGetters(
-          clazz, schema, new AvroSpecificRecordFieldValueTypeSupplier(), new AvroTypeConversionFactory());
+          clazz,
+          schema,
+          new AvroSpecificRecordFieldValueTypeSupplier(),
+          new AvroTypeConversionFactory());
     } else {
-      return POJOUtils.getGetters(clazz, schema, new AvroPojoFieldValueTypeSupplier(), new AvroTypeConversionFactory());
+      return POJOUtils.getGetters(
+          clazz, schema, new AvroPojoFieldValueTypeSupplier(), new AvroTypeConversionFactory());
     }
   }
 
@@ -578,7 +582,8 @@ public class AvroUtils {
     if (TypeDescriptor.of(clazz).isSubtypeOf(TypeDescriptor.of(SpecificRecord.class))) {
       return AvroByteBuddyUtils.getCreator((Class<? extends SpecificRecord>) clazz, schema);
     } else {
-      return POJOUtils.getSetFieldCreator(clazz, schema, new AvroPojoFieldValueTypeSupplier(), new AvroTypeConversionFactory());
+      return POJOUtils.getSetFieldCreator(
+          clazz, schema, new AvroPojoFieldValueTypeSupplier(), new AvroTypeConversionFactory());
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.apache.avro.generic.GenericFixed;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.FieldValueSetter;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
@@ -187,9 +186,6 @@ public class ByteBuddyUtils {
         return convertDateTime(typeDescriptor);
       } else if (typeDescriptor.isSubtypeOf(TypeDescriptor.of(ByteBuffer.class))) {
         return convertByteBuffer(typeDescriptor);
-      } else if (typeDescriptor.isSubtypeOf(TypeDescriptor.of(GenericFixed.class))) {
-        // TODO: Refactor AVRO-specific check into separate class.
-        return convertGenericFixed(typeDescriptor);
       } else if (typeDescriptor.isSubtypeOf(TypeDescriptor.of(CharSequence.class))) {
         return convertCharSequence(typeDescriptor);
       } else if (typeDescriptor.getRawType().isPrimitive()) {
@@ -218,8 +214,6 @@ public class ByteBuddyUtils {
     protected abstract T convertDateTime(TypeDescriptor<?> type);
 
     protected abstract T convertByteBuffer(TypeDescriptor<?> type);
-
-    protected abstract T convertGenericFixed(TypeDescriptor<?> type);
 
     protected abstract T convertCharSequence(TypeDescriptor<?> type);
 
@@ -283,11 +277,6 @@ public class ByteBuddyUtils {
 
     @Override
     protected Type convertByteBuffer(TypeDescriptor<?> type) {
-      return byte[].class;
-    }
-
-    @Override
-    protected Type convertGenericFixed(TypeDescriptor<?> type) {
       return byte[].class;
     }
 
@@ -477,23 +466,6 @@ public class ByteBuddyUtils {
                   .getDeclaredMethods()
                   .filter(
                       ElementMatchers.named("array").and(ElementMatchers.returns(BYTE_ARRAY_TYPE)))
-                  .getOnly()));
-    }
-
-    @Override
-    protected StackManipulation convertGenericFixed(TypeDescriptor<?> type) {
-      // TODO: Refactor AVRO-specific code into separate class.
-
-      // Generate the following code:
-      // return value.bytes();
-
-      return new Compound(
-          readValue,
-          MethodInvocation.invoke(
-              new ForLoadedType(GenericFixed.class)
-                  .getDeclaredMethods()
-                  .filter(
-                      ElementMatchers.named("bytes").and(ElementMatchers.returns(BYTE_ARRAY_TYPE)))
                   .getOnly()));
     }
 
@@ -704,29 +676,6 @@ public class ByteBuddyUtils {
                   .getDeclaredMethods()
                   .filter(
                       ElementMatchers.named("wrap")
-                          .and(ElementMatchers.takesArguments(BYTE_ARRAY_TYPE)))
-                  .getOnly()));
-    }
-
-    @Override
-    protected StackManipulation convertGenericFixed(TypeDescriptor<?> type) {
-      // Generate the following code:
-      // return new T((byte[]) value);
-
-      // TODO: Refactor AVRO-specific code out of this class.
-      ForLoadedType loadedType = new ForLoadedType(type.getRawType());
-      return new Compound(
-          TypeCreation.of(loadedType),
-          Duplication.SINGLE,
-          // Load the parameter and cast it to a byte[].
-          readValue,
-          TypeCasting.to(BYTE_ARRAY_TYPE),
-          // Create a new instance that wraps this byte[].
-          MethodInvocation.invoke(
-              loadedType
-                  .getDeclaredMethods()
-                  .filter(
-                      ElementMatchers.isConstructor()
                           .and(ElementMatchers.takesArguments(BYTE_ARRAY_TYPE)))
                   .getOnly()));
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -75,7 +75,7 @@ import org.joda.time.ReadableInstant;
 import org.joda.time.ReadablePartial;
 import org.joda.time.base.BaseLocal;
 
-class ByteBuddyUtils {
+public class ByteBuddyUtils {
   private static final ForLoadedType ARRAYS_TYPE = new ForLoadedType(Arrays.class);
   private static final ForLoadedType ARRAY_UTILS_TYPE = new ForLoadedType(ArrayUtils.class);
   private static final ForLoadedType BYTE_ARRAY_TYPE = new ForLoadedType(byte[].class);
@@ -122,6 +122,31 @@ class ByteBuddyUtils {
     }
   };
 
+  public interface TypeConversionsFactory {
+    TypeConversion<Type> createTypeConversion(boolean returnRawTypes);
+
+    TypeConversion<StackManipulation> createGetterConversions(StackManipulation readValue);
+
+    TypeConversion<StackManipulation> createSetterConversions(StackManipulation readValue);
+  }
+
+  public static class DefaultTypeConversionsFactory implements TypeConversionsFactory {
+    @Override
+    public TypeConversion<Type> createTypeConversion(boolean returnRawTypes) {
+      return new ConvertType(returnRawTypes);
+    }
+
+    @Override
+    public TypeConversion<StackManipulation> createGetterConversions(StackManipulation readValue) {
+      return new ConvertValueForGetter(readValue);
+    }
+
+    @Override
+    public TypeConversion<StackManipulation> createSetterConversions(StackManipulation readValue) {
+      return new ConvertValueForSetter(readValue);
+    }
+  }
+
   // Create a new FieldValueGetter subclass.
   @SuppressWarnings("unchecked")
   static DynamicType.Builder<FieldValueGetter> subclassGetterInterface(
@@ -148,7 +173,7 @@ class ByteBuddyUtils {
 
   // Base class used below to convert types.
   @SuppressWarnings("unchecked")
-  abstract static class TypeConversion<T> {
+  public abstract static class TypeConversion<T> {
     public T convert(TypeDescriptor typeDescriptor) {
       if (typeDescriptor.isArray()
           && !typeDescriptor.getComponentType().getRawType().equals(byte.class)) {
@@ -223,10 +248,10 @@ class ByteBuddyUtils {
    *
    * <pre><code>{@literal FieldValueGetter<POJO, List<Integer>>}</code></pre>
    */
-  static class ConvertType extends TypeConversion<Type> {
+  public static class ConvertType extends TypeConversion<Type> {
     private boolean returnRawTypes;
 
-    public ConvertType(boolean returnRawTypes) {
+    protected ConvertType(boolean returnRawTypes) {
       this.returnRawTypes = returnRawTypes;
     }
 
@@ -302,12 +327,16 @@ class ByteBuddyUtils {
    * these types before returning. These conversions correspond to the ones defined in {@link
    * ConvertType}. This class generates the code to do these conversion.
    */
-  static class ConvertValueForGetter extends TypeConversion<StackManipulation> {
+  public static class ConvertValueForGetter extends TypeConversion<StackManipulation> {
     // The code that reads the value.
-    private final StackManipulation readValue;
+    protected final StackManipulation readValue;
 
-    ConvertValueForGetter(StackManipulation readValue) {
+    protected ConvertValueForGetter(StackManipulation readValue) {
       this.readValue = readValue;
+    }
+
+    protected TypeConversionsFactory getFactory() {
+      return new DefaultTypeConversionsFactory();
     }
 
     @Override
@@ -519,11 +548,15 @@ class ByteBuddyUtils {
    * String} type (for string fields), but the user type might have a {@link StringBuffer} member
    * there. This class generates code to convert between these types.
    */
-  static class ConvertValueForSetter extends TypeConversion<StackManipulation> {
+  public static class ConvertValueForSetter extends TypeConversion<StackManipulation> {
     StackManipulation readValue;
 
-    ConvertValueForSetter(StackManipulation readValue) {
+    protected ConvertValueForSetter(StackManipulation readValue) {
       this.readValue = readValue;
+    }
+
+    protected TypeConversionsFactory getFactory() {
+      return new DefaultTypeConversionsFactory();
     }
 
     @Override
@@ -605,7 +638,7 @@ class ByteBuddyUtils {
       ForLoadedType loadedType = new ForLoadedType(type.getRawType());
       List<StackManipulation> stackManipulations = new ArrayList<>();
 
-      // Create a new instance of the target ype.
+      // Create a new instance of the target type.
       stackManipulations.add(TypeCreation.of(loadedType));
       stackManipulations.add(Duplication.SINGLE);
       // Load the parameter and cast it to a ReadableInstant.
@@ -769,8 +802,15 @@ class ByteBuddyUtils {
     private final Constructor constructor;
 
     ConstructorCreateInstruction(
-        List<FieldValueTypeInformation> fields, Class targetClass, Constructor constructor) {
-      super(fields, targetClass, Lists.newArrayList(constructor.getParameters()));
+        List<FieldValueTypeInformation> fields,
+        Class targetClass,
+        Constructor constructor,
+        TypeConversionsFactory typeConversionsFactory) {
+      super(
+          fields,
+          targetClass,
+          Lists.newArrayList(constructor.getParameters()),
+          typeConversionsFactory);
       this.constructor = constructor;
     }
 
@@ -801,8 +841,12 @@ class ByteBuddyUtils {
     private final Method creator;
 
     StaticFactoryMethodInstruction(
-        List<FieldValueTypeInformation> fields, Class targetClass, Method creator) {
-      super(fields, targetClass, Lists.newArrayList(creator.getParameters()));
+        List<FieldValueTypeInformation> fields,
+        Class targetClass,
+        Method creator,
+        TypeConversionsFactory typeConversionsFactory) {
+      super(
+          fields, targetClass, Lists.newArrayList(creator.getParameters()), typeConversionsFactory);
       if (!Modifier.isStatic(creator.getModifiers())) {
         throw new IllegalArgumentException("Method " + creator + " is not static");
       }
@@ -825,12 +869,17 @@ class ByteBuddyUtils {
     protected final Class targetClass;
     protected final List<Parameter> parameters;
     protected final Map<Integer, Integer> fieldMapping;
+    private final TypeConversionsFactory typeConversionsFactory;
 
     protected InvokeUserCreateInstruction(
-        List<FieldValueTypeInformation> fields, Class targetClass, List<Parameter> parameters) {
+        List<FieldValueTypeInformation> fields,
+        Class targetClass,
+        List<Parameter> parameters,
+        TypeConversionsFactory typeConversionsFactory) {
       this.fields = fields;
       this.targetClass = targetClass;
       this.parameters = parameters;
+      this.typeConversionsFactory = typeConversionsFactory;
 
       // Method parameters might not be in the same order as the schema fields, and the input
       // array to SchemaUserTypeCreator.create is in schema order. Examine the parameter names
@@ -880,7 +929,7 @@ class ByteBuddyUtils {
         StackManipulation stackManipulation = beforePushingParameters();
 
         // Push all creator parameters on the stack.
-        ConvertType convertType = new ConvertType(true);
+        TypeConversion<Type> convertType = typeConversionsFactory.createTypeConversion(true);
         for (int i = 0; i < parameters.size(); i++) {
           Parameter parameter = parameters.get(i);
           ForLoadedType convertedType =
@@ -898,7 +947,8 @@ class ByteBuddyUtils {
           stackManipulation =
               new StackManipulation.Compound(
                   stackManipulation,
-                  new ConvertValueForSetter(readParameter)
+                  typeConversionsFactory
+                      .createSetterConversions(readParameter)
                       .convert(TypeDescriptor.of(parameter.getType())));
         }
         stackManipulation =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
@@ -32,7 +32,6 @@ import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConstructorCreateInstruction;
-import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.InjectPackageStrategy;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.StaticFactoryMethodInstruction;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversionsFactory;
@@ -131,11 +130,6 @@ public class JavaBeanUtils {
         });
   }
 
-  public static List<FieldValueGetter> getGetters(
-      Class<?> clazz, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
-    return getGetters(clazz, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory());
-  }
-
   private static <T> FieldValueGetter createGetter(
       FieldValueTypeInformation typeInformation, TypeConversionsFactory typeConversionsFactory) {
     DynamicType.Builder<FieldValueGetter> builder =
@@ -199,11 +193,6 @@ public class JavaBeanUtils {
         });
   }
 
-  public static List<FieldValueSetter> getSetters(
-      Class<?> clazz, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
-    return getSetters(clazz, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory());
-  }
-
   private static FieldValueSetter createSetter(
       FieldValueTypeInformation typeInformation, TypeConversionsFactory typeConversionsFactory) {
     DynamicType.Builder<FieldValueSetter> builder =
@@ -263,14 +252,6 @@ public class JavaBeanUtils {
         });
   }
 
-  public static SchemaUserTypeCreator getConstructorCreator(
-      Class clazz,
-      Constructor constructor,
-      Schema schema,
-      FieldValueTypeSupplier fieldValueTypeSupplier) {
-    return getConstructorCreator(
-        clazz, constructor, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory());
-  }
 
   public static <T> SchemaUserTypeCreator createConstructorCreator(
       Class<T> clazz,
@@ -316,12 +297,6 @@ public class JavaBeanUtils {
           List<FieldValueTypeInformation> types = fieldValueTypeSupplier.get(clazz, schema);
           return createStaticCreator(clazz, creator, schema, types, typeConversionsFactory);
         });
-  }
-
-  public static SchemaUserTypeCreator getStaticCreator(
-      Class clazz, Method creator, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
-    return getStaticCreator(
-        clazz, creator, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory());
   }
 
   public static <T> SchemaUserTypeCreator createStaticCreator(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
@@ -252,7 +252,6 @@ public class JavaBeanUtils {
         });
   }
 
-
   public static <T> SchemaUserTypeCreator createConstructorCreator(
       Class<T> clazz,
       Constructor<T> constructor,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
@@ -32,10 +32,10 @@ import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConstructorCreateInstruction;
-import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertType;
-import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertValueForGetter;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.InjectPackageStrategy;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.StaticFactoryMethodInstruction;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils.ClassWithSchema;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.ByteBuddy;
@@ -117,22 +117,33 @@ public class JavaBeanUtils {
    * <p>The returned list is ordered by the order of fields in the schema.
    */
   public static List<FieldValueGetter> getGetters(
-      Class<?> clazz, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
+      Class<?> clazz,
+      Schema schema,
+      FieldValueTypeSupplier fieldValueTypeSupplier,
+      TypeConversionsFactory typeConversionsFactory) {
     return CACHED_GETTERS.computeIfAbsent(
         new ClassWithSchema(clazz, schema),
         c -> {
           List<FieldValueTypeInformation> types = fieldValueTypeSupplier.get(clazz, schema);
-          return types.stream().map(JavaBeanUtils::createGetter).collect(Collectors.toList());
+          return types.stream()
+              .map(t -> createGetter(t, typeConversionsFactory))
+              .collect(Collectors.toList());
         });
   }
 
-  private static <T> FieldValueGetter createGetter(FieldValueTypeInformation typeInformation) {
+  public static List<FieldValueGetter> getGetters(
+      Class<?> clazz, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
+    return getGetters(clazz, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory());
+  }
+
+  private static <T> FieldValueGetter createGetter(
+      FieldValueTypeInformation typeInformation, TypeConversionsFactory typeConversionsFactory) {
     DynamicType.Builder<FieldValueGetter> builder =
         ByteBuddyUtils.subclassGetterInterface(
             BYTE_BUDDY,
             typeInformation.getMethod().getDeclaringClass(),
-            new ConvertType(false).convert(typeInformation.getType()));
-    builder = implementGetterMethods(builder, typeInformation);
+            typeConversionsFactory.createTypeConversion(false).convert(typeInformation.getType()));
+    builder = implementGetterMethods(builder, typeInformation, typeConversionsFactory);
     try {
       return builder
           .make()
@@ -153,12 +164,14 @@ public class JavaBeanUtils {
   }
 
   private static DynamicType.Builder<FieldValueGetter> implementGetterMethods(
-      DynamicType.Builder<FieldValueGetter> builder, FieldValueTypeInformation typeInformation) {
+      DynamicType.Builder<FieldValueGetter> builder,
+      FieldValueTypeInformation typeInformation,
+      TypeConversionsFactory typeConversionsFactory) {
     return builder
         .method(ElementMatchers.named("name"))
         .intercept(FixedValue.reference(typeInformation.getName()))
         .method(ElementMatchers.named("get"))
-        .intercept(new InvokeGetterInstruction(typeInformation));
+        .intercept(new InvokeGetterInstruction(typeInformation, typeConversionsFactory));
   }
 
   // The list of setters for a class is cached, so we only create the classes the first time
@@ -172,22 +185,33 @@ public class JavaBeanUtils {
    * <p>The returned list is ordered by the order of fields in the schema.
    */
   public static List<FieldValueSetter> getSetters(
-      Class<?> clazz, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
+      Class<?> clazz,
+      Schema schema,
+      FieldValueTypeSupplier fieldValueTypeSupplier,
+      TypeConversionsFactory typeConversionsFactory) {
     return CACHED_SETTERS.computeIfAbsent(
         new ClassWithSchema(clazz, schema),
         c -> {
           List<FieldValueTypeInformation> types = fieldValueTypeSupplier.get(clazz, schema);
-          return types.stream().map(JavaBeanUtils::createSetter).collect(Collectors.toList());
+          return types.stream()
+              .map(t -> createSetter(t, typeConversionsFactory))
+              .collect(Collectors.toList());
         });
   }
 
-  private static FieldValueSetter createSetter(FieldValueTypeInformation typeInformation) {
+  public static List<FieldValueSetter> getSetters(
+      Class<?> clazz, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
+    return getSetters(clazz, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory());
+  }
+
+  private static FieldValueSetter createSetter(
+      FieldValueTypeInformation typeInformation, TypeConversionsFactory typeConversionsFactory) {
     DynamicType.Builder<FieldValueSetter> builder =
         ByteBuddyUtils.subclassSetterInterface(
             BYTE_BUDDY,
             typeInformation.getMethod().getDeclaringClass(),
-            new ConvertType(false).convert(typeInformation.getType()));
-    builder = implementSetterMethods(builder, typeInformation.getMethod());
+            typeConversionsFactory.createTypeConversion(false).convert(typeInformation.getType()));
+    builder = implementSetterMethods(builder, typeInformation.getMethod(), typeConversionsFactory);
     try {
       return builder
           .make()
@@ -208,13 +232,15 @@ public class JavaBeanUtils {
   }
 
   private static DynamicType.Builder<FieldValueSetter> implementSetterMethods(
-      DynamicType.Builder<FieldValueSetter> builder, Method method) {
+      DynamicType.Builder<FieldValueSetter> builder,
+      Method method,
+      TypeConversionsFactory typeConversionsFactory) {
     FieldValueTypeInformation javaTypeInformation = FieldValueTypeInformation.forSetter(method);
     return builder
         .method(ElementMatchers.named("name"))
         .intercept(FixedValue.reference(javaTypeInformation.getName()))
         .method(ElementMatchers.named("set"))
-        .intercept(new InvokeSetterInstruction(method));
+        .intercept(new InvokeSetterInstruction(method, typeConversionsFactory));
   }
 
   // The list of constructors for a class is cached, so we only create the classes the first time
@@ -226,27 +252,41 @@ public class JavaBeanUtils {
       Class clazz,
       Constructor constructor,
       Schema schema,
-      FieldValueTypeSupplier fieldValueTypeSupplier) {
+      FieldValueTypeSupplier fieldValueTypeSupplier,
+      TypeConversionsFactory typeConversionsFactory) {
     return CACHED_CREATORS.computeIfAbsent(
         new ClassWithSchema(clazz, schema),
         c -> {
           List<FieldValueTypeInformation> types = fieldValueTypeSupplier.get(clazz, schema);
-          return createConstructorCreator(clazz, constructor, schema, types);
+          return createConstructorCreator(
+              clazz, constructor, schema, types, typeConversionsFactory);
         });
+  }
+
+  public static SchemaUserTypeCreator getConstructorCreator(
+      Class clazz,
+      Constructor constructor,
+      Schema schema,
+      FieldValueTypeSupplier fieldValueTypeSupplier) {
+    return getConstructorCreator(
+        clazz, constructor, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory());
   }
 
   public static <T> SchemaUserTypeCreator createConstructorCreator(
       Class<T> clazz,
       Constructor<T> constructor,
       Schema schema,
-      List<FieldValueTypeInformation> types) {
+      List<FieldValueTypeInformation> types,
+      TypeConversionsFactory typeConversionsFactory) {
     try {
       DynamicType.Builder<SchemaUserTypeCreator> builder =
           BYTE_BUDDY
               .with(new InjectPackageStrategy(clazz))
               .subclass(SchemaUserTypeCreator.class)
               .method(ElementMatchers.named("create"))
-              .intercept(new ConstructorCreateInstruction(types, clazz, constructor));
+              .intercept(
+                  new ConstructorCreateInstruction(
+                      types, clazz, constructor, typeConversionsFactory));
       return builder
           .make()
           .load(
@@ -265,24 +305,40 @@ public class JavaBeanUtils {
   }
 
   public static SchemaUserTypeCreator getStaticCreator(
-      Class clazz, Method creator, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
+      Class clazz,
+      Method creator,
+      Schema schema,
+      FieldValueTypeSupplier fieldValueTypeSupplier,
+      TypeConversionsFactory typeConversionsFactory) {
     return CACHED_CREATORS.computeIfAbsent(
         new ClassWithSchema(clazz, schema),
         c -> {
           List<FieldValueTypeInformation> types = fieldValueTypeSupplier.get(clazz, schema);
-          return createStaticCreator(clazz, creator, schema, types);
+          return createStaticCreator(clazz, creator, schema, types, typeConversionsFactory);
         });
   }
 
+  public static SchemaUserTypeCreator getStaticCreator(
+      Class clazz, Method creator, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier) {
+    return getStaticCreator(
+        clazz, creator, schema, fieldValueTypeSupplier, new DefaultTypeConversionsFactory());
+  }
+
   public static <T> SchemaUserTypeCreator createStaticCreator(
-      Class<T> clazz, Method creator, Schema schema, List<FieldValueTypeInformation> types) {
+      Class<T> clazz,
+      Method creator,
+      Schema schema,
+      List<FieldValueTypeInformation> types,
+      TypeConversionsFactory typeConversionsFactory) {
     try {
       DynamicType.Builder<SchemaUserTypeCreator> builder =
           BYTE_BUDDY
               .with(new InjectPackageStrategy(clazz))
               .subclass(SchemaUserTypeCreator.class)
               .method(ElementMatchers.named("create"))
-              .intercept(new StaticFactoryMethodInstruction(types, clazz, creator));
+              .intercept(
+                  new StaticFactoryMethodInstruction(
+                      types, clazz, creator, typeConversionsFactory));
 
       return builder
           .make()
@@ -304,9 +360,12 @@ public class JavaBeanUtils {
   // Implements a method to read a public getter out of an object.
   private static class InvokeGetterInstruction implements Implementation {
     private final FieldValueTypeInformation typeInformation;
+    private final TypeConversionsFactory typeConversionsFactory;
 
-    InvokeGetterInstruction(FieldValueTypeInformation typeInformation) {
+    InvokeGetterInstruction(
+        FieldValueTypeInformation typeInformation, TypeConversionsFactory typeConversionsFactory) {
       this.typeInformation = typeInformation;
+      this.typeConversionsFactory = typeConversionsFactory;
     }
 
     @Override
@@ -330,7 +389,9 @@ public class JavaBeanUtils {
 
         StackManipulation stackManipulation =
             new StackManipulation.Compound(
-                new ConvertValueForGetter(readValue).convert(typeInformation.getType()),
+                typeConversionsFactory
+                    .createGetterConversions(readValue)
+                    .convert(typeInformation.getType()),
                 MethodReturn.REFERENCE);
 
         StackManipulation.Size size = stackManipulation.apply(methodVisitor, implementationContext);
@@ -341,11 +402,13 @@ public class JavaBeanUtils {
 
   // Implements a method to write a public set out on an object.
   private static class InvokeSetterInstruction implements Implementation {
-    // Setter method that wil be invoked
+    // Setter method that will be invoked
     private Method method;
+    private final TypeConversionsFactory typeConversionsFactory;
 
-    InvokeSetterInstruction(Method method) {
+    InvokeSetterInstruction(Method method, TypeConversionsFactory typeConversionsFactory) {
       this.method = method;
+      this.typeConversionsFactory = typeConversionsFactory;
     }
 
     @Override
@@ -370,7 +433,8 @@ public class JavaBeanUtils {
                 // Object param is offset 1.
                 MethodVariableAccess.REFERENCE.loadFrom(1),
                 // Do any conversions necessary.
-                new ByteBuddyUtils.ConvertValueForSetter(readField)
+                typeConversionsFactory
+                    .createSetterConversions(readField)
                     .convert(javaTypeInformation.getType()),
                 // Now update the field and return void.
                 MethodInvocation.invoke(new ForLoadedMethod(method)));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -90,7 +90,9 @@ public class POJOUtils {
       Maps.newConcurrentMap();
 
   public static List<FieldValueGetter> getGetters(
-      Class<?> clazz, Schema schema, FieldValueTypeSupplier fieldValueTypeSupplier,
+      Class<?> clazz,
+      Schema schema,
+      FieldValueTypeSupplier fieldValueTypeSupplier,
       TypeConversionsFactory typeConversionsFactory) {
     // Return the getters ordered by their position in the schema.
     return CACHED_GETTERS.computeIfAbsent(
@@ -98,7 +100,9 @@ public class POJOUtils {
         c -> {
           List<FieldValueTypeInformation> types = fieldValueTypeSupplier.get(clazz, schema);
           List<FieldValueGetter> getters =
-              types.stream().map(t -> createGetter(t, typeConversionsFactory)).collect(Collectors.toList());
+              types.stream()
+                  .map(t -> createGetter(t, typeConversionsFactory))
+                  .collect(Collectors.toList());
           if (getters.size() != schema.getFieldCount()) {
             throw new RuntimeException(
                 "Was not able to generate getters for schema: " + schema + " class: " + clazz);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnSchemaInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnSchemaInformation.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ConvertHelpers;
 import org.apache.beam.sdk.schemas.utils.SelectHelpers;
 import org.apache.beam.sdk.values.Row;
@@ -230,7 +231,8 @@ public abstract class DoFnSchemaInformation implements Serializable {
       if (conversionFunction == null) {
         conversionFunction =
             (SerializableFunction<InputT, OutputT>)
-                ConvertHelpers.getConvertPrimitive(primitiveType, primitiveOutputType);
+                ConvertHelpers.getConvertPrimitive(
+                    primitiveType, primitiveOutputType, new DefaultTypeConversionsFactory());
       }
       return conversionFunction;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
@@ -134,7 +134,10 @@ public class JavaBeanUtilsTest {
 
     List<FieldValueGetter> getters =
         JavaBeanUtils.getGetters(
-            SimpleBean.class, SIMPLE_BEAN_SCHEMA, new JavaBeanSchema.GetterTypeSupplier(), new DefaultTypeConversionsFactory());
+            SimpleBean.class,
+            SIMPLE_BEAN_SCHEMA,
+            new JavaBeanSchema.GetterTypeSupplier(),
+            new DefaultTypeConversionsFactory());
     assertEquals(12, getters.size());
     assertEquals("str", getters.get(0).name());
 
@@ -162,7 +165,11 @@ public class JavaBeanUtilsTest {
   public void testGeneratedSimpleSetters() {
     SimpleBean simpleBean = new SimpleBean();
     List<FieldValueSetter> setters =
-        JavaBeanUtils.getSetters(SimpleBean.class, SIMPLE_BEAN_SCHEMA, new SetterTypeSupplier(), new DefaultTypeConversionsFactory());
+        JavaBeanUtils.getSetters(
+            SimpleBean.class,
+            SIMPLE_BEAN_SCHEMA,
+            new SetterTypeSupplier(),
+            new DefaultTypeConversionsFactory());
     assertEquals(12, setters.size());
 
     setters.get(0).set(simpleBean, "field1");
@@ -208,7 +215,7 @@ public class JavaBeanUtilsTest {
             BeanWithBoxedFields.class,
             BEAN_WITH_BOXED_FIELDS_SCHEMA,
             new JavaBeanSchema.GetterTypeSupplier(),
-                new DefaultTypeConversionsFactory());
+            new DefaultTypeConversionsFactory());
     assertEquals((byte) 41, getters.get(0).get(bean));
     assertEquals((short) 42, getters.get(1).get(bean));
     assertEquals((int) 43, getters.get(2).get(bean));
@@ -221,7 +228,10 @@ public class JavaBeanUtilsTest {
     BeanWithBoxedFields bean = new BeanWithBoxedFields();
     List<FieldValueSetter> setters =
         JavaBeanUtils.getSetters(
-            BeanWithBoxedFields.class, BEAN_WITH_BOXED_FIELDS_SCHEMA, new SetterTypeSupplier(), new DefaultTypeConversionsFactory());
+            BeanWithBoxedFields.class,
+            BEAN_WITH_BOXED_FIELDS_SCHEMA,
+            new SetterTypeSupplier(),
+            new DefaultTypeConversionsFactory());
 
     setters.get(0).set(bean, (byte) 41);
     setters.get(1).set(bean, (short) 42);
@@ -241,7 +251,10 @@ public class JavaBeanUtilsTest {
     BeanWithByteArray bean = new BeanWithByteArray();
     List<FieldValueSetter> setters =
         JavaBeanUtils.getSetters(
-            BeanWithByteArray.class, BEAN_WITH_BYTE_ARRAY_SCHEMA, new SetterTypeSupplier(), new DefaultTypeConversionsFactory());
+            BeanWithByteArray.class,
+            BEAN_WITH_BYTE_ARRAY_SCHEMA,
+            new SetterTypeSupplier(),
+            new DefaultTypeConversionsFactory());
     setters.get(0).set(bean, "field1".getBytes(Charset.defaultCharset()));
     setters.get(1).set(bean, "field2".getBytes(Charset.defaultCharset()));
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
@@ -41,6 +41,7 @@ import org.apache.beam.sdk.schemas.JavaBeanSchema;
 import org.apache.beam.sdk.schemas.JavaBeanSchema.GetterTypeSupplier;
 import org.apache.beam.sdk.schemas.JavaBeanSchema.SetterTypeSupplier;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.BeanWithBoxedFields;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.BeanWithByteArray;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.NestedArrayBean;
@@ -133,7 +134,7 @@ public class JavaBeanUtilsTest {
 
     List<FieldValueGetter> getters =
         JavaBeanUtils.getGetters(
-            SimpleBean.class, SIMPLE_BEAN_SCHEMA, new JavaBeanSchema.GetterTypeSupplier());
+            SimpleBean.class, SIMPLE_BEAN_SCHEMA, new JavaBeanSchema.GetterTypeSupplier(), new DefaultTypeConversionsFactory());
     assertEquals(12, getters.size());
     assertEquals("str", getters.get(0).name());
 
@@ -161,7 +162,7 @@ public class JavaBeanUtilsTest {
   public void testGeneratedSimpleSetters() {
     SimpleBean simpleBean = new SimpleBean();
     List<FieldValueSetter> setters =
-        JavaBeanUtils.getSetters(SimpleBean.class, SIMPLE_BEAN_SCHEMA, new SetterTypeSupplier());
+        JavaBeanUtils.getSetters(SimpleBean.class, SIMPLE_BEAN_SCHEMA, new SetterTypeSupplier(), new DefaultTypeConversionsFactory());
     assertEquals(12, setters.size());
 
     setters.get(0).set(simpleBean, "field1");
@@ -206,7 +207,8 @@ public class JavaBeanUtilsTest {
         JavaBeanUtils.getGetters(
             BeanWithBoxedFields.class,
             BEAN_WITH_BOXED_FIELDS_SCHEMA,
-            new JavaBeanSchema.GetterTypeSupplier());
+            new JavaBeanSchema.GetterTypeSupplier(),
+                new DefaultTypeConversionsFactory());
     assertEquals((byte) 41, getters.get(0).get(bean));
     assertEquals((short) 42, getters.get(1).get(bean));
     assertEquals((int) 43, getters.get(2).get(bean));
@@ -219,7 +221,7 @@ public class JavaBeanUtilsTest {
     BeanWithBoxedFields bean = new BeanWithBoxedFields();
     List<FieldValueSetter> setters =
         JavaBeanUtils.getSetters(
-            BeanWithBoxedFields.class, BEAN_WITH_BOXED_FIELDS_SCHEMA, new SetterTypeSupplier());
+            BeanWithBoxedFields.class, BEAN_WITH_BOXED_FIELDS_SCHEMA, new SetterTypeSupplier(), new DefaultTypeConversionsFactory());
 
     setters.get(0).set(bean, (byte) 41);
     setters.get(1).set(bean, (short) 42);
@@ -239,7 +241,7 @@ public class JavaBeanUtilsTest {
     BeanWithByteArray bean = new BeanWithByteArray();
     List<FieldValueSetter> setters =
         JavaBeanUtils.getSetters(
-            BeanWithByteArray.class, BEAN_WITH_BYTE_ARRAY_SCHEMA, new SetterTypeSupplier());
+            BeanWithByteArray.class, BEAN_WITH_BYTE_ARRAY_SCHEMA, new SetterTypeSupplier(), new DefaultTypeConversionsFactory());
     setters.get(0).set(bean, "field1".getBytes(Charset.defaultCharset()));
     setters.get(1).set(bean, "field2".getBytes(Charset.defaultCharset()));
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
@@ -135,7 +135,11 @@ public class POJOUtilsTest {
             new StringBuilder("stringBuilder"));
 
     List<FieldValueGetter> getters =
-        POJOUtils.getGetters(SimplePOJO.class, SIMPLE_POJO_SCHEMA, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+        POJOUtils.getGetters(
+            SimplePOJO.class,
+            SIMPLE_POJO_SCHEMA,
+            JavaFieldTypeSupplier.INSTANCE,
+            new DefaultTypeConversionsFactory());
     assertEquals(12, getters.size());
     assertEquals("str", getters.get(0).name());
     assertEquals("field1", getters.get(0).get(simplePojo));
@@ -157,7 +161,11 @@ public class POJOUtilsTest {
   public void testGeneratedSimpleSetters() {
     SimplePOJO simplePojo = new SimplePOJO();
     List<FieldValueSetter> setters =
-        POJOUtils.getSetters(SimplePOJO.class, SIMPLE_POJO_SCHEMA, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+        POJOUtils.getSetters(
+            SimplePOJO.class,
+            SIMPLE_POJO_SCHEMA,
+            JavaFieldTypeSupplier.INSTANCE,
+            new DefaultTypeConversionsFactory());
     assertEquals(12, setters.size());
 
     setters.get(0).set(simplePojo, "field1");
@@ -195,7 +203,8 @@ public class POJOUtilsTest {
         POJOUtils.getGetters(
             POJOWithBoxedFields.class,
             POJO_WITH_BOXED_FIELDS_SCHEMA,
-            JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+            JavaFieldTypeSupplier.INSTANCE,
+            new DefaultTypeConversionsFactory());
     assertEquals((byte) 41, getters.get(0).get(pojo));
     assertEquals((short) 42, getters.get(1).get(pojo));
     assertEquals((int) 43, getters.get(2).get(pojo));
@@ -210,7 +219,8 @@ public class POJOUtilsTest {
         POJOUtils.getSetters(
             POJOWithBoxedFields.class,
             POJO_WITH_BOXED_FIELDS_SCHEMA,
-            JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+            JavaFieldTypeSupplier.INSTANCE,
+            new DefaultTypeConversionsFactory());
 
     setters.get(0).set(pojo, (byte) 41);
     setters.get(1).set(pojo, (short) 42);
@@ -230,7 +240,10 @@ public class POJOUtilsTest {
     POJOWithByteArray pojo = new POJOWithByteArray();
     List<FieldValueSetter> setters =
         POJOUtils.getSetters(
-            POJOWithByteArray.class, POJO_WITH_BYTE_ARRAY_SCHEMA, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
+            POJOWithByteArray.class,
+            POJO_WITH_BYTE_ARRAY_SCHEMA,
+            JavaFieldTypeSupplier.INSTANCE,
+            new DefaultTypeConversionsFactory());
     setters.get(0).set(pojo, BYTE_ARRAY);
     setters.get(1).set(pojo, BYTE_BUFFER.array());
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.FieldValueSetter;
 import org.apache.beam.sdk.schemas.JavaFieldSchema.JavaFieldTypeSupplier;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.TestPOJOs.NestedArrayPOJO;
 import org.apache.beam.sdk.schemas.utils.TestPOJOs.NestedCollectionPOJO;
 import org.apache.beam.sdk.schemas.utils.TestPOJOs.NestedMapPOJO;
@@ -134,7 +135,7 @@ public class POJOUtilsTest {
             new StringBuilder("stringBuilder"));
 
     List<FieldValueGetter> getters =
-        POJOUtils.getGetters(SimplePOJO.class, SIMPLE_POJO_SCHEMA, JavaFieldTypeSupplier.INSTANCE);
+        POJOUtils.getGetters(SimplePOJO.class, SIMPLE_POJO_SCHEMA, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     assertEquals(12, getters.size());
     assertEquals("str", getters.get(0).name());
     assertEquals("field1", getters.get(0).get(simplePojo));
@@ -156,7 +157,7 @@ public class POJOUtilsTest {
   public void testGeneratedSimpleSetters() {
     SimplePOJO simplePojo = new SimplePOJO();
     List<FieldValueSetter> setters =
-        POJOUtils.getSetters(SimplePOJO.class, SIMPLE_POJO_SCHEMA, JavaFieldTypeSupplier.INSTANCE);
+        POJOUtils.getSetters(SimplePOJO.class, SIMPLE_POJO_SCHEMA, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     assertEquals(12, setters.size());
 
     setters.get(0).set(simplePojo, "field1");
@@ -194,7 +195,7 @@ public class POJOUtilsTest {
         POJOUtils.getGetters(
             POJOWithBoxedFields.class,
             POJO_WITH_BOXED_FIELDS_SCHEMA,
-            JavaFieldTypeSupplier.INSTANCE);
+            JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     assertEquals((byte) 41, getters.get(0).get(pojo));
     assertEquals((short) 42, getters.get(1).get(pojo));
     assertEquals((int) 43, getters.get(2).get(pojo));
@@ -209,7 +210,7 @@ public class POJOUtilsTest {
         POJOUtils.getSetters(
             POJOWithBoxedFields.class,
             POJO_WITH_BOXED_FIELDS_SCHEMA,
-            JavaFieldTypeSupplier.INSTANCE);
+            JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
 
     setters.get(0).set(pojo, (byte) 41);
     setters.get(1).set(pojo, (short) 42);
@@ -229,7 +230,7 @@ public class POJOUtilsTest {
     POJOWithByteArray pojo = new POJOWithByteArray();
     List<FieldValueSetter> setters =
         POJOUtils.getSetters(
-            POJOWithByteArray.class, POJO_WITH_BYTE_ARRAY_SCHEMA, JavaFieldTypeSupplier.INSTANCE);
+            POJOWithByteArray.class, POJO_WITH_BYTE_ARRAY_SCHEMA, JavaFieldTypeSupplier.INSTANCE, new DefaultTypeConversionsFactory());
     setters.get(0).set(pojo, BYTE_ARRAY);
     setters.get(1).set(pojo, BYTE_BUFFER.array());
 


### PR DESCRIPTION
In preparation for ProtoBuffer schema types, allow type conversions to be injected by schema providers. Move AVRO specialization out of ByteByteUtils and have it injected by the Avro provider.

R: @alexvanboxel 