### PR TITLE
[BEAM-7274] Support recursive type transformation in ByteBuddyUtils

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FromRowUsingCreator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FromRowUsingCreator.java
@@ -21,7 +21,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
 import java.lang.reflect.Type;
-import java.util.Iterator;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +31,9 @@ import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowWithGetters;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Function;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Collections2;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 
@@ -107,7 +110,8 @@ class FromRowUsingCreator<T> implements SerializableFunction<Row, T> {
       return (ValueT) fromRow((Row) value, (Class) fieldType, typeFactory);
     } else if (TypeName.ARRAY.equals(type.getTypeName())) {
       return (ValueT)
-          fromListValue(type.getCollectionElementType(), (List) value, elementType, typeFactory);
+          fromCollectionValue(
+              type.getCollectionElementType(), (Collection) value, elementType, typeFactory);
     } else if (TypeName.ITERABLE.equals(type.getTypeName())) {
       return (ValueT)
           fromIterableValue(
@@ -127,25 +131,34 @@ class FromRowUsingCreator<T> implements SerializableFunction<Row, T> {
     }
   }
 
+  private static <F, T> Collection<T> transformCollection(
+      Collection<F> collection, Function<F, T> function) {
+    if (collection instanceof List) {
+      // For performance reasons if the input is a list, make sure that we produce a list. Otherwise Row unwrapping
+      // is forced to physically copy the collection into a new List object.
+      return Lists.transform((List) collection, function);
+    } else {
+      return Collections2.transform(collection, function);
+    }
+  }
+
   @SuppressWarnings("unchecked")
-  private <ElementT> List fromListValue(
+  private <ElementT> Collection fromCollectionValue(
       FieldType elementType,
-      List<ElementT> rowList,
+      Collection<ElementT> rowCollection,
       FieldValueTypeInformation elementTypeInformation,
       Factory<List<FieldValueTypeInformation>> typeFactory) {
-    List list = Lists.newArrayList();
-    for (ElementT element : rowList) {
-      list.add(
-          fromValue(
-              elementType,
-              element,
-              elementTypeInformation.getType().getType(),
-              elementTypeInformation.getElementType(),
-              elementTypeInformation.getMapKeyType(),
-              elementTypeInformation.getMapValueType(),
-              typeFactory));
-    }
-    return list;
+    return transformCollection(
+        rowCollection,
+        element ->
+            fromValue(
+                elementType,
+                element,
+                elementTypeInformation.getType().getType(),
+                elementTypeInformation.getElementType(),
+                elementTypeInformation.getMapKeyType(),
+                elementTypeInformation.getMapValueType(),
+                typeFactory));
   }
 
   @SuppressWarnings("unchecked")
@@ -154,32 +167,17 @@ class FromRowUsingCreator<T> implements SerializableFunction<Row, T> {
       Iterable<ElementT> rowIterable,
       FieldValueTypeInformation elementTypeInformation,
       Factory<List<FieldValueTypeInformation>> typeFactory) {
-    return new Iterable<ElementT>() {
-      @Override
-      public Iterator<ElementT> iterator() {
-        return new Iterator<ElementT>() {
-          Iterator<ElementT> innerIter = rowIterable.iterator();
-
-          @Override
-          public boolean hasNext() {
-            return innerIter.hasNext();
-          }
-
-          @Override
-          public ElementT next() {
-            ElementT element = innerIter.next();
-            return fromValue(
+    return Iterables.transform(
+        rowIterable,
+        element ->
+            fromValue(
                 elementType,
                 element,
                 elementTypeInformation.getType().getType(),
                 elementTypeInformation.getElementType(),
                 elementTypeInformation.getMapKeyType(),
                 elementTypeInformation.getMapValueType(),
-                typeFactory);
-          }
-        };
-      }
-    };
+                typeFactory));
   }
 
   @SuppressWarnings("unchecked")

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FromRowUsingCreator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FromRowUsingCreator.java
@@ -131,10 +131,11 @@ class FromRowUsingCreator<T> implements SerializableFunction<Row, T> {
     }
   }
 
-  private static <F, T> Collection<T> transformCollection(
-      Collection<F> collection, Function<F, T> function) {
+  private static <SourceT, DestT> Collection<DestT> transformCollection(
+      Collection<SourceT> collection, Function<SourceT, DestT> function) {
     if (collection instanceof List) {
-      // For performance reasons if the input is a list, make sure that we produce a list. Otherwise Row unwrapping
+      // For performance reasons if the input is a list, make sure that we produce a list. Otherwise
+      // Row unwrapping
       // is forced to physically copy the collection into a new List object.
       return Lists.transform((List) collection, function);
     } else {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -75,6 +75,11 @@ public class Schema implements Serializable {
     public int hashCode() {
       return Arrays.hashCode(array);
     }
+
+    @Override
+    public String toString() {
+      return Arrays.toString(array);
+    }
   }
   // A mapping between field names an indices.
   private final BiMap<String, Integer> fieldIndices = HashBiMap.create();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.FieldValueSetter;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
@@ -44,6 +46,7 @@ import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.description.method.
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.description.type.TypeDescription;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.description.type.TypeDescription.ForLoadedType;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.dynamic.DynamicType;
+import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.dynamic.scaffold.InstrumentedType;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.implementation.Implementation;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.implementation.bytecode.ByteCodeAppender;
@@ -64,8 +67,12 @@ import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.implementation.byte
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.matcher.ElementMatchers;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.utility.RandomString;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Function;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Collections2;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Primitives;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ClassUtils;
 import org.joda.time.DateTimeZone;
@@ -82,7 +89,7 @@ public class ByteBuddyUtils {
   private static final ForLoadedType CHAR_SEQUENCE_TYPE = new ForLoadedType(CharSequence.class);
   private static final ForLoadedType INSTANT_TYPE = new ForLoadedType(Instant.class);
   private static final ForLoadedType DATE_TIME_ZONE_TYPE = new ForLoadedType(DateTimeZone.class);
-  private static final ForLoadedType LIST_TYPE = new ForLoadedType(List.class);
+  private static final ForLoadedType COLLECTION_TYPE = new ForLoadedType(Collection.class);
   private static final ForLoadedType READABLE_INSTANT_TYPE =
       new ForLoadedType(ReadableInstant.class);
   private static final ForLoadedType READABLE_PARTIAL_TYPE =
@@ -90,6 +97,8 @@ public class ByteBuddyUtils {
   private static final ForLoadedType OBJECT_TYPE = new ForLoadedType(Object.class);
   private static final ForLoadedType INTEGER_TYPE = new ForLoadedType(Integer.class);
   private static final ForLoadedType ENUM_TYPE = new ForLoadedType(Enum.class);
+  private static final ForLoadedType BYTE_BUDDY_UTILS_TYPE =
+      new ForLoadedType(ByteBuddyUtils.class);
 
   /**
    * A naming strategy for ByteBuddy classes.
@@ -98,7 +107,7 @@ public class ByteBuddyUtils {
    * This way, if the class fields or methods are package private, our generated class can still
    * access them.
    */
-  static class InjectPackageStrategy extends NamingStrategy.AbstractBase {
+  public static class InjectPackageStrategy extends NamingStrategy.AbstractBase {
     /** A resolver for the base name for naming the unnamed type. */
     private static final BaseNameResolver baseNameResolver =
         BaseNameResolver.ForUnnamedType.INSTANCE;
@@ -122,6 +131,30 @@ public class ByteBuddyUtils {
       return targetPackage + className + "$" + SUFFIX + "$" + randomString.nextString();
     }
   };
+
+  // Create a new FieldValueGetter subclass.
+  @SuppressWarnings("unchecked")
+  static DynamicType.Builder<FieldValueGetter> subclassGetterInterface(
+      ByteBuddy byteBuddy, Type objectType, Type fieldType) {
+    TypeDescription.Generic getterGenericType =
+        TypeDescription.Generic.Builder.parameterizedType(
+                FieldValueGetter.class, objectType, fieldType)
+            .build();
+    return (DynamicType.Builder<FieldValueGetter>)
+        byteBuddy.with(new InjectPackageStrategy((Class) objectType)).subclass(getterGenericType);
+  }
+
+  // Create a new FieldValueSetter subclass.
+  @SuppressWarnings("unchecked")
+  static DynamicType.Builder<FieldValueSetter> subclassSetterInterface(
+      ByteBuddy byteBuddy, Type objectType, Type fieldType) {
+    TypeDescription.Generic setterGenericType =
+        TypeDescription.Generic.Builder.parameterizedType(
+                FieldValueSetter.class, objectType, fieldType)
+            .build();
+    return (DynamicType.Builder<FieldValueSetter>)
+        byteBuddy.with(new InjectPackageStrategy((Class) objectType)).subclass(setterGenericType);
+  }
 
   public interface TypeConversionsFactory {
     TypeConversion<Type> createTypeConversion(boolean returnRawTypes);
@@ -148,30 +181,6 @@ public class ByteBuddyUtils {
     }
   }
 
-  // Create a new FieldValueGetter subclass.
-  @SuppressWarnings("unchecked")
-  static DynamicType.Builder<FieldValueGetter> subclassGetterInterface(
-      ByteBuddy byteBuddy, Type objectType, Type fieldType) {
-    TypeDescription.Generic getterGenericType =
-        TypeDescription.Generic.Builder.parameterizedType(
-                FieldValueGetter.class, objectType, fieldType)
-            .build();
-    return (DynamicType.Builder<FieldValueGetter>)
-        byteBuddy.with(new InjectPackageStrategy((Class) objectType)).subclass(getterGenericType);
-  }
-
-  // Create a new FieldValueSetter subclass.
-  @SuppressWarnings("unchecked")
-  static DynamicType.Builder<FieldValueSetter> subclassSetterInterface(
-      ByteBuddy byteBuddy, Type objectType, Type fieldType) {
-    TypeDescription.Generic setterGenericType =
-        TypeDescription.Generic.Builder.parameterizedType(
-                FieldValueSetter.class, objectType, fieldType)
-            .build();
-    return (DynamicType.Builder<FieldValueSetter>)
-        byteBuddy.with(new InjectPackageStrategy((Class) objectType)).subclass(setterGenericType);
-  }
-
   // Base class used below to convert types.
   @SuppressWarnings("unchecked")
   public abstract static class TypeConversion<T> {
@@ -195,7 +204,9 @@ public class ByteBuddyUtils {
       } else if (typeDescriptor.getRawType().isEnum()) {
         return convertEnum(typeDescriptor);
       } else if (typeDescriptor.isSubtypeOf(TypeDescriptor.of(Iterable.class))) {
-        if (typeDescriptor.isSubtypeOf(TypeDescriptor.of(Collection.class))) {
+        if (typeDescriptor.isSubtypeOf(TypeDescriptor.of(List.class))) {
+          return convertList(typeDescriptor);
+        } else if (typeDescriptor.isSubtypeOf(TypeDescriptor.of(Collection.class))) {
           return convertCollection(typeDescriptor);
         } else {
           return convertIterable(typeDescriptor);
@@ -210,6 +221,8 @@ public class ByteBuddyUtils {
     protected abstract T convertIterable(TypeDescriptor<?> type);
 
     protected abstract T convertCollection(TypeDescriptor<?> type);
+
+    protected abstract T convertList(TypeDescriptor<?> type);
 
     protected abstract T convertMap(TypeDescriptor<?> type);
 
@@ -253,18 +266,26 @@ public class ByteBuddyUtils {
 
     @Override
     protected Type convertArray(TypeDescriptor<?> type) {
-      TypeDescriptor ret = createListType(type);
+      TypeDescriptor ret = createCollectionType(type.getComponentType());
       return returnRawTypes ? ret.getRawType() : ret.getType();
     }
 
     @Override
     protected Type convertCollection(TypeDescriptor<?> type) {
-      return Collection.class;
+      TypeDescriptor ret = createCollectionType(ReflectUtils.getIterableComponentType(type));
+      return returnRawTypes ? ret.getRawType() : ret.getType();
+    }
+
+    @Override
+    protected Type convertList(TypeDescriptor<?> type) {
+      TypeDescriptor ret = createCollectionType(ReflectUtils.getIterableComponentType(type));
+      return returnRawTypes ? ret.getRawType() : ret.getType();
     }
 
     @Override
     protected Type convertIterable(TypeDescriptor<?> type) {
-      return Iterable.class;
+      TypeDescriptor ret = createIterableType(ReflectUtils.getIterableComponentType(type));
+      return returnRawTypes ? ret.getRawType() : ret.getType();
     }
 
     @Override
@@ -305,11 +326,187 @@ public class ByteBuddyUtils {
     }
 
     @SuppressWarnings("unchecked")
-    private <ElementT> TypeDescriptor<List<ElementT>> createListType(TypeDescriptor<?> type) {
-      TypeDescriptor componentType =
-          TypeDescriptor.of(ClassUtils.primitiveToWrapper(type.getComponentType().getRawType()));
-      return new TypeDescriptor<List<ElementT>>() {}.where(
-          new TypeParameter<ElementT>() {}, componentType);
+    private <ElementT> TypeDescriptor<Collection<ElementT>> createCollectionType(
+        TypeDescriptor<?> componentType) {
+      TypeDescriptor wrappedComponentType =
+          TypeDescriptor.of(ClassUtils.primitiveToWrapper(componentType.getRawType()));
+      return new TypeDescriptor<Collection<ElementT>>() {}.where(
+          new TypeParameter<ElementT>() {}, wrappedComponentType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <ElementT> TypeDescriptor<Iterable<ElementT>> createIterableType(
+        TypeDescriptor<?> componentType) {
+      TypeDescriptor wrappedComponentType =
+          TypeDescriptor.of(ClassUtils.primitiveToWrapper(componentType.getRawType()));
+      return new TypeDescriptor<Iterable<ElementT>>() {}.where(
+          new TypeParameter<ElementT>() {}, wrappedComponentType);
+    }
+  }
+
+  private static final ByteBuddy BYTE_BUDDY = new ByteBuddy();
+
+  // When processing a container (e.g. List<T>) we need to recursively process the element type. This function
+  // generates a subclass of Function that can be used to recursively transform each element of the container.
+  static Class createCollectionTransformFunction(
+      Type fromType, Type toType, Function<StackManipulation, StackManipulation> convertElement) {
+    // Generate a TypeDescription for the class we want to generate.
+    TypeDescription.Generic functionGenericType =
+        TypeDescription.Generic.Builder.parameterizedType(
+                Function.class, Primitives.wrap((Class) fromType), Primitives.wrap((Class) toType))
+            .build();
+
+    DynamicType.Builder<Function> builder =
+        (DynamicType.Builder<Function>)
+            BYTE_BUDDY
+                .subclass(functionGenericType)
+                .method(ElementMatchers.named("apply"))
+                .intercept(
+                    new Implementation() {
+                      @Override
+                      public ByteCodeAppender appender(Target target) {
+                        return (methodVisitor, implementationContext, instrumentedMethod) -> {
+                          // this + method parameters.
+                          int numLocals = 1 + instrumentedMethod.getParameters().size();
+
+                          StackManipulation readValue = MethodVariableAccess.REFERENCE.loadFrom(1);
+                          StackManipulation stackManipulation =
+                              new StackManipulation.Compound(
+                                  convertElement.apply(readValue), MethodReturn.REFERENCE);
+
+                          StackManipulation.Size size =
+                              stackManipulation.apply(methodVisitor, implementationContext);
+                          return new Size(size.getMaximalSize(), numLocals);
+                        };
+                      }
+
+                      @Override
+                      public InstrumentedType prepare(InstrumentedType instrumentedType) {
+                        return instrumentedType;
+                      }
+                    });
+
+    return builder
+        .make()
+        .load(ByteBuddyUtils.class.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+        .getLoaded();
+  }
+
+  // A function to transform a container, special casing List and Collection types. This is used in byte-buddy
+  // generated code.
+  public static <F, T> Iterable<T> transformContainer(
+      Iterable<F> iterable, Function<F, T> function) {
+    if (iterable instanceof List) {
+      return Lists.transform((List<F>) iterable, function);
+    } else if (iterable instanceof Collection) {
+      return Collections2.transform((Collection<F>) iterable, function);
+    } else {
+      return Iterables.transform(iterable, function);
+    }
+  }
+
+  static StackManipulation createTransformingContainer(
+      ForLoadedType functionType, StackManipulation readValue) {
+    StackManipulation stackManipulation =
+        new Compound(
+            readValue,
+            TypeCreation.of(functionType),
+            Duplication.SINGLE,
+            MethodInvocation.invoke(
+                functionType
+                    .getDeclaredMethods()
+                    .filter(ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
+                    .getOnly()),
+            MethodInvocation.invoke(
+                BYTE_BUDDY_UTILS_TYPE
+                    .getDeclaredMethods()
+                    .filter(ElementMatchers.named("transformContainer"))
+                    .getOnly()));
+    return stackManipulation;
+  }
+
+  public static <K1, V1, K2, V2> TransformingMap<K1, V1, K2, V2> getTransformingMap(
+      Map<K1, V1> sourceMap, Function<K1, K2> keyFunction, Function<V1, V2> valueFunction) {
+    return new TransformingMap<>(sourceMap, keyFunction, valueFunction);
+  }
+
+  public static class TransformingMap<K1, V1, K2, V2> implements Map<K2, V2> {
+    private final Map<K2, V2> delegateMap;
+
+    public TransformingMap(
+        Map<K1, V1> sourceMap, Function<K1, K2> keyFunction, Function<V1, V2> valueFunction) {
+      if (sourceMap instanceof SortedMap) {
+        delegateMap =
+            (Map<K2, V2>)
+                Maps.newTreeMap(); // We don't support copying the comparator. Makes no sense if key
+        // is changing.
+      } else {
+        delegateMap = Maps.newHashMap();
+      }
+      for (Map.Entry<K1, V1> entry : sourceMap.entrySet()) {
+        delegateMap.put(keyFunction.apply(entry.getKey()), valueFunction.apply(entry.getValue()));
+      }
+    }
+
+    @Override
+    public int size() {
+      return delegateMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return delegateMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return delegateMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+      return delegateMap.containsValue(value);
+    }
+
+    @Override
+    public V2 get(Object key) {
+      return delegateMap.get(key);
+    }
+
+    @Override
+    public V2 put(K2 key, V2 value) {
+      return delegateMap.put(key, value);
+    }
+
+    @Override
+    public V2 remove(Object key) {
+      return delegateMap.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K2, ? extends V2> m) {
+      delegateMap.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+      delegateMap.clear();
+      ;
+    }
+
+    @Override
+    public Set<K2> keySet() {
+      return delegateMap.keySet();
+    }
+
+    @Override
+    public Collection<V2> values() {
+      return delegateMap.values();
+    }
+
+    @Override
+    public Set<Entry<K2, V2>> entrySet() {
+      return delegateMap.entrySet();
     }
   }
 
@@ -338,46 +535,153 @@ public class ByteBuddyUtils {
       // return isComponentTypePrimitive ? Arrays.asList(ArrayUtils.toObject(value))
       //     : Arrays.asList(value);
 
-      ForLoadedType loadedType = new ForLoadedType(type.getRawType());
-      StackManipulation stackManipulation = readValue;
+      TypeDescriptor<?> componentType = type.getComponentType();
+      ForLoadedType loadedArrayType = new ForLoadedType(type.getRawType());
+      StackManipulation readArrayValue = readValue;
       // Row always expects to get an Iterable back for array types. Wrap this array into a
       // List using Arrays.asList before returning.
-      if (loadedType.getComponentType().isPrimitive()) {
+      if (loadedArrayType.getComponentType().isPrimitive()) {
         // Arrays.asList doesn't take primitive arrays, so convert first using ArrayUtils.toObject.
-        stackManipulation =
+        readArrayValue =
             new Compound(
-                stackManipulation,
+                readArrayValue,
                 MethodInvocation.invoke(
                     ARRAY_UTILS_TYPE
                         .getDeclaredMethods()
                         .filter(
                             ElementMatchers.isStatic()
                                 .and(ElementMatchers.named("toObject"))
-                                .and(ElementMatchers.takesArguments(loadedType)))
+                                .and(ElementMatchers.takesArguments(loadedArrayType)))
                         .getOnly()));
+
+        componentType = TypeDescriptor.of(Primitives.wrap(componentType.getRawType()));
       }
-      return new Compound(
-          stackManipulation,
-          MethodInvocation.invoke(
-              ARRAYS_TYPE
-                  .getDeclaredMethods()
-                  .filter(ElementMatchers.isStatic().and(ElementMatchers.named("asList")))
-                  .getOnly()));
+      // Now convert to a List object.
+      StackManipulation readListValue =
+          new Compound(
+              readArrayValue,
+              MethodInvocation.invoke(
+                  ARRAYS_TYPE
+                      .getDeclaredMethods()
+                      .filter(ElementMatchers.isStatic().and(ElementMatchers.named("asList")))
+                      .getOnly()));
+
+      // Generate a SerializableFunction to convert the element-type objects.
+      final TypeDescriptor finalComponentType = ReflectUtils.boxIfPrimitive(componentType);
+      if (!finalComponentType.hasUnresolvedParameters()) {
+        Type convertedComponentType =
+            getFactory().createTypeConversion(true).convert(componentType);
+        ForLoadedType functionType =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    componentType.getRawType(),
+                    convertedComponentType,
+                    (s) -> getFactory().createGetterConversions(s).convert(finalComponentType)));
+        return createTransformingContainer(functionType, readListValue);
+      } else {
+        return readListValue;
+      }
     }
 
     @Override
     protected StackManipulation convertIterable(TypeDescriptor<?> type) {
-      return readValue;
+      TypeDescriptor componentType = ReflectUtils.getIterableComponentType(type);
+      Type convertedComponentType = getFactory().createTypeConversion(true).convert(componentType);
+      final TypeDescriptor finalComponentType = ReflectUtils.boxIfPrimitive(componentType);
+      if (!finalComponentType.hasUnresolvedParameters()) {
+        ForLoadedType functionType =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    componentType.getRawType(),
+                    convertedComponentType,
+                    (s) -> getFactory().createGetterConversions(s).convert(finalComponentType)));
+        return createTransformingContainer(functionType, readValue);
+      } else {
+        return readValue;
+      }
     }
 
     @Override
     protected StackManipulation convertCollection(TypeDescriptor<?> type) {
-      return readValue;
+      TypeDescriptor componentType = ReflectUtils.getIterableComponentType(type);
+      Type convertedComponentType = getFactory().createTypeConversion(true).convert(componentType);
+      final TypeDescriptor finalComponentType = ReflectUtils.boxIfPrimitive(componentType);
+      if (!finalComponentType.hasUnresolvedParameters()) {
+        ForLoadedType functionType =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    componentType.getRawType(),
+                    convertedComponentType,
+                    (s) -> getFactory().createGetterConversions(s).convert(finalComponentType)));
+        return createTransformingContainer(functionType, readValue);
+      } else {
+        return readValue;
+      }
+    }
+
+    @Override
+    protected StackManipulation convertList(TypeDescriptor<?> type) {
+      TypeDescriptor componentType = ReflectUtils.getIterableComponentType(type);
+      Type convertedComponentType = getFactory().createTypeConversion(true).convert(componentType);
+      final TypeDescriptor finalComponentType = ReflectUtils.boxIfPrimitive(componentType);
+      if (!finalComponentType.hasUnresolvedParameters()) {
+        ForLoadedType functionType =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    componentType.getRawType(),
+                    convertedComponentType,
+                    (s) -> getFactory().createGetterConversions(s).convert(finalComponentType)));
+        return createTransformingContainer(functionType, readValue);
+      } else {
+        return readValue;
+      }
     }
 
     @Override
     protected StackManipulation convertMap(TypeDescriptor<?> type) {
-      return readValue;
+      final TypeDescriptor keyType = ReflectUtils.getMapType(type, 0);
+      final TypeDescriptor valueType = ReflectUtils.getMapType(type, 1);
+
+      Type convertedKeyType = getFactory().createTypeConversion(true).convert(keyType);
+      Type convertedValueType = getFactory().createTypeConversion(true).convert(valueType);
+
+      if (!keyType.hasUnresolvedParameters() && !valueType.hasUnresolvedParameters()) {
+        ForLoadedType keyFunctionType =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    keyType.getRawType(),
+                    convertedKeyType,
+                    (s) -> getFactory().createGetterConversions(s).convert(keyType)));
+        ForLoadedType valueFunctionType =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    valueType.getRawType(),
+                    convertedValueType,
+                    (s) -> getFactory().createGetterConversions(s).convert(valueType)));
+        return new Compound(
+            readValue,
+            TypeCreation.of(keyFunctionType),
+            Duplication.SINGLE,
+            MethodInvocation.invoke(
+                keyFunctionType
+                    .getDeclaredMethods()
+                    .filter(ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
+                    .getOnly()),
+            TypeCreation.of(valueFunctionType),
+            Duplication.SINGLE,
+            MethodInvocation.invoke(
+                valueFunctionType
+                    .getDeclaredMethods()
+                    .filter(ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
+                    .getOnly()),
+            MethodInvocation.invoke(
+                BYTE_BUDDY_UTILS_TYPE
+                    .getDeclaredMethods()
+                    .filter(ElementMatchers.named("getTransformingMap"))
+                    .getOnly()));
+      } else {
+        return readValue;
+      }
     }
 
     @Override
@@ -529,7 +833,7 @@ public class ByteBuddyUtils {
    * there. This class generates code to convert between these types.
    */
   public static class ConvertValueForSetter extends TypeConversion<StackManipulation> {
-    StackManipulation readValue;
+    protected StackManipulation readValue;
 
     protected ConvertValueForSetter(StackManipulation readValue) {
       this.readValue = readValue;
@@ -553,18 +857,31 @@ public class ByteBuddyUtils {
               .build()
               .asErasure();
 
+      Type rowElementType =
+          getFactory().createTypeConversion(false).convert(type.getComponentType());
+      final TypeDescriptor arrayElementType = ReflectUtils.boxIfPrimitive(type.getComponentType());
+      if (!arrayElementType.hasUnresolvedParameters()) {
+        ForLoadedType conversionFunction =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    TypeDescriptor.of(rowElementType).getRawType(),
+                    Primitives.wrap(arrayElementType.getRawType()),
+                    (s) -> getFactory().createSetterConversions(s).convert(arrayElementType)));
+        readValue = createTransformingContainer(conversionFunction, readValue);
+      }
+
       // Extract an array from the collection.
       StackManipulation stackManipulation =
           new Compound(
               readValue,
-              TypeCasting.to(LIST_TYPE),
+              TypeCasting.to(COLLECTION_TYPE),
               // Call Collection.toArray(T[[]) to extract the array. Push new T[0] on the stack
               // before
               // calling toArray.
               ArrayFactory.forType(loadedType.getComponentType().asBoxed().asGenericType())
                   .withValues(Collections.emptyList()),
               MethodInvocation.invoke(
-                  LIST_TYPE
+                  COLLECTION_TYPE
                       .getDeclaredMethods()
                       .filter(
                           ElementMatchers.named("toArray").and(ElementMatchers.takesArguments(1)))
@@ -591,16 +908,128 @@ public class ByteBuddyUtils {
 
     @Override
     protected StackManipulation convertIterable(TypeDescriptor<?> type) {
-      return readValue;
+      Type rowElementType =
+          getFactory()
+              .createTypeConversion(false)
+              .convert(ReflectUtils.getIterableComponentType(type));
+      final TypeDescriptor iterableElementType = ReflectUtils.getIterableComponentType(type);
+      if (!iterableElementType.hasUnresolvedParameters()) {
+        ForLoadedType conversionFunction =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    TypeDescriptor.of(rowElementType).getRawType(),
+                    iterableElementType.getRawType(),
+                    (s) -> getFactory().createSetterConversions(s).convert(iterableElementType)));
+        StackManipulation transformedContainer =
+            createTransformingContainer(conversionFunction, readValue);
+        return transformedContainer;
+      } else {
+        return readValue;
+      }
     }
 
     @Override
     protected StackManipulation convertCollection(TypeDescriptor<?> type) {
-      return readValue;
+      Type rowElementType =
+          getFactory()
+              .createTypeConversion(false)
+              .convert(ReflectUtils.getIterableComponentType(type));
+      final TypeDescriptor collectionElementType = ReflectUtils.getIterableComponentType(type);
+
+      if (!collectionElementType.hasUnresolvedParameters()) {
+        ForLoadedType conversionFunction =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    TypeDescriptor.of(rowElementType).getRawType(),
+                    collectionElementType.getRawType(),
+                    (s) -> getFactory().createSetterConversions(s).convert(collectionElementType)));
+        StackManipulation transformedContainer =
+            createTransformingContainer(conversionFunction, readValue);
+        return transformedContainer;
+      } else {
+        return readValue;
+      }
+    }
+
+    @Override
+    protected StackManipulation convertList(TypeDescriptor<?> type) {
+      Type rowElementType =
+          getFactory()
+              .createTypeConversion(false)
+              .convert(ReflectUtils.getIterableComponentType(type));
+      final TypeDescriptor collectionElementType = ReflectUtils.getIterableComponentType(type);
+
+      if (!collectionElementType.hasUnresolvedParameters()) {
+        ForLoadedType conversionFunction =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    TypeDescriptor.of(rowElementType).getRawType(),
+                    collectionElementType.getRawType(),
+                    (s) -> getFactory().createSetterConversions(s).convert(collectionElementType)));
+        readValue = createTransformingContainer(conversionFunction, readValue);
+      }
+      // TODO: Don't copy if already a list!
+      StackManipulation transformedList =
+          new Compound(
+              readValue,
+              MethodInvocation.invoke(
+                  new ForLoadedType(Lists.class)
+                      .getDeclaredMethods()
+                      .filter(
+                          ElementMatchers.named("newArrayList")
+                              .and(ElementMatchers.takesArguments(Iterable.class)))
+                      .getOnly()));
+      return transformedList;
     }
 
     @Override
     protected StackManipulation convertMap(TypeDescriptor<?> type) {
+      Type rowKeyType =
+          getFactory().createTypeConversion(false).convert(ReflectUtils.getMapType(type, 0));
+      final TypeDescriptor keyElementType = ReflectUtils.getMapType(type, 0);
+      Type rowValueType =
+          getFactory().createTypeConversion(false).convert(ReflectUtils.getMapType(type, 1));
+      final TypeDescriptor valueElementType = ReflectUtils.getMapType(type, 1);
+
+      if (!keyElementType.hasUnresolvedParameters()
+          && !valueElementType.hasUnresolvedParameters()) {
+        ForLoadedType keyConversionFunction =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    TypeDescriptor.of(rowKeyType).getRawType(),
+                    keyElementType.getRawType(),
+                    (s) -> getFactory().createSetterConversions(s).convert(keyElementType)));
+        ForLoadedType valueConversionFunction =
+            new ForLoadedType(
+                createCollectionTransformFunction(
+                    TypeDescriptor.of(rowValueType).getRawType(),
+                    valueElementType.getRawType(),
+                    (s) -> getFactory().createSetterConversions(s).convert(valueElementType)));
+        readValue =
+            new Compound(
+                readValue,
+                TypeCreation.of(keyConversionFunction),
+                Duplication.SINGLE,
+                MethodInvocation.invoke(
+                    keyConversionFunction
+                        .getDeclaredMethods()
+                        .filter(
+                            ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
+                        .getOnly()),
+                TypeCreation.of(valueConversionFunction),
+                Duplication.SINGLE,
+                MethodInvocation.invoke(
+                    valueConversionFunction
+                        .getDeclaredMethods()
+                        .filter(
+                            ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
+                        .getOnly()),
+                MethodInvocation.invoke(
+                    BYTE_BUDDY_UTILS_TYPE
+                        .getDeclaredMethods()
+                        .filter(ElementMatchers.named("getTransformingMap"))
+                        .getOnly()));
+      }
       return readValue;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -346,8 +346,10 @@ public class ByteBuddyUtils {
 
   private static final ByteBuddy BYTE_BUDDY = new ByteBuddy();
 
-  // When processing a container (e.g. List<T>) we need to recursively process the element type. This function
-  // generates a subclass of Function that can be used to recursively transform each element of the container.
+  // When processing a container (e.g. List<T>) we need to recursively process the element type.
+  // This function
+  // generates a subclass of Function that can be used to recursively transform each element of the
+  // container.
   static Class createCollectionTransformFunction(
       Type fromType, Type toType, Function<StackManipulation, StackManipulation> convertElement) {
     // Generate a TypeDescription for the class we want to generate.
@@ -392,14 +394,15 @@ public class ByteBuddyUtils {
         .getLoaded();
   }
 
-  // A function to transform a container, special casing List and Collection types. This is used in byte-buddy
+  // A function to transform a container, special casing List and Collection types. This is used in
+  // byte-buddy
   // generated code.
-  public static <F, T> Iterable<T> transformContainer(
-      Iterable<F> iterable, Function<F, T> function) {
+  public static <FromT, DestT> Iterable<DestT> transformContainer(
+      Iterable<FromT> iterable, Function<FromT, DestT> function) {
     if (iterable instanceof List) {
-      return Lists.transform((List<F>) iterable, function);
+      return Lists.transform((List<FromT>) iterable, function);
     } else if (iterable instanceof Collection) {
-      return Collections2.transform((Collection<F>) iterable, function);
+      return Collections2.transform((Collection<FromT>) iterable, function);
     } else {
       return Iterables.transform(iterable, function);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ReflectUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ReflectUtils.java
@@ -84,7 +84,9 @@ public class ReflectUtils {
         clazz,
         c -> {
           return Arrays.stream(c.getDeclaredMethods())
-              .filter(m -> !m.isBridge()) // Covariant overloads insert bridge functions, which we must ignore.
+              .filter(
+                  m -> !m.isBridge()) // Covariant overloads insert bridge functions, which we must
+              // ignore.
               .filter(m -> !Modifier.isPrivate(m.getModifiers()))
               .filter(m -> !Modifier.isProtected(m.getModifiers()))
               .filter(m -> !Modifier.isStatic(m.getModifiers()))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ReflectUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ReflectUtils.java
@@ -23,8 +23,11 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.security.InvalidParameterException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,16 +36,19 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Primitives;
 
 /** A set of reflection helper methods. */
 public class ReflectUtils {
-  static class ClassWithSchema {
+  /** Represents a class and a schema. */
+  public static class ClassWithSchema {
     private final Class clazz;
     private final Schema schema;
 
-    ClassWithSchema(Class clazz, Schema schema) {
+    public ClassWithSchema(Class clazz, Schema schema) {
       this.clazz = clazz;
       this.schema = schema;
     }
@@ -78,6 +84,7 @@ public class ReflectUtils {
         clazz,
         c -> {
           return Arrays.stream(c.getDeclaredMethods())
+              .filter(m -> !m.isBridge()) // Covariant overloads insert bridge functions, which we must ignore.
               .filter(m -> !Modifier.isPrivate(m.getModifiers()))
               .filter(m -> !Modifier.isProtected(m.getModifiers()))
               .filter(m -> !Modifier.isStatic(m.getModifiers()))
@@ -182,5 +189,50 @@ public class ReflectUtils {
 
   public static String stripSetterPrefix(String method) {
     return stripPrefix(method, "set");
+  }
+
+  /** For an array T[] or a subclass of Iterable<T>, return a TypeDescriptor describing T. */
+  @Nullable
+  public static TypeDescriptor getIterableComponentType(TypeDescriptor valueType) {
+    TypeDescriptor componentType = null;
+    if (valueType.isArray()) {
+      Type component = valueType.getComponentType().getType();
+      if (!component.equals(byte.class)) {
+        // Byte arrays are special cased since we have a schema type corresponding to them.
+        componentType = TypeDescriptor.of(component);
+      }
+    } else if (valueType.isSubtypeOf(TypeDescriptor.of(Iterable.class))) {
+      TypeDescriptor<Iterable<?>> collection = valueType.getSupertype(Iterable.class);
+      if (collection.getType() instanceof ParameterizedType) {
+        ParameterizedType ptype = (ParameterizedType) collection.getType();
+        java.lang.reflect.Type[] params = ptype.getActualTypeArguments();
+        checkArgument(params.length == 1);
+        componentType = TypeDescriptor.of(params[0]);
+      } else {
+        throw new RuntimeException("Collection parameter is not parameterized!");
+      }
+    }
+    return componentType;
+  }
+
+  public static TypeDescriptor getMapType(TypeDescriptor valueType, int index) {
+    TypeDescriptor mapType = null;
+    if (valueType.isSubtypeOf(TypeDescriptor.of(Map.class))) {
+      TypeDescriptor<Collection<?>> map = valueType.getSupertype(Map.class);
+      if (map.getType() instanceof ParameterizedType) {
+        ParameterizedType ptype = (ParameterizedType) map.getType();
+        java.lang.reflect.Type[] params = ptype.getActualTypeArguments();
+        mapType = TypeDescriptor.of(params[index]);
+      } else {
+        throw new RuntimeException("Map type is not parameterized! " + map);
+      }
+    }
+    return mapType;
+  }
+
+  public static TypeDescriptor boxIfPrimitive(TypeDescriptor typeDescriptor) {
+    return typeDescriptor.getRawType().isPrimitive()
+        ? TypeDescriptor.of(Primitives.wrap(typeDescriptor.getRawType()))
+        : typeDescriptor;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -25,6 +25,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -187,7 +188,7 @@ public abstract class Row implements Serializable {
    * match.
    */
   @Nullable
-  public <T> List<T> getArray(String fieldName) {
+  public <T> Collection<T> getArray(String fieldName) {
     return getArray(getSchema().indexOf(fieldName));
   }
 
@@ -332,7 +333,7 @@ public abstract class Row implements Serializable {
    * match.
    */
   @Nullable
-  public <T> List<T> getArray(int idx) {
+  public <T> Collection<T> getArray(int idx) {
     return getValue(idx);
   }
 
@@ -421,8 +422,8 @@ public abstract class Row implements Serializable {
       } else if (fieldType.getTypeName() == Schema.TypeName.BYTES) {
         return Arrays.equals((byte[]) a, (byte[]) b);
       } else if (fieldType.getTypeName() == TypeName.ARRAY) {
-        return deepEqualsForList(
-            (List<Object>) a, (List<Object>) b, fieldType.getCollectionElementType());
+        return deepEqualsForCollection(
+            (Collection<Object>) a, (Collection<Object>) b, fieldType.getCollectionElementType());
       } else if (fieldType.getTypeName() == TypeName.ITERABLE) {
         return deepEqualsForIterable(
             (Iterable<Object>) a, (Iterable<Object>) b, fieldType.getCollectionElementType());
@@ -493,7 +494,8 @@ public abstract class Row implements Serializable {
       return h;
     }
 
-    static boolean deepEqualsForList(List<Object> a, List<Object> b, Schema.FieldType elementType) {
+    static boolean deepEqualsForCollection(
+        Collection<Object> a, Collection<Object> b, Schema.FieldType elementType) {
       if (a == b) {
         return true;
       }
@@ -584,7 +586,7 @@ public abstract class Row implements Serializable {
       return addValues(Arrays.asList(values));
     }
 
-    public <T> Builder addArray(List<T> values) {
+    public <T> Builder addArray(Collection<T> values) {
       this.values.add(values);
       return this;
     }
@@ -662,16 +664,16 @@ public abstract class Row implements Serializable {
     private List<Object> verifyArray(
         Object value, FieldType collectionElementType, String fieldName) {
       boolean collectionElementTypeNullable = collectionElementType.getNullable();
-      if (!(value instanceof List)) {
+      if (!(value instanceof Collection)) {
         throw new IllegalArgumentException(
             String.format(
-                "For field name %s and array type expected List class. Instead "
+                "For field name %s and array type expected Collection class. Instead "
                     + "class type was %s.",
                 fieldName, value.getClass()));
       }
-      List<Object> valueList = (List<Object>) value;
-      List<Object> verifiedList = Lists.newArrayListWithCapacity(valueList.size());
-      for (Object listValue : valueList) {
+      Collection<Object> valueCollection = (Collection<Object>) value;
+      List<Object> verifiedList = Lists.newArrayListWithCapacity(valueCollection.size());
+      for (Object listValue : valueCollection) {
         if (listValue == null) {
           if (!collectionElementTypeNullable) {
             throw new IllegalArgumentException(
@@ -696,8 +698,8 @@ public abstract class Row implements Serializable {
                     + "class type was %s.",
                 fieldName, value.getClass()));
       }
-      Iterable<Object> valueList = (Iterable<Object>) value;
-      for (Object listValue : valueList) {
+      Iterable<Object> valueIterable = (Iterable<Object>) value;
+      for (Object listValue : valueIterable) {
         if (listValue == null) {
           if (!collectionElementTypeNullable) {
             throw new IllegalArgumentException(
@@ -708,7 +710,7 @@ public abstract class Row implements Serializable {
           verify(listValue, collectionElementType, fieldName);
         }
       }
-      return valueList;
+      return valueIterable;
     }
 
     private Map<Object, Object> verifyMap(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.sdk.values;
 
-import java.util.Iterator;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -29,6 +29,8 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Collections2;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 
@@ -44,7 +46,7 @@ public class RowWithGetters extends Row {
   private final Object getterTarget;
   private final List<FieldValueGetter> getters;
 
-  private final Map<Integer, List> cachedLists = Maps.newHashMap();
+  private final Map<Integer, Collection> cachedCollections = Maps.newHashMap();
   private final Map<Integer, Iterable> cachedIterables = Maps.newHashMap();
   private final Map<Integer, Map> cachedMaps = Maps.newHashMap();
 
@@ -69,36 +71,21 @@ public class RowWithGetters extends Row {
     return fieldValue != null ? getValue(type, fieldValue, fieldIdx) : null;
   }
 
-  private List getListValue(FieldType elementType, Object fieldValue) {
-    Iterable iterable = (Iterable) fieldValue;
-    List<Object> list = Lists.newArrayList();
-    for (Object o : iterable) {
-      list.add(getValue(elementType, o, null));
+  private Collection getCollectionValue(FieldType elementType, Object fieldValue) {
+    Collection collection = (Collection) fieldValue;
+    if (collection instanceof List) {
+      // For performance reasons if the input is a list, make sure that we produce a list. Otherwise Row forwarding
+      // is forced to physically copy the collection into a new List object.
+      return Lists.transform((List) collection, v -> getValue(elementType, v, null));
+    } else {
+      return Collections2.transform(collection, v -> getValue(elementType, v, null));
     }
-    return list;
   }
 
   private Iterable getIterableValue(FieldType elementType, Object fieldValue) {
     Iterable iterable = (Iterable) fieldValue;
     // Wrap the iterable to avoid having to materialize the entire collection.
-    return new Iterable() {
-      @Override
-      public Iterator iterator() {
-        return new Iterator() {
-          Iterator iterator = iterable.iterator();
-
-          @Override
-          public boolean hasNext() {
-            return iterator.hasNext();
-          }
-
-          @Override
-          public Object next() {
-            return getValue(elementType, iterator.next(), null);
-          }
-        };
-      }
-    };
+    return Iterables.transform(iterable, v -> getValue(elementType, v, null));
   }
 
   private Map<?, ?> getMapValue(FieldType keyType, FieldType valueType, Map<?, ?> fieldValue) {
@@ -117,9 +104,9 @@ public class RowWithGetters extends Row {
     } else if (type.getTypeName().equals(TypeName.ARRAY)) {
       return cacheKey != null
           ? (T)
-              cachedLists.computeIfAbsent(
-                  cacheKey, i -> getListValue(type.getCollectionElementType(), fieldValue))
-          : (T) getListValue(type.getCollectionElementType(), fieldValue);
+              cachedCollections.computeIfAbsent(
+                  cacheKey, i -> getCollectionValue(type.getCollectionElementType(), fieldValue))
+          : (T) getCollectionValue(type.getCollectionElementType(), fieldValue);
     } else if (type.getTypeName().equals(TypeName.ITERABLE)) {
       return cacheKey != null
           ? (T)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
@@ -74,7 +74,8 @@ public class RowWithGetters extends Row {
   private Collection getCollectionValue(FieldType elementType, Object fieldValue) {
     Collection collection = (Collection) fieldValue;
     if (collection instanceof List) {
-      // For performance reasons if the input is a list, make sure that we produce a list. Otherwise Row forwarding
+      // For performance reasons if the input is a list, make sure that we produce a list. Otherwise
+      // Row forwarding
       // is forced to physically copy the collection into a new List object.
       return Lists.transform((List) collection, v -> getValue(elementType, v, null));
     } else {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaFieldSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaFieldSchemaTest.java
@@ -305,7 +305,7 @@ public class JavaFieldSchemaTest {
 
     NestedArrayPOJO pojo = new NestedArrayPOJO(simple1, simple2, simple3);
     Row row = registry.getToRowFunction(NestedArrayPOJO.class).apply(pojo);
-    List<Row> rows = row.getArray("pojos");
+    List<Row> rows = (List) row.getArray("pojos");
     assertSame(simple1, registry.getFromRowFunction(SimplePOJO.class).apply(rows.get(0)));
     assertSame(simple2, registry.getFromRowFunction(SimplePOJO.class).apply(rows.get(1)));
     assertSame(simple3, registry.getFromRowFunction(SimplePOJO.class).apply(rows.get(2)));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
+import java.util.Collection;
 import java.util.List;
 import org.apache.beam.sdk.TestUtils.KvMatcher;
 import org.apache.beam.sdk.schemas.Schema;
@@ -691,7 +692,7 @@ public class CoGroupTest {
       Schema valueSchema = value.getSchema();
       for (int i = 0; i < valueSchema.getFieldCount(); ++i) {
         assertEquals(TypeName.ARRAY, valueSchema.getField(i).getType().getTypeName());
-        fieldMatchers.add(new ArrayFieldMatchesAnyOrder(i, value.getArray(i)));
+        fieldMatchers.add(new ArrayFieldMatchesAnyOrder(i, (List) value.getArray(i)));
       }
       matchers.add(
           KvMatcher.isKv(equalTo(row.getKey()), allOf(fieldMatchers.toArray(new Matcher[0]))));
@@ -715,7 +716,7 @@ public class CoGroupTest {
         return false;
       }
       Row row = (Row) item;
-      List<Row> actual = row.getArray(fieldIndex);
+      Collection<Row> actual = row.getArray(fieldIndex);
       return containsInAnyOrder(expected).matches(actual);
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/SelectTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/SelectTest.java
@@ -424,12 +424,17 @@ public class SelectTest {
         return false;
       }
       PartialRowMultipleArray that = (PartialRowMultipleArray) o;
-      return Objects.equals(field1, that.field1);
+      return Objects.equals(field1, that.field1) && Objects.equals(field3, that.field3);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(field1);
+      return Objects.hash(field1, field3);
+    }
+
+    @Override
+    public String toString() {
+      return "PartialRowMultipleArray{" + "field1=" + field1 + ", field3=" + field3 + '}';
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -972,4 +972,45 @@ public class TestJavaBeans {
   /** The schema for {@link NestedArrayBean}. * */
   public static final Schema ITERABLE_BEAM_SCHEMA =
       Schema.builder().addIterableField("strings", FieldType.STRING).build();
+
+  /** A bean containing an Array of ByteArray. * */
+  @DefaultSchema(JavaBeanSchema.class)
+  public static class ArrayOfByteArray {
+    private List<ByteBuffer> byteBuffers;
+
+    public ArrayOfByteArray(List<ByteBuffer> byteBuffers) {
+      this.byteBuffers = byteBuffers;
+    }
+
+    public ArrayOfByteArray() {}
+
+    public List<ByteBuffer> getByteBuffers() {
+      return byteBuffers;
+    }
+
+    public void setByteBuffers(List<ByteBuffer> byteBuffers) {
+      this.byteBuffers = byteBuffers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ArrayOfByteArray that = (ArrayOfByteArray) o;
+      return Objects.equals(byteBuffers, that.byteBuffers);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(byteBuffers);
+    }
+  }
+
+  /** The schema for {@link NestedArrayBean}. * */
+  public static final Schema ARRAY_OF_BYTE_ARRAY_BEAM_SCHEMA =
+      Schema.builder().addArrayField("byteBuffers", FieldType.BYTES).build();
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
 import java.util.Collection;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.extensions.sql.impl.planner.BeamCostModel;
 import org.apache.beam.sdk.extensions.sql.impl.planner.NodeStats;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.extensions.sql.impl.planner.BeamCostModel;
@@ -129,7 +130,7 @@ public class BeamUnnestRel extends Uncollect implements BeamRelNode {
     @ProcessElement
     public void process(@Element Row row, OutputReceiver<Row> out) {
 
-      @Nullable List<Object> rawValues = row.getArray(unnestIndex);
+      @Nullable Collection<Object> rawValues = row.getArray(unnestIndex);
 
       if (rawValues == null) {
         return;


### PR DESCRIPTION
This was uncovered by the attempt to add protocol buffer support to schemas. This PR refactors the schema utils to convert parameter types (e.g. for List<T> to convert T as well). As part of this PR, Row now represents ARRAY types as a Collection instead of as a List.

R: @alexvanboxel 