### PR TITLE
[BEAM-4287] Add trySplit API to Java restriction tracker matching Python SDK definition. Remove GetPartition()

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDoNaiveBounded.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDoNaiveBounded.java
@@ -147,7 +147,7 @@ public class SplittableParDoNaiveBounded {
         ProcessContinuation continuation =
             invoker.invokeProcessElement(new NestedProcessContext<>(fn, c, element, w, tracker));
         if (continuation.shouldResume()) {
-          restriction = tracker.checkpoint();
+          restriction = tracker.currentRestriction();
           Uninterruptibles.sleepUninterruptibly(
               continuation.resumeDelay().getMillis(), TimeUnit.MILLISECONDS);
         } else {

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
@@ -68,8 +69,8 @@ public class SplittableParDoTest {
     }
 
     @Override
-    public SomeRestriction checkpoint() {
-      return someRestriction;
+    public SplitResult<SomeRestriction> trySplit(double fractionOfRemainder) {
+      return SplitResult.of(null, someRestriction);
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -38,6 +38,7 @@ import org.apache.beam.sdk.transforms.DoFn.StartBundleContext;
 import org.apache.beam.sdk.transforms.DoFnOutputReceivers;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -342,7 +343,10 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
       // Only one of them "wins" - tracker.checkpoint() must be called only once.
       if (checkpoint == null) {
         residualWatermark = lastReportedWatermark;
-        checkpoint = checkNotNull(tracker.checkpoint());
+        SplitResult<RestrictionT> split = tracker.trySplit(0);
+        if (split != null) {
+          checkpoint = checkNotNull(split.getResidual());
+        }
       }
       return getTakenCheckpoint();
     }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
@@ -52,6 +52,7 @@ import org.apache.beam.sdk.transforms.DoFnTester;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.OffsetRangeTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -105,8 +106,8 @@ public class SplittableParDoProcessFnTest {
     }
 
     @Override
-    public SomeRestriction checkpoint() {
-      return someRestriction;
+    public SplitResult<SomeRestriction> trySplit(double fractionOfRemainder) {
+      return SplitResult.of(null, someRestriction);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -587,7 +587,6 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <ul>
    *   <li>It <i>must</i> define a {@link GetInitialRestriction} method.
    *   <li>It <i>may</i> define a {@link GetSize} method.
-   *   <li>It <i>may</i> define a {@link GetPartitition} method.
    *   <li>It <i>may</i> define a {@link SplitRestriction} method.
    *   <li>It <i>may</i> define a {@link NewTracker} method returning a subtype of {@code
    *       RestrictionTracker<R>} where {@code R} is the restriction type returned by {@link
@@ -741,10 +740,6 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *
    * <p>Returns a double representing the size of the element and restriction.
    *
-   * <p>A representation for the amount of known work represented as a size. Size representations
-   * should preferably represent a linear space and be comparable within the same partition (see
-   * {@link GetPartition} for details on partition identifiers}).
-   *
    * <p>Splittable {@link DoFn}s should only provide this method if the default implementation
    * within the {@link RestrictionTracker} is an inaccurate representation of known work.
    *
@@ -769,38 +764,6 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
   @Target(ElementType.METHOD)
   @Experimental(Kind.SPLITTABLE_DO_FN)
   public @interface GetSize {}
-
-  /**
-   * Annotation for the method that returns the corresponding partition identifier for an element
-   * and restriction pair.
-   *
-   * <p>Signature: {@code byte[] getPartitition(InputT element, RestrictionT restriction);}
-   *
-   * <p>Returns an immutable representation of the partition identifier as a byte[].
-   *
-   * <p>By default, the partition identifier is represented as the encoded element and restriction
-   * pair and should only be provided if the splittable {@link DoFn} can only provide a size over a
-   * shared resource such as a message queue that potentially multiple element and restriction pairs
-   * are doing work on. The partition identifier is used by runners for various size calculations.
-   * Sizes reported with the same partition identifier represent a point in time reporting of the
-   * size for that partition. For example, a runner can compute a global size by summing all
-   * reported sizes over all unique partition identifiers while it can compute the size of a
-   * specific partition based upon the last reported value.
-   *
-   * <p>For example splittable {@link DoFn}s which consume elements from:
-   *
-   * <ul>
-   *   <li>a globally shared resource such as a Pubsub queue should set this to "".
-   *   <li>a shared partitioned resource should use the partition identifier.
-   *   <li>a uniquely partitioned resource such as a file and offset range should not override this
-   *       since the default element and restriction pair should suffice.
-   * </ul>
-   */
-  @Documented
-  @Retention(RetentionPolicy.RUNTIME)
-  @Target(ElementType.METHOD)
-  @Experimental(Kind.SPLITTABLE_DO_FN)
-  public @interface GetPartition {}
 
   /**
    * Annotation for the method that returns the coder to use for the restriction of a <a

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
@@ -57,6 +57,7 @@ import org.apache.beam.sdk.transforms.DoFn.UnboundedPerElement;
 import org.apache.beam.sdk.transforms.Watch.Growth.PollResult;
 import org.apache.beam.sdk.transforms.splittabledofn.OffsetRangeTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.VarInt;
 import org.apache.beam.sdk.values.KV;
@@ -1028,7 +1029,10 @@ public class Watch {
     }
 
     @Override
-    public GrowthState checkpoint() {
+    public SplitResult<GrowthState> trySplit(double fractionOfRemainder) {
+      // TODO(BEAM-8873): Add support for splitting off a fixed amount of work for this restriction
+      // instead of only supporting checkpointing.
+
       // residual should contain exactly the work *not* claimed in the current ProcessElement call -
       // unclaimed pending outputs or future polling output
       GrowthState residual;
@@ -1061,7 +1065,7 @@ public class Watch {
       }
 
       shouldStop = true;
-      return residual;
+      return SplitResult.of(state, residual);
     }
 
     private HashCode hash128(OutputT value) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
@@ -45,12 +45,15 @@ public class OffsetRangeTracker extends RestrictionTracker<OffsetRange, Long>
   }
 
   @Override
-  public OffsetRange checkpoint() {
+  public SplitResult<OffsetRange> trySplit(double fractionOfRemainder) {
+    // TODO(BEAM-8872): Add support for splitting off a fixed amount of work for this restriction
+    // instead of only supporting checkpointing.
+
     checkState(
         lastClaimedOffset != null, "Can't checkpoint before any offset was successfully claimed");
     OffsetRange res = new OffsetRange(lastClaimedOffset + 1, range.getTo());
     this.range = new OffsetRange(range.getFrom(), lastClaimedOffset + 1);
-    return res;
+    return SplitResult.of(range, res);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -47,17 +47,37 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
   public abstract RestrictionT currentRestriction();
 
   /**
-   * Signals that the current {@link DoFn.ProcessElement} call should terminate as soon as possible:
-   * after this method returns, the tracker MUST refuse all future claim calls, and {@link
-   * #checkDone} MUST succeed.
+   * Splits current restriction based on {@code fractionOfRemainder}.
    *
-   * <p>Modifies {@link #currentRestriction}. Returns a restriction representing the rest of the
-   * work: the old value of {@link #currentRestriction} is equivalent to the new value and the
-   * return value of this method combined.
+   * <p>If splitting the current restriction is possible, the current restriction is split into a
+   * primary and residual restriction pair. This invocation updates the {@link
+   * #currentRestriction()} to be the primary restriction effectively having the current {@link
+   * DoFn.ProcessElement} execution responsible for performing the work that the primary restriction
+   * represents. The residual restriction will be executed in a separate {@link DoFn.ProcessElement}
+   * invocation (likely in a different process). The work performed by executing the primary and
+   * residual restrictions as separate {@link DoFn.ProcessElement} invocations MUST be equivalent to
+   * the work performed as if this split never occurred.
    *
-   * <p>Must be called at most once on a given object.
+   * <p>The {@code fractionOfRemainder} should be used in a best effort manner to choose a primary
+   * and residual restriction based upon the fraction of the remaining work that the current {@link
+   * DoFn.ProcessElement} invocation is responsible for. For example, if a {@link
+   * DoFn.ProcessElement} was reading a file with a restriction representing the offset range {@code
+   * [100, 200)} and has processed up to offset 130 with a {@code fractionOfRemainder} of {@code
+   * 0.7}, the primary and residual restrictions returned would be {@code [100, 179), [179, 200)}
+   * (note: {@code currentOffset + fractionOfRemainder * remainingWork = 130 + 0.7 * 70 = 179}).
+   *
+   * <p>{@code fractionOfRemainder = 0} means a checkpoint is required.
+   *
+   * <p>The API is recommended to be implemented for batch pipeline given that it is very important
+   * for pipeline scaling and end to end pipeline execution.
+   *
+   * <p>The API is required to be implemented for a streaming pipeline.
+   *
+   * @param fractionOfRemainder: A hint as to the fraction of work the primary restriction should
+   *     represent based upon the current known remaining amount of work.
+   * @return a {@link SplitResult} if a split was possible, otherwise returns {@code null}.
    */
-  public abstract RestrictionT checkpoint();
+  public abstract SplitResult<RestrictionT> trySplit(double fractionOfRemainder);
 
   /**
    * Called by the runner after {@link DoFn.ProcessElement} returns.
@@ -66,6 +86,4 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
    * work remaining in the restriction.
    */
   public abstract void checkDone() throws IllegalStateException;
-
-  // TODO: Add the more general splitRemainderAfterFraction() and other methods.
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -73,7 +73,7 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
    *
    * <p>The API is required to be implemented for a streaming pipeline.
    *
-   * @param fractionOfRemainder: A hint as to the fraction of work the primary restriction should
+   * @param fractionOfRemainder A hint as to the fraction of work the primary restriction should
    *     represent based upon the current known remaining amount of work.
    * @return a {@link SplitResult} if a split was possible, otherwise returns {@code null}.
    */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/Sizes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/Sizes.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.transforms.splittabledofn;
 
-import org.apache.beam.sdk.transforms.DoFn;
-
 /** Definitions and convenience methods for reporting sizes for SplittableDoFns. */
 public final class Sizes {
   /**
@@ -29,8 +27,7 @@ public final class Sizes {
   public interface HasSize {
     /**
      * A representation for the amount of known work represented as a size. Size {@code double}
-     * representations should preferably represent a linear space and be comparable within the same
-     * partition.
+     * representations should preferably represent a linear space.
      *
      * <p>It is up to each restriction tracker to convert between their natural representation of
      * outstanding work and this representation. For example:
@@ -47,10 +44,6 @@ public final class Sizes {
      *       of encoded bytes for the keys and values is known for the key range, the number of
      *       remaining bytes can be used.
      * </ul>
-     *
-     * <p>{@link DoFn}s should provide a method annotated with {@link DoFn.GetPartition} to report a
-     * partition identifier if the element and restriction represent the size for a shared resource
-     * such as a message queue topic. See {@link DoFn.GetPartition} for additional details.
      */
     double getSize();
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/SplitResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/SplitResult.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.transforms.splittabledofn;
 
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 
 /** A representation of a split result. */
 @AutoValue
@@ -29,8 +30,10 @@ public abstract class SplitResult<RestrictionT> {
   }
 
   /** Returns the primary restriction. */
+  @Nullable
   public abstract RestrictionT getPrimary();
 
   /** Returns the residual restriction. */
+  @Nullable
   public abstract RestrictionT getResidual();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/SplitResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/SplitResult.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms.splittabledofn;
+
+import com.google.auto.value.AutoValue;
+
+/** A representation of a split result. */
+@AutoValue
+public abstract class SplitResult<RestrictionT> {
+  /** Returns a {@link SplitResult} for the specified primary and residual restrictions. */
+  public static <RestrictionT> SplitResult<RestrictionT> of(
+      RestrictionT primary, RestrictionT residual) {
+    return new AutoValue_SplitResult(primary, residual);
+  }
+
+  /** Returns the primary restriction. */
+  public abstract RestrictionT getPrimary();
+
+  /** Returns the residual restriction. */
+  public abstract RestrictionT getResidual();
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WatchTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WatchTest.java
@@ -554,7 +554,8 @@ public class WatchTest implements Serializable {
 
     assertTrue(tracker.tryClaim(KV.of(claim, 1 /* termination state */)));
 
-    PollingGrowthState<Integer> residual = (PollingGrowthState<Integer>) tracker.checkpoint();
+    PollingGrowthState<Integer> residual =
+        (PollingGrowthState<Integer>) tracker.trySplit(0).getResidual();
     NonPollingGrowthState<String> primary =
         (NonPollingGrowthState<String>) tracker.currentRestriction();
     tracker.checkDone();
@@ -574,7 +575,8 @@ public class WatchTest implements Serializable {
   public void testPollingGrowthTrackerCheckpointEmpty() {
     GrowthTracker<String, Integer> tracker = newPollingGrowthTracker();
 
-    PollingGrowthState<Integer> residual = (PollingGrowthState<Integer>) tracker.checkpoint();
+    PollingGrowthState<Integer> residual =
+        (PollingGrowthState<Integer>) tracker.trySplit(0).getResidual();
     GrowthState primary = tracker.currentRestriction();
     tracker.checkDone();
 
@@ -603,7 +605,8 @@ public class WatchTest implements Serializable {
 
     assertTrue(tracker.tryClaim(KV.of(claim, 1 /* termination state */)));
 
-    PollingGrowthState<Integer> residual = (PollingGrowthState<Integer>) tracker.checkpoint();
+    PollingGrowthState<Integer> residual =
+        (PollingGrowthState<Integer>) tracker.trySplit(0).getResidual();
 
     assertFalse(newTracker(residual).tryClaim(KV.of(claim, 2)));
   }
@@ -623,7 +626,7 @@ public class WatchTest implements Serializable {
     GrowthTracker<String, Integer> tracker = newTracker(NonPollingGrowthState.of(claim));
 
     assertTrue(tracker.tryClaim(KV.of(claim, 1 /* termination state */)));
-    GrowthState residual = tracker.checkpoint();
+    GrowthState residual = tracker.trySplit(0).getResidual();
     NonPollingGrowthState<String> primary =
         (NonPollingGrowthState<String>) tracker.currentRestriction();
     tracker.checkDone();
@@ -649,7 +652,8 @@ public class WatchTest implements Serializable {
 
     GrowthTracker<String, Integer> tracker = newTracker(NonPollingGrowthState.of(claim));
 
-    NonPollingGrowthState<String> residual = (NonPollingGrowthState<String>) tracker.checkpoint();
+    NonPollingGrowthState<String> residual =
+        (NonPollingGrowthState<String>) tracker.trySplit(0).getResidual();
     GrowthState primary = tracker.currentRestriction();
     tracker.checkDone();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -55,6 +55,7 @@ import org.apache.beam.sdk.transforms.reflect.DoFnInvoker.FakeArgumentProvider;
 import org.apache.beam.sdk.transforms.reflect.testhelper.DoFnInvokersTestHelper;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.util.UserCodeException;
@@ -506,7 +507,7 @@ public class DoFnInvokersTest {
     }
 
     @Override
-    public RestrictionWithDefaultTracker checkpoint() {
+    public SplitResult<RestrictionWithDefaultTracker> trySplit(double fractionOfRemainder) {
       throw new UnsupportedOperationException();
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTrackerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTrackerTest.java
@@ -57,7 +57,7 @@ public class ByteKeyRangeTrackerTest {
     ByteKeyRangeTracker tracker =
         ByteKeyRangeTracker.of(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)));
 
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     // We expect to get the original range back and that the current restriction
     // is effectively made empty.
     assertEquals(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)), checkpoint);
@@ -68,7 +68,7 @@ public class ByteKeyRangeTrackerTest {
   public void testCheckpointUnstartedForAllKeysRange() throws Exception {
     ByteKeyRangeTracker tracker = ByteKeyRangeTracker.of(ByteKeyRange.ALL_KEYS);
 
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     // We expect to get the original range back and that the current restriction
     // is effectively made empty.
     assertEquals(ByteKeyRange.ALL_KEYS, checkpoint);
@@ -80,7 +80,7 @@ public class ByteKeyRangeTrackerTest {
     ByteKeyRangeTracker tracker =
         ByteKeyRangeTracker.of(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)));
     assertFalse(tracker.tryClaim(ByteKey.of(0xd0)));
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)), tracker.currentRestriction());
     assertEquals(ByteKeyRangeTracker.NO_KEYS, checkpoint);
   }
@@ -90,7 +90,7 @@ public class ByteKeyRangeTrackerTest {
     ByteKeyRangeTracker tracker =
         ByteKeyRangeTracker.of(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)));
     assertTrue(tracker.tryClaim(ByteKey.of(0x10)));
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(
         ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0x10, 0x00)), tracker.currentRestriction());
     assertEquals(ByteKeyRange.of(ByteKey.of(0x10, 0x00), ByteKey.of(0xc0)), checkpoint);
@@ -102,7 +102,7 @@ public class ByteKeyRangeTrackerTest {
         ByteKeyRangeTracker.of(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)));
     assertTrue(tracker.tryClaim(ByteKey.of(0x50)));
     assertTrue(tracker.tryClaim(ByteKey.of(0x90)));
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(
         ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0x90, 0x00)), tracker.currentRestriction());
     assertEquals(ByteKeyRange.of(ByteKey.of(0x90, 0x00), ByteKey.of(0xc0)), checkpoint);
@@ -115,7 +115,7 @@ public class ByteKeyRangeTrackerTest {
     assertTrue(tracker.tryClaim(ByteKey.of(0x50)));
     assertTrue(tracker.tryClaim(ByteKey.of(0x90)));
     assertFalse(tracker.tryClaim(ByteKey.of(0xc0)));
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)), tracker.currentRestriction());
     assertEquals(ByteKeyRangeTracker.NO_KEYS, checkpoint);
   }
@@ -126,7 +126,7 @@ public class ByteKeyRangeTrackerTest {
     assertTrue(tracker.tryClaim(ByteKey.of(0x50)));
     assertTrue(tracker.tryClaim(ByteKey.of(0x90)));
     assertFalse(tracker.tryClaim(ByteKey.EMPTY));
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(ByteKeyRange.ALL_KEYS, tracker.currentRestriction());
     assertEquals(ByteKeyRangeTracker.NO_KEYS, checkpoint);
   }
@@ -139,7 +139,7 @@ public class ByteKeyRangeTrackerTest {
     assertTrue(tracker.tryClaim(ByteKey.of(0x90)));
     assertTrue(tracker.tryClaim(ByteKey.of(0xa0)));
     assertFalse(tracker.tryClaim(ByteKey.of(0xd0)));
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)), tracker.currentRestriction());
     assertEquals(ByteKeyRangeTracker.NO_KEYS, checkpoint);
   }
@@ -152,7 +152,7 @@ public class ByteKeyRangeTrackerTest {
     assertTrue(tracker.tryClaim(ByteKey.of(0x90)));
     assertTrue(tracker.tryClaim(ByteKey.of(0xa0)));
     assertFalse(tracker.tryClaim(ByteKey.EMPTY));
-    ByteKeyRange checkpoint = tracker.checkpoint();
+    ByteKeyRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(ByteKeyRange.of(ByteKey.of(0x10), ByteKey.of(0xc0)), tracker.currentRestriction());
     assertEquals(ByteKeyRangeTracker.NO_KEYS, checkpoint);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTrackerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTrackerTest.java
@@ -48,7 +48,7 @@ public class OffsetRangeTrackerTest {
   public void testCheckpointUnstarted() throws Exception {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
     expected.expect(IllegalStateException.class);
-    tracker.checkpoint();
+    tracker.trySplit(0).getResidual();
   }
 
   @Test
@@ -56,14 +56,14 @@ public class OffsetRangeTrackerTest {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
     assertFalse(tracker.tryClaim(250L));
     expected.expect(IllegalStateException.class);
-    OffsetRange checkpoint = tracker.checkpoint();
+    OffsetRange checkpoint = tracker.trySplit(0).getResidual();
   }
 
   @Test
   public void testCheckpointJustStarted() throws Exception {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
     assertTrue(tracker.tryClaim(100L));
-    OffsetRange checkpoint = tracker.checkpoint();
+    OffsetRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(new OffsetRange(100, 101), tracker.currentRestriction());
     assertEquals(new OffsetRange(101, 200), checkpoint);
   }
@@ -73,7 +73,7 @@ public class OffsetRangeTrackerTest {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
     assertTrue(tracker.tryClaim(105L));
     assertTrue(tracker.tryClaim(110L));
-    OffsetRange checkpoint = tracker.checkpoint();
+    OffsetRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(new OffsetRange(100, 111), tracker.currentRestriction());
     assertEquals(new OffsetRange(111, 200), checkpoint);
   }
@@ -84,7 +84,7 @@ public class OffsetRangeTrackerTest {
     assertTrue(tracker.tryClaim(105L));
     assertTrue(tracker.tryClaim(110L));
     assertTrue(tracker.tryClaim(199L));
-    OffsetRange checkpoint = tracker.checkpoint();
+    OffsetRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(new OffsetRange(100, 200), tracker.currentRestriction());
     assertEquals(new OffsetRange(200, 200), checkpoint);
   }
@@ -96,7 +96,7 @@ public class OffsetRangeTrackerTest {
     assertTrue(tracker.tryClaim(110L));
     assertTrue(tracker.tryClaim(160L));
     assertFalse(tracker.tryClaim(240L));
-    OffsetRange checkpoint = tracker.checkpoint();
+    OffsetRange checkpoint = tracker.trySplit(0).getResidual();
     assertEquals(new OffsetRange(100, 161), tracker.currentRestriction());
     assertEquals(new OffsetRange(161, 200), checkpoint);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/SplitResultTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/SplitResultTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms.splittabledofn;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SplitResultTest {
+  @Test
+  public void testPrimaryAndResidualAreSet() {
+    SplitResult<String> result = SplitResult.of("primary", "residual");
+    assertEquals("primary", result.getPrimary());
+    assertEquals("residual", result.getResidual());
+  }
+}

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.fn.splittabledofn;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.Sizes;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 
 /** Support utilities for interacting with {@link RestrictionTracker RestrictionTrackers}. */
 public class RestrictionTrackers {
@@ -67,8 +68,8 @@ public class RestrictionTrackers {
     }
 
     @Override
-    public synchronized RestrictionT checkpoint() {
-      return delegate.checkpoint();
+    public synchronized SplitResult<RestrictionT> trySplit(double fractionOfRemainder) {
+      return delegate.trySplit(fractionOfRemainder);
     }
 
     @Override

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.apache.beam.sdk.fn.splittabledofn.RestrictionTrackers.ClaimObserver;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.Sizes;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -50,7 +51,7 @@ public class RestrictionTrackersTest {
           }
 
           @Override
-          public Object checkpoint() {
+          public SplitResult<Object> trySplit(double fractionOfRemainder) {
             throw new UnsupportedOperationException();
           }
 
@@ -103,7 +104,7 @@ public class RestrictionTrackersTest {
     }
 
     @Override
-    public Object checkpoint() {
+    public SplitResult<Object> trySplit(double fractionOfRemainder) {
       return null;
     }
 


### PR DESCRIPTION
Modify all existing checkpoint() implementations to ignore the fraction and file TODOs.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
