### PR TITLE
[BEAM-3713] pytest migration: py3x-{gcp,cython}

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,14 +214,6 @@ task pythonPreCommit() {
   // have caught. Note that the same tests will still run in postcommit.
 }
 
-// TODO(BEAM-3713): Temporary task for testing pytest.
-task pythonPreCommitPytest() {
-  dependsOn ":sdks:python:test-suites:tox:py2:preCommitPy2Pytest"
-  dependsOn ":sdks:python:test-suites:tox:py35:preCommitPy35Pytest"
-  dependsOn ":sdks:python:test-suites:tox:py36:preCommitPy36Pytest"
-  dependsOn ":sdks:python:test-suites:tox:py37:preCommitPy37Pytest"
-}
-
 task pythonLintPreCommit() {
   dependsOn ":sdks:python:test-suites:tox:py2:lint"
   dependsOn ":sdks:python:test-suites:tox:py37:lint"

--- a/sdks/python/test-suites/tox/py2/build.gradle
+++ b/sdks/python/test-suites/tox/py2/build.gradle
@@ -42,9 +42,7 @@ test.dependsOn testPython2
 toxTask "testPy2Cython", "py27-cython-pytest"
 test.dependsOn testPy2Cython
 
-// Ensure that testPy2Cython runs exclusively to other tests. This line is not
-// actually required, since gradle doesn't do parallel execution within a
-// project.
+// TODO(BEAM-8954): Remove this once tox uses isolated builds.
 testPy2Cython.mustRunAfter testPython2, testPy2Gcp
 
 toxTask "cover", "cover"

--- a/sdks/python/test-suites/tox/py35/build.gradle
+++ b/sdks/python/test-suites/tox/py35/build.gradle
@@ -26,35 +26,20 @@ applyPythonNature()
 // Required to setup a Python 3 virtualenv.
 pythonVersion = '3.5'
 
+// TODO(BEAM-3713): Migrate to -pytest env variant.
 toxTask "testPython35", "py35"
 test.dependsOn testPython35
 
-toxTask "testPy35Gcp", "py35-gcp"
+toxTask "testPy35Gcp", "py35-gcp-pytest"
 test.dependsOn testPy35Gcp
 
-toxTask "testPy35Cython", "py35-cython"
+toxTask "testPy35Cython", "py35-cython-pytest"
 test.dependsOn testPy35Cython
 
-// Ensure that testPy35Cython runs exclusively to other tests. This line is not
-// actually required, since gradle doesn't do parallel execution within a
-// project.
+// TODO(BEAM-8954): Remove this once tox uses isolated builds.
 testPy35Cython.mustRunAfter testPython35, testPy35Gcp
-
-// TODO(BEAM-3713): Temporary pytest tasks that should eventually replace
-//  nose-based test tasks.
-toxTask "testPy35GcpPytest", "py35-gcp-pytest"
-toxTask "testPython35Pytest", "py35-pytest"
-toxTask "testPy35CythonPytest", "py35-cython-pytest"
-// Ensure that cython tests run exclusively to other tests.
-testPy35CythonPytest.mustRunAfter testPython35Pytest, testPy35GcpPytest
 
 task preCommitPy35() {
     dependsOn "testPy35Gcp"
     dependsOn "testPy35Cython"
-}
-
-task preCommitPy35Pytest {
-  dependsOn "testPy35GcpPytest"
-  dependsOn "testPy35CythonPytest"
-  dependsOn "lint"
 }

--- a/sdks/python/test-suites/tox/py36/build.gradle
+++ b/sdks/python/test-suites/tox/py36/build.gradle
@@ -26,34 +26,20 @@ applyPythonNature()
 // Required to setup a Python 3 virtualenv.
 pythonVersion = '3.6'
 
+// TODO(BEAM-3713): Migrate to -pytest env variant.
 toxTask "testPython36", "py36"
 test.dependsOn testPython36
 
-toxTask "testPy36Gcp", "py36-gcp"
+toxTask "testPy36Gcp", "py36-gcp-pytest"
 test.dependsOn testPy36Gcp
 
-toxTask "testPy36Cython", "py36-cython"
+toxTask "testPy36Cython", "py36-cython-pytest"
 test.dependsOn testPy36Cython
 
-// Ensure that testPy36Cython runs exclusively to other tests. This line is not
-// actually required, since gradle doesn't do parallel execution within a
-// project.
+// TODO(BEAM-8954): Remove this once tox uses isolated builds.
 testPy36Cython.mustRunAfter testPython36, testPy36Gcp
-
-// TODO(BEAM-3713): Temporary pytest tasks that should eventually replace
-//  nose-based test tasks.
-toxTask "testPy36GcpPytest", "py36-gcp-pytest"
-toxTask "testPython36Pytest", "py36-pytest"
-toxTask "testPy36CythonPytest", "py36-cython-pytest"
-// Ensure that cython tests run exclusively to other tests.
-testPy36CythonPytest.mustRunAfter testPython36Pytest, testPy36GcpPytest
 
 task preCommitPy36() {
     dependsOn "testPy36Gcp"
     dependsOn "testPy36Cython"
-}
-
-task preCommitPy36Pytest {
-  dependsOn "testPy36GcpPytest"
-  dependsOn "testPy36CythonPytest"
 }

--- a/sdks/python/test-suites/tox/py37/build.gradle
+++ b/sdks/python/test-suites/tox/py37/build.gradle
@@ -35,34 +35,20 @@ lint.dependsOn lintPy37
 toxTask "mypyPy37", "py37-mypy"
 lint.dependsOn mypyPy37
 
+// TODO(BEAM-3713): Migrate to -pytest env variant.
 toxTask "testPython37", "py37"
 test.dependsOn testPython37
 
-toxTask "testPy37Gcp", "py37-gcp"
+toxTask "testPy37Gcp", "py37-gcp-pytest"
 test.dependsOn testPy37Gcp
 
-toxTask "testPy37Cython", "py37-cython"
+toxTask "testPy37Cython", "py37-cython-pytest"
 test.dependsOn testPy37Cython
 
-// Ensure that testPy37Cython runs exclusively to other tests. This line is not
-// actually required, since gradle doesn't do parallel execution within a
-// project.
+// TODO(BEAM-8954): Remove this once tox uses isolated builds.
 testPy37Cython.mustRunAfter testPython37, testPy37Gcp
-
-// TODO(BEAM-3713): Temporary pytest tasks that should eventually replace
-//  nose-based test tasks.
-toxTask "testPy37GcpPytest", "py37-gcp-pytest"
-toxTask "testPython37Pytest", "py37-pytest"
-toxTask "testPy37CythonPytest", "py37-cython-pytest"
-// Ensure that cython tests run exclusively to other tests.
-testPy37CythonPytest.mustRunAfter testPython37Pytest, testPy37GcpPytest
 
 task preCommitPy37() {
     dependsOn "testPy37Gcp"
     dependsOn "testPy37Cython"
-}
-
-task preCommitPy37Pytest {
-  dependsOn "testPy37GcpPytest"
-  dependsOn "testPy37CythonPytest"
 }

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -148,6 +148,9 @@ platform = linux
 setenv =
   RUN_SKIPPED_PY3_TESTS=0
 commands =
+  # TODO(BEAM-8954): Remove this build_ext invocation once local source no longer
+  #   shadows the installed apache_beam.
+  python setup.py build_ext --inplace
   python apache_beam/examples/complete/autocomplete_test.py
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
@@ -172,6 +175,9 @@ platform = linux
 setenv =
   RUN_SKIPPED_PY3_TESTS=0
 commands =
+  # TODO(BEAM-8954): Remove this build_ext invocation once local source no longer
+  #   shadows the installed apache_beam.
+  python setup.py build_ext --inplace
   python apache_beam/examples/complete/autocomplete_test.py
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
@@ -196,6 +202,9 @@ platform = linux
 setenv =
   RUN_SKIPPED_PY3_TESTS=0
 commands =
+  # TODO(BEAM-8954): Remove this build_ext invocation once local source no longer
+  #   shadows the installed apache_beam.
+  python setup.py build_ext --inplace
   python apache_beam/examples/complete/autocomplete_test.py
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 


### PR DESCRIPTION
Same diffs as in: #10322 and #10355

Diffs: https://gist.github.com/udim/635f0ccdf337df966878b1f17560207a

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
