### PR TITLE
[BEAM-8335] Implement the StreamingCacheManager

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/cache_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager_test.py
@@ -69,12 +69,11 @@ class FileBasedCacheManagerTest(object):
 
     # Usually, the pcoder will be inferred from `pcoll.element_type`
     pcoder = coders.registry.get_coder(object)
+    # Save a pcoder for reading.
     self.cache_manager.save_pcoder(pcoder, *labels)
-    sink = self.cache_manager.sink(*labels)
-
-    with open(self.cache_manager._path(prefix, cache_file), 'wb') as f:
-      for line in pcoll_list:
-        sink.write_record(f, line)
+    # Save a pcoder for the fake write to the file.
+    self.cache_manager.save_pcoder(pcoder, prefix, cache_file)
+    self.cache_manager.write(pcoll_list, prefix, cache_file)
 
   def test_exists(self):
     """Test that CacheManager can correctly tell if the cache exists or not."""
@@ -97,7 +96,8 @@ class FileBasedCacheManagerTest(object):
     cache_version_one = ['cache', 'version', 'one']
 
     self.mock_write_cache(cache_version_one, prefix, cache_label)
-    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    reader, version = self.cache_manager.read(prefix, cache_label)
+    pcoll_list = list(reader)
     self.assertListEqual(pcoll_list, cache_version_one)
     self.assertEqual(version, 0)
     self.assertTrue(
@@ -111,13 +111,15 @@ class FileBasedCacheManagerTest(object):
     cache_version_two = ['cache', 'version', 'two']
 
     self.mock_write_cache(cache_version_one, prefix, cache_label)
-    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    reader, version = self.cache_manager.read(prefix, cache_label)
+    pcoll_list = list(reader)
 
     self.mock_write_cache(cache_version_two, prefix, cache_label)
     self.assertFalse(
         self.cache_manager.is_latest_version(version, prefix, cache_label))
 
-    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    reader, version = self.cache_manager.read(prefix, cache_label)
+    pcoll_list = list(reader)
     self.assertListEqual(pcoll_list, cache_version_two)
     self.assertEqual(version, 1)
     self.assertTrue(
@@ -130,7 +132,8 @@ class FileBasedCacheManagerTest(object):
 
     self.assertFalse(self.cache_manager.exists(prefix, cache_label))
 
-    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    reader, version = self.cache_manager.read(prefix, cache_label)
+    pcoll_list = list(reader)
     self.assertListEqual(pcoll_list, [])
     self.assertEqual(version, -1)
     self.assertTrue(
@@ -145,7 +148,8 @@ class FileBasedCacheManagerTest(object):
 
     # The initial write and read.
     self.mock_write_cache(cache_version_one, prefix, cache_label)
-    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    reader, version = self.cache_manager.read(prefix, cache_label)
+    pcoll_list = list(reader)
 
     # Cache cleanup.
     self.cache_manager.cleanup()
@@ -153,7 +157,8 @@ class FileBasedCacheManagerTest(object):
     self.assertTrue(
         self.cache_manager.is_latest_version(version, prefix, cache_label))
 
-    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    reader, version = self.cache_manager.read(prefix, cache_label)
+    pcoll_list = list(reader)
     self.assertListEqual(pcoll_list, [])
     self.assertEqual(version, -1)
     self.assertFalse(
@@ -164,7 +169,8 @@ class FileBasedCacheManagerTest(object):
     self.assertFalse(
         self.cache_manager.is_latest_version(version, prefix, cache_label))
 
-    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    reader, version = self.cache_manager.read(prefix, cache_label)
+    pcoll_list = list(reader)
     self.assertListEqual(pcoll_list, cache_version_two)
     # Check that version continues from the previous value instead of starting
     # from 0 again.

--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
@@ -17,9 +17,27 @@
 
 from __future__ import absolute_import
 
+import apache_beam as beam
 from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 from apache_beam.utils import timestamp
 from apache_beam.utils.timestamp import Timestamp
+
+
+class StreamingCacheReceiver(beam.transforms.PTransform):
+  """Marks a PCollection to be read from cache.
+
+  This class is used in the PipelineInstrument to mark that an unbounded
+  Pcollection should be read from cache. This is because the TestStream needs
+  to know all the PCollections before being created.
+  """
+  def expand(self, pbegin):
+    assert isinstance(pbegin, beam.pvalue.PBegin)
+    self.pipeline = pbegin.pipeline
+
+    return beam.pvalue.PCollection(self.pipeline, is_bounded=False)
+
+  def get_windowing(self, unused_inputs):
+    return beam.Windowing(beam.window.GlobalWindows())
 
 
 class StreamingCache(object):

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -29,6 +29,8 @@ from apache_beam.pipeline import PipelineVisitor
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.runners.interactive import cache_manager as cache
 from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive.caching import streaming_cache
+from apache_beam.testing import test_stream
 
 READ_CACHE = "_ReadCache_"
 WRITE_CACHE = "_WriteCache_"
@@ -375,12 +377,15 @@ class PipelineInstrument(object):
     # Can only read from cache when the cache with expected key exists.
     if self._cache_manager.exists('full', key):
       if key not in self._cached_pcoll_read:
+        if pcoll.is_bounded:
+          read_transform = cache.ReadCache(self._cache_manager, key)
+        else:
+          read_transform = streaming_cache.StreamingCacheReceiver()
+
         # Mutates the pipeline with cache read transform attached
         # to root of the pipeline.
-        pcoll_from_cache = (
-            pipeline
-            | '{}{}'.format(READ_CACHE, key) >> cache.ReadCache(
-                self._cache_manager, key))
+        pcoll_from_cache = (pipeline
+                            | '{}{}'.format(READ_CACHE, key) >> read_transform)
         self._cached_pcoll_read[key] = pcoll_from_cache
     # else: NOOP when cache doesn't exist, just compute the original graph.
 
@@ -392,6 +397,45 @@ class PipelineInstrument(object):
     AppliedPtransform that sources pvalue from the cache. If there is no valid
     cache, noop.
     """
+
+    # Find all cached unbounded PCollections.
+    class CacheableUnboundedPCollectionVisitor(PipelineVisitor):
+      def __init__(self, pin):
+        self._pin = pin
+        self.unbounded_pcolls = set()
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        if transform_node.inputs:
+          for input_pcoll in transform_node.inputs:
+            key = self._pin.cache_key(input_pcoll)
+            if (key in self._pin._cached_pcoll_read and
+                not input_pcoll.is_bounded):
+              self.unbounded_pcolls.add(key)
+
+    v = CacheableUnboundedPCollectionVisitor(self)
+    pipeline.visit(v)
+
+    # The set of keys from the cached unbounded PCollections will be used as the
+    # output tags for the TestStream. This is to remember what cache-key is
+    # associated with which PCollection.
+    unbounded_cacheables = v.unbounded_pcolls
+    output_tags = unbounded_cacheables
+
+    # Take the PCollections that will be read from the TestStream and insert
+    # them back into the dictionary of cached PCollections. The next step will
+    # replace the downstream consumer of the non-cached PCollections with these
+    # PCollections.
+    if output_tags:
+      output_pcolls = pipeline | test_stream.TestStream(output_tags=output_tags)
+      if len(output_tags) == 1:
+        self._cached_pcoll_read[None] = output_pcolls
+      else:
+        for tag, pcoll in output_pcolls.items():
+          self._cached_pcoll_read[tag] = pcoll
+
 
     class ReadCacheWireVisitor(PipelineVisitor):
       """Visitor wires cache read as inputs to replace corresponding original
@@ -408,10 +452,14 @@ class PipelineInstrument(object):
       def visit_transform(self, transform_node):
         if transform_node.inputs:
           input_list = list(transform_node.inputs)
-          for i in range(len(input_list)):
-            key = self._pin.cache_key(input_list[i])
+          for i, input_pcoll in enumerate(input_list):
+            key = self._pin.cache_key(input_pcoll)
+
+            # Replace the input pcollection with the cached pcollection (if it
+            # already cached).
             if key in self._pin._cached_pcoll_read:
               input_list[i] = self._pin._cached_pcoll_read[key]
+          # Update the transform with its new inputs.
           transform_node.inputs = tuple(input_list)
 
     v = ReadCacheWireVisitor(self)

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -31,10 +31,12 @@ from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import pipeline_instrument as instr
 from apache_beam.runners.interactive import interactive_runner
+from apache_beam.runners.interactive.caching import streaming_cache
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_equal
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_proto_equal
+from apache_beam.testing.test_stream import TestStream
 
-# Work around nose tests using Python2 without unittest.mock module.
+#Work around nose tests using Python2 without unittest.mock module.
 try:
   from unittest.mock import MagicMock
 except ImportError:
@@ -48,7 +50,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
   def test_pcolls_to_pcoll_id(self):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
-    # pylint: disable=range-builtin-not-iterating
+# pylint: disable=range-builtin-not-iterating
     init_pcoll = p | 'Init Create' >> beam.Impulse()
     _, ctx = p.to_runner_api(use_fake_coders=True, return_context=True)
     self.assertEqual(instr.pcolls_to_pcoll_id(p, ctx), {
@@ -184,10 +186,16 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     assert_pipeline_proto_equal(self, expected_pipeline, actual_pipeline)
 
-  def _example_pipeline(self, watch=True):
+  def _example_pipeline(self, watch=True, bounded=True):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
     # pylint: disable=range-builtin-not-iterating
-    init_pcoll = p | 'Init Create' >> beam.Create(range(10))
+    if bounded:
+      source = beam.Create(range(10))
+    else:
+      source = beam.io.ReadFromPubSub(
+          subscription='projects/fake-project/subscriptions/fake_sub')
+
+    init_pcoll = p | 'Init Source' >> source
     second_pcoll = init_pcoll | 'Second' >> beam.Map(lambda x: x * x)
     if watch:
       ib.watch(locals())
@@ -252,6 +260,47 @@ class PipelineInstrumentTest(unittest.TestCase):
     cached_init_pcoll = p_origin | (
         '_ReadCache_' + init_pcoll_cache_key) >> cache.ReadCache(
             ie.current_env().cache_manager(), init_pcoll_cache_key)
+
+    # second_pcoll is never used as input and there is no need to read cache.
+
+    class TestReadCacheWireVisitor(PipelineVisitor):
+      """Replace init_pcoll with cached_init_pcoll for all occuring inputs."""
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        if transform_node.inputs:
+          input_list = list(transform_node.inputs)
+          for i in range(len(input_list)):
+            if input_list[i] == init_pcoll:
+              input_list[i] = cached_init_pcoll
+          transform_node.inputs = tuple(input_list)
+
+    v = TestReadCacheWireVisitor()
+    p_origin.visit(v)
+    assert_pipeline_equal(self, p_origin, p_copy)
+
+  def test_instrument_example_unbounded_pipeline_to_read_cache(self):
+    p_origin, init_pcoll, second_pcoll = self._example_pipeline(watch=True,
+                                                                bounded=False)
+    p_copy, _, _ = self._example_pipeline(watch=False, bounded=False)
+
+    # Mock as if cacheable PCollections are cached.
+    init_pcoll_cache_key = 'init_pcoll_' + str(
+        id(init_pcoll)) + '_' + str(id(init_pcoll.producer))
+    self._mock_write_cache(init_pcoll, init_pcoll_cache_key)
+    second_pcoll_cache_key = 'second_pcoll_' + str(
+        id(second_pcoll)) + '_' + str(id(second_pcoll.producer))
+    self._mock_write_cache(second_pcoll, second_pcoll_cache_key)
+    ie.current_env().cache_manager().exists = MagicMock(return_value=True)
+    instr.pin(p_copy)
+
+    # Add the caching transforms.
+    key = '_ReadCache_' + init_pcoll_cache_key
+    cached_init_pcoll = (p_origin
+                         | key >> streaming_cache.StreamingCacheReceiver())
+    cached_init_pcoll = p_origin | TestStream(output_tags=[key])
 
     # second_pcoll is never used as input and there is no need to read cache.
 

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -171,13 +171,14 @@ class TestStream(PTransform):
   output.
   """
 
-  def __init__(self, coder=coders.FastPrimitivesCoder(), events=()):
+  def __init__(self, coder=coders.FastPrimitivesCoder(), events=None,
+               output_tags=None):
     super(TestStream, self).__init__()
     assert coder is not None
     self.coder = coder
     self.watermarks = {None: timestamp.MIN_TIMESTAMP}
-    self._events = list(events)
-    self.output_tags = set()
+    self._events = list(events) if events is not None else []
+    self.output_tags = set(output_tags) if output_tags is not None else set()
 
   def get_windowing(self, unused_inputs):
     return core.Windowing(window.GlobalWindows())


### PR DESCRIPTION
cache_manager.py:
 - Add the 'write' method to write an element to the cache
 - Refactor the 'source/sink' methods to return a PTransform
 - Refactor the 'read' method to return a generator instead of the full
 list
 - Refactor the ReadCache and WriteCache methods to use the source/sink
 methods directly

cache_manager_test.py:
 - Refactor to use the new implementations

streaming_cache.py:
 - Refactor to implement the CacheManager interface
 - Refactor 'Reader' class to take in a list of headers
 - Refactor 'read' method to read the headers from the cache
 - Refactor the 'reader' method into the 'read_multiple' method to read
 multiple PCollections from cache given their headers.

streaming_cache_test.py:
 - Refactor to use the new implementations
 - Create a new class the "InMemoryCache" that is able to write and read
 PCollections directly from memory instead of from file.

pipeline_instrument.py:
 - Refactor the _read_cache method to only use the ReadCache method

pipeline_instrument_test.py:
 - Create a new class the "InMemoryCache" that is able to write and read
 PCollections directly from memory instead of from file.
 - Simplify the mock writes and tests to use the InMemoryCache

#interactive
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
