### PR TITLE
[release-2.18.0][BEAM-8861] Disallow self-signed certificates by default in ElasticsearchIO

### DIFF
--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -73,6 +73,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.BasicCredentialsProvider;
@@ -253,6 +254,9 @@ public class ElasticsearchIO {
     @Nullable
     public abstract Integer getConnectTimeout();
 
+    @Nullable
+    public abstract Boolean getTrustSelfSignedCerts();
+
     abstract Builder builder();
 
     @AutoValue.Builder
@@ -274,6 +278,8 @@ public class ElasticsearchIO {
       abstract Builder setSocketAndRetryTimeout(Integer maxRetryTimeout);
 
       abstract Builder setConnectTimeout(Integer connectTimeout);
+
+      abstract Builder setTrustSelfSignedCerts(Boolean trustSelfSignedCerts);
 
       abstract ConnectionConfiguration build();
     }
@@ -352,6 +358,19 @@ public class ElasticsearchIO {
     }
 
     /**
+     * If Elasticsearch uses SSL/TLS then configure whether to trust self signed certs or not. The
+     * default is false.
+     *
+     * @param trustSelfSignedCerts Whether to trust self signed certs
+     * @return a {@link ConnectionConfiguration} describes a connection configuration to
+     *     Elasticsearch.
+     */
+    public ConnectionConfiguration withTrustSelfSignedCerts(Boolean trustSelfSignedCerts) {
+      checkArgument(trustSelfSignedCerts != null, "trustSelfSignedCerts can not be null");
+      return builder().setTrustSelfSignedCerts(trustSelfSignedCerts).build();
+    }
+
+    /**
      * If set, overwrites the default max retry timeout (30000ms) in the Elastic {@link RestClient}
      * and the default socket timeout (30000ms) in the {@link RequestConfig} of the Elastic {@link
      * RestClient}.
@@ -386,6 +405,7 @@ public class ElasticsearchIO {
       builder.addIfNotNull(DisplayData.item("keystore.path", getKeystorePath()));
       builder.addIfNotNull(DisplayData.item("socketAndRetryTimeout", getSocketAndRetryTimeout()));
       builder.addIfNotNull(DisplayData.item("connectTimeout", getConnectTimeout()));
+      builder.addIfNotNull(DisplayData.item("trustSelfSignedCerts", getTrustSelfSignedCerts()));
     }
 
     @VisibleForTesting
@@ -413,10 +433,12 @@ public class ElasticsearchIO {
             String keystorePassword = getKeystorePassword();
             keyStore.load(is, (keystorePassword == null) ? null : keystorePassword.toCharArray());
           }
+          final TrustStrategy trustStrategy =
+              getTrustSelfSignedCerts() != null && getTrustSelfSignedCerts()
+                  ? new TrustSelfSignedStrategy()
+                  : null;
           final SSLContext sslContext =
-              SSLContexts.custom()
-                  .loadTrustMaterial(keyStore, new TrustSelfSignedStrategy())
-                  .build();
+              SSLContexts.custom().loadTrustMaterial(keyStore, trustStrategy).build();
           final SSLIOSessionStrategy sessionStrategy = new SSLIOSessionStrategy(sslContext);
           restClientBuilder.setHttpClientConfigCallback(
               httpClientBuilder ->


### PR DESCRIPTION
Same that the one I accidentally push forced to cherry pick another issue.
R: @udim 
CC: @coheigea 