### PR TITLE
[BEAM-8335] Background caching job

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -70,6 +70,7 @@ def attempt_to_run_background_caching_job(runner, user_pipeline, options=None):
     return background_caching_job_result
   return None
 
+
 def is_background_caching_job_needed(user_pipeline):
   """Determines if a background caching job needs to be started."""
   background_caching_job_result = ie.current_env().pipeline_result(
@@ -87,13 +88,15 @@ def is_background_caching_job_needed(user_pipeline):
                # running.
                runners.runner.PipelineState.RUNNING)))
 
+
 def has_source_to_cache(user_pipeline):
   """Determines if a user-defined pipeline contains any source that need to be
   cached."""
   from apache_beam.runners.interactive import pipeline_instrument as instr
-  # We temporarily only cache replaceable unbounded sources. Add other cacheable
-  # source logic here when they are available.
+  # TODO(BEAM-8335): we temporarily only cache replaceable unbounded sources.
+  # Add logic for other cacheable sources here when they are available.
   return instr.has_unbounded_sources(user_pipeline)
+
 
 def attempt_to_cancel_background_caching_job(user_pipeline):
   """Attempts to cancel background caching job for a user-defined pipeline.

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -45,8 +45,6 @@ from apache_beam.runners.interactive import interactive_environment as ie
 def attempt_to_run_background_caching_job(runner, user_pipeline, options=None):
   """Attempts to run a background caching job for a user-defined pipeline.
 
-  If a background caching job is started, return the pipeline result. Otherwise,
-  return None.
   The pipeline result is automatically tracked by Interactive Beam in case
   future cancellation/cleanup is needed.
   """
@@ -67,8 +65,6 @@ def attempt_to_run_background_caching_job(runner, user_pipeline, options=None):
     ie.current_env().set_pipeline_result(user_pipeline,
                                          background_caching_job_result,
                                          is_main_job=False)
-    return background_caching_job_result
-  return None
 
 
 def is_background_caching_job_needed(user_pipeline):
@@ -101,13 +97,11 @@ def has_source_to_cache(user_pipeline):
 def attempt_to_cancel_background_caching_job(user_pipeline):
   """Attempts to cancel background caching job for a user-defined pipeline.
 
-  If no background caching job needs to be cancelled, return None. Otherwise,
-  cancel such job and return the pipeline result to the background caching job.
+  If no background caching job needs to be cancelled, NOOP. Otherwise, cancel
+  such job.
   """
   background_caching_job_result = ie.current_env().pipeline_result(
       user_pipeline, is_main_job=False)
   if (background_caching_job_result and
       not ie.current_env().is_terminated(user_pipeline, is_main_job=False)):
     background_caching_job_result.cancel()
-    return background_caching_job_result
-  return None

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -1,0 +1,101 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Module to build and run background caching job.
+
+For internal use only; no backwards-compatibility guarantees.
+
+A background caching job is a job that caches events for all unbounded sources
+of a given pipeline. With Interactive Beam, one such job is started when a
+pipeline run happens (which produces a main job in contrast to the background
+caching job) and meets the following conditions:
+
+  #. The pipeline contains unbounded sources.
+  #. No such background job is running.
+  #. No such background job has completed successfully and the cached events are
+     still valid (invalidated when unbounded sources change in the pipeline).
+
+Once started, the background caching job runs asynchronously until it hits some
+cache size limit. Meanwhile, the main job and future main jobs from the pipeline
+will run using the deterministic replay-able cached events until they are
+invalidated.
+"""
+
+from __future__ import absolute_import
+
+import apache_beam as beam
+from apache_beam import runners
+from apache_beam.runners.interactive import interactive_environment as ie
+
+
+def attempt_to_run_background_caching_job(runner, user_pipeline, options=None):
+  """Attempts to run a background caching job for a user-defined pipeline.
+
+  If a background caching job is started, return the pipeline result. Otherwise,
+  return None.
+  The pipeline result is automatically tracked by Interactive Beam in case
+  future cancellation/cleanup is needed.
+  """
+  if is_background_caching_job_needed(user_pipeline):
+    # Cancel non-terminal jobs if there is any before starting a new one.
+    attempt_to_cancel_background_caching_job(user_pipeline)
+    # TODO(BEAM-8335): refactor background caching job logic from
+    # pipeline_instrument module to this module and aggregate tests.
+    from apache_beam.runners.interactive import pipeline_instrument as instr
+    runner_pipeline = beam.pipeline.Pipeline.from_runner_api(
+        user_pipeline.to_runner_api(use_fake_coders=True),
+        runner,
+        options)
+    background_caching_job_result = beam.pipeline.Pipeline.from_runner_api(
+        instr.pin(runner_pipeline).background_caching_pipeline_proto(),
+        runner,
+        options).run()
+    ie.current_env().set_pipeline_result(user_pipeline,
+                                         background_caching_job_result,
+                                         is_main_job=False)
+
+def is_background_caching_job_needed(user_pipeline):
+  """Determines if a background caching job needs to be started."""
+  background_caching_job_result = ie.current_env().pipeline_result(
+      user_pipeline, is_main_job=False)
+  from apache_beam.runners.interactive import pipeline_instrument as instr
+  # Checks if the pipeline contains unbounded sources.
+  return (instr.has_unbounded_sources(user_pipeline) and
+          # Checks if it's the first time running a job from the pipeline.
+          (not background_caching_job_result or
+           # Or checks if there is no valid previous job.
+           background_caching_job_result.state not in (
+               # DONE means a previous job has completed successfully and the
+               # cached events are still valid.
+               runners.runner.PipelineState.DONE,
+               # RUNNING means a previous job has been started and is still
+               # running.
+               runners.runner.PipelineState.RUNNING)))
+
+def attempt_to_cancel_background_caching_job(user_pipeline):
+  """Attempts to cancel background caching job for a user-defined pipeline.
+
+  If no background caching job needs to be cancelled, return None. Otherwise,
+  cancel such job and return the pipeline result to the background caching job.
+  """
+  background_caching_job_result = ie.current_env().pipeline_result(
+      user_pipeline, is_main_job=False)
+  if (background_caching_job_result and
+      not ie.current_env().is_terminated(user_pipeline, is_main_job=False)):
+    background_caching_job_result.cancel()
+    return background_caching_job_result
+  return None

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
@@ -98,3 +98,7 @@ class BackgroundCachingJobTest(unittest.TestCase):
     # A new main job is started so result of the main job is set.
     self.assertIs(main_job_result,
                   ie.current_env().pipeline_result(p))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for apache_beam.runners.interactive.background_caching_job."""
+from __future__ import absolute_import
+
+import unittest
+
+import apache_beam as beam
+from apache_beam.runners import runner
+from apache_beam.runners.interactive import interactive_beam as ib
+from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive import interactive_runner
+from apache_beam.testing.test_stream import TestStream
+from apache_beam.transforms.window import TimestampedValue
+
+# TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
+# unittest.mock module.
+try:
+  from unittest.mock import patch
+except ImportError:
+  from mock import patch
+
+
+def _build_a_test_stream_pipeline():
+  test_stream = (TestStream()
+                 .advance_watermark_to(0)
+                 .add_elements([TimestampedValue('a', 1)])
+                 .advance_processing_time(5)
+                 .advance_watermark_to_infinity())
+  p = beam.Pipeline(runner=interactive_runner.InteractiveRunner())
+  events = p | test_stream  # pylint: disable=possibly-unused-variable
+  ib.watch(locals())
+  return p
+
+
+class BackgroundCachingJobTest(unittest.TestCase):
+
+  def tearDown(self):
+    ie.new_env()
+
+  # A patch is needed until the boundedness check considers a TestStream as
+  # an unbounded source.
+  @patch('apache_beam.runners.interactive.pipeline_instrument'
+         '.has_unbounded_sources', lambda x: True)
+  def test_background_caching_job_starts_when_none_such_job_exists(self):
+    p = _build_a_test_stream_pipeline()
+    p.run()
+    self.assertIsNotNone(
+        ie.current_env().pipeline_result(p, is_main_job=False))
+
+  @patch('apache_beam.runners.interactive.pipeline_instrument'
+         '.has_unbounded_sources', lambda x: False)
+  def test_background_caching_job_not_start_for_batch_pipeline(self):
+    p = _build_a_test_stream_pipeline()
+    p.run()
+    self.assertIsNone(
+        ie.current_env().pipeline_result(p, is_main_job=False))
+
+  @patch('apache_beam.runners.interactive.pipeline_instrument'
+         '.has_unbounded_sources', lambda x: True)
+  def test_background_caching_job_not_start_when_such_job_exists(self):
+    p = _build_a_test_stream_pipeline()
+    a_running_result = runner.PipelineResult(runner.PipelineState.RUNNING)
+    ie.current_env().set_pipeline_result(p, a_running_result, is_main_job=False)
+    main_job_result = p.run()
+    # No background caching job is started so result is still the running one.
+    self.assertIs(a_running_result,
+                  ie.current_env().pipeline_result(p, is_main_job=False))
+    # A new main job is started so result of the main job is set.
+    self.assertIs(main_job_result,
+                  ie.current_env().pipeline_result(p))
+
+  @patch('apache_beam.runners.interactive.pipeline_instrument'
+         '.has_unbounded_sources', lambda x: True)
+  def test_background_caching_job_not_start_when_such_job_is_done(self):
+    p = _build_a_test_stream_pipeline()
+    a_done_result = runner.PipelineResult(runner.PipelineState.DONE)
+    ie.current_env().set_pipeline_result(p, a_done_result, is_main_job=False)
+    main_job_result = p.run()
+    # No background caching job is started so result is still the running one.
+    self.assertIs(a_done_result,
+                  ie.current_env().pipeline_result(p, is_main_job=False))
+    # A new main job is started so result of the main job is set.
+    self.assertIs(main_job_result,
+                  ie.current_env().pipeline_result(p))

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
@@ -53,8 +53,8 @@ class BackgroundCachingJobTest(unittest.TestCase):
   def tearDown(self):
     ie.new_env()
 
-  # A patch is needed until the boundedness check considers a TestStream as
-  # an unbounded source.
+  # TODO(BEAM-8335): remove the patches when there are appropriate test sources
+  # that meet the boundedness checks.
   @patch('apache_beam.runners.interactive.pipeline_instrument'
          '.has_unbounded_sources', lambda x: True)
   def test_background_caching_job_starts_when_none_such_job_exists(self):

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
@@ -92,7 +92,10 @@ class PCollectionVisualizationTest(unittest.TestCase):
   def test_dynamic_plotting_update_same_display(self,
                                                 mocked_display_facets):
     fake_pipeline_result = runner.PipelineResult(runner.PipelineState.RUNNING)
-    ie.current_env().set_pipeline_result(self._p, fake_pipeline_result)
+    ie.current_env().set_pipeline_result(
+        self._p,
+        fake_pipeline_result,
+        is_main_job=True)
     # Starts async dynamic plotting that never ends in this test.
     h = pv.visualize(self._pcoll, dynamic_plotting_interval=0.001)
     # Blocking so the above async task can execute some iterations.
@@ -114,14 +117,20 @@ class PCollectionVisualizationTest(unittest.TestCase):
       self,
       mocked_timeloop):
     fake_pipeline_result = runner.PipelineResult(runner.PipelineState.RUNNING)
-    ie.current_env().set_pipeline_result(self._p, fake_pipeline_result)
+    ie.current_env().set_pipeline_result(
+        self._p,
+        fake_pipeline_result,
+        is_main_job=True)
     # Starts non-stopping async dynamic plotting until the job is terminated.
     pv.visualize(self._pcoll, dynamic_plotting_interval=0.001)
     # Blocking so the above async task can execute some iterations.
     time.sleep(1)
     mocked_timeloop.assert_not_called()
     fake_pipeline_result = runner.PipelineResult(runner.PipelineState.DONE)
-    ie.current_env().set_pipeline_result(self._p, fake_pipeline_result)
+    ie.current_env().set_pipeline_result(
+        self._p,
+        fake_pipeline_result,
+        is_main_job=True)
     # Blocking so the above async task can execute some iterations.
     time.sleep(1)
     # "assert_called" is new in Python 3.6.

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -83,7 +83,7 @@ class InteractiveEnvironment(object):
     # Each key is a pipeline instance defined by the end user. The
     # InteractiveRunner is responsible for populating this dictionary
     # implicitly.
-    self._pipeline_results = {}
+    self._main_pipeline_results = {}
     # Holds results of background caching jobs as
     # Dict[Pipeline, PipelineResult]. Each key is a pipeline instance defined by
     # the end user. The InteractiveRunner is responsible for populating this
@@ -212,20 +212,20 @@ class InteractiveEnvironment(object):
         'result must be an instance of '
         'apache_beam.runners.runner.PipelineResult or its subclass')
     if is_main_job:
-      self._pipeline_results[pipeline] = result
+      self._main_pipeline_results[pipeline] = result
     else:
       self._background_caching_pipeline_results[pipeline] = result
 
   def evict_pipeline_result(self, pipeline, is_main_job=True):
     """Evicts the tracking of given pipeline run. Noop if absent."""
     if is_main_job:
-      return self._pipeline_results.pop(pipeline, None)
+      return self._main_pipeline_results.pop(pipeline, None)
     return self._background_caching_pipeline_results.pop(pipeline, None)
 
   def pipeline_result(self, pipeline, is_main_job=True):
     """Gets the pipeline run result. None if absent."""
     if is_main_job:
-      return self._pipeline_results.get(pipeline, None)
+      return self._main_pipeline_results.get(pipeline, None)
     return self._background_caching_pipeline_results.get(pipeline, None)
 
   def is_terminated(self, pipeline, is_main_job=True):

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -204,8 +204,12 @@ class InteractiveEnvironment(object):
     """Gets the cache manager held by current Interactive Environment."""
     return self._cache_manager
 
-  def set_pipeline_result(self, pipeline, result, is_main_job=True):
-    """Sets the pipeline run result. Adds one if absent. Otherwise, replace."""
+  def set_pipeline_result(self, pipeline, result, is_main_job):
+    """Sets the pipeline run result. Adds one if absent. Otherwise, replace.
+
+    When is_main_job is True, set the result for the main job; otherwise, set
+    the result for the background caching job.
+    """
     assert issubclass(type(pipeline), beam.Pipeline), (
         'pipeline must be an instance of apache_beam.Pipeline or its subclass')
     assert issubclass(type(result), runner.PipelineResult), (

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -79,11 +79,16 @@ class InteractiveEnvironment(object):
     self._watching_set = set()
     # Holds variables list of (Dict[str, object]).
     self._watching_dict_list = []
-    # Holds results of pipeline runs as Dict[Pipeline, PipelineResult].
+    # Holds results of main jobs as Dict[Pipeline, PipelineResult].
     # Each key is a pipeline instance defined by the end user. The
     # InteractiveRunner is responsible for populating this dictionary
     # implicitly.
     self._pipeline_results = {}
+    # Holds results of background caching jobs as
+    # Dict[Pipeline, PipelineResult]. Each key is a pipeline instance defined by
+    # the end user. The InteractiveRunner is responsible for populating this
+    # dictionary implicitly when a background caching jobs is started.
+    self._background_caching_pipeline_results = {}
     self._tracked_user_pipelines = set()
     # Always watch __main__ module.
     self.watch('__main__')
@@ -199,27 +204,34 @@ class InteractiveEnvironment(object):
     """Gets the cache manager held by current Interactive Environment."""
     return self._cache_manager
 
-  def set_pipeline_result(self, pipeline, result):
+  def set_pipeline_result(self, pipeline, result, is_main_job=True):
     """Sets the pipeline run result. Adds one if absent. Otherwise, replace."""
     assert issubclass(type(pipeline), beam.Pipeline), (
         'pipeline must be an instance of apache_beam.Pipeline or its subclass')
     assert issubclass(type(result), runner.PipelineResult), (
         'result must be an instance of '
         'apache_beam.runners.runner.PipelineResult or its subclass')
-    self._pipeline_results[pipeline] = result
+    if is_main_job:
+      self._pipeline_results[pipeline] = result
+    else:
+      self._background_caching_pipeline_results[pipeline] = result
 
-  def evict_pipeline_result(self, pipeline):
+  def evict_pipeline_result(self, pipeline, is_main_job=True):
     """Evicts the tracking of given pipeline run. Noop if absent."""
-    return self._pipeline_results.pop(pipeline, None)
+    if is_main_job:
+      return self._pipeline_results.pop(pipeline, None)
+    return self._background_caching_pipeline_results.pop(pipeline, None)
 
-  def pipeline_result(self, pipeline):
+  def pipeline_result(self, pipeline, is_main_job=True):
     """Gets the pipeline run result. None if absent."""
-    return self._pipeline_results.get(pipeline, None)
+    if is_main_job:
+      return self._pipeline_results.get(pipeline, None)
+    return self._background_caching_pipeline_results.get(pipeline, None)
 
-  def is_terminated(self, pipeline):
+  def is_terminated(self, pipeline, is_main_job=True):
     """Queries if the most recent job (by executing the given pipeline) state
     is in a terminal state. True if absent."""
-    result = self.pipeline_result(pipeline)
+    result = self.pipeline_result(pipeline, is_main_job=is_main_job)
     if result:
       return runner.PipelineState.is_terminal(result.state)
     return True

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
@@ -109,7 +109,8 @@ class InteractiveEnvironmentTest(unittest.TestCase):
     with self.assertRaises(AssertionError) as ctx:
       ie.current_env().set_pipeline_result(NotPipeline(),
                                            runner.PipelineResult(
-                                               runner.PipelineState.RUNNING))
+                                               runner.PipelineState.RUNNING),
+                                           is_main_job=True)
       self.assertTrue('pipeline must be an instance of apache_beam.Pipeline '
                       'or its subclass' in ctx.exception)
 
@@ -118,7 +119,10 @@ class InteractiveEnvironmentTest(unittest.TestCase):
       pass
 
     with self.assertRaises(AssertionError) as ctx:
-      ie.current_env().set_pipeline_result(self._p, NotResult())
+      ie.current_env().set_pipeline_result(
+          self._p,
+          NotResult(),
+          is_main_job=True)
       self.assertTrue('result must be an instance of '
                       'apache_beam.runners.runner.PipelineResult or its '
                       'subclass' in ctx.exception)
@@ -132,7 +136,10 @@ class InteractiveEnvironmentTest(unittest.TestCase):
 
     pipeline = PipelineSubClass()
     pipeline_result = PipelineResultSubClass(runner.PipelineState.RUNNING)
-    ie.current_env().set_pipeline_result(pipeline, pipeline_result)
+    ie.current_env().set_pipeline_result(
+        pipeline,
+        pipeline_result,
+        is_main_job=True)
     self.assertIs(ie.current_env().pipeline_result(pipeline), pipeline_result)
 
   def test_determine_terminal_state(self):
@@ -141,8 +148,10 @@ class InteractiveEnvironmentTest(unittest.TestCase):
                   runner.PipelineState.CANCELLED,
                   runner.PipelineState.UPDATED,
                   runner.PipelineState.DRAINED):
-      ie.current_env().set_pipeline_result(self._p, runner.PipelineResult(
-          state))
+      ie.current_env().set_pipeline_result(
+          self._p,
+          runner.PipelineResult(state),
+          is_main_job=True)
       self.assertTrue(ie.current_env().is_terminated(self._p))
     for state in (runner.PipelineState.UNKNOWN,
                   runner.PipelineState.STARTING,
@@ -152,13 +161,18 @@ class InteractiveEnvironmentTest(unittest.TestCase):
                   runner.PipelineState.PENDING,
                   runner.PipelineState.CANCELLING,
                   runner.PipelineState.UNRECOGNIZED):
-      ie.current_env().set_pipeline_result(self._p, runner.PipelineResult(
-          state))
+      ie.current_env().set_pipeline_result(
+          self._p,
+          runner.PipelineResult(state),
+          is_main_job=True)
       self.assertFalse(ie.current_env().is_terminated(self._p))
 
   def test_evict_pipeline_result(self):
     pipeline_result = runner.PipelineResult(runner.PipelineState.DONE)
-    ie.current_env().set_pipeline_result(self._p, pipeline_result)
+    ie.current_env().set_pipeline_result(
+        self._p,
+        pipeline_result,
+        is_main_job=True)
     self.assertIs(ie.current_env().evict_pipeline_result(self._p),
                   pipeline_result)
     self.assertIs(ie.current_env().pipeline_result(self._p), None)

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -29,10 +29,10 @@ import logging
 import apache_beam as beam
 from apache_beam import runners
 from apache_beam.runners.direct import direct_runner
-from apache_beam.runners.interactive import background_caching_job
 from apache_beam.runners.interactive import cache_manager as cache
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import pipeline_instrument as inst
+from apache_beam.runners.interactive import background_caching_job
 from apache_beam.runners.interactive.display import pipeline_graph
 
 # size of PCollection samples cached.

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -155,7 +155,10 @@ class InteractiveRunner(runners.PipelineRunner):
     # outer scopes are also recommended since the user_pipeline might not be
     # available from within this scope.
     if user_pipeline:
-      ie.current_env().set_pipeline_result(user_pipeline, main_job_result)
+      ie.current_env().set_pipeline_result(
+          user_pipeline,
+          main_job_result,
+          is_main_job=True)
     main_job_result.wait_until_finish()
 
     return main_job_result

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -143,9 +143,9 @@ class InteractiveRunner(runners.PipelineRunner):
         background_caching_job_result.cancel()
       if user_pipeline and pipeline_instrument.has_unbounded_sources:
         background_caching_job_result = beam.pipeline.Pipeline.from_runner_api(
-              pipeline_instrument.background_caching_pipeline_proto(),
-              self._underlying_runner,
-              options).run()
+            pipeline_instrument.background_caching_pipeline_proto(),
+            self._underlying_runner,
+            options).run()
         ie.current_env().set_pipeline_result(user_pipeline,
                                              background_caching_job_result,
                                              is_main_job=False)

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -27,31 +27,57 @@ from __future__ import print_function
 import unittest
 
 import apache_beam as beam
+from apache_beam.runners import runner
 from apache_beam.runners.direct import direct_runner
 from apache_beam.runners.interactive import interactive_beam as ib
+from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner
+from apache_beam.testing.test_stream import TestStream
+from apache_beam.transforms.window import TimestampedValue
+
+# TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
+# unittest.mock module.
+try:
+  from unittest.mock import patch
+except ImportError:
+  from mock import patch
 
 
 def print_with_message(msg):
-
   def printer(elem):
     print(msg, elem)
     return elem
 
   return printer
 
+def _build_a_test_stream_pipeline():
+  test_stream = (TestStream()
+                 .advance_watermark_to(0)
+                 .add_elements([TimestampedValue('a', 1)])
+                 .advance_processing_time(5)
+                 .advance_watermark_to_infinity())
+  p = beam.Pipeline(runner=interactive_runner.InteractiveRunner())
+  events = p | test_stream
+  ib.watch(locals())
+  return p
+
 
 class InteractiveRunnerTest(unittest.TestCase):
+
+  def setUp(self):
+    ie.new_env()
 
   def test_basic(self):
     p = beam.Pipeline(
         runner=interactive_runner.InteractiveRunner(
             direct_runner.DirectRunner()))
+    ib.watch({'p': p})
     p.run().wait_until_finish()
     pc0 = (
         p | 'read' >> beam.Create([1, 2, 3])
         | 'Print1.1' >> beam.Map(print_with_message('Run1.1')))
     pc = pc0 | 'Print1.2' >> beam.Map(print_with_message('Run1.2'))
+    ib.watch(locals())
     p.run().wait_until_finish()
     _ = pc | 'Print2' >> beam.Map(print_with_message('Run2'))
     p.run().wait_until_finish()
@@ -59,7 +85,6 @@ class InteractiveRunnerTest(unittest.TestCase):
     p.run().wait_until_finish()
 
   def test_wordcount(self):
-
     class WordExtractingDoFn(beam.DoFn):
 
       def process(self, element):
@@ -116,6 +141,52 @@ class InteractiveRunnerTest(unittest.TestCase):
     self.assertTrue(underlying_runner._in_session)
     runner.end_session()
     self.assertFalse(underlying_runner._in_session)
+
+  # A patch is needed until the boundedness check considers a TestStream as
+  # an unbounded source.
+  @patch('apache_beam.runners.interactive.pipeline_instrument.'
+         'PipelineInstrument.has_unbounded_sources', True)
+  def test_background_caching_job_starts_when_none_such_job_exists(self):
+    p = _build_a_test_stream_pipeline()
+    p.run()
+    self.assertIsNotNone(
+        ie.current_env().pipeline_result(p, is_main_job=False))
+
+  @patch('apache_beam.runners.interactive.pipeline_instrument.'
+         'PipelineInstrument.has_unbounded_sources', False)
+  def test_background_caching_job_not_start_for_batch_pipeline(self):
+    p = _build_a_test_stream_pipeline()
+    p.run()
+    self.assertIsNone(
+        ie.current_env().pipeline_result(p, is_main_job=False))
+
+  @patch('apache_beam.runners.interactive.pipeline_instrument.'
+         'PipelineInstrument.has_unbounded_sources', True)
+  def test_background_caching_job_not_start_when_such_job_exists(self):
+    p = _build_a_test_stream_pipeline()
+    a_running_result = runner.PipelineResult(runner.PipelineState.RUNNING)
+    ie.current_env().set_pipeline_result(p, a_running_result, is_main_job=False)
+    main_job_result = p.run()
+    # No background caching job is started so result is still the running one.
+    self.assertIs(a_running_result,
+                  ie.current_env().pipeline_result(p, is_main_job=False))
+    # A new main job is started so result of the main job is set.
+    self.assertIs(main_job_result,
+                  ie.current_env().pipeline_result(p))
+
+  @patch('apache_beam.runners.interactive.pipeline_instrument.'
+         'PipelineInstrument.has_unbounded_sources', True)
+  def test_background_caching_job_not_start_when_such_job_is_done(self):
+    p = _build_a_test_stream_pipeline()
+    a_done_result = runner.PipelineResult(runner.PipelineState.DONE)
+    ie.current_env().set_pipeline_result(p, a_done_result, is_main_job=False)
+    main_job_result = p.run()
+    # No background caching job is started so result is still the running one.
+    self.assertIs(a_done_result,
+                  ie.current_env().pipeline_result(p, is_main_job=False))
+    # A new main job is started so result of the main job is set.
+    self.assertIs(main_job_result,
+                  ie.current_env().pipeline_result(p))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -33,7 +33,6 @@ from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner
 
 
-
 def print_with_message(msg):
   def printer(elem):
     print(msg, elem)

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -57,7 +57,7 @@ def _build_a_test_stream_pipeline():
                  .advance_processing_time(5)
                  .advance_watermark_to_infinity())
   p = beam.Pipeline(runner=interactive_runner.InteractiveRunner())
-  events = p | test_stream
+  events = p | test_stream  # pylint: disable=possibly-unused-variable
   ib.watch(locals())
   return p
 

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -27,20 +27,11 @@ from __future__ import print_function
 import unittest
 
 import apache_beam as beam
-from apache_beam.runners import runner
 from apache_beam.runners.direct import direct_runner
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner
-from apache_beam.testing.test_stream import TestStream
-from apache_beam.transforms.window import TimestampedValue
 
-# TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
-# unittest.mock module.
-try:
-  from unittest.mock import patch
-except ImportError:
-  from mock import patch
 
 
 def print_with_message(msg):
@@ -49,17 +40,6 @@ def print_with_message(msg):
     return elem
 
   return printer
-
-def _build_a_test_stream_pipeline():
-  test_stream = (TestStream()
-                 .advance_watermark_to(0)
-                 .add_elements([TimestampedValue('a', 1)])
-                 .advance_processing_time(5)
-                 .advance_watermark_to_infinity())
-  p = beam.Pipeline(runner=interactive_runner.InteractiveRunner())
-  events = p | test_stream  # pylint: disable=possibly-unused-variable
-  ib.watch(locals())
-  return p
 
 
 class InteractiveRunnerTest(unittest.TestCase):
@@ -141,52 +121,6 @@ class InteractiveRunnerTest(unittest.TestCase):
     self.assertTrue(underlying_runner._in_session)
     runner.end_session()
     self.assertFalse(underlying_runner._in_session)
-
-  # A patch is needed until the boundedness check considers a TestStream as
-  # an unbounded source.
-  @patch('apache_beam.runners.interactive.pipeline_instrument.'
-         'PipelineInstrument.has_unbounded_sources', True)
-  def test_background_caching_job_starts_when_none_such_job_exists(self):
-    p = _build_a_test_stream_pipeline()
-    p.run()
-    self.assertIsNotNone(
-        ie.current_env().pipeline_result(p, is_main_job=False))
-
-  @patch('apache_beam.runners.interactive.pipeline_instrument.'
-         'PipelineInstrument.has_unbounded_sources', False)
-  def test_background_caching_job_not_start_for_batch_pipeline(self):
-    p = _build_a_test_stream_pipeline()
-    p.run()
-    self.assertIsNone(
-        ie.current_env().pipeline_result(p, is_main_job=False))
-
-  @patch('apache_beam.runners.interactive.pipeline_instrument.'
-         'PipelineInstrument.has_unbounded_sources', True)
-  def test_background_caching_job_not_start_when_such_job_exists(self):
-    p = _build_a_test_stream_pipeline()
-    a_running_result = runner.PipelineResult(runner.PipelineState.RUNNING)
-    ie.current_env().set_pipeline_result(p, a_running_result, is_main_job=False)
-    main_job_result = p.run()
-    # No background caching job is started so result is still the running one.
-    self.assertIs(a_running_result,
-                  ie.current_env().pipeline_result(p, is_main_job=False))
-    # A new main job is started so result of the main job is set.
-    self.assertIs(main_job_result,
-                  ie.current_env().pipeline_result(p))
-
-  @patch('apache_beam.runners.interactive.pipeline_instrument.'
-         'PipelineInstrument.has_unbounded_sources', True)
-  def test_background_caching_job_not_start_when_such_job_is_done(self):
-    p = _build_a_test_stream_pipeline()
-    a_done_result = runner.PipelineResult(runner.PipelineState.DONE)
-    ie.current_env().set_pipeline_result(p, a_done_result, is_main_job=False)
-    main_job_result = p.run()
-    # No background caching job is started so result is still the running one.
-    self.assertIs(a_done_result,
-                  ie.current_env().pipeline_result(p, is_main_job=False))
-    # A new main job is started so result of the main job is set.
-    self.assertIs(main_job_result,
-                  ie.current_env().pipeline_result(p))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -273,6 +273,23 @@ class PipelineInstrumentTest(unittest.TestCase):
     p_origin.visit(v)
     assert_pipeline_equal(self, p_origin, p_copy)
 
+  def test_find_out_correct_user_pipeline(self):
+    # This is the user pipeline instance we care in the watched scope.
+    user_pipeline, _, _ = self._example_pipeline()
+    # This is a new runner pipeline instance with the same pipeline graph to
+    # what the user_pipeline represents.
+    runner_pipeline = beam.pipeline.Pipeline.from_runner_api(
+        user_pipeline.to_runner_api(use_fake_coders=True),
+        user_pipeline.runner,
+        options=None)
+    # This is a totally irrelevant user pipeline in the watched scope.
+    irrelevant_user_pipeline = beam.Pipeline(
+        interactive_runner.InteractiveRunner())
+    ib.watch({'irrelevant_user_pipeline': irrelevant_user_pipeline})
+    # Build instrument from the runner pipeline.
+    pipeline_instrument = instr.pin(runner_pipeline)
+    self.assertTrue(pipeline_instrument.user_pipeline is user_pipeline)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
1. Added background caching job startup/cancel logic.
2. Updated tests.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
