### PR TITLE
[BEAM-3713] pytest migration: py27-gcp-pytest

### DIFF
--- a/.test-infra/junitxml_report.py
+++ b/.test-infra/junitxml_report.py
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Parses and extracts data from JUnitXML format files.
+
+Example usage, comparing nosetests and pytest test collection:
+$ cd sdks/python
+$ rm *.xml
+$ tox --recreate -e py27-gcp
+$ tox --recreate -e py27-gcp-pytest
+$ python3 ../../.test-infra/junitxml_report.py nosetests*.xml | sort -u > nosetests.out
+$ python3 ../../.test-infra/junitxml_report.py pytest*.xml | sort -u > pytest.out
+$ diff -u nosetests.out pytest.out | less
+"""
+
+import sys
+import xml.etree.ElementTree as et
+
+
+def print_testsuite(testsuite):
+  assert testsuite.tag == 'testsuite'
+  for testcase in testsuite:
+    assert testcase.tag == 'testcase'
+    attrib = testcase.attrib
+    status = ''
+    for child in testcase:
+      if child.tag == 'skipped':
+        assert status == ''
+        status = 'S'
+      elif child.tag in ['system-err', 'system-out']:
+        pass
+      else:
+        raise NotImplementedError('tag not supported: %s' % child.tag)
+    print('%s.%s %s' % (attrib['classname'], attrib['name'], status))
+
+
+def process_xml(filename):
+  tree = et.parse(filename)
+  root = tree.getroot()
+  if root.tag == 'testsuites':
+    for testsuite in root:
+      print_testsuite(testsuite)
+  else:
+    print_testsuite(root)
+
+
+def main():
+  for filename in sys.argv[1:]:
+    process_xml(filename)
+
+
+if __name__ == '__main__':
+  main()

--- a/sdks/python/apache_beam/io/gcp/datastore/v1new/datastoreio_test.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1new/datastoreio_test.py
@@ -40,7 +40,6 @@ try:
   from apache_beam.io.gcp.datastore.v1new.datastoreio import ReadFromDatastore
   from apache_beam.io.gcp.datastore.v1new.datastoreio import WriteToDatastore
   from apache_beam.io.gcp.datastore.v1new.types import Key
-  from apache_beam.testing.test_utils import patch_retry
   from google.cloud.datastore import client
   from google.cloud.datastore import entity
   from google.cloud.datastore import helpers
@@ -114,9 +113,6 @@ class FakeBatch(object):
 @unittest.skipIf(client is None, 'Datastore dependencies are not installed')
 class MutateTest(unittest.TestCase):
 
-  def setUp(self):
-    patch_retry(self, datastoreio)
-
   def test_write_mutations_no_errors(self):
     mock_batch = MagicMock()
     mock_throttler = MagicMock()
@@ -129,7 +125,8 @@ class MutateTest(unittest.TestCase):
         call(successes=1),
     ])
 
-  def test_write_mutations_reconstruct_on_error(self):
+  @patch('time.sleep', return_value=None)
+  def test_write_mutations_reconstruct_on_error(self, unused_sleep):
     mock_batch = MagicMock()
     mock_batch.begin.side_effect = [None, ValueError]
     mock_batch.commit.side_effect = [exceptions.DeadlineExceeded('retryable'),
@@ -149,7 +146,8 @@ class MutateTest(unittest.TestCase):
     ])
     self.assertEqual(1, mock_add_to_batch.call_count)
 
-  def test_write_mutations_throttle_delay_retryable_error(self):
+  @patch('time.sleep', return_value=None)
+  def test_write_mutations_throttle_delay_retryable_error(self, unused_sleep):
     mock_batch = MagicMock()
     mock_batch.commit.side_effect = [exceptions.DeadlineExceeded('retryable'),
                                      None]

--- a/sdks/python/scripts/run_pytest.sh
+++ b/sdks/python/scripts/run_pytest.sh
@@ -28,11 +28,11 @@ envname=${1?First argument required: suite base name}
 posargs=$2
 
 # Run with pytest-xdist and without.
-python setup.py pytest --addopts="-o junit_suite_name=${envname} \
-  --junitxml=pytest_${envname}.xml -m 'not no_xdist' -n 6 --pyargs ${posargs}"
+pytest -o junit_suite_name=${envname} \
+  --junitxml=pytest_${envname}.xml -m 'not no_xdist' -n 6 --pyargs ${posargs}
 status1=$?
-python setup.py pytest --addopts="-o junit_suite_name=${envname}_no_xdist \
-  --junitxml=pytest_${envname}_no_xdist.xml -m 'no_xdist' --pyargs ${posargs}"
+pytest -o junit_suite_name=${envname}_no_xdist \
+  --junitxml=pytest_${envname}_no_xdist.xml -m 'no_xdist' --pyargs ${posargs}
 status2=$?
 
 # Exit with error if no tests were run (status code 5).

--- a/sdks/python/test-suites/tox/py2/build.gradle
+++ b/sdks/python/test-suites/tox/py2/build.gradle
@@ -32,7 +32,7 @@ lint.dependsOn lintPy27
 toxTask "lintPy27_3", "py27-lint3"
 lint.dependsOn lintPy27_3
 
-toxTask "testPy2Gcp", "py27-gcp"
+toxTask "testPy2Gcp", "py27-gcp-pytest"
 test.dependsOn testPy2Gcp
 
 toxTask "testPython2", "py27"

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -205,14 +205,20 @@ commands =
   # due to conflicting protobuf modules.
   # TODO(BEAM-4543): Remove these separate nosetests invocations once the
   # googledatastore dependency is removed.
-  python setup.py nosetests {posargs} --tests apache_beam.io.gcp.datastore.v1
-  python setup.py nosetests {posargs} --tests apache_beam.io.gcp.datastore.v1new
+  python setup.py nosetests {posargs} --tests apache_beam.io.gcp.datastore.v1 --xunit-file nosetests-v1.xml
+  python setup.py nosetests {posargs} --tests apache_beam.io.gcp.datastore.v1new --xunit-file nosetests-v1new.xml
 
 [testenv:py27-gcp-pytest]
 extras = test,gcp
 commands =
   python apache_beam/examples/complete/autocomplete_test.py
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+  # Old and new Datastore client unit tests cannot be run in the same process
+  # due to conflicting protobuf modules.
+  # TODO(BEAM-4543): Remove these separate nosetests invocations once the
+  # googledatastore dependency is removed.
+  pytest -o junit_suite_name={envname}_v1 --junitxml=pytest_{envname}_v1.xml apache_beam/io/gcp/datastore/v1
+  pytest -o junit_suite_name={envname}_v1new --junitxml=pytest_{envname}_v1new.xml apache_beam/io/gcp/datastore/v1new
 
 [testenv:py35-gcp]
 setenv =


### PR DESCRIPTION
Replace s/py27-gcp/py27-gcp-pytest/ in Gradle config.

Tested collection via junitxml_report.py.
Diff: https://gist.github.com/udim/acc7f91ab035e20ec5678e6645cea8b4
- coders_test_common - I believe these are duplicated in
  slow_coders_test
- TestBigQueryReader.get_test_rows - not a test
- external_test_it - opened BEAM-8916, is not a unit test so not a part
  of py27-gcp
- 5 new tests not previously collected

v1new/datastoreio_test - replaced patch_retry with alternative since it
was causing weird errors with pytest. Probably has to do with imp.reload
usage: https://github.com/sublimehq/sublime_text/issues/2641

run_pytest.sh - corrected to not use setup.py (which is a deprecated
usage)

Also corrected old py27-gcp tox target to prevent multiple nose
invocations from overwriting previous XML outputs.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
