### PR TITLE
[BEAM-8891] Spark uber jar job server

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineRunner.java
@@ -169,6 +169,10 @@ public class SparkPipelineRunner implements PortablePipelineRunner {
     SparkPipelineOptions sparkOptions = portablePipelineOptions.as(SparkPipelineOptions.class);
     String invocationId =
         String.format("%s_%s", sparkOptions.getJobName(), UUID.randomUUID().toString());
+    if (sparkOptions.getAppName() == null) {
+      LOG.debug("App name was null. Using invocationId {}", invocationId);
+      sparkOptions.setAppName(invocationId);
+    }
 
     SparkPipelineRunner runner = new SparkPipelineRunner(sparkOptions);
     JobInfo jobInfo =

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1005,10 +1005,12 @@ class SparkRunnerOptions(PipelineOptions):
     parser.add_argument('--spark_submit_uber_jar',
                         default=False,
                         action='store_true',
-                        help='Create and upload an uber jar to the Spark master'
-                             ' directly, rather than starting up a job server.'
-                             ' Only applies when Spark master is set to a'
-                             ' cluster address. Requires Python 3.6+.')
+                        help='Create and upload an uber jar to the Spark REST'
+                             ' endpoint, rather than starting up a job server.'
+                             ' Requires Python 3.6+.')
+    parser.add_argument('--spark_rest_url',
+                        help='URL for the Spark REST endpoint. '
+                             'Only required when using spark_submit_uber_jar.')
 
 
 class TestOptions(PipelineOptions):

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -991,6 +991,26 @@ class FlinkRunnerOptions(PipelineOptions):
                              ' cluster address.  Requires Python 3.6+.')
 
 
+class SparkRunnerOptions(PipelineOptions):
+  @classmethod
+  def _add_argparse_args(cls, parser):
+    parser.add_argument('--spark_master_url',
+                        default='local[4]',
+                        help='Spark master URL (spark://HOST:PORT). '
+                             'Use "local" (single-threaded) or "local[*]" '
+                             '(multi-threaded) to start a local cluster for '
+                             'the execution.')
+    parser.add_argument('--spark_job_server_jar',
+                        help='Path or URL to a Beam Spark jobserver jar.')
+    parser.add_argument('--spark_submit_uber_jar',
+                        default=False,
+                        action='store_true',
+                        help='Create and upload an uber jar to the Spark master'
+                             ' directly, rather than starting up a job server.'
+                             ' Only applies when Spark master is set to a'
+                             ' cluster address. Requires Python 3.6+.')
+
+
 class TestOptions(PipelineOptions):
 
   @classmethod

--- a/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py
+++ b/sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py
@@ -20,25 +20,17 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import json
 import logging
 import os
-import shutil
 import tempfile
 import time
 import zipfile
-from concurrent import futures
 
-import grpc
 import requests
-from google.protobuf import json_format
 
 from apache_beam.options import pipeline_options
-from apache_beam.portability.api import beam_artifact_api_pb2_grpc
 from apache_beam.portability.api import beam_job_api_pb2
-from apache_beam.portability.api import endpoints_pb2
 from apache_beam.runners.portability import abstract_job_service
-from apache_beam.runners.portability import artifact_service
 from apache_beam.runners.portability import job_server
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,72 +81,17 @@ class FlinkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
         artifact_port=self._artifact_port)
 
 
-class FlinkBeamJob(abstract_job_service.AbstractBeamJob):
+class FlinkBeamJob(abstract_job_service.UberJarBeamJob):
   """Runs a single Beam job on Flink by staging all contents into a Jar
   and uploading it via the Flink Rest API."""
-
-  # These must agree with those defined in PortablePipelineJarUtils.java.
-  PIPELINE_FOLDER = 'BEAM-PIPELINE'
-  PIPELINE_MANIFEST = PIPELINE_FOLDER + '/pipeline-manifest.json'
-
-  # We only stage a single pipeline in the jar.
-  PIPELINE_NAME = 'pipeline'
-  PIPELINE_PATH = '/'.join(
-      [PIPELINE_FOLDER, PIPELINE_NAME, "pipeline.json"])
-  PIPELINE_OPTIONS_PATH = '/'.join(
-      [PIPELINE_FOLDER, PIPELINE_NAME, 'pipeline-options.json'])
-  ARTIFACT_MANIFEST_PATH = '/'.join(
-      [PIPELINE_FOLDER, PIPELINE_NAME, 'artifact-manifest.json'])
-  ARTIFACT_FOLDER = '/'.join([PIPELINE_FOLDER, PIPELINE_NAME, 'artifacts'])
 
   def __init__(
       self, master_url, executable_jar, job_id, job_name, pipeline, options,
       artifact_port=0):
-    super(FlinkBeamJob, self).__init__(job_id, job_name, pipeline, options)
+    super(FlinkBeamJob, self).__init__(
+        executable_jar, job_id, job_name, pipeline, options,
+        artifact_port=artifact_port)
     self._master_url = master_url
-    self._executable_jar = executable_jar
-    self._jar_uploaded = False
-    self._artifact_port = artifact_port
-
-  def prepare(self):
-    # Copy the executable jar, injecting the pipeline and options as resources.
-    with tempfile.NamedTemporaryFile(suffix='.jar') as tout:
-      self._jar = tout.name
-    shutil.copy(self._executable_jar, self._jar)
-    with zipfile.ZipFile(self._jar, 'a', compression=zipfile.ZIP_DEFLATED) as z:
-      with z.open(self.PIPELINE_PATH, 'w') as fout:
-        fout.write(json_format.MessageToJson(
-            self._pipeline_proto).encode('utf-8'))
-      with z.open(self.PIPELINE_OPTIONS_PATH, 'w') as fout:
-        fout.write(json_format.MessageToJson(
-            self._pipeline_options).encode('utf-8'))
-      with z.open(self.PIPELINE_MANIFEST, 'w') as fout:
-        fout.write(json.dumps(
-            {'defaultJobName': self.PIPELINE_NAME}).encode('utf-8'))
-    self._start_artifact_service(self._jar, self._artifact_port)
-
-  def _start_artifact_service(self, jar, requested_port):
-    self._artifact_staging_service = artifact_service.ZipFileArtifactService(
-        jar, self.ARTIFACT_FOLDER)
-    self._artifact_staging_server = grpc.server(futures.ThreadPoolExecutor())
-    port = self._artifact_staging_server.add_insecure_port(
-        '[::]:%s' % requested_port)
-    beam_artifact_api_pb2_grpc.add_ArtifactStagingServiceServicer_to_server(
-        self._artifact_staging_service, self._artifact_staging_server)
-    self._artifact_staging_endpoint = endpoints_pb2.ApiServiceDescriptor(
-        url='localhost:%d' % port)
-    self._artifact_staging_server.start()
-    _LOGGER.info('Artifact server started on port %s', port)
-    return port
-
-  def _stop_artifact_service(self):
-    self._artifact_staging_server.stop(1)
-    self._artifact_staging_service.close()
-    self._artifact_manifest_location = (
-        self._artifact_staging_service.retrieval_token(self._job_id))
-
-  def artifact_staging_endpoint(self):
-    return self._artifact_staging_endpoint
 
   def request(self, method, path, expected_status=200, **kwargs):
     response = method('%s/%s' % (self._master_url, path), **kwargs)

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -417,6 +417,7 @@ class PipelineResult(runner.PipelineResult):
   def wait_until_finish(self):
 
     def read_messages():
+      previous_state = -1
       for message in self._message_stream:
         if message.HasField('message_response'):
           logging.log(
@@ -424,10 +425,12 @@ class PipelineResult(runner.PipelineResult):
               "%s",
               message.message_response.message_text)
         else:
-          _LOGGER.info(
-              "Job state changed to %s",
-              self._runner_api_state_to_pipeline_state(
-                  message.state_response.state))
+          current_state = message.state_response.state
+          if current_state != previous_state:
+            _LOGGER.info(
+                "Job state changed to %s",
+                self._runner_api_state_to_pipeline_state(current_state))
+            previous_state = current_state
         self._messages.append(message)
 
     t = threading.Thread(target=read_messages, name='wait_until_finish_read')

--- a/sdks/python/apache_beam/runners/portability/spark_runner.py
+++ b/sdks/python/apache_beam/runners/portability/spark_runner.py
@@ -21,10 +21,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import re
+import sys
 
 from apache_beam.options import pipeline_options
 from apache_beam.runners.portability import job_server
 from apache_beam.runners.portability import portable_runner
+from apache_beam.runners.portability import spark_uber_jar_job_server
 
 # https://spark.apache.org/docs/latest/submitting-applications.html#master-urls
 LOCAL_MASTER_PATTERN = r'^local(\[.+\])?$'
@@ -32,7 +34,7 @@ LOCAL_MASTER_PATTERN = r'^local(\[.+\])?$'
 
 class SparkRunner(portable_runner.PortableRunner):
   def run_pipeline(self, pipeline, options):
-    spark_options = options.view_as(SparkRunnerOptions)
+    spark_options = options.view_as(pipeline_options.SparkRunnerOptions)
     portable_options = options.view_as(pipeline_options.PortableOptions)
     if (re.match(LOCAL_MASTER_PATTERN, spark_options.spark_master_url)
         and not portable_options.environment_type
@@ -41,27 +43,23 @@ class SparkRunner(portable_runner.PortableRunner):
     return super(SparkRunner, self).run_pipeline(pipeline, options)
 
   def default_job_server(self, options):
-    # TODO(BEAM-8139) submit a Spark jar to a cluster
+    spark_options = options.view_as(pipeline_options.SparkRunnerOptions)
+    if (spark_options.spark_submit_uber_jar
+        and not re.match(LOCAL_MASTER_PATTERN, spark_options.spark_master_url)):
+      if sys.version_info < (3, 6):
+        raise ValueError(
+            'spark_submit_uber_jar requires Python 3.6+, current version %s'
+            % sys.version)
+      return spark_uber_jar_job_server.SparkUberJarJobServer(
+          re.sub('^spark://', 'http://', spark_options.spark_master_url),
+          options)
     return job_server.StopOnExitJobServer(SparkJarJobServer(options))
-
-
-class SparkRunnerOptions(pipeline_options.PipelineOptions):
-  @classmethod
-  def _add_argparse_args(cls, parser):
-    parser.add_argument('--spark_master_url',
-                        default='local[4]',
-                        help='Spark master URL (spark://HOST:PORT). '
-                             'Use "local" (single-threaded) or "local[*]" '
-                             '(multi-threaded) to start a local cluster for '
-                             'the execution.')
-    parser.add_argument('--spark_job_server_jar',
-                        help='Path or URL to a Beam Spark jobserver jar.')
 
 
 class SparkJarJobServer(job_server.JavaJarJobServer):
   def __init__(self, options):
     super(SparkJarJobServer, self).__init__(options)
-    options = options.view_as(SparkRunnerOptions)
+    options = options.view_as(pipeline_options.SparkRunnerOptions)
     self._jar = options.spark_job_server_jar
     self._master_url = options.spark_master_url
 

--- a/sdks/python/apache_beam/runners/portability/spark_runner.py
+++ b/sdks/python/apache_beam/runners/portability/spark_runner.py
@@ -44,15 +44,15 @@ class SparkRunner(portable_runner.PortableRunner):
 
   def default_job_server(self, options):
     spark_options = options.view_as(pipeline_options.SparkRunnerOptions)
-    if (spark_options.spark_submit_uber_jar
-        and not re.match(LOCAL_MASTER_PATTERN, spark_options.spark_master_url)):
+    if spark_options.spark_submit_uber_jar:
       if sys.version_info < (3, 6):
         raise ValueError(
             'spark_submit_uber_jar requires Python 3.6+, current version %s'
             % sys.version)
+      if not spark_options.spark_rest_url:
+        raise ValueError('Option spark_rest_url must be set.')
       return spark_uber_jar_job_server.SparkUberJarJobServer(
-          re.sub('^spark://', 'http://', spark_options.spark_master_url),
-          options)
+          spark_options.spark_rest_url, options)
     return job_server.StopOnExitJobServer(SparkJarJobServer(options))
 
 

--- a/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server.py
+++ b/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server.py
@@ -1,0 +1,318 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A job server submitting portable pipelines as uber jars to Spark."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import itertools
+import json
+import logging
+import shutil
+import tempfile
+import time
+import zipfile
+from concurrent import futures
+
+import grpc
+import requests
+from google.protobuf import json_format
+
+from apache_beam.options import pipeline_options
+from apache_beam.portability.api import beam_artifact_api_pb2_grpc
+from apache_beam.portability.api import beam_job_api_pb2
+from apache_beam.portability.api import endpoints_pb2
+from apache_beam.runners.portability import abstract_job_service
+from apache_beam.runners.portability import artifact_service
+from apache_beam.runners.portability import job_server
+from apache_beam.utils.timestamp import Timestamp
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SparkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
+  """A Job server which submits a self-contained Jar to a Spark cluster.
+
+  The jar contains the Beam pipeline definition, dependencies, and
+  the pipeline artifacts.
+  """
+
+  def __init__(self, master_url, options):
+    super(SparkUberJarJobServer, self).__init__()
+    self._master_url = master_url
+    self._executable_jar = (options.view_as(pipeline_options.SparkRunnerOptions)
+                            .spark_job_server_jar)
+    self._artifact_port = (options.view_as(pipeline_options.JobServerOptions)
+                           .artifact_port)
+    self._temp_dir = tempfile.mkdtemp(prefix='apache-beam-spark')
+
+  def start(self):
+    return self
+
+  def stop(self):
+    pass
+
+  def executable_jar(self):
+    url = (self._executable_jar or
+           job_server.JavaJarJobServer.path_to_beam_jar(
+               'runners:spark:job-server:shadowJar'))
+    return job_server.JavaJarJobServer.local_jar(url)
+
+  def create_beam_job(self, job_id, job_name, pipeline, options):
+    return SparkBeamJob(
+        self._master_url,
+        self.executable_jar(),
+        job_id,
+        job_name,
+        pipeline,
+        options,
+        artifact_port=self._artifact_port)
+
+
+class SparkBeamJob(abstract_job_service.AbstractBeamJob):
+  """Runs a single Beam job on Spark by staging all contents into a Jar
+  and uploading it via the Spark Rest API.
+
+  Note that the Spark Rest API is not enabled by default. It must be enabled by
+  setting the configuration property spark.master.rest.enabled to true."""
+
+  # These must agree with those defined in PortablePipelineJarUtils.java.
+  PIPELINE_FOLDER = 'BEAM-PIPELINE'
+  PIPELINE_MANIFEST = PIPELINE_FOLDER + '/pipeline-manifest.json'
+
+  # We only stage a single pipeline in the jar.
+  PIPELINE_NAME = 'pipeline'
+  PIPELINE_PATH = '/'.join(
+      [PIPELINE_FOLDER, PIPELINE_NAME, "pipeline.json"])
+  PIPELINE_OPTIONS_PATH = '/'.join(
+      [PIPELINE_FOLDER, PIPELINE_NAME, 'pipeline-options.json'])
+  ARTIFACT_MANIFEST_PATH = '/'.join(
+      [PIPELINE_FOLDER, PIPELINE_NAME, 'artifact-manifest.json'])
+  ARTIFACT_FOLDER = '/'.join([PIPELINE_FOLDER, PIPELINE_NAME, 'artifacts'])
+
+  def __init__(
+      self, master_url, executable_jar, job_id, job_name, pipeline, options,
+      artifact_port=0):
+    super(SparkBeamJob, self).__init__(job_id, job_name, pipeline, options)
+    self._master_url = master_url
+    self._executable_jar = executable_jar
+    self._jar_uploaded = False
+    self._artifact_port = artifact_port
+    # Message history is a superset of state history.
+    self._message_history = self._state_history[:]
+
+  def prepare(self):
+    # Copy the executable jar, injecting the pipeline and options as resources.
+    with tempfile.NamedTemporaryFile(suffix='.jar') as tout:
+      self._jar = tout.name
+    shutil.copy(self._executable_jar, self._jar)
+    with zipfile.ZipFile(self._jar, 'a', compression=zipfile.ZIP_DEFLATED) as z:
+      with z.open(self.PIPELINE_PATH, 'w') as fout:
+        fout.write(json_format.MessageToJson(
+            self._pipeline_proto).encode('utf-8'))
+      with z.open(self.PIPELINE_OPTIONS_PATH, 'w') as fout:
+        fout.write(json_format.MessageToJson(
+            self._pipeline_options).encode('utf-8'))
+      with z.open(self.PIPELINE_MANIFEST, 'w') as fout:
+        fout.write(json.dumps(
+            {'defaultJobName': self.PIPELINE_NAME}).encode('utf-8'))
+    self._start_artifact_service(self._jar, self._artifact_port)
+
+  def _start_artifact_service(self, jar, requested_port):
+    self._artifact_staging_service = artifact_service.ZipFileArtifactService(
+        jar, self.ARTIFACT_FOLDER)
+    self._artifact_staging_server = grpc.server(futures.ThreadPoolExecutor())
+    port = self._artifact_staging_server.add_insecure_port(
+        '[::]:%s' % requested_port)
+    beam_artifact_api_pb2_grpc.add_ArtifactStagingServiceServicer_to_server(
+        self._artifact_staging_service, self._artifact_staging_server)
+    self._artifact_staging_endpoint = endpoints_pb2.ApiServiceDescriptor(
+        url='localhost:%d' % port)
+    self._artifact_staging_server.start()
+    _LOGGER.info('Artifact server started on port %s', port)
+    return port
+
+  def _stop_artifact_service(self):
+    self._artifact_staging_server.stop(1)
+    self._artifact_staging_service.close()
+    self._artifact_manifest_location = (
+        self._artifact_staging_service.retrieval_token(self._job_id))
+
+  def artifact_staging_endpoint(self):
+    return self._artifact_staging_endpoint
+
+  def request(self, method, path, expected_status=200, **kwargs):
+    url = '%s/%s' % (self._master_url, path)
+    response = method(url, **kwargs)
+    if response.status_code != expected_status:
+      raise RuntimeError("Request to %s failed with status %d: %s" %
+                         (url, response.status_code, response.text))
+    if response.text:
+      return response.json()
+
+  def get(self, path, **kwargs):
+    return self.request(requests.get, path, **kwargs)
+
+  def post(self, path, **kwargs):
+    return self.request(requests.post, path, **kwargs)
+
+  def delete(self, path, **kwargs):
+    return self.request(requests.delete, path, **kwargs)
+
+  def _get_server_spark_version(self):
+    # Spark REST API doesn't seem to offer a dedicated endpoint for getting the
+    # version, but it does include the version in all responses, even errors.
+    return self.get('', expected_status=400)['serverSparkVersion']
+
+  def _get_client_spark_version_from_properties(self, jar):
+    """Parse Spark version from spark-version-info.properties file in the jar.
+    https://github.com/apache/spark/blob/dddfeca175bdce5294debe00d4a993daef92ca60/build/spark-build-info#L30
+    """
+    with zipfile.ZipFile(jar, 'a', compression=zipfile.ZIP_DEFLATED) as z:
+      with z.open('spark-version-info.properties') as fin:
+        for line in fin.read().decode('utf-8').splitlines():
+          split = list(map(lambda s: s.strip(), line.split('=')))
+          if len(split) == 2 and split[0] == 'version' and split[1] != '':
+            return split[1]
+        raise ValueError(
+            'Property "version" not found in spark-version-info.properties.')
+
+  def _get_client_spark_version(self, jar):
+    try:
+      return self._get_client_spark_version_from_properties(jar)
+    except Exception as e:
+      _LOGGER.debug(e)
+      server_version = self._get_server_spark_version()
+      _LOGGER.warning('Unable to parse Spark version from '
+                      'spark-version-info.properties. Defaulting to %s' %
+                      server_version)
+      return server_version
+
+  def _create_submission_request(self, jar, job_name):
+    jar_url = "file:%s" % jar
+    return {
+        "action": "CreateSubmissionRequest",
+        "appArgs": [],
+        "appResource": jar_url,
+        "clientSparkVersion": self._get_client_spark_version(jar),
+        "environmentVariables": {},
+        "mainClass": "org.apache.beam.runners.spark.SparkPipelineRunner",
+        "sparkProperties": {
+            "spark.jars": jar_url,
+            "spark.app.name": job_name,
+            "spark.submit.deployMode": "cluster",
+        }
+    }
+
+  def run(self):
+    self._stop_artifact_service()
+    # Move the artifact manifest to the expected location.
+    with zipfile.ZipFile(self._jar, 'a', compression=zipfile.ZIP_DEFLATED) as z:
+      with z.open(self._artifact_manifest_location) as fin:
+        manifest_contents = fin.read()
+      with z.open(self.ARTIFACT_MANIFEST_PATH, 'w') as fout:
+        fout.write(manifest_contents)
+
+    # Upload the jar and start the job.
+    self._spark_submission_id = self.post(
+        'v1/submissions/create',
+        json=self._create_submission_request(self._jar, self._job_name)
+    )['submissionId']
+    _LOGGER.info('Submitted Spark job with ID %s' % self._spark_submission_id)
+
+  def cancel(self):
+    self.post('v1/submissions/kill/%s' % self._spark_submission_id)
+
+  @staticmethod
+  def _get_beam_state(spark_response):
+    return {
+        'SUBMITTED': beam_job_api_pb2.JobState.STARTING,
+        'RUNNING': beam_job_api_pb2.JobState.RUNNING,
+        'FINISHED': beam_job_api_pb2.JobState.DONE,
+        'RELAUNCHING': beam_job_api_pb2.JobState.RUNNING,
+        'UNKNOWN': beam_job_api_pb2.JobState.UNSPECIFIED,
+        'KILLED': beam_job_api_pb2.JobState.CANCELLED,
+        'FAILED': beam_job_api_pb2.JobState.FAILED,
+        'ERROR': beam_job_api_pb2.JobState.FAILED,
+    }.get(spark_response['driverState'], beam_job_api_pb2.JobState.UNSPECIFIED)
+
+  def _get_spark_status(self):
+    return self.get('v1/submissions/status/%s' % self._spark_submission_id)
+
+  def get_state(self):
+    response = self._get_spark_status()
+    state = self._get_beam_state(response)
+    timestamp = self.set_state(state)
+    if timestamp is None:
+      # State has not changed since last check. Use previous timestamp.
+      return super(SparkBeamJob, self).get_state()
+    else:
+      return state, timestamp
+
+  def _with_message_history(self, message_stream):
+    return itertools.chain(self._message_history[:], message_stream)
+
+  def _get_message_iter(self):
+    """Returns an iterator of messages from the Spark server.
+    Note that while message history is de-duped, this function's returned
+    iterator may contain duplicate values."""
+    sleep_secs = 1.0
+    message_ix = 0
+    while True:
+      response = self._get_spark_status()
+      state = self._get_beam_state(response)
+      timestamp = Timestamp.now()
+      message = None
+      if 'message' in response:
+        importance = (
+            beam_job_api_pb2.JobMessage.MessageImportance.JOB_MESSAGE_ERROR if
+            state == beam_job_api_pb2.JobState.FAILED else
+            beam_job_api_pb2.JobMessage.MessageImportance.JOB_MESSAGE_BASIC)
+        message = beam_job_api_pb2.JobMessage(
+            message_id='message%d' % message_ix,
+            time=str(int(timestamp)),
+            importance=importance,
+            message_text=response['message'])
+        yield message
+        message_ix += 1
+        # TODO(BEAM-8983) In the event of a failure, query
+        #  additional info from Spark master and/or workers.
+      check_timestamp = self.set_state(state)
+      if check_timestamp is not None:
+        if message:
+          self._message_history.append(message)
+        self._message_history.append((state, check_timestamp))
+      yield state, timestamp
+      sleep_secs = min(60, sleep_secs * 1.2)
+      time.sleep(sleep_secs)
+
+  def get_state_stream(self):
+    for msg in self._with_message_history(self._get_message_iter()):
+      if isinstance(msg, tuple):
+        state, timestamp = msg
+        yield state, timestamp
+        if self.is_terminal_state(state):
+          break
+
+  def get_message_stream(self):
+    for msg in self._with_message_history(self._get_message_iter()):
+      yield msg
+      if isinstance(msg, tuple):
+        state, _ = msg
+        if self.is_terminal_state(state):
+          break

--- a/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server.py
+++ b/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server.py
@@ -44,9 +44,9 @@ class SparkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
   the pipeline artifacts.
   """
 
-  def __init__(self, master_url, options):
+  def __init__(self, rest_url, options):
     super(SparkUberJarJobServer, self).__init__()
-    self._master_url = master_url
+    self._rest_url = rest_url
     self._executable_jar = (options.view_as(pipeline_options.SparkRunnerOptions)
                             .spark_job_server_jar)
     self._artifact_port = (options.view_as(pipeline_options.JobServerOptions)
@@ -67,7 +67,7 @@ class SparkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
 
   def create_beam_job(self, job_id, job_name, pipeline, options):
     return SparkBeamJob(
-        self._master_url,
+        self._rest_url,
         self.executable_jar(),
         job_id,
         job_name,
@@ -84,17 +84,17 @@ class SparkBeamJob(abstract_job_service.UberJarBeamJob):
   setting the configuration property spark.master.rest.enabled to true."""
 
   def __init__(
-      self, master_url, executable_jar, job_id, job_name, pipeline, options,
+      self, rest_url, executable_jar, job_id, job_name, pipeline, options,
       artifact_port=0):
     super(SparkBeamJob, self).__init__(
         executable_jar, job_id, job_name, pipeline, options,
         artifact_port=artifact_port)
-    self._master_url = master_url
+    self._rest_url = rest_url
     # Message history is a superset of state history.
     self._message_history = self._state_history[:]
 
   def request(self, method, path, expected_status=200, **kwargs):
-    url = '%s/%s' % (self._master_url, path)
+    url = '%s/%s' % (self._rest_url, path)
     response = method(url, **kwargs)
     if response.status_code != expected_status:
       raise RuntimeError("Request to %s failed with status %d: %s" %

--- a/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server.py
+++ b/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server.py
@@ -21,24 +21,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import itertools
-import json
 import logging
-import shutil
 import tempfile
 import time
 import zipfile
-from concurrent import futures
 
-import grpc
 import requests
-from google.protobuf import json_format
 
 from apache_beam.options import pipeline_options
-from apache_beam.portability.api import beam_artifact_api_pb2_grpc
 from apache_beam.portability.api import beam_job_api_pb2
-from apache_beam.portability.api import endpoints_pb2
 from apache_beam.runners.portability import abstract_job_service
-from apache_beam.runners.portability import artifact_service
 from apache_beam.runners.portability import job_server
 from apache_beam.utils.timestamp import Timestamp
 
@@ -84,77 +76,22 @@ class SparkUberJarJobServer(abstract_job_service.AbstractJobServiceServicer):
         artifact_port=self._artifact_port)
 
 
-class SparkBeamJob(abstract_job_service.AbstractBeamJob):
+class SparkBeamJob(abstract_job_service.UberJarBeamJob):
   """Runs a single Beam job on Spark by staging all contents into a Jar
   and uploading it via the Spark Rest API.
 
   Note that the Spark Rest API is not enabled by default. It must be enabled by
   setting the configuration property spark.master.rest.enabled to true."""
 
-  # These must agree with those defined in PortablePipelineJarUtils.java.
-  PIPELINE_FOLDER = 'BEAM-PIPELINE'
-  PIPELINE_MANIFEST = PIPELINE_FOLDER + '/pipeline-manifest.json'
-
-  # We only stage a single pipeline in the jar.
-  PIPELINE_NAME = 'pipeline'
-  PIPELINE_PATH = '/'.join(
-      [PIPELINE_FOLDER, PIPELINE_NAME, "pipeline.json"])
-  PIPELINE_OPTIONS_PATH = '/'.join(
-      [PIPELINE_FOLDER, PIPELINE_NAME, 'pipeline-options.json'])
-  ARTIFACT_MANIFEST_PATH = '/'.join(
-      [PIPELINE_FOLDER, PIPELINE_NAME, 'artifact-manifest.json'])
-  ARTIFACT_FOLDER = '/'.join([PIPELINE_FOLDER, PIPELINE_NAME, 'artifacts'])
-
   def __init__(
       self, master_url, executable_jar, job_id, job_name, pipeline, options,
       artifact_port=0):
-    super(SparkBeamJob, self).__init__(job_id, job_name, pipeline, options)
+    super(SparkBeamJob, self).__init__(
+        executable_jar, job_id, job_name, pipeline, options,
+        artifact_port=artifact_port)
     self._master_url = master_url
-    self._executable_jar = executable_jar
-    self._jar_uploaded = False
-    self._artifact_port = artifact_port
     # Message history is a superset of state history.
     self._message_history = self._state_history[:]
-
-  def prepare(self):
-    # Copy the executable jar, injecting the pipeline and options as resources.
-    with tempfile.NamedTemporaryFile(suffix='.jar') as tout:
-      self._jar = tout.name
-    shutil.copy(self._executable_jar, self._jar)
-    with zipfile.ZipFile(self._jar, 'a', compression=zipfile.ZIP_DEFLATED) as z:
-      with z.open(self.PIPELINE_PATH, 'w') as fout:
-        fout.write(json_format.MessageToJson(
-            self._pipeline_proto).encode('utf-8'))
-      with z.open(self.PIPELINE_OPTIONS_PATH, 'w') as fout:
-        fout.write(json_format.MessageToJson(
-            self._pipeline_options).encode('utf-8'))
-      with z.open(self.PIPELINE_MANIFEST, 'w') as fout:
-        fout.write(json.dumps(
-            {'defaultJobName': self.PIPELINE_NAME}).encode('utf-8'))
-    self._start_artifact_service(self._jar, self._artifact_port)
-
-  def _start_artifact_service(self, jar, requested_port):
-    self._artifact_staging_service = artifact_service.ZipFileArtifactService(
-        jar, self.ARTIFACT_FOLDER)
-    self._artifact_staging_server = grpc.server(futures.ThreadPoolExecutor())
-    port = self._artifact_staging_server.add_insecure_port(
-        '[::]:%s' % requested_port)
-    beam_artifact_api_pb2_grpc.add_ArtifactStagingServiceServicer_to_server(
-        self._artifact_staging_service, self._artifact_staging_server)
-    self._artifact_staging_endpoint = endpoints_pb2.ApiServiceDescriptor(
-        url='localhost:%d' % port)
-    self._artifact_staging_server.start()
-    _LOGGER.info('Artifact server started on port %s', port)
-    return port
-
-  def _stop_artifact_service(self):
-    self._artifact_staging_server.stop(1)
-    self._artifact_staging_service.close()
-    self._artifact_manifest_location = (
-        self._artifact_staging_service.retrieval_token(self._job_id))
-
-  def artifact_staging_endpoint(self):
-    return self._artifact_staging_endpoint
 
   def request(self, method, path, expected_status=200, **kwargs):
     url = '%s/%s' % (self._master_url, path)

--- a/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server_test.py
+++ b/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server_test.py
@@ -1,0 +1,209 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+from __future__ import print_function
+
+import contextlib
+import logging
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+
+import freezegun
+import grpc
+import requests_mock
+
+from apache_beam.options import pipeline_options
+from apache_beam.portability.api import beam_artifact_api_pb2
+from apache_beam.portability.api import beam_artifact_api_pb2_grpc
+from apache_beam.portability.api import beam_job_api_pb2
+from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.runners.portability import spark_uber_jar_job_server
+
+
+@contextlib.contextmanager
+def temp_name(*args, **kwargs):
+  with tempfile.NamedTemporaryFile(*args, **kwargs) as t:
+    name = t.name
+  yield name
+  if os.path.exists(name):
+    os.unlink(name)
+
+def spark_job():
+  return spark_uber_jar_job_server.SparkBeamJob(
+      'http://host:6066', '', '', '', '', '',
+      pipeline_options.SparkRunnerOptions())
+
+
+@unittest.skipIf(sys.version_info < (3, 6), "Requires Python 3.6+")
+class SparkUberJarJobServerTest(unittest.TestCase):
+
+  @requests_mock.mock()
+  def test_get_server_spark_version(self, http_mock):
+    http_mock.get('http://host:6066', json={
+        "action": "ErrorResponse",
+        "message": "Missing protocol version. Please submit requests through "
+                   "http://[host]:[port]/v1/submissions/...",
+        "serverSparkVersion": "1.2.3"
+    }, status_code=400)
+    self.assertEqual(spark_job()._get_server_spark_version(), "1.2.3")
+
+  def test_get_client_spark_version_from_properties(self):
+    with temp_name(suffix='fake.jar') as fake_jar:
+      with zipfile.ZipFile(fake_jar, 'w') as zip:
+        with zip.open('spark-version-info.properties', 'w') as fout:
+          fout.write(b'version=4.5.6')
+      self.assertEqual(spark_job().
+                       _get_client_spark_version_from_properties(fake_jar),
+                       "4.5.6")
+
+  def test_get_client_spark_version_from_properties_no_properties_file(self):
+    with self.assertRaises(KeyError):
+      with temp_name(suffix='fake.jar') as fake_jar:
+        with zipfile.ZipFile(fake_jar, 'w') as zip:
+          # Write some other file to the jar.
+          with zip.open('FakeClass.class', 'w') as fout:
+            fout.write(b'[original_contents]')
+        spark_job()._get_client_spark_version_from_properties(fake_jar)
+
+  def test_get_client_spark_version_from_properties_missing_version(self):
+    with self.assertRaises(ValueError):
+      with temp_name(suffix='fake.jar') as fake_jar:
+        with zipfile.ZipFile(fake_jar, 'w') as zip:
+          with zip.open('spark-version-info.properties', 'w') as fout:
+            fout.write(b'version=')
+        spark_job()._get_client_spark_version_from_properties(fake_jar)
+
+  @requests_mock.mock()
+  @freezegun.freeze_time("1970-01-01")
+  def test_end_to_end(self, http_mock):
+    submission_id = "submission-id"
+    worker_host_port = "workerhost:12345"
+    worker_id = "worker-id"
+    server_spark_version = "1.2.3"
+
+    def spark_submission_status_response(state):
+      return {
+          'json': {
+              "action": "SubmissionStatusResponse",
+              "driverState": state,
+              "serverSparkVersion": server_spark_version,
+              "submissionId": submission_id,
+              "success": "true",
+              "workerHostPort": worker_host_port,
+              "workerId": worker_id
+          }
+      }
+
+    with temp_name(suffix='fake.jar') as fake_jar:
+      with zipfile.ZipFile(fake_jar, 'w') as zip:
+        with zip.open('spark-version-info.properties', 'w') as fout:
+          fout.write(b'version=4.5.6')
+
+      options = pipeline_options.SparkRunnerOptions()
+      options.spark_job_server_jar = fake_jar
+      job_server = spark_uber_jar_job_server.SparkUberJarJobServer(
+          'http://host:6066', options)
+
+      # Prepare the job.
+      prepare_response = job_server.Prepare(
+          beam_job_api_pb2.PrepareJobRequest(
+              job_name='job',
+              pipeline=beam_runner_api_pb2.Pipeline()))
+      channel = grpc.insecure_channel(
+          prepare_response.artifact_staging_endpoint.url)
+      retrieval_token = beam_artifact_api_pb2_grpc.ArtifactStagingServiceStub(
+          channel).CommitManifest(
+              beam_artifact_api_pb2.CommitManifestRequest(
+                  staging_session_token=prepare_response.staging_session_token,
+                  manifest=beam_artifact_api_pb2.Manifest())
+          ).retrieval_token
+      channel.close()
+
+      # Now actually run the job.
+      http_mock.post(
+          'http://host:6066/v1/submissions/create',
+          json={
+              "action": "CreateSubmissionResponse",
+              "message": "Driver successfully submitted as submission-id",
+              "serverSparkVersion": "1.2.3",
+              "submissionId": "submission-id",
+              "success": "true"
+          })
+      job_server.Run(
+          beam_job_api_pb2.RunJobRequest(
+              preparation_id=prepare_response.preparation_id,
+              retrieval_token=retrieval_token))
+
+      # Check the status until the job is "done" and get all error messages.
+      http_mock.get(
+          'http://host:6066/v1/submissions/status/submission-id',
+          [spark_submission_status_response('RUNNING'),
+           spark_submission_status_response('RUNNING'),
+           {
+               'json': {
+                   "action": "SubmissionStatusResponse",
+                   "driverState": "ERROR",
+                   "message": "oops",
+                   "serverSparkVersion": "1.2.3",
+                   "submissionId": submission_id,
+                   "success": "true",
+                   "workerHostPort": worker_host_port,
+                   "workerId": worker_id
+               }}])
+
+      state_stream = job_server.GetStateStream(
+          beam_job_api_pb2.GetJobStateRequest(
+              job_id=prepare_response.preparation_id))
+
+      self.assertEqual(
+          [s.state for s in state_stream],
+          [beam_job_api_pb2.JobState.STOPPED,
+           beam_job_api_pb2.JobState.RUNNING,
+           beam_job_api_pb2.JobState.RUNNING,
+           beam_job_api_pb2.JobState.FAILED])
+
+      message_stream = job_server.GetMessageStream(
+          beam_job_api_pb2.JobMessagesRequest(
+              job_id=prepare_response.preparation_id))
+
+      def get_item(x):
+        if x.HasField('message_response'):
+          return x.message_response
+        else:
+          return x.state_response.state
+
+      self.assertEqual(
+          [get_item(m) for m in message_stream],
+          [
+              beam_job_api_pb2.JobState.STOPPED,
+              beam_job_api_pb2.JobState.RUNNING,
+              beam_job_api_pb2.JobMessage(
+                  message_id='message0',
+                  time='0',
+                  importance=beam_job_api_pb2.JobMessage.MessageImportance
+                  .JOB_MESSAGE_ERROR,
+                  message_text="oops"),
+              beam_job_api_pb2.JobState.FAILED,
+          ])
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -173,6 +173,7 @@ if sys.platform == 'win32' and sys.maxsize <= 2**32:
   ]
 
 REQUIRED_TEST_PACKAGES = [
+    'freezegun>=0.3.12',
     'nose>=1.3.7',
     'nose_xunitmp>=0.4.1',
     'pandas>=0.23.4,<0.25',


### PR DESCRIPTION
- The state and message streams got a little messy, as they're
treated as if they're independent, but at least in this implementation
the message stream is just a superset of the state stream (assuming that states last long enough to be picked up by both streams). To untangle
things a bit, I decided to a) allow duplicate messages and b) store
message history, in addition to state history.
- For unit testing, I added library `freezegun` to freeze time at 0,
which was way easier than doing a bunch of elaborate mocking just to get
one insignificant value lined up.

Follow-ups:
- The Spark REST API will return errors if there's a problem with the
job submission, but it doesn't return errors from the cluster itself
once the job is running. I couldn't figure out a good solution to this,
so I left it as a TODO(BEAM-8983).
- There should be an e2e test for this. BEAM-8984

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
