### PR TITLE
[BEAM-8335] Modify PipelineInstrument to add TestStream for unbounded PCollections

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
@@ -19,9 +19,27 @@
 
 from __future__ import absolute_import
 
+import apache_beam as beam
 from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 from apache_beam.utils import timestamp
 from apache_beam.utils.timestamp import Timestamp
+
+
+class StreamingCacheReceiver(beam.transforms.PTransform):
+  """Marks a PCollection to be read from cache.
+
+  This class is used in the PipelineInstrument to mark that an unbounded
+  Pcollection should be read from cache. This is because the TestStream needs
+  to know all the PCollections before being created.
+  """
+  def expand(self, pbegin):
+    assert isinstance(pbegin, beam.pvalue.PBegin)
+    self.pipeline = pbegin.pipeline
+
+    return beam.pvalue.PCollection(self.pipeline, is_bounded=False)
+
+  def get_windowing(self, unused_inputs):
+    return beam.Windowing(beam.window.GlobalWindows())
 
 
 class StreamingCache(object):

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -446,8 +446,7 @@ class PipelineInstrument(object):
     # The set of keys from the cached unbounded PCollections will be used as the
     # output tags for the TestStream. This is to remember what cache-key is
     # associated with which PCollection.
-    unbounded_cacheables = v.unbounded_pcolls
-    output_tags = unbounded_cacheables
+    output_tags = v.unbounded_pcolls
 
     # Take the PCollections that will be read from the TestStream and insert
     # them back into the dictionary of cached PCollections. The next step will
@@ -458,8 +457,7 @@ class PipelineInstrument(object):
       if len(output_tags) == 1:
         self._cached_pcoll_read[None] = output_pcolls
       else:
-        for tag, pcoll in output_pcolls.items():
-          self._cached_pcoll_read[tag] = pcoll
+        self._cached_pcoll_read.update(output_pcolls)
 
 
     class ReadCacheWireVisitor(PipelineVisitor):
@@ -481,7 +479,7 @@ class PipelineInstrument(object):
             key = self._pin.cache_key(input_pcoll)
 
             # Replace the input pcollection with the cached pcollection (if it
-            # already cached).
+            # has been cached).
             if key in self._pin._cached_pcoll_read:
               input_list[i] = self._pin._cached_pcoll_read[key]
           # Update the transform with its new inputs.

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -31,6 +31,8 @@ from apache_beam.pipeline import PipelineVisitor
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.runners.interactive import cache_manager as cache
 from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive.caching import streaming_cache
+from apache_beam.testing import test_stream
 
 READ_CACHE = "_ReadCache_"
 WRITE_CACHE = "_WriteCache_"
@@ -400,12 +402,15 @@ class PipelineInstrument(object):
     # Can only read from cache when the cache with expected key exists.
     if self._cache_manager.exists('full', key):
       if key not in self._cached_pcoll_read:
+        if pcoll.is_bounded:
+          read_transform = cache.ReadCache(self._cache_manager, key)
+        else:
+          read_transform = streaming_cache.StreamingCacheReceiver()
+
         # Mutates the pipeline with cache read transform attached
         # to root of the pipeline.
-        pcoll_from_cache = (
-            pipeline
-            | '{}{}'.format(READ_CACHE, key) >> cache.ReadCache(
-                self._cache_manager, key))
+        pcoll_from_cache = (pipeline
+                            | '{}{}'.format(READ_CACHE, key) >> read_transform)
         self._cached_pcoll_read[key] = pcoll_from_cache
     # else: NOOP when cache doesn't exist, just compute the original graph.
 
@@ -417,6 +422,45 @@ class PipelineInstrument(object):
     AppliedPtransform that sources pvalue from the cache. If there is no valid
     cache, noop.
     """
+
+    # Find all cached unbounded PCollections.
+    class CacheableUnboundedPCollectionVisitor(PipelineVisitor):
+      def __init__(self, pin):
+        self._pin = pin
+        self.unbounded_pcolls = set()
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        if transform_node.inputs:
+          for input_pcoll in transform_node.inputs:
+            key = self._pin.cache_key(input_pcoll)
+            if (key in self._pin._cached_pcoll_read and
+                not input_pcoll.is_bounded):
+              self.unbounded_pcolls.add(key)
+
+    v = CacheableUnboundedPCollectionVisitor(self)
+    pipeline.visit(v)
+
+    # The set of keys from the cached unbounded PCollections will be used as the
+    # output tags for the TestStream. This is to remember what cache-key is
+    # associated with which PCollection.
+    unbounded_cacheables = v.unbounded_pcolls
+    output_tags = unbounded_cacheables
+
+    # Take the PCollections that will be read from the TestStream and insert
+    # them back into the dictionary of cached PCollections. The next step will
+    # replace the downstream consumer of the non-cached PCollections with these
+    # PCollections.
+    if output_tags:
+      output_pcolls = pipeline | test_stream.TestStream(output_tags=output_tags)
+      if len(output_tags) == 1:
+        self._cached_pcoll_read[None] = output_pcolls
+      else:
+        for tag, pcoll in output_pcolls.items():
+          self._cached_pcoll_read[tag] = pcoll
+
 
     class ReadCacheWireVisitor(PipelineVisitor):
       """Visitor wires cache read as inputs to replace corresponding original
@@ -433,10 +477,14 @@ class PipelineInstrument(object):
       def visit_transform(self, transform_node):
         if transform_node.inputs:
           input_list = list(transform_node.inputs)
-          for i in range(len(input_list)):
-            key = self._pin.cache_key(input_list[i])
+          for i, input_pcoll in enumerate(input_list):
+            key = self._pin.cache_key(input_pcoll)
+
+            # Replace the input pcollection with the cached pcollection (if it
+            # already cached).
             if key in self._pin._cached_pcoll_read:
               input_list[i] = self._pin._cached_pcoll_read[key]
+          # Update the transform with its new inputs.
           transform_node.inputs = tuple(input_list)
 
     v = ReadCacheWireVisitor(self)

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -38,7 +38,7 @@ from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pi
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_proto_equal
 from apache_beam.testing.test_stream import TestStream
 
-#Work around nose tests using Python2 without unittest.mock module.
+# Work around nose tests using Python2 without unittest.mock module.
 try:
   from unittest.mock import MagicMock
 except ImportError:
@@ -52,7 +52,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
   def test_pcolls_to_pcoll_id(self):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
-# pylint: disable=range-builtin-not-iterating
+    # pylint: disable=range-builtin-not-iterating
     init_pcoll = p | 'Init Create' >> beam.Impulse()
     _, ctx = p.to_runner_api(use_fake_coders=True, return_context=True)
     self.assertEqual(instr.pcolls_to_pcoll_id(p, ctx), {

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -178,8 +178,8 @@ class TestStream(PTransform):
     assert coder is not None
     self.coder = coder
     self.watermarks = {None: timestamp.MIN_TIMESTAMP}
-    self._events = list(events) if events is not None else []
-    self.output_tags = set(output_tags) if output_tags is not None else set()
+    self._events = list(events) if events else list()
+    self.output_tags = set(output_tags) if output_tags else set()
 
   def get_windowing(self, unused_inputs):
     return core.Windowing(window.GlobalWindows())

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -172,13 +172,14 @@ class TestStream(PTransform):
   output.
   """
 
-  def __init__(self, coder=coders.FastPrimitivesCoder(), events=None):
+  def __init__(self, coder=coders.FastPrimitivesCoder(), events=None,
+               output_tags=None):
     super(TestStream, self).__init__()
     assert coder is not None
     self.coder = coder
     self.watermarks = {None: timestamp.MIN_TIMESTAMP}
-    self._events = [] if events is None else list(events)
-    self.output_tags = set()
+    self._events = list(events) if events is not None else []
+    self.output_tags = set(output_tags) if output_tags is not None else set()
 
   def get_windowing(self, unused_inputs):
     return core.Windowing(window.GlobalWindows())


### PR DESCRIPTION
- Adds a StreamingCacheReceiver to mark any unbounded PCollections that will need to be cached and used as input to the TestStream.
- Modifies the PipelineInstrument class to add the TestStream and output to the marked PCollections

R: @davidyan74 
R: @KevinGG 

#interactive
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
