### PR TITLE
[BEAM-7926] Data-centric Interactive Part2

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -175,6 +175,7 @@ class InteractiveRunner(runners.PipelineRunner):
     main_job_result.wait_until_finish()
 
     if main_job_result.state is beam.runners.runner.PipelineState.DONE:
+      # pylint: disable=dict-values-not-iterating
       ie.current_env().mark_pcollection_computed(
           pipeline_instrument.runner_pcoll_to_user_pcoll.values())
 

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -55,7 +55,8 @@ class InteractiveRunner(runners.PipelineRunner):
                cache_dir=None,
                cache_format='text',
                render_option=None,
-               skip_display=False):
+               skip_display=False,
+               force_compute=True):
     """Constructor of InteractiveRunner.
 
     Args:
@@ -68,6 +69,12 @@ class InteractiveRunner(runners.PipelineRunner):
       skip_display: (bool) whether to skip display operations when running the
           pipeline. Useful if running large pipelines when display is not
           needed.
+      force_compute: (bool) whether sequential pipeline runs can use cached data
+          of PCollections computed from the previous runs including show API
+          invocation from interactive_beam module. If True, always run the whole
+          pipeline and compute data for PCollections forcefully. If False, use
+          available data and run minimum pipeline fragment to only compute data
+          not available.
     """
     self._underlying_runner = (underlying_runner
                                or direct_runner.DirectRunner())
@@ -79,6 +86,7 @@ class InteractiveRunner(runners.PipelineRunner):
     self._render_option = render_option
     self._in_session = False
     self._skip_display = skip_display
+    self._force_compute = force_compute
 
   def is_fnapi_compatible(self):
     # TODO(BEAM-8436): return self._underlying_runner.is_fnapi_compatible()
@@ -127,6 +135,9 @@ class InteractiveRunner(runners.PipelineRunner):
     return self._underlying_runner.apply(transform, pvalueish, options)
 
   def run_pipeline(self, pipeline, options):
+    if self._force_compute:
+      ie.current_env().evict_computed_pcollections()
+
     pipeline_instrument = inst.pin(pipeline, options)
 
     # The user_pipeline analyzed might be None if the pipeline given has nothing
@@ -162,6 +173,10 @@ class InteractiveRunner(runners.PipelineRunner):
           main_job_result,
           is_main_job=True)
     main_job_result.wait_until_finish()
+
+    if main_job_result.state is beam.runners.runner.PipelineState.DONE:
+      ie.current_env().mark_pcollection_computed(
+          pipeline_instrument.runner_pcoll_to_user_pcoll.values())
 
     return main_job_result
 

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -133,17 +133,17 @@ class InteractiveRunnerTest(unittest.TestCase):
 
   @unittest.skipIf(not ie.current_env().is_interactive_ready,
                    '[interactive] dependency is not installed.')
-  @patch('IPython.get_ipython', mock_get_ipython)
-  def test_mark_pcollection_completed_after_successful_run(self):
-    with mock_get_ipython():  # Cell 1
+  @patch('IPython.get_ipython', new_callable=mock_get_ipython)
+  def test_mark_pcollection_completed_after_successful_run(self, cell):
+    with cell:  # Cell 1
       p = beam.Pipeline(interactive_runner.InteractiveRunner())
       ib.watch({'p': p})
 
-    with mock_get_ipython():  # Cell 2
+    with cell:  # Cell 2
       # pylint: disable=range-builtin-not-iterating
       init = p | 'Init' >> beam.Create(range(5))
 
-    with mock_get_ipython():  # Cell 3
+    with cell:  # Cell 3
       square = init | 'Square' >> beam.Map(lambda x: x * x)
       cube = init | 'Cube' >> beam.Map(lambda x: x ** 3)
 

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -33,6 +33,14 @@ from apache_beam.runners.direct import direct_runner
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner
+from apache_beam.runners.interactive.testing.mock_ipython import mock_get_ipython
+
+# TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
+# unittest.mock module.
+try:
+  from unittest.mock import patch
+except ImportError:
+  from mock import patch
 
 
 def print_with_message(msg):
@@ -122,6 +130,31 @@ class InteractiveRunnerTest(unittest.TestCase):
     self.assertTrue(underlying_runner._in_session)
     runner.end_session()
     self.assertFalse(underlying_runner._in_session)
+
+  @unittest.skipIf(not ie.current_env().is_interactive_ready,
+                   '[interactive] dependency is not installed.')
+  @patch('IPython.get_ipython', mock_get_ipython)
+  def test_mark_pcollection_completed_after_successful_run(self):
+    with mock_get_ipython():  # Cell 1
+      p = beam.Pipeline(interactive_runner.InteractiveRunner())
+      ib.watch({'p': p})
+
+    with mock_get_ipython():  # Cell 2
+      # pylint: disable=range-builtin-not-iterating
+      init = p | 'Init' >> beam.Create(range(5))
+
+    with mock_get_ipython():  # Cell 3
+      square = init | 'Square' >> beam.Map(lambda x: x * x)
+      cube = init | 'Cube' >> beam.Map(lambda x: x ** 3)
+
+    ib.watch(locals())
+    result = p.run()
+    self.assertTrue(init in ie.current_env().computed_pcollections)
+    self.assertEqual([0, 1, 2, 3, 4], result.get(init))
+    self.assertTrue(square in ie.current_env().computed_pcollections)
+    self.assertEqual([0, 1, 4, 9, 16], result.get(square))
+    self.assertTrue(cube in ie.current_env().computed_pcollections)
+    self.assertEqual([0, 1, 8, 27, 64], result.get(cube))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
@@ -57,7 +57,7 @@ class PipelineFragment(object):
       assert pcoll.pipeline is self._user_pipeline, (
           '{} belongs to a different user pipeline than other PCollections '
           'given and cannot be used to build a pipeline fragment that produces '
-          'the given PCollections.')
+          'the given PCollections.'.format(pcoll))
     self._options = options
 
     # A copied pipeline instance for modification without changing the user

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
@@ -1,0 +1,225 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Module to build pipeline fragment that produces given PCollections.
+
+For internal use only; no backwards-compatibility guarantees.
+"""
+from __future__ import absolute_import
+
+import apache_beam as beam
+from apache_beam.pipeline import PipelineVisitor
+
+
+class PipelineFragment(object):
+  """A fragment of a pipeline definition.
+
+  A pipeline fragment is built from the original pipeline definition to include
+  only PTransforms that are necessary to produce the given PCollections.
+  """
+
+  def __init__(self, pcolls, options=None):
+    """Constructor of PipelineFragment.
+
+    Args:
+      pcolls: (List[PCollection]) a list of PCollections to build pipeline
+          fragment for.
+      options: (PipelineOptions) the pipeline options for the implicit
+          pipeline run.
+    """
+    assert len(pcolls) > 0, (
+        'Need at least 1 PCollection as the target data to build a pipeline '
+        'fragment that produces it.')
+    for pcoll in pcolls:
+      assert isinstance(pcoll, beam.pvalue.PCollection), (
+          '{} is not an apache_beam.pvalue.PCollection.'.format(pcoll))
+    # No modification to self._user_pipeline is allowed.
+    self._user_pipeline = pcolls[0].pipeline
+    # These are user PCollections. Do not use them to deduce anything that
+    # will be executed by any runner. Instead, use
+    # `self._runner_pcolls_to_user_pcolls.keys()` to get copied PCollections.
+    self._pcolls = set(pcolls)
+    for pcoll in self._pcolls:
+      assert pcoll.pipeline is self._user_pipeline, (
+          '{} belongs to a different user pipeline than other PCollections '
+          'given and cannot be used to build a pipeline fragment that produces '
+          'the given PCollections.')
+    self._options = options
+
+    # A copied pipeline instance for modification without changing the user
+    # pipeline instance held by the end user. This instance can be processed
+    # into a pipeline fragment that later run by the underlying runner.
+    self._runner_pipeline = self._build_runner_pipeline()
+    _, self._context = self._runner_pipeline.to_runner_api(
+        return_context=True, use_fake_coders=True)
+    from apache_beam.runners.interactive import pipeline_instrument as instr
+    self._runner_pcoll_to_id = instr.pcolls_to_pcoll_id(
+        self._runner_pipeline, self._context)
+    # Correlate components in the runner pipeline to components in the user
+    # pipeline. The target pcolls are the pcolls given and defined in the user
+    # pipeline.
+    self._id_to_target_pcoll = self._calculate_target_pcoll_ids()
+    self._label_to_user_transform = self._calculate_user_transform_labels()
+    # Below will give us the 1:1 correlation between
+    # PCollections/AppliedPTransforms from the copied runner pipeline and
+    # PCollections/AppliedPTransforms from the user pipeline.
+    # (Dict[PCollection, PCollection])
+    (self._runner_pcolls_to_user_pcolls,
+     # (Dict[AppliedPTransform, AppliedPTransform])
+     self._runner_transforms_to_user_transforms
+    ) = self._build_correlation_between_pipelines(
+        self._runner_pcoll_to_id,
+        self._id_to_target_pcoll,
+        self._label_to_user_transform)
+
+    # Below are operated on the runner pipeline.
+    (self._necessary_transforms,
+     self._necessary_pcollections) = self._mark_necessary_transforms_and_pcolls(
+         self._runner_pcolls_to_user_pcolls)
+    self._runner_pipeline = self._prune_runner_pipeline_to_fragment(
+        self._runner_pipeline,
+        self._necessary_transforms)
+
+  def deduce_fragment(self):
+    """Deduce the pipeline fragment as an apache_beam.Pipeline instance."""
+    return beam.pipeline.Pipeline.from_runner_api(
+        self._runner_pipeline.to_runner_api(use_fake_coders=True),
+        self._runner_pipeline.runner,
+        self._options)
+
+  def run(self, display_pipeline_graph=False, use_cache=True):
+    """Shorthand to run the pipeline fragment."""
+    try:
+      skip_pipeline_graph = self._runner_pipeline.runner._skip_display
+      force_compute = self._runner_pipeline.runner._force_compute
+      self._runner_pipeline.runner._skip_display = not display_pipeline_graph
+      self._runner_pipeline.runner._force_compute = not use_cache
+      return self.deduce_fragment().run()
+    finally:
+      self._runner_pipeline.runner._skip_display = skip_pipeline_graph
+      self._runner_pipeline.runner._force_compute = force_compute
+
+  def _build_runner_pipeline(self):
+    return beam.pipeline.Pipeline.from_runner_api(
+        self._user_pipeline.to_runner_api(use_fake_coders=True),
+        self._user_pipeline.runner,
+        self._options)
+
+  def _calculate_target_pcoll_ids(self):
+    pcoll_id_to_target_pcoll = {}
+    for pcoll in self._pcolls:
+      pcoll_id_to_target_pcoll[self._runner_pcoll_to_id.get(str(pcoll),
+                                                            '')] = pcoll
+    return pcoll_id_to_target_pcoll
+
+  def _calculate_user_transform_labels(self):
+    label_to_user_transform = {}
+
+    class UserTransformVisitor(PipelineVisitor):
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        if transform_node is not None:
+          label_to_user_transform[transform_node.full_label] = transform_node
+
+    v = UserTransformVisitor()
+    self._runner_pipeline.visit(v)
+    return label_to_user_transform
+
+  def _build_correlation_between_pipelines(self,
+                                           runner_pcoll_to_id,
+                                           id_to_target_pcoll,
+                                           label_to_user_transform):
+    runner_pcolls_to_user_pcolls = {}
+    runner_transforms_to_user_transforms = {}
+
+    class CorrelationVisitor(PipelineVisitor):
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        self._process_transform(transform_node)
+        for in_pcoll in transform_node.inputs:
+          self._process_pcoll(in_pcoll)
+        for out_pcoll in transform_node.outputs.values():
+          self._process_pcoll(out_pcoll)
+
+      def _process_pcoll(self, pcoll):
+        pcoll_id = runner_pcoll_to_id.get(str(pcoll), '')
+        if pcoll_id in id_to_target_pcoll:
+          runner_pcolls_to_user_pcolls[pcoll] = (
+              id_to_target_pcoll[pcoll_id])
+
+      def _process_transform(self, transform_node):
+        if transform_node.full_label in label_to_user_transform:
+          runner_transforms_to_user_transforms[transform_node] = (
+              label_to_user_transform[transform_node.full_label])
+
+    v = CorrelationVisitor()
+    self._runner_pipeline.visit(v)
+    return runner_pcolls_to_user_pcolls, runner_transforms_to_user_transforms
+
+  def _mark_necessary_transforms_and_pcolls(self,
+                                            runner_pcolls_to_user_pcolls):
+    necessary_transforms = set()
+    all_inputs = set()
+    updated_all_inputs = set(runner_pcolls_to_user_pcolls.keys())
+    # Do this until no more new PCollection is recorded.
+    while len(updated_all_inputs) != len(all_inputs):
+      all_inputs = set(updated_all_inputs)
+      for pcoll in all_inputs:
+        producer = pcoll.producer
+        while producer:
+          if producer in necessary_transforms:
+            break
+          # Mark the AppliedPTransform as necessary.
+          necessary_transforms.add(producer)
+          # Record all necessary input and side input PCollections.
+          updated_all_inputs.update(producer.inputs)
+          # pylint: disable=map-builtin-not-iterating
+          side_input_pvalues = set(
+              map(lambda side_input: side_input.pvalue,
+                  producer.side_inputs))
+          updated_all_inputs.update(side_input_pvalues)
+          # Go to its parent AppliedPTransform.
+          producer = producer.parent
+    return necessary_transforms, all_inputs
+
+  def _prune_runner_pipeline_to_fragment(self,
+                                         runner_pipeline,
+                                         necessary_transforms):
+
+    class PruneVisitor(PipelineVisitor):
+
+      def enter_composite_transform(self, transform_node):
+        pruned_parts = list(transform_node.parts)
+        for part in transform_node.parts:
+          if part not in necessary_transforms:
+            pruned_parts.remove(part)
+        transform_node.parts = tuple(pruned_parts)
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        if transform_node not in necessary_transforms:
+          transform_node.parent = None
+
+    v = PruneVisitor()
+    runner_pipeline.visit(v)
+    return runner_pipeline

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment_test.py
@@ -46,20 +46,20 @@ class PipelineFragmentTest(unittest.TestCase):
     ie.current_env()._is_in_ipython = True
     ie.current_env()._is_in_notebook = True
 
-  @patch('IPython.get_ipython', mock_get_ipython)
-  def test_build_pipeline_fragment(self):
-    with mock_get_ipython():  # Cell 1
+  @patch('IPython.get_ipython', new_callable=mock_get_ipython)
+  def test_build_pipeline_fragment(self, cell):
+    with cell:  # Cell 1
       p = beam.Pipeline(ir.InteractiveRunner())
       p_expected = beam.Pipeline(ir.InteractiveRunner())
       # Watch local scope now to allow interactive beam to track the pipelines.
       ib.watch(locals())
 
-    with mock_get_ipython():  # Cell 2
+    with cell:  # Cell 2
       # pylint: disable=range-builtin-not-iterating
       init = p | 'Init' >> beam.Create(range(10))
       init_expected = p_expected | 'Init' >> beam.Create(range(10))
 
-    with mock_get_ipython():  # Cell 3
+    with cell:  # Cell 3
       square = init | 'Square' >> beam.Map(lambda x: x * x)
       _ = init | 'Cube' >> beam.Map(lambda x: x ** 3)
       _ = init_expected | 'Square' >> beam.Map(lambda x: x * x)
@@ -69,21 +69,21 @@ class PipelineFragmentTest(unittest.TestCase):
     fragment = pf.PipelineFragment([square]).deduce_fragment()
     assert_pipeline_equal(self, p_expected, fragment)
 
-  @patch('IPython.get_ipython', mock_get_ipython)
-  def test_user_pipeline_intact_after_deducing_pipeline_fragment(self):
-    with mock_get_ipython():  # Cell 1
+  @patch('IPython.get_ipython', new_callable=mock_get_ipython)
+  def test_user_pipeline_intact_after_deducing_pipeline_fragment(self, cell):
+    with cell:  # Cell 1
       p = beam.Pipeline(ir.InteractiveRunner())
       # Watch the pipeline `p` immediately without calling locals().
       ib.watch({'p': p})
 
-    with mock_get_ipython():  # Cell 2
+    with cell:  # Cell 2
       # pylint: disable=range-builtin-not-iterating
       init = p | 'Init' >> beam.Create(range(10))
 
-    with mock_get_ipython():  # Cell 3
+    with cell:  # Cell 3
       square = init | 'Square' >> beam.Map(lambda x: x * x)
 
-    with mock_get_ipython():  # Cell 4
+    with cell:  # Cell 4
       cube = init | 'Cube' >> beam.Map(lambda x: x ** 3)
 
     # Watch every PCollection has been defined so far in local scope without
@@ -102,17 +102,17 @@ class PipelineFragmentTest(unittest.TestCase):
                                 user_pipeline_proto_before_deducing_fragment,
                                 user_pipeline_proto_after_deducing_fragment)
 
-  @patch('IPython.get_ipython', mock_get_ipython)
-  def test_pipeline_fragment_produces_correct_data(self):
-    with mock_get_ipython():  # Cell 1
+  @patch('IPython.get_ipython', new_callable=mock_get_ipython)
+  def test_pipeline_fragment_produces_correct_data(self, cell):
+    with cell:  # Cell 1
       p = beam.Pipeline(ir.InteractiveRunner())
       ib.watch({'p': p})
 
-    with mock_get_ipython():  # Cell 2
+    with cell:  # Cell 2
       # pylint: disable=range-builtin-not-iterating
       init = p | 'Init' >> beam.Create(range(5))
 
-    with mock_get_ipython():  # Cell 3
+    with cell:  # Cell 3
       square = init | 'Square' >> beam.Map(lambda x: x * x)
       _ = init | 'Cube' >> beam.Map(lambda x: x ** 3)
 

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment_test.py
@@ -1,0 +1,125 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for apache_beam.runners.interactive.pipeline_fragment."""
+from __future__ import absolute_import
+
+import unittest
+
+import apache_beam as beam
+from apache_beam.runners.interactive import interactive_beam as ib
+from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive import interactive_runner as ir
+from apache_beam.runners.interactive import pipeline_fragment as pf
+from apache_beam.runners.interactive.testing.mock_ipython import mock_get_ipython
+from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_equal
+from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_proto_equal
+
+# TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
+# unittest.mock module.
+try:
+  from unittest.mock import patch
+except ImportError:
+  from mock import patch
+
+
+@unittest.skipIf(not ie.current_env().is_interactive_ready,
+                 '[interactive] dependency is not installed.')
+class PipelineFragmentTest(unittest.TestCase):
+
+  def setUp(self):
+    # Assume a notebook frontend is connected to the mocked ipython kernel.
+    ie.current_env()._is_in_ipython = True
+    ie.current_env()._is_in_notebook = True
+
+  @patch('IPython.get_ipython', mock_get_ipython)
+  def test_build_pipeline_fragment(self):
+    with mock_get_ipython():  # Cell 1
+      p = beam.Pipeline(ir.InteractiveRunner())
+      p_expected = beam.Pipeline(ir.InteractiveRunner())
+      # Watch local scope now to allow interactive beam to track the pipelines.
+      ib.watch(locals())
+
+    with mock_get_ipython():  # Cell 2
+      # pylint: disable=range-builtin-not-iterating
+      init = p | 'Init' >> beam.Create(range(10))
+      init_expected = p_expected | 'Init' >> beam.Create(range(10))
+
+    with mock_get_ipython():  # Cell 3
+      square = init | 'Square' >> beam.Map(lambda x: x * x)
+      _ = init | 'Cube' >> beam.Map(lambda x: x ** 3)
+      _ = init_expected | 'Square' >> beam.Map(lambda x: x * x)
+
+    # Watch every PCollection has been defined so far in local scope.
+    ib.watch(locals())
+    fragment = pf.PipelineFragment([square]).deduce_fragment()
+    assert_pipeline_equal(self, p_expected, fragment)
+
+  @patch('IPython.get_ipython', mock_get_ipython)
+  def test_user_pipeline_intact_after_deducing_pipeline_fragment(self):
+    with mock_get_ipython():  # Cell 1
+      p = beam.Pipeline(ir.InteractiveRunner())
+      # Watch the pipeline `p` immediately without calling locals().
+      ib.watch({'p': p})
+
+    with mock_get_ipython():  # Cell 2
+      # pylint: disable=range-builtin-not-iterating
+      init = p | 'Init' >> beam.Create(range(10))
+
+    with mock_get_ipython():  # Cell 3
+      square = init | 'Square' >> beam.Map(lambda x: x * x)
+
+    with mock_get_ipython():  # Cell 4
+      cube = init | 'Cube' >> beam.Map(lambda x: x ** 3)
+
+    # Watch every PCollection has been defined so far in local scope without
+    # calling locals().
+    ib.watch({
+        'init': init,
+        'square': square,
+        'cube': cube
+    })
+    user_pipeline_proto_before_deducing_fragment = p.to_runner_api(
+        return_context=False, use_fake_coders=True)
+    _ = pf.PipelineFragment([square]).deduce_fragment()
+    user_pipeline_proto_after_deducing_fragment = p.to_runner_api(
+        return_context=False, use_fake_coders=True)
+    assert_pipeline_proto_equal(self,
+                                user_pipeline_proto_before_deducing_fragment,
+                                user_pipeline_proto_after_deducing_fragment)
+
+  @patch('IPython.get_ipython', mock_get_ipython)
+  def test_pipeline_fragment_produces_correct_data(self):
+    with mock_get_ipython():  # Cell 1
+      p = beam.Pipeline(ir.InteractiveRunner())
+      ib.watch({'p': p})
+
+    with mock_get_ipython():  # Cell 2
+      # pylint: disable=range-builtin-not-iterating
+      init = p | 'Init' >> beam.Create(range(5))
+
+    with mock_get_ipython():  # Cell 3
+      square = init | 'Square' >> beam.Map(lambda x: x * x)
+      _ = init | 'Cube' >> beam.Map(lambda x: x ** 3)
+
+    ib.watch(locals())
+    result = pf.PipelineFragment([square]).run()
+    self.assertEqual([0, 1, 4, 9, 16], result.get(square))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -249,6 +249,9 @@ class PipelineInstrumentTest(unittest.TestCase):
         id(second_pcoll)) + '_' + str(id(second_pcoll.producer))
     self._mock_write_cache(second_pcoll, second_pcoll_cache_key)
     ie.current_env().cache_manager().exists = MagicMock(return_value=True)
+    # Mark the completeness of PCollections from the original(user) pipeline.
+    ie.current_env().mark_pcollection_computed(
+        (p_origin, init_pcoll, second_pcoll))
     instr.pin(p_copy)
 
     cached_init_pcoll = p_origin | (


### PR DESCRIPTION
1. Added pipeline_fragment module to build pipeline fragments including
only transforms necessary to produce user-desired PCollections and
implicitly execute the fragment to emit data for user-desired
PCollections.
2. Added the notion of cached PCollection completeness. Only cache of
completely computed PCollections can be read. `p.run()` of the
InteractiveRunner by default displays the pipeline graph and doesn't use
any cached intermediate PCollections but generates new cache for them.
3. Whenever a pipeline fragment is executed, by default the implicit
pipeline run doesn't display pipeline graph but uses available cached
intermediate PCollections and generates cache for PCollections haven't
been computed.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
