### PR TITLE
[BEAM-8342]: upgrade to samza 1.3.0

### DIFF
--- a/runners/samza/build.gradle
+++ b/runners/samza/build.gradle
@@ -34,7 +34,7 @@ configurations {
   validatesRunner
 }
 
-def samza_version = "1.1.0"
+def samza_version = "1.3.0"
 
 dependencies {
   compile library.java.vendored_guava_26_0_jre

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptionsValidator.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptionsValidator.java
@@ -19,10 +19,10 @@ package org.apache.beam.runners.samza;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
+import static org.apache.samza.config.TaskConfig.MAX_CONCURRENCY;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.samza.config.TaskConfig;
 
 /** Validates that the {@link SamzaPipelineOptions} conforms to all the criteria. */
 public class SamzaPipelineOptionsValidator {
@@ -41,7 +41,7 @@ public class SamzaPipelineOptionsValidator {
           isPortable(pipelineOptions),
           "Bundling is not supported in non portable mode. Please disable by setting maxBundleSize to 1.");
 
-      String taskConcurrencyConfig = TaskConfig.MAX_CONCURRENCY();
+      String taskConcurrencyConfig = MAX_CONCURRENCY;
       Map<String, String> configs =
           pipelineOptions.getConfigOverride() == null
               ? new HashMap<>()

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineResult.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineResult.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.samza;
 
 import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
+import static org.apache.samza.config.TaskConfig.TASK_SHUTDOWN_MS;
 
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
@@ -26,7 +27,6 @@ import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.Config;
-import org.apache.samza.config.TaskConfig;
 import org.apache.samza.job.ApplicationStatus;
 import org.apache.samza.runtime.ApplicationRunner;
 import org.joda.time.Duration;
@@ -39,6 +39,7 @@ public class SamzaPipelineResult implements PipelineResult {
   private static final long DEFAULT_SHUTDOWN_MS = 5000L;
   // allow some buffer on top of samza's own shutdown timeout
   private static final long SHUTDOWN_TIMEOUT_BUFFER = 5000L;
+  private static final long DEFAULT_TASK_SHUTDOWN_MS = 30000L;
 
   private final SamzaExecutionContext executionContext;
   private final ApplicationRunner runner;
@@ -57,7 +58,7 @@ public class SamzaPipelineResult implements PipelineResult {
     this.app = app;
     this.listener = listener;
     this.shutdownTiemoutMs =
-        config.getLong(TaskConfig.SHUTDOWN_MS(), DEFAULT_SHUTDOWN_MS) + SHUTDOWN_TIMEOUT_BUFFER;
+        config.getLong(TASK_SHUTDOWN_MS, DEFAULT_TASK_SHUTDOWN_MS) + SHUTDOWN_TIMEOUT_BUFFER;
   }
 
   @Override

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/TestSamzaRunner.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/TestSamzaRunner.java
@@ -17,6 +17,9 @@
  */
 package org.apache.beam.runners.samza;
 
+import static org.apache.samza.config.JobConfig.JOB_LOGGED_STORE_BASE_DIR;
+import static org.apache.samza.config.JobConfig.JOB_NON_LOGGED_STORE_BASE_DIR;
+
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -28,10 +31,10 @@ import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
 import org.apache.commons.io.FileUtils;
-import org.apache.samza.config.JobConfig;
 
 /** Test {@link SamzaRunner}. */
 public class TestSamzaRunner extends PipelineRunner<PipelineResult> {
+
   private final SamzaRunner delegate;
 
   public static TestSamzaRunner fromOptions(PipelineOptions options) {
@@ -51,8 +54,8 @@ public class TestSamzaRunner extends PipelineRunner<PipelineResult> {
         // ignore
       }
 
-      config.put(JobConfig.JOB_LOGGED_STORE_BASE_DIR(), storeDir.getAbsolutePath());
-      config.put(JobConfig.JOB_NON_LOGGED_STORE_BASE_DIR(), storeDir.getAbsolutePath());
+      config.put(JOB_LOGGED_STORE_BASE_DIR, storeDir.getAbsolutePath());
+      config.put(JOB_NON_LOGGED_STORE_BASE_DIR, storeDir.getAbsolutePath());
 
       if (samzaOptions.getConfigOverride() != null) {
         config.putAll(samzaOptions.getConfigOverride());

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternals.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternals.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.ref.SoftReference;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -64,7 +65,11 @@ import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Ints;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.UnsignedBytes;
+import org.apache.samza.config.Config;
 import org.apache.samza.context.TaskContext;
+import org.apache.samza.serializers.Serde;
+import org.apache.samza.serializers.SerdeFactory;
 import org.apache.samza.storage.kv.Entry;
 import org.apache.samza.storage.kv.KeyValueIterator;
 import org.apache.samza.storage.kv.KeyValueStore;
@@ -78,14 +83,14 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
       new ThreadLocal<>();
 
   // the stores include both beamStore for system states as well as stores for user state
-  private final Map<String, KeyValueStore<byte[], byte[]>> stores;
+  private final Map<String, KeyValueStore<ByteArray, byte[]>> stores;
   private final K key;
   private final byte[] keyBytes;
   private final int batchGetSize;
   private final String stageId;
 
   private SamzaStoreStateInternals(
-      Map<String, KeyValueStore<byte[], byte[]>> stores,
+      Map<String, KeyValueStore<ByteArray, byte[]>> stores,
       @Nullable K key,
       @Nullable byte[] keyBytes,
       String stageId,
@@ -98,8 +103,8 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
   }
 
   @SuppressWarnings("unchecked")
-  static KeyValueStore<byte[], byte[]> getBeamStore(TaskContext context) {
-    return (KeyValueStore<byte[], byte[]>) context.getStore(SamzaStoreStateInternals.BEAM_STORE);
+  static KeyValueStore<ByteArray, byte[]> getBeamStore(TaskContext context) {
+    return (KeyValueStore<ByteArray, byte[]>) context.getStore(SamzaStoreStateInternals.BEAM_STORE);
   }
 
   static Factory createStateInternalFactory(
@@ -109,7 +114,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
       SamzaPipelineOptions pipelineOptions,
       DoFnSignature signature) {
     final int batchGetSize = pipelineOptions.getStoreBatchGetSize();
-    final Map<String, KeyValueStore<byte[], byte[]>> stores = new HashMap<>();
+    final Map<String, KeyValueStore<ByteArray, byte[]>> stores = new HashMap<>();
     stores.put(BEAM_STORE, getBeamStore(context));
 
     final Coder stateKeyCoder;
@@ -119,7 +124,8 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
           .keySet()
           .forEach(
               stateId ->
-                  stores.put(stateId, (KeyValueStore<byte[], byte[]>) context.getStore(stateId)));
+                  stores.put(
+                      stateId, (KeyValueStore<ByteArray, byte[]>) context.getStore(stateId)));
       stateKeyCoder = keyCoder;
     } else {
       stateKeyCoder = VoidCoder.of();
@@ -208,13 +214,13 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
   /** Factory class to create {@link SamzaStoreStateInternals}. */
   public static class Factory<K> implements StateInternalsFactory<K> {
     private final String stageId;
-    private final Map<String, KeyValueStore<byte[], byte[]>> stores;
+    private final Map<String, KeyValueStore<ByteArray, byte[]>> stores;
     private final Coder<K> keyCoder;
     private final int batchGetSize;
 
     public Factory(
         String stageId,
-        Map<String, KeyValueStore<byte[], byte[]>> stores,
+        Map<String, KeyValueStore<ByteArray, byte[]>> stores,
         Coder<K> keyCoder,
         int batchGetSize) {
       this.stageId = stageId;
@@ -254,14 +260,14 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
     private final Coder<T> coder;
     private final byte[] encodedStoreKey;
     private final String namespace;
-    protected final KeyValueStore<byte[], byte[]> store;
+    protected final KeyValueStore<ByteArray, byte[]> store;
 
     protected AbstractSamzaState(
         StateNamespace namespace, StateTag<? extends State> address, Coder<T> coder) {
       this.coder = coder;
       this.namespace = namespace.stringKey();
 
-      final KeyValueStore<byte[], byte[]> userStore = stores.get(address.getId());
+      final KeyValueStore<ByteArray, byte[]> userStore = stores.get(address.getId());
       this.store = userStore != null ? userStore : stores.get(BEAM_STORE);
 
       final ByteArrayOutputStream baos = getThreadLocalBaos();
@@ -308,7 +314,11 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
       };
     }
 
-    protected byte[] getEncodedStoreKey() {
+    protected ByteArray getEncodedStoreKey() {
+      return ByteArray.of(encodedStoreKey);
+    }
+
+    protected byte[] getEncodedStoreKeyBytes() {
       return encodedStoreKey;
     }
 
@@ -393,7 +403,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
     public void add(T value) {
       synchronized (store) {
         final int size = getSize();
-        final byte[] encodedKey = encodeKey(size);
+        final ByteArray encodedKey = encodeKey(size);
         store.put(encodedKey, encodeValue(value));
         store.put(getEncodedStoreKey(), Ints.toByteArray(size + 1));
       }
@@ -416,7 +426,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
         }
 
         final List<T> values = new ArrayList<>(size);
-        final List<byte[]> keys = new ArrayList<>(size);
+        final List<ByteArray> keys = new ArrayList<>(size);
         int start = 0;
         while (start < size) {
           final int end = Math.min(size, start + batchGetSize);
@@ -442,7 +452,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
       synchronized (store) {
         final int size = getSize();
         if (size != 0) {
-          final List<byte[]> keys = new ArrayList<>(size);
+          final List<ByteArray> keys = new ArrayList<>(size);
           for (int i = 0; i < size; i++) {
             keys.add(encodeKey(i));
           }
@@ -457,12 +467,12 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
       return sizeBytes == null ? 0 : Ints.fromByteArray(sizeBytes);
     }
 
-    private byte[] encodeKey(int size) {
+    private ByteArray encodeKey(int size) {
       final ByteArrayOutputStream baos = getThreadLocalBaos();
       try (DataOutputStream dos = new DataOutputStream(baos)) {
-        dos.write(getEncodedStoreKey());
+        dos.write(getEncodedStoreKeyBytes());
         dos.writeInt(size);
-        return baos.toByteArray();
+        return ByteArray.of(baos.toByteArray());
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -567,7 +577,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
 
     private final Coder<KeyT> keyCoder;
     private final int storeKeySize;
-    private final List<KeyValueIterator<byte[], byte[]>> openIterators =
+    private final List<KeyValueIterator<ByteArray, byte[]>> openIterators =
         Collections.synchronizedList(new ArrayList<>());
 
     private int maxKeySize;
@@ -580,22 +590,22 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
       super(namespace, address, valueCoder);
 
       this.keyCoder = keyCoder;
-      this.storeKeySize = getEncodedStoreKey().length;
+      this.storeKeySize = getEncodedStoreKeyBytes().length;
       // initial max key size is around 100k, so we can restore timer keys
       this.maxKeySize = this.storeKeySize + 100_000;
     }
 
     @Override
     public void put(KeyT key, ValueT value) {
-      final byte[] encodedKey = encodeKey(key);
-      maxKeySize = Math.max(maxKeySize, encodedKey.length);
+      final ByteArray encodedKey = encodeKey(key);
+      maxKeySize = Math.max(maxKeySize, encodedKey.getValue().length);
       store.put(encodedKey, encodeValue(value));
     }
 
     @Override
     @Nullable
     public ReadableState<ValueT> putIfAbsent(KeyT key, ValueT value) {
-      final byte[] encodedKey = encodeKey(key);
+      final ByteArray encodedKey = encodeKey(key);
       final ValueT current = decodeValue(store.get(encodedKey));
       if (current == null) {
         put(key, value);
@@ -665,8 +675,8 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
 
     @Override
     public ReadableState<Iterator<Map.Entry<KeyT, ValueT>>> readIterator() {
-      final byte[] maxKey = createMaxKey();
-      final KeyValueIterator<byte[], byte[]> kvIter = store.range(getEncodedStoreKey(), maxKey);
+      final ByteArray maxKey = createMaxKey();
+      final KeyValueIterator<ByteArray, byte[]> kvIter = store.range(getEncodedStoreKey(), maxKey);
       openIterators.add(kvIter);
 
       return new ReadableState<Iterator<Map.Entry<KeyT, ValueT>>>() {
@@ -686,7 +696,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
 
             @Override
             public Map.Entry<KeyT, ValueT> next() {
-              Entry<byte[], byte[]> entry = kvIter.next();
+              Entry<ByteArray, byte[]> entry = kvIter.next();
               return new AbstractMap.SimpleEntry<>(
                   decodeKey(entry.getKey()), decodeValue(entry.getValue()));
             }
@@ -705,16 +715,16 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
      * properly, we need to load the content into memory.
      */
     private <OutputT> Iterable<OutputT> createIterable(
-        SerializableFunction<org.apache.samza.storage.kv.Entry<byte[], byte[]>, OutputT> fn) {
-      final byte[] maxKey = createMaxKey();
-      final KeyValueIterator<byte[], byte[]> kvIter = store.range(getEncodedStoreKey(), maxKey);
-      final List<Entry<byte[], byte[]>> iterable = ImmutableList.copyOf(kvIter);
+        SerializableFunction<org.apache.samza.storage.kv.Entry<ByteArray, byte[]>, OutputT> fn) {
+      final ByteArray maxKey = createMaxKey();
+      final KeyValueIterator<ByteArray, byte[]> kvIter = store.range(getEncodedStoreKey(), maxKey);
+      final List<Entry<ByteArray, byte[]>> iterable = ImmutableList.copyOf(kvIter);
       kvIter.close();
 
       return new Iterable<OutputT>() {
         @Override
         public Iterator<OutputT> iterator() {
-          final Iterator<Entry<byte[], byte[]>> iter = iterable.iterator();
+          final Iterator<Entry<ByteArray, byte[]>> iter = iterable.iterator();
 
           return new Iterator<OutputT>() {
             @Override
@@ -733,41 +743,42 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
 
     @Override
     public void clear() {
-      final byte[] maxKey = createMaxKey();
-      final KeyValueIterator<byte[], byte[]> kvIter = store.range(getEncodedStoreKey(), maxKey);
+      final ByteArray maxKey = createMaxKey();
+      final KeyValueIterator<ByteArray, byte[]> kvIter = store.range(getEncodedStoreKey(), maxKey);
       while (kvIter.hasNext()) {
         store.delete(kvIter.next().getKey());
       }
       kvIter.close();
     }
 
-    private byte[] encodeKey(KeyT key) {
+    private ByteArray encodeKey(KeyT key) {
       try {
         final ByteArrayOutputStream baos = getThreadLocalBaos();
-        baos.write(getEncodedStoreKey());
+        baos.write(getEncodedStoreKeyBytes());
         keyCoder.encode(key, baos);
-        return baos.toByteArray();
+        return ByteArray.of(baos.toByteArray());
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
     }
 
-    private KeyT decodeKey(byte[] keyBytes) {
+    private KeyT decodeKey(ByteArray keyBytes) {
       try {
-        final byte[] realKey = Arrays.copyOfRange(keyBytes, storeKeySize, keyBytes.length);
+        final byte[] realKey =
+            Arrays.copyOfRange(keyBytes.value, storeKeySize, keyBytes.value.length);
         return keyCoder.decode(new ByteArrayInputStream(realKey));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
     }
 
-    private byte[] createMaxKey() {
+    private ByteArray createMaxKey() {
       byte[] maxKey = new byte[maxKeySize];
       Arrays.fill(maxKey, (byte) 0xff);
 
-      final byte[] encodedKey = getEncodedStoreKey();
+      final byte[] encodedKey = getEncodedStoreKeyBytes();
       System.arraycopy(encodedKey, 0, maxKey, 0, encodedKey.length);
-      return maxKey;
+      return ByteArray.of(maxKey);
     }
 
     @Override
@@ -891,6 +902,66 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
     @Override
     public void clear() {
       clearInternal();
+    }
+  }
+
+  /** Wrapper of byte[] so it can used as key in the KeyValueStore for caching. */
+  public static class ByteArray implements Serializable, Comparable<ByteArray> {
+
+    private final byte[] value;
+
+    public static ByteArray of(byte[] value) {
+      return new ByteArray(value);
+    }
+
+    private ByteArray(byte[] value) {
+      this.value = value;
+    }
+
+    public byte[] getValue() {
+      return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ByteArray byteArray = (ByteArray) o;
+      return Arrays.equals(value, byteArray.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return value != null ? Arrays.hashCode(value) : 0;
+    }
+
+    @Override
+    public int compareTo(ByteArray other) {
+      return UnsignedBytes.lexicographicalComparator().compare(value, other.value);
+    }
+  }
+
+  /** Factory class to provide {@link ByteArraySerde}. */
+  public static class ByteArraySerdeFactory implements SerdeFactory<ByteArray> {
+
+    @Override
+    public Serde<ByteArray> getSerde(String name, Config config) {
+      return new ByteArraySerde();
+    }
+
+    /** Serde for {@link ByteArray}. */
+    public static class ByteArraySerde implements Serde<ByteArray> {
+
+      @Override
+      public byte[] toBytes(ByteArray byteArray) {
+        return byteArray.value;
+      }
+
+      @Override
+      public ByteArray fromBytes(byte[] bytes) {
+        return ByteArray.of(bytes);
+      }
     }
   }
 }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ParDoBoundMultiTranslator.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ParDoBoundMultiTranslator.java
@@ -310,7 +310,7 @@ class ParDoBoundMultiTranslator<InT, OutT>
         config.put(
             "stores." + storeId + ".factory",
             "org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory");
-        config.put("stores." + storeId + ".key.serde", "byteSerde");
+        config.put("stores." + storeId + ".key.serde", "byteArraySerde");
         config.put("stores." + storeId + ".msg.serde", "byteSerde");
 
         if (options.getStateDurable()) {

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactoryTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactoryTest.java
@@ -26,14 +26,19 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.beam.runners.core.StateNamespace;
 import org.apache.beam.runners.core.StateNamespaces;
 import org.apache.beam.runners.core.TimerInternals;
 import org.apache.beam.runners.samza.SamzaPipelineOptions;
+import org.apache.beam.runners.samza.runtime.SamzaStoreStateInternals.ByteArray;
+import org.apache.beam.runners.samza.runtime.SamzaStoreStateInternals.ByteArraySerdeFactory;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.TimeDomain;
@@ -44,9 +49,13 @@ import org.apache.samza.config.MapConfig;
 import org.apache.samza.context.TaskContext;
 import org.apache.samza.metrics.MetricsRegistryMap;
 import org.apache.samza.operators.Scheduler;
+import org.apache.samza.serializers.ByteSerde;
+import org.apache.samza.serializers.Serde;
 import org.apache.samza.storage.kv.KeyValueStore;
 import org.apache.samza.storage.kv.KeyValueStoreMetrics;
 import org.apache.samza.storage.kv.RocksDbKeyValueStore;
+import org.apache.samza.storage.kv.SerializedKeyValueStore;
+import org.apache.samza.storage.kv.SerializedKeyValueStoreMetrics;
 import org.joda.time.Instant;
 import org.junit.Test;
 import org.rocksdb.FlushOptions;
@@ -58,23 +67,30 @@ import org.rocksdb.WriteOptions;
  * timers.
  */
 public class SamzaTimerInternalsFactoryTest {
-  private static RocksDbKeyValueStore createStore(String name) {
+  private static KeyValueStore<ByteArray, byte[]> createStore(String name) {
     final Options options = new Options();
     options.setCreateIfMissing(true);
 
-    return new RocksDbKeyValueStore(
-        new File(System.getProperty("java.io.tmpdir") + "/" + name),
-        options,
-        new MapConfig(),
-        false,
-        "beamStore",
-        new WriteOptions(),
-        new FlushOptions(),
-        new KeyValueStoreMetrics("beamStore", new MetricsRegistryMap()));
+    RocksDbKeyValueStore rocksStore =
+        new RocksDbKeyValueStore(
+            new File(System.getProperty("java.io.tmpdir") + "/" + name),
+            options,
+            new MapConfig(),
+            false,
+            "beamStore",
+            new WriteOptions(),
+            new FlushOptions(),
+            new KeyValueStoreMetrics("beamStore", new MetricsRegistryMap()));
+
+    return new SerializedKeyValueStore<>(
+        rocksStore,
+        new ByteArraySerdeFactory.ByteArraySerde(),
+        new ByteSerde(),
+        new SerializedKeyValueStoreMetrics("beamStore", new MetricsRegistryMap()));
   }
 
   private static SamzaStoreStateInternals.Factory<?> createNonKeyedStateInternalsFactory(
-      SamzaPipelineOptions pipelineOptions, RocksDbKeyValueStore store) {
+      SamzaPipelineOptions pipelineOptions, KeyValueStore<ByteArray, byte[]> store) {
     final TaskContext context = mock(TaskContext.class);
     when(context.getStore(anyString())).thenReturn((KeyValueStore) store);
     final TupleTag<?> mainOutputTag = new TupleTag<>("output");
@@ -87,7 +103,7 @@ public class SamzaTimerInternalsFactoryTest {
       Scheduler<KeyedTimerData<String>> timerRegistry,
       String timerStateId,
       SamzaPipelineOptions pipelineOptions,
-      RocksDbKeyValueStore store) {
+      KeyValueStore<ByteArray, byte[]> store) {
 
     final SamzaStoreStateInternals.Factory<?> nonKeyedStateInternalsFactory =
         createNonKeyedStateInternalsFactory(pipelineOptions, store);
@@ -121,7 +137,7 @@ public class SamzaTimerInternalsFactoryTest {
     final SamzaPipelineOptions pipelineOptions =
         PipelineOptionsFactory.create().as(SamzaPipelineOptions.class);
 
-    final RocksDbKeyValueStore store = createStore("store1");
+    final KeyValueStore<ByteArray, byte[]> store = createStore("store1");
     final SamzaTimerInternalsFactory<String> timerInternalsFactory =
         createTimerInternalsFactory(null, "timer", pipelineOptions, store);
 
@@ -157,7 +173,7 @@ public class SamzaTimerInternalsFactoryTest {
     final SamzaPipelineOptions pipelineOptions =
         PipelineOptionsFactory.create().as(SamzaPipelineOptions.class);
 
-    RocksDbKeyValueStore store = createStore("store2");
+    KeyValueStore<ByteArray, byte[]> store = createStore("store2");
     final SamzaTimerInternalsFactory<String> timerInternalsFactory =
         createTimerInternalsFactory(null, "timer", pipelineOptions, store);
 
@@ -200,7 +216,7 @@ public class SamzaTimerInternalsFactoryTest {
     final SamzaPipelineOptions pipelineOptions =
         PipelineOptionsFactory.create().as(SamzaPipelineOptions.class);
 
-    RocksDbKeyValueStore store = createStore("store3");
+    KeyValueStore<ByteArray, byte[]> store = createStore("store3");
     TestTimerRegistry timerRegistry = new TestTimerRegistry();
 
     final SamzaTimerInternalsFactory<String> timerInternalsFactory =
@@ -244,7 +260,7 @@ public class SamzaTimerInternalsFactoryTest {
     final SamzaPipelineOptions pipelineOptions =
         PipelineOptionsFactory.create().as(SamzaPipelineOptions.class);
 
-    RocksDbKeyValueStore store = createStore("store4");
+    KeyValueStore<ByteArray, byte[]> store = createStore("store4");
     final SamzaTimerInternalsFactory<String> timerInternalsFactory =
         createTimerInternalsFactory(null, "timer", pipelineOptions, store);
 
@@ -277,5 +293,22 @@ public class SamzaTimerInternalsFactoryTest {
     assertEquals(1, readyTimers.size());
 
     store.close();
+  }
+
+  @Test
+  public void testByteArray() {
+    ByteArray key1 = ByteArray.of("hello world".getBytes(StandardCharsets.UTF_8));
+    Serde<ByteArray> serde = new ByteArraySerdeFactory().getSerde("", null);
+    byte[] keyBytes = serde.toBytes(key1);
+    ByteArray key2 = serde.fromBytes(keyBytes);
+    assertEquals(key1, key2);
+
+    Map<ByteArray, String> map = new HashMap<>();
+    map.put(key1, "found it");
+    assertEquals("found it", map.get(key2));
+
+    map.remove(key1);
+    assertTrue(!map.containsKey(key2));
+    assertTrue(map.isEmpty());
   }
 }

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/translation/ConfigGeneratorTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/translation/ConfigGeneratorTest.java
@@ -73,7 +73,7 @@ public class ConfigGeneratorTest {
     assertEquals(
         RocksDbKeyValueStorageEngineFactory.class.getName(),
         config.get("stores.beamStore.factory"));
-    assertEquals("byteSerde", config.get("stores.beamStore.key.serde"));
+    assertEquals("byteArraySerde", config.get("stores.beamStore.key.serde"));
     assertEquals("byteSerde", config.get("stores.beamStore.msg.serde"));
     assertNull(config.get("stores.beamStore.changelog"));
 
@@ -203,7 +203,7 @@ public class ConfigGeneratorTest {
     assertEquals(
         RocksDbKeyValueStorageEngineFactory.class.getName(),
         config.get("stores.testState.factory"));
-    assertEquals("byteSerde", config.get("stores.testState.key.serde"));
+    assertEquals("byteArraySerde", config.get("stores.testState.key.serde"));
     assertEquals("byteSerde", config.get("stores.testState.msg.serde"));
     assertNull(config.get("stores.testState.changelog"));
 


### PR DESCRIPTION
1. Upgrade and refactor to use samza 1.3.0  
2. Write pipeline dot graph to config
3. Use ByteArray wrapper for byte[] for key-value store key type


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
