### PR TITLE
[BEAM-8801] PubsubMessageToRow should not check useFlatSchema() in pr…

### DIFF
--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
@@ -36,16 +36,15 @@ import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TimestampedValue;
-import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -69,7 +68,7 @@ public class PubsubMessageToRowTest implements Serializable {
             .addRowField("payload", payloadSchema)
             .build();
 
-    PCollection<Row> rows =
+    PCollectionTuple rows =
         pipeline
             .apply(
                 "create",
@@ -81,14 +80,13 @@ public class PubsubMessageToRowTest implements Serializable {
                     message(4, map("dttr", "vdl"), "{ \"name\" : null, \"id\" : null }")))
             .apply(
                 "convert",
-                ParDo.of(
-                    PubsubMessageToRow.builder()
-                        .messageSchema(messageSchema)
-                        .useDlq(false)
-                        .useFlatSchema(false)
-                        .build()));
+                PubsubMessageToRow.builder()
+                    .messageSchema(messageSchema)
+                    .useDlq(false)
+                    .useFlatSchema(false)
+                    .build());
 
-    PAssert.that(rows)
+    PAssert.that(rows.get(MAIN_TAG))
         .containsInAnyOrder(
             Row.withSchema(messageSchema)
                 .addValues(ts(1), map("attr", "val"), row(payloadSchema, 3, "foo"))
@@ -131,13 +129,11 @@ public class PubsubMessageToRowTest implements Serializable {
                     message(4, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }")))
             .apply(
                 "convert",
-                ParDo.of(
-                        PubsubMessageToRow.builder()
-                            .messageSchema(messageSchema)
-                            .useDlq(true)
-                            .useFlatSchema(false)
-                            .build())
-                    .withOutputTags(MAIN_TAG, TupleTagList.of(DLQ_TAG)));
+                PubsubMessageToRow.builder()
+                    .messageSchema(messageSchema)
+                    .useDlq(true)
+                    .useFlatSchema(false)
+                    .build());
 
     PCollection<Row> rows = outputs.get(MAIN_TAG);
     PCollection<PubsubMessage> dlqMessages = outputs.get(DLQ_TAG);
@@ -177,7 +173,7 @@ public class PubsubMessageToRowTest implements Serializable {
             .addNullableField("name", FieldType.STRING)
             .build();
 
-    PCollection<Row> rows =
+    PCollectionTuple rows =
         pipeline
             .apply(
                 "create",
@@ -189,14 +185,13 @@ public class PubsubMessageToRowTest implements Serializable {
                     message(4, map("dttr", "vdl"), "{ \"name\" : null, \"id\" : null }")))
             .apply(
                 "convert",
-                ParDo.of(
-                    PubsubMessageToRow.builder()
-                        .messageSchema(messageSchema)
-                        .useDlq(false)
-                        .useFlatSchema(true)
-                        .build()));
+                PubsubMessageToRow.builder()
+                    .messageSchema(messageSchema)
+                    .useDlq(false)
+                    .useFlatSchema(true)
+                    .build());
 
-    PAssert.that(rows)
+    PAssert.that(rows.get(MAIN_TAG))
         .containsInAnyOrder(
             Row.withSchema(messageSchema)
                 .addValues(ts(1), /* map("attr", "val"), */ 3, "foo")
@@ -237,17 +232,14 @@ public class PubsubMessageToRowTest implements Serializable {
                     message(4, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }")))
             .apply(
                 "convert",
-                ParDo.of(
-                        PubsubMessageToRow.builder()
-                            .messageSchema(messageSchema)
-                            .useDlq(true)
-                            .useFlatSchema(true)
-                            .build())
-                    .withOutputTags(
-                        PubsubMessageToRow.MAIN_TAG, TupleTagList.of(PubsubMessageToRow.DLQ_TAG)));
+                PubsubMessageToRow.builder()
+                    .messageSchema(messageSchema)
+                    .useDlq(true)
+                    .useFlatSchema(true)
+                    .build());
 
-    PCollection<Row> rows = outputs.get(PubsubMessageToRow.MAIN_TAG);
-    PCollection<PubsubMessage> dlqMessages = outputs.get(PubsubMessageToRow.DLQ_TAG);
+    PCollection<Row> rows = outputs.get(MAIN_TAG);
+    PCollection<PubsubMessage> dlqMessages = outputs.get(DLQ_TAG);
 
     PAssert.that(dlqMessages)
         .satisfies(
@@ -273,6 +265,66 @@ public class PubsubMessageToRowTest implements Serializable {
                 .build());
 
     pipeline.run();
+  }
+
+  @Test
+  public void testFlatSchemaMessageInvalidElement() {
+    Schema messageSchema =
+        Schema.builder()
+            .addDateTimeField("event_timestamp")
+            .addInt32Field("id")
+            .addStringField("name")
+            .build();
+
+    pipeline
+        .apply(
+            "create",
+            Create.timestamped(
+                message(1, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
+                message(2, map("attr1", "val1"), "{ \"invalid1\" : \"sdfsd\" }")))
+        .apply(
+            "convert",
+            PubsubMessageToRow.builder()
+                .messageSchema(messageSchema)
+                .useDlq(false)
+                .useFlatSchema(true)
+                .build());
+
+    Exception exception = Assert.assertThrows(RuntimeException.class, () -> pipeline.run());
+    Assert.assertTrue(exception.getMessage().contains("Error parsing message"));
+  }
+
+  @Test
+  public void testNestedSchemaMessageInvalidElement() {
+    Schema payloadSchema =
+        Schema.builder()
+            .addNullableField("id", FieldType.INT32)
+            .addNullableField("name", FieldType.STRING)
+            .build();
+
+    Schema messageSchema =
+        Schema.builder()
+            .addDateTimeField("event_timestamp")
+            .addMapField("attributes", VARCHAR, VARCHAR)
+            .addRowField("payload", payloadSchema)
+            .build();
+
+    pipeline
+        .apply(
+            "create",
+            Create.timestamped(
+                message(1, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
+                message(2, map("attr1", "val1"), "{ \"invalid1\" : \"sdfsd\" }")))
+        .apply(
+            "convert",
+            PubsubMessageToRow.builder()
+                .messageSchema(messageSchema)
+                .useDlq(false)
+                .useFlatSchema(false)
+                .build());
+
+    Exception exception = Assert.assertThrows(RuntimeException.class, () -> pipeline.run());
+    Assert.assertTrue(exception.getMessage().contains("Error parsing message"));
   }
 
   private Row row(Schema schema, Object... objects) {


### PR DESCRIPTION
…ocessElement.

The PR will make _PubsubMessage_ a **PTransform** instead of DoFn.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
