### PR TITLE
[release-2.18.0][BEAM-8967] Maven artifact beam-sdks-java-core does not have JSR305 specified as "compile"

### DIFF
--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -69,7 +69,7 @@ dependencies {
   compile library.java.protobuf_java
   compile library.java.commons_compress
   compile library.java.commons_lang3
-  compile library.java.jsr305
+  shadow library.java.jsr305
   shadow library.java.jackson_core
   shadow library.java.jackson_annotations
   shadow library.java.jackson_databind


### PR DESCRIPTION
A tiny error we found when validating the generated pom files from the previous cherry-pick. We should be good to go after this one.

R: @udim 
CC: @suztomo 
