### PR TITLE
[BEAM-8933] Update BigQuery proto dependency

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -382,7 +382,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def netty_version = "4.1.30.Final"
     def postgres_version = "42.2.2"
     def powermock_version = "2.0.2"
-    def proto_google_common_protos_version = "1.12.0"
+    def proto_google_common_protos_version = "1.17.0"
     def protobuf_version = "3.6.0"
     def quickcheck_version = "0.8"
     def spark_version = "2.4.4"
@@ -438,7 +438,7 @@ class BeamModulePlugin implements Plugin<Project> {
         google_api_client                           : "com.google.api-client:google-api-client:$google_clients_version",
         google_api_client_jackson2                  : "com.google.api-client:google-api-client-jackson2:$google_clients_version",
         google_api_client_java6                     : "com.google.api-client:google-api-client-java6:$google_clients_version",
-        google_api_common                           : "com.google.api:api-common:1.7.0",
+        google_api_common                           : "com.google.api:api-common:1.8.1",
         google_api_services_bigquery                : "com.google.apis:google-api-services-bigquery:v2-rev20181221-$google_clients_version",
         google_api_services_clouddebugger           : "com.google.apis:google-api-services-clouddebugger:v2-rev20181114-$google_clients_version",
         google_api_services_cloudresourcemanager    : "com.google.apis:google-api-services-cloudresourcemanager:v1-rev20181015-$google_clients_version",
@@ -504,7 +504,7 @@ class BeamModulePlugin implements Plugin<Project> {
         powermock_mockito                           : "org.powermock:powermock-api-mockito2:$powermock_version",
         protobuf_java                               : "com.google.protobuf:protobuf-java:$protobuf_version",
         protobuf_java_util                          : "com.google.protobuf:protobuf-java-util:$protobuf_version",
-        proto_google_cloud_bigquery_storage_v1beta1 : "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta1:$generated_grpc_beta_version",
+        proto_google_cloud_bigquery_storage_v1beta1 : "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta1:0.83.0",
         proto_google_cloud_bigtable_v2              : "com.google.api.grpc:proto-google-cloud-bigtable-v2:$generated_grpc_beta_version",
         proto_google_cloud_datacatalog_v1beta1      : "com.google.api.grpc:proto-google-cloud-datacatalog-v1beta1:$generated_grpc_dc_beta_version",
         proto_google_cloud_datastore_v1             : "com.google.api.grpc:proto-google-cloud-datastore-v1:$generated_grpc_beta_version",

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
@@ -24,8 +24,8 @@ import com.google.api.services.bigquery.model.Table;
 import com.google.cloud.bigquery.storage.v1beta1.ReadOptions.TableReadOptions;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadSession;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ShardingStrategy;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.Stream;
-import com.google.protobuf.UnknownFieldSet;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -118,12 +118,7 @@ abstract class BigQueryStorageSourceBase<T> extends BoundedSource<T> {
             .setParent("projects/" + bqOptions.getProject())
             .setTableReference(BigQueryHelpers.toTableRefProto(targetTable.getTableReference()))
             .setRequestedStreams(streamCount)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build());
+            .setShardingStrategy(ShardingStrategy.BALANCED);
 
     if (selectedFieldsProvider != null || rowRestrictionProvider != null) {
       TableReadOptions.Builder builder = TableReadOptions.newBuilder();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -30,7 +30,6 @@ import com.google.cloud.bigquery.storage.v1beta1.Storage.SplitReadStreamRequest;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.SplitReadStreamResponse;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.Stream;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.StreamPosition;
-import com.google.protobuf.UnknownFieldSet;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -52,7 +51,6 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -292,16 +290,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
       SplitReadStreamRequest splitRequest =
           SplitReadStreamRequest.newBuilder()
               .setOriginalStream(source.stream)
-              // TODO(aryann): Once we rebuild the generated client code, we should change this to
-              // use setFraction().
-              .setUnknownFields(
-                  UnknownFieldSet.newBuilder()
-                      .addField(
-                          2,
-                          UnknownFieldSet.Field.newBuilder()
-                              .addFixed32(java.lang.Float.floatToIntBits((float) fraction))
-                              .build())
-                      .build())
+              .setFraction((float) fraction)
               .build();
       SplitReadStreamResponse splitResponse = storageClient.splitReadStream(splitRequest);
 
@@ -390,16 +379,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     }
 
     private static float getFractionConsumed(ReadRowsResponse response) {
-      // TODO(aryann): Once we rebuild the generated client code, we should change this to
-      // use getFractionConsumed().
-      List<Integer> fractionConsumedField =
-          response.getStatus().getUnknownFields().getField(2).getFixed32List();
-      if (fractionConsumedField.isEmpty()) {
-        Metrics.counter(BigQueryStorageStreamReader.class, "fraction-consumed-not-set").inc();
-        return 0f;
-      }
-
-      return Float.intBitsToFloat(Iterables.getOnlyElement(fractionConsumedField));
+      return response.getStatus().getFractionConsumed();
     }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageQueryTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageQueryTest.java
@@ -45,11 +45,11 @@ import com.google.cloud.bigquery.storage.v1beta1.Storage.CreateReadSessionReques
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadSession;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ShardingStrategy;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.Stream;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.StreamPosition;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.StreamStatus;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.UnknownFieldSet;
 import java.io.ByteArrayOutputStream;
 import java.util.Collection;
 import java.util.List;
@@ -387,12 +387,7 @@ public class BigQueryIOStorageQueryTest {
             .setParent("projects/" + options.getProject())
             .setTableReference(BigQueryHelpers.toTableRefProto(tempTableReference))
             .setRequestedStreams(requestedStreamCount)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession.Builder builder = ReadSession.newBuilder();
@@ -463,12 +458,7 @@ public class BigQueryIOStorageQueryTest {
             .setParent("projects/" + options.getProject())
             .setTableReference(BigQueryHelpers.toTableRefProto(tempTableReference))
             .setRequestedStreams(1024)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession.Builder builder = ReadSession.newBuilder();
@@ -544,19 +534,7 @@ public class BigQueryIOStorageQueryTest {
             AvroRows.newBuilder()
                 .setSerializedBinaryRows(ByteString.copyFrom(outputStream.toByteArray()))
                 .setRowCount(genericRecords.size()))
-        .setStatus(
-            StreamStatus.newBuilder()
-                // TODO(aryann): Once we rebuild the generated client code, we should change this to
-                // use setFractionConsumed().
-                .setUnknownFields(
-                    UnknownFieldSet.newBuilder()
-                        .addField(
-                            2,
-                            UnknownFieldSet.Field.newBuilder()
-                                .addFixed32(
-                                    java.lang.Float.floatToIntBits((float) fractionConsumed))
-                                .build())
-                        .build()))
+        .setStatus(StreamStatus.newBuilder().setFractionConsumed((float) fractionConsumed))
         .build();
   }
 
@@ -616,12 +594,7 @@ public class BigQueryIOStorageQueryTest {
             .setParent("projects/" + options.getProject())
             .setTableReference(BigQueryHelpers.toTableRefProto(tempTableReference))
             .setRequestedStreams(10)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession emptyReadSession = ReadSession.newBuilder().build();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
@@ -45,13 +45,13 @@ import com.google.cloud.bigquery.storage.v1beta1.Storage.CreateReadSessionReques
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadSession;
+import com.google.cloud.bigquery.storage.v1beta1.Storage.ShardingStrategy;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.SplitReadStreamRequest;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.SplitReadStreamResponse;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.Stream;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.StreamPosition;
 import com.google.cloud.bigquery.storage.v1beta1.Storage.StreamStatus;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.UnknownFieldSet;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -417,12 +417,7 @@ public class BigQueryIOStorageReadTest {
             .setParent("projects/project-id")
             .setTableReference(BigQueryHelpers.toTableRefProto(tableRef))
             .setRequestedStreams(streamCount)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession.Builder builder = ReadSession.newBuilder();
@@ -480,12 +475,7 @@ public class BigQueryIOStorageReadTest {
             .setTableReference(BigQueryHelpers.toTableRefProto(tableRef))
             .setRequestedStreams(10)
             .setReadOptions(readOptions)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession.Builder builder = ReadSession.newBuilder();
@@ -543,12 +533,7 @@ public class BigQueryIOStorageReadTest {
             .setTableReference(BigQueryHelpers.toTableRefProto(tableRef))
             .setRequestedStreams(10)
             .setReadOptions(readOptions)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession.Builder builder = ReadSession.newBuilder();
@@ -593,12 +578,7 @@ public class BigQueryIOStorageReadTest {
             .setParent("projects/project-id")
             .setTableReference(BigQueryHelpers.toTableRefProto(tableRef))
             .setRequestedStreams(1024)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession.Builder builder = ReadSession.newBuilder();
@@ -643,12 +623,7 @@ public class BigQueryIOStorageReadTest {
             .setParent("projects/project-id")
             .setTableReference(BigQueryHelpers.toTableRefProto(tableRef))
             .setRequestedStreams(1024)
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession emptyReadSession = ReadSession.newBuilder().build();
@@ -734,19 +709,7 @@ public class BigQueryIOStorageReadTest {
             AvroRows.newBuilder()
                 .setSerializedBinaryRows(ByteString.copyFrom(outputStream.toByteArray()))
                 .setRowCount(genericRecords.size()))
-        .setStatus(
-            StreamStatus.newBuilder()
-                // TODO(aryann): Once we rebuild the generated client code, we should change this to
-                // use setFractionConsumed().
-                .setUnknownFields(
-                    UnknownFieldSet.newBuilder()
-                        .addField(
-                            2,
-                            UnknownFieldSet.Field.newBuilder()
-                                .addFixed32(
-                                    java.lang.Float.floatToIntBits((float) fractionConsumed))
-                                .build())
-                        .build()))
+        .setStatus(StreamStatus.newBuilder().setFractionConsumed((float) fractionConsumed))
         .build();
   }
 
@@ -949,16 +912,7 @@ public class BigQueryIOStorageReadTest {
     when(fakeStorageClient.splitReadStream(
             SplitReadStreamRequest.newBuilder()
                 .setOriginalStream(parentStream)
-                // TODO(aryann): Once we rebuild the generated client code, we should change this to
-                // use setFraction().
-                .setUnknownFields(
-                    UnknownFieldSet.newBuilder()
-                        .addField(
-                            2,
-                            UnknownFieldSet.Field.newBuilder()
-                                .addFixed32(java.lang.Float.floatToIntBits(0.5f))
-                                .build())
-                        .build())
+                .setFraction(0.5f)
                 .build()))
         .thenReturn(
             SplitReadStreamResponse.newBuilder()
@@ -1052,16 +1006,7 @@ public class BigQueryIOStorageReadTest {
     when(fakeStorageClient.splitReadStream(
             SplitReadStreamRequest.newBuilder()
                 .setOriginalStream(parentStream)
-                // TODO(aryann): Once we rebuild the generated client code, we should change this to
-                // use setFraction().
-                .setUnknownFields(
-                    UnknownFieldSet.newBuilder()
-                        .addField(
-                            2,
-                            UnknownFieldSet.Field.newBuilder()
-                                .addFixed32(java.lang.Float.floatToIntBits(0.5f))
-                                .build())
-                        .build())
+                .setFraction(0.5f)
                 .build()))
         .thenReturn(
             SplitReadStreamResponse.newBuilder()
@@ -1166,16 +1111,7 @@ public class BigQueryIOStorageReadTest {
     when(fakeStorageClient.splitReadStream(
             SplitReadStreamRequest.newBuilder()
                 .setOriginalStream(streams.get(0))
-                // TODO(aryann): Once we rebuild the generated client code, we should change this to
-                // use setFraction().
-                .setUnknownFields(
-                    UnknownFieldSet.newBuilder()
-                        .addField(
-                            2,
-                            UnknownFieldSet.Field.newBuilder()
-                                .addFixed32(java.lang.Float.floatToIntBits(0.83f))
-                                .build())
-                        .build())
+                .setFraction(0.83f)
                 .build()))
         .thenReturn(
             SplitReadStreamResponse.newBuilder()
@@ -1206,16 +1142,7 @@ public class BigQueryIOStorageReadTest {
     when(fakeStorageClient.splitReadStream(
             SplitReadStreamRequest.newBuilder()
                 .setOriginalStream(streams.get(1))
-                // TODO(aryann): Once we rebuild the generated client code, we should change this to
-                // use setFraction().
-                .setUnknownFields(
-                    UnknownFieldSet.newBuilder()
-                        .addField(
-                            2,
-                            UnknownFieldSet.Field.newBuilder()
-                                .addFixed32(java.lang.Float.floatToIntBits(0.75f))
-                                .build())
-                        .build())
+                .setFraction(0.75f)
                 .build()))
         .thenReturn(
             SplitReadStreamResponse.newBuilder()
@@ -1302,16 +1229,7 @@ public class BigQueryIOStorageReadTest {
     when(fakeStorageClient.splitReadStream(
             SplitReadStreamRequest.newBuilder()
                 .setOriginalStream(parentStream)
-                // TODO(aryann): Once we rebuild the generated client code, we should change this to
-                // use setFraction().
-                .setUnknownFields(
-                    UnknownFieldSet.newBuilder()
-                        .addField(
-                            2,
-                            UnknownFieldSet.Field.newBuilder()
-                                .addFixed32(java.lang.Float.floatToIntBits(0.5f))
-                                .build())
-                        .build())
+                .setFraction(0.5f)
                 .build()))
         .thenReturn(SplitReadStreamResponse.getDefaultInstance());
 
@@ -1379,16 +1297,7 @@ public class BigQueryIOStorageReadTest {
     when(fakeStorageClient.splitReadStream(
             SplitReadStreamRequest.newBuilder()
                 .setOriginalStream(parentStream)
-                // TODO(aryann): Once we rebuild the generated client code, we should change this to
-                // use setFraction().
-                .setUnknownFields(
-                    UnknownFieldSet.newBuilder()
-                        .addField(
-                            2,
-                            UnknownFieldSet.Field.newBuilder()
-                                .addFixed32(java.lang.Float.floatToIntBits(0.5f))
-                                .build())
-                        .build())
+                .setFraction(0.5f)
                 .build()))
         .thenReturn(
             SplitReadStreamResponse.newBuilder()
@@ -1472,12 +1381,7 @@ public class BigQueryIOStorageReadTest {
             .setRequestedStreams(10)
             .setReadOptions(
                 TableReadOptions.newBuilder().addSelectedFields("name").addSelectedFields("number"))
-            // TODO(aryann): Once we rebuild the generated client code, we should change this to
-            // use setShardingStrategy().
-            .setUnknownFields(
-                UnknownFieldSet.newBuilder()
-                    .addField(7, UnknownFieldSet.Field.newBuilder().addVarint(2).build())
-                    .build())
+            .setShardingStrategy(ShardingStrategy.BALANCED)
             .build();
 
     ReadSession readSession =


### PR DESCRIPTION
Before adding a capability to a BigQuery IO connector to read and write in Arrow format we need to update proto dependency.
1. Updated `proto-bigquerystorage-v1beta1` to `0.83.0`.
2. Update tests to use proper proto fields.

R: @TheNeuralBit 
CC: @apilloud 
CC: @amaliujia 
CC: @aryann 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
