### PR TITLE
[BEAM-8895] Add BigQuery table name sanitization to BigQueryIOIT

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_BigQueryIO_Java.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_BigQueryIO_Java.groovy
@@ -34,7 +34,7 @@ def jobConfigs = [
                         tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
                         writeMethod           : 'STREAMING_INSERTS',
                         testBigQueryDataset   : 'beam_performance',
-                        testBigQueryTable     : 'bqio_write_10GB_java',
+                        testBigQueryTable     : 'bqio_write_10GB_java_' + now,
                         metricsBigQueryDataset: 'beam_performance',
                         metricsBigQueryTable  : 'bqio_10GB_results_java_stream',
                         sourceOptions         : """
@@ -61,7 +61,7 @@ def jobConfigs = [
                         tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
                         writeMethod           : 'FILE_LOADS',
                         testBigQueryDataset   : 'beam_performance',
-                        testBigQueryTable     : 'bqio_write_10GB_java',
+                        testBigQueryTable     : 'bqio_write_10GB_java_' + now,
                         metricsBigQueryDataset: 'beam_performance',
                         metricsBigQueryTable  : 'bqio_10GB_results_java_batch',
                         sourceOptions         : """

--- a/.test-infra/jenkins/job_PerformanceTests_BigQueryIO_Java.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_BigQueryIO_Java.groovy
@@ -33,8 +33,9 @@ def jobConfigs = [
                         tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                         tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
                         writeMethod           : 'STREAMING_INSERTS',
+                        writeFormat           : 'JSON',
                         testBigQueryDataset   : 'beam_performance',
-                        testBigQueryTable     : 'bqio_write_10GB_java_' + now,
+                        testBigQueryTable     : 'bqio_write_10GB_java_stream_' + now,
                         metricsBigQueryDataset: 'beam_performance',
                         metricsBigQueryTable  : 'bqio_10GB_results_java_stream',
                         sourceOptions         : """
@@ -51,19 +52,48 @@ def jobConfigs = [
                 ]
         ],
         [
-                title        : 'BigQueryIO Batch Performance Test Java 10 GB',
-                triggerPhrase: 'Run BigQueryIO Batch Performance Test Java',
-                name      : 'beam_BiqQueryIO_Batch_Performance_Test_Java',
+                title        : 'BigQueryIO Batch Performance Test Java 10 GB JSON',
+                triggerPhrase: 'Run BigQueryIO Batch Performance Test Java Json',
+                name      : 'beam_BiqQueryIO_Batch_Performance_Test_Java_Json',
                 itClass      : 'org.apache.beam.sdk.bigqueryioperftests.BigQueryIOIT',
                 properties: [
                         project               : 'apache-beam-testing',
                         tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
                         tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
                         writeMethod           : 'FILE_LOADS',
+                        writeFormat           : 'JSON',
                         testBigQueryDataset   : 'beam_performance',
-                        testBigQueryTable     : 'bqio_write_10GB_java_' + now,
+                        testBigQueryTable     : 'bqio_write_10GB_java_json_' + now,
                         metricsBigQueryDataset: 'beam_performance',
-                        metricsBigQueryTable  : 'bqio_10GB_results_java_batch',
+                        metricsBigQueryTable  : 'bqio_10GB_results_java_batch_json',
+                        sourceOptions         : """
+                                            {
+                                              "numRecords": "10485760",
+                                              "keySizeBytes": "1",
+                                              "valueSizeBytes": "1024"
+                                            }
+                                      """.trim().replaceAll("\\s", ""),
+                        runner                : "DataflowRunner",
+                        maxNumWorkers         : '5',
+                        numWorkers            : '5',
+                        autoscalingAlgorithm  : 'NONE',
+                ]
+        ],
+        [
+                title        : 'BigQueryIO Batch Performance Test Java 10 GB AVRO',
+                triggerPhrase: 'Run BigQueryIO Batch Performance Test Java Avro',
+                name      : 'beam_BiqQueryIO_Batch_Performance_Test_Java_Avro',
+                itClass      : 'org.apache.beam.sdk.bigqueryioperftests.BigQueryIOIT',
+                properties: [
+                        project               : 'apache-beam-testing',
+                        tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                        tempRoot              : 'gs://temp-storage-for-perf-tests/loadtests',
+                        writeMethod           : 'FILE_LOADS',
+                        writeFormat           : 'AVRO',
+                        testBigQueryDataset   : 'beam_performance',
+                        testBigQueryTable     : 'bqio_write_10GB_java_avro_' + now,
+                        metricsBigQueryDataset: 'beam_performance',
+                        metricsBigQueryTable  : 'bqio_10GB_results_java_batch_avro',
                         sourceOptions         : """
                                             {
                                               "numRecords": "10485760",

--- a/sdks/java/io/bigquery-io-perf-tests/src/test/java/org/apache/beam/sdk/bigqueryioperftests/BigQueryIOIT.java
+++ b/sdks/java/io/bigquery-io-perf-tests/src/test/java/org/apache/beam/sdk/bigqueryioperftests/BigQueryIOIT.java
@@ -100,7 +100,7 @@ public class BigQueryIOIT {
     metricsBigQueryDataset = options.getMetricsBigQueryDataset();
     metricsBigQueryTable = options.getMetricsBigQueryTable();
     testBigQueryDataset = options.getTestBigQueryDataset();
-    testBigQueryTable = String.format("%s_%s", options.getTestBigQueryTable(), TEST_ID);
+    testBigQueryTable = options.getTestBigQueryTable();
     BigQueryOptions bigQueryOptions = BigQueryOptions.newBuilder().build();
     tableQualifier =
         String.format(

--- a/sdks/java/io/bigquery-io-perf-tests/src/test/java/org/apache/beam/sdk/bigqueryioperftests/BigQueryIOIT.java
+++ b/sdks/java/io/bigquery-io-perf-tests/src/test/java/org/apache/beam/sdk/bigqueryioperftests/BigQueryIOIT.java
@@ -68,6 +68,7 @@ import org.junit.runners.JUnit4;
  *    "--metricsBigQueryDataset=metrics_dataset", \
  *    "--metricsBigQueryTable=metrics_table", \
  *    "--writeMethod=FILE_LOADS", \
+ *    "--writeFormat=AVRO", \
  *    "--sourceOptions={\"numRecords\":\"1000\", \"keySizeBytes\":\"1\", \"valueSizeBytes\":\"1024\"}" \
  *    ]' \
  *  --tests org.apache.beam.sdk.bigqueryioperftests.BigQueryIOIT \
@@ -90,6 +91,7 @@ public class BigQueryIOIT {
   private static String tableQualifier;
   private static String tempRoot;
   private static BigQueryPerfTestOptions options;
+  private static WriteFormat writeFormat;
 
   @BeforeClass
   public static void setup() throws IOException {
@@ -101,6 +103,7 @@ public class BigQueryIOIT {
     metricsBigQueryTable = options.getMetricsBigQueryTable();
     testBigQueryDataset = options.getTestBigQueryDataset();
     testBigQueryTable = options.getTestBigQueryTable();
+    writeFormat = WriteFormat.valueOf(options.getWriteFormat());
     BigQueryOptions bigQueryOptions = BigQueryOptions.newBuilder().build();
     tableQualifier =
         String.format(
@@ -117,8 +120,14 @@ public class BigQueryIOIT {
 
   @Test
   public void testWriteThenRead() {
-    testJsonWrite();
-    testAvroWrite();
+    switch (writeFormat) {
+      case AVRO:
+        testAvroWrite();
+        break;
+      case JSON:
+        testJsonWrite();
+        break;
+    }
     testRead();
   }
 
@@ -235,6 +244,11 @@ public class BigQueryIOIT {
     String getWriteMethod();
 
     void setWriteMethod(String value);
+
+    String getWriteFormat();
+
+    @Description("Write Avro or JSON to BQ")
+    void setWriteFormat(String value);
   }
 
   private static class MapKVToV extends DoFn<KV<byte[], byte[]>, byte[]> {
@@ -242,5 +256,10 @@ public class BigQueryIOIT {
     public void process(ProcessContext context) {
       context.output(context.element().getValue());
     }
+  }
+
+  private enum WriteFormat {
+    AVRO,
+    JSON
   }
 }


### PR DESCRIPTION
R: @lgajowy 
WDYT?

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
