### PR TITLE
[BEAM-8972] Add Jenkins job with Combine test for portable Java

### DIFF
--- a/.test-infra/dataproc/flink_cluster.sh
+++ b/.test-infra/dataproc/flink_cluster.sh
@@ -133,7 +133,7 @@ function create_cluster() {
 
   # Docker init action restarts yarn so we need to start yarn session after this restart happens.
   # This is why flink init action is invoked last.
-  gcloud dataproc clusters create $CLUSTER_NAME --region=global --num-workers=$num_dataproc_workers --initialization-actions $DOCKER_INIT,$BEAM_INIT,$FLINK_INIT --metadata "${metadata}", --image-version=$image_version --zone=$GCLOUD_ZONE --quiet
+  gcloud dataproc clusters create $CLUSTER_NAME --region=global --num-workers=$num_dataproc_workers --initialization-actions $DOCKER_INIT,$BEAM_INIT,$FLINK_INIT --initialization-action-timeout 15m --metadata "${metadata}", --image-version=$image_version --zone=$GCLOUD_ZONE --quiet
 }
 
 # Runs init actions for Docker, Portability framework (Beam) and Flink cluster

--- a/.test-infra/jenkins/CommonTestProperties.groovy
+++ b/.test-infra/jenkins/CommonTestProperties.groovy
@@ -39,7 +39,8 @@ class CommonTestProperties {
                         SPARK: ":runners:spark",
                         SPARK_STRUCTURED_STREAMING: ":runners:spark",
                         FLINK: ":runners:flink:1.10",
-                        DIRECT: ":runners:direct-java"
+                        DIRECT: ":runners:direct-java",
+                        PORTABLE: ":runners:portability:java"
                 ],
                 PYTHON: [
                         DATAFLOW: "TestDataflowRunner",

--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Java.groovy
@@ -103,13 +103,13 @@ def loadTest = { scope, triggeringContext, mode, isStreaming ->
     flink.setUp([javaHarnessImageTag], numberOfWorkers, publisher.getFullImageName('beam_flink1.10_job_server'))
 
     def configurations = testScenarios.findAll { it.pipelineOptions?.sdkWorkerParallelism?.value == numberOfWorkers }
-    loadTestsBuilder.loadTests(scope, sdk, configurations, "Combine", mode)
     if (isStreaming) {
-        for (config in configurations) {
-            config.pipelineOptions << [inputWindowDurationSec: 1200]
-        }
+      for (config in configurations) {
+        config.pipelineOptions << [inputWindowDurationSec: 1200]
+      }
     }
-    numberOfWorkers = 5
+  loadTestsBuilder.loadTests(scope, sdk, configurations, "Combine", mode)
+  numberOfWorkers = 5
     flink.scaleCluster(numberOfWorkers)
 
     configurations = testScenarios.findAll { it.pipelineOptions?.sdkWorkerParallelism?.value == numberOfWorkers }

--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Java.groovy
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import CommonJobProperties as commonJobProperties
+import CommonTestProperties
+import CronJobBuilder
+import LoadTestsBuilder as loadTestsBuilder
+import PhraseTriggeringPostCommitBuilder
+
+def loadTestConfigurations = { mode, isStreaming, datasetName, sdkHarnessImageTag ->
+  [
+          [
+                  title          : 'Load test: 2GB of 10B records on Flink in Portable mode',
+                  test           : 'org.apache.beam.sdk.loadtests.CombineLoadTest',
+                  runner         : CommonTestProperties.Runner.PORTABLE,
+                  pipelineOptions: [
+                          project             : 'apache-beam-testing',
+                          appName             : "load_tests_Java_Portable_Flink_${mode}_Combine_1",
+                          tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                          publishToBigQuery   : true,
+                          bigQueryDataset     : datasetName,
+                          bigQueryTable       : "java_portable_flink_${mode}_Combine_1",
+                          sourceOptions       : """
+                                            {
+                                              "numRecords": 200000000,
+                                              "keySizeBytes": 1,
+                                              "valueSizeBytes": 9
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                          fanout              : 1,
+                          iterations          : 1,
+                          topCount            : 20,
+                          sdkWorkerParallelism: 5,
+                          perKeyCombiner      : "TOP_LARGEST",
+                          streaming           : isStreaming,
+                          jobEndpoint         : 'localhost:8099',
+                          defaultEnvironmentConfig    : sdkHarnessImageTag,
+                          defaultEnvironmentType      : 'DOCKER',
+                          experiments         : 'beam_fn_api'
+                  ]
+          ],
+            [
+                    title          : 'Load test: fanout 8 times with 2GB 10-byte records total on Flink in Portable mode',
+                    test           : 'org.apache.beam.sdk.loadtests.CombineLoadTest',
+                    runner         : CommonTestProperties.Runner.PORTABLE,
+                    pipelineOptions: [
+                            project             : 'apache-beam-testing',
+                            appName             : "load_tests_Java_Portable_Flink_${mode}_Combine_5",
+                            tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery   : true,
+                            bigQueryDataset     : datasetName,
+                            bigQueryTable       : "java_portable_flink_${mode}_Combine_5",
+                            sourceOptions       : """
+                                                    {
+                                                      "numRecords": 25000000,
+                                                      "keySizeBytes": 1,
+                                                      "valueSizeBytes": 9
+                                                    }
+                                               """.trim().replaceAll("\\s", ""),
+                            fanout              : 8,
+                            iterations          : 1,
+                            topCount            : 20,
+                            sdkWorkerParallelism          : 16,
+                            perKeyCombiner      : "TOP_LARGEST",
+                            streaming           : isStreaming,
+                            jobEndpoint          : 'localhost:8099',
+                            defaultEnvironmentConfig    : sdkHarnessImageTag,
+                            defaultEnvironmentType      : 'DOCKER',
+                            experiments         : 'beam_fn_api'
+                    ]
+            ]
+    ]
+}
+
+
+def loadTest = { scope, triggeringContext, mode, isStreaming ->
+    Docker publisher = new Docker(scope, loadTestsBuilder.DOCKER_CONTAINER_REGISTRY)
+    def sdk = CommonTestProperties.SDK.JAVA
+    String javaHarnessImageTag = publisher.getFullImageName('beam_java_sdk')
+
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    def numberOfWorkers = 16
+    List<Map> testScenarios = loadTestConfigurations(mode, isStreaming, datasetName, javaHarnessImageTag)
+
+    publisher.publish(':sdks:java:container:docker', 'beam_java_sdk')
+    publisher.publish(':runners:flink:1.10:job-server-container:docker', 'beam_flink1.10_job_server')
+    def flink = new Flink(scope, "beam_LoadTests_Java_Portable_Flink_$mode")
+    flink.setUp([javaHarnessImageTag], numberOfWorkers, publisher.getFullImageName('beam_flink1.10_job_server'))
+
+    def configurations = testScenarios.findAll { it.pipelineOptions?.sdkWorkerParallelism?.value == numberOfWorkers }
+    loadTestsBuilder.loadTests(scope, sdk, configurations, "Combine", mode)
+    if (isStreaming) {
+        for (config in configurations) {
+            config.pipelineOptions << [inputWindowDurationSec: 1200]
+        }
+    }
+    numberOfWorkers = 5
+    flink.scaleCluster(numberOfWorkers)
+
+    configurations = testScenarios.findAll { it.pipelineOptions?.sdkWorkerParallelism?.value == numberOfWorkers }
+    if (isStreaming) {
+        for (config in configurations) {
+            config.pipelineOptions << [inputWindowDurationSec: 1200]
+        }
+    }
+    loadTestsBuilder.loadTests(scope, sdk, configurations, "Combine", mode)
+}
+
+
+def batchLoadTestJob = { scope, triggeringContext ->
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, commonLoadTestConfig('batch', false, datasetName), "Combine", "batch")
+}
+
+def streamingLoadTestJob = {scope, triggeringContext ->
+    scope.description('Runs Java Combine load tests on Portable runner on Flink in streaming mode')
+    commonJobProperties.setTopLevelMainJobProperties(scope, 'master', 240)
+
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    for (testConfiguration in commonLoadTestConfig('streaming', true, datasetName)) {
+        testConfiguration.pipelineOptions << [inputWindowDurationSec: 1200]
+        loadTestsBuilder.loadTest(scope, testConfiguration.title, testConfiguration.runner, CommonTestProperties.SDK.JAVA, testConfiguration.pipelineOptions, testConfiguration.test)
+    }
+}
+
+CronJobBuilder.cronJob('beam_LoadTests_Java_Combine_Portable_Flink_Batch', 'H 12 * * *', this) {
+    loadTest(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT, 'batch', false)
+}
+
+CronJobBuilder.cronJob('beam_LoadTests_Java_Combine_Portable_Flink_Streaming', 'H 12 * * *', this) {
+    loadTest(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT, 'streaming', true)
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_LoadTests_Java_Combine_Portable_Flink_Batch',
+        'Run Load Tests Java Combine Portable Flink Batch',
+        'Load Tests Java Combine Flink Batch suite in Portable mode',
+        this
+) {
+    loadTest(delegate, CommonTestProperties.TriggeringContext.PR, 'batch', false)
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_LoadTests_Java_Combine_Portable_Flink_Streaming',
+        'Run Load Tests Java Combine Portable Flink Streaming',
+        'Load Tests Java Combine Flink Streaming suite in Portable mode',
+        this
+) {
+    loadTest(delegate, CommonTestProperties.TriggeringContext.PR, 'streaming', true)
+}

--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Java.groovy
@@ -39,11 +39,7 @@ def loadTestConfigurations = { mode, isStreaming, datasetName, sdkHarnessImageTa
                                             {
                                               "numRecords": 200000000,
                                               "keySizeBytes": 1,
-                                              "valueSizeBytes": 9,
-                                                "delayDistribution": {
-                                                  "type":"const",
-                                                  "const":1
-                                                  }
+                                              "valueSizeBytes": 9
                                             }
                                        """.trim().replaceAll("\\s", ""),
                           fanout              : 1,
@@ -73,11 +69,7 @@ def loadTestConfigurations = { mode, isStreaming, datasetName, sdkHarnessImageTa
                                                     {
                                                       "numRecords": 12500000,
                                                       "keySizeBytes": 1,
-                                                      "valueSizeBytes": 9,
-                                                      "delayDistribution": {
-                                                        "type":"const",
-                                                        "const":1
-                                                        }
+                                                      "valueSizeBytes": 9
                                                     }
                                                """.trim().replaceAll("\\s", ""),
                             fanout              : 8,

--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Java.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Java.groovy
@@ -39,7 +39,11 @@ def loadTestConfigurations = { mode, isStreaming, datasetName, sdkHarnessImageTa
                                             {
                                               "numRecords": 200000000,
                                               "keySizeBytes": 1,
-                                              "valueSizeBytes": 9
+                                              "valueSizeBytes": 9,
+                                                "delayDistribution": {
+                                                  "type":"const",
+                                                  "const":1
+                                                  }
                                             }
                                        """.trim().replaceAll("\\s", ""),
                           fanout              : 1,
@@ -69,7 +73,11 @@ def loadTestConfigurations = { mode, isStreaming, datasetName, sdkHarnessImageTa
                                                     {
                                                       "numRecords": 12500000,
                                                       "keySizeBytes": 1,
-                                                      "valueSizeBytes": 9
+                                                      "valueSizeBytes": 9,
+                                                      "delayDistribution": {
+                                                        "type":"const",
+                                                        "const":1
+                                                        }
                                                     }
                                                """.trim().replaceAll("\\s", ""),
                             fanout              : 8,


### PR DESCRIPTION


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
