### PR TITLE
[BEAM-8962] Report Flink metric accumulator only when pipeline ends

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -159,15 +159,6 @@ public interface FlinkPipelineOptions
 
   void setDisableMetrics(Boolean enableMetrics);
 
-  @Description(
-      "By default, uses Flink accumulators to store the metrics which allows to query metrics from the PipelineResult. "
-          + "If set to true, metrics will still be reported but can't be queried via PipelineResult. "
-          + "This saves network and memory.")
-  @Default.Boolean(false)
-  Boolean getDisableMetricAccumulator();
-
-  void setDisableMetricAccumulator(Boolean disableMetricAccumulator);
-
   /** Enables or disables externalized checkpoints. */
   @Description(
       "Enables or disables externalized checkpoints. "

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
@@ -61,42 +61,43 @@ public class FlinkMetricContainer {
   private static final String METRIC_KEY_SEPARATOR =
       GlobalConfiguration.loadConfiguration().getString(MetricOptions.SCOPE_DELIMITER);
 
+  private final MetricsContainerStepMap metricsContainers;
   private final RuntimeContext runtimeContext;
   private final Map<String, Counter> flinkCounterCache;
   private final Map<String, FlinkDistributionGauge> flinkDistributionGaugeCache;
   private final Map<String, FlinkGauge> flinkGaugeCache;
-  private final MetricsAccumulator metricsAccumulator;
 
-  public FlinkMetricContainer(RuntimeContext runtimeContext, boolean accumulatorDisabled) {
+  public FlinkMetricContainer(RuntimeContext runtimeContext) {
     this.runtimeContext = runtimeContext;
     this.flinkCounterCache = new HashMap<>();
     this.flinkDistributionGaugeCache = new HashMap<>();
     this.flinkGaugeCache = new HashMap<>();
-
-    Accumulator<MetricsContainerStepMap, MetricsContainerStepMap> metricsAccumulator;
-    if (accumulatorDisabled) {
-      // Do not register the accumulator with Flink
-      metricsAccumulator = new MetricsAccumulator();
-    } else {
-      metricsAccumulator = runtimeContext.getAccumulator(ACCUMULATOR_NAME);
-      if (metricsAccumulator == null) {
-        metricsAccumulator = new MetricsAccumulator();
-        try {
-          runtimeContext.addAccumulator(ACCUMULATOR_NAME, metricsAccumulator);
-        } catch (UnsupportedOperationException e) {
-          // Not supported in all environments, e.g. tests
-        } catch (Exception e) {
-          LOG.error("Failed to create metrics accumulator.", e);
-        }
-      }
-    }
-    this.metricsAccumulator = (MetricsAccumulator) metricsAccumulator;
+    this.metricsContainers = new MetricsContainerStepMap();
   }
 
   public MetricsContainerImpl getMetricsContainer(String stepName) {
-    return metricsAccumulator != null
-        ? metricsAccumulator.getLocalValue().getContainer(stepName)
-        : null;
+    return metricsContainers.getContainer(stepName);
+  }
+
+  /**
+   * This should be called at the end of the Flink job and sets up an accumulator to push the
+   * metrics to the PipelineResult. This should not be called beforehand, to avoid the overhead
+   * which accumulators cause at runtime.
+   */
+  public void registerMetricsForPipelineResult() {
+    Accumulator<MetricsContainerStepMap, MetricsContainerStepMap> metricsAccumulator =
+        runtimeContext.getAccumulator(ACCUMULATOR_NAME);
+    if (metricsAccumulator == null) {
+      metricsAccumulator = new MetricsAccumulator();
+      try {
+        runtimeContext.addAccumulator(ACCUMULATOR_NAME, metricsAccumulator);
+      } catch (UnsupportedOperationException e) {
+        // Not supported in all environments, e.g. tests
+      } catch (Exception e) {
+        LOG.error("Failed to create metrics accumulator.", e);
+      }
+    }
+    metricsAccumulator.add(metricsContainers);
   }
 
   /**
@@ -113,7 +114,7 @@ public class FlinkMetricContainer {
    * given step.
    */
   void updateMetrics(String stepName) {
-    MetricResults metricResults = asAttemptedOnlyMetricResults(metricsAccumulator.getLocalValue());
+    MetricResults metricResults = asAttemptedOnlyMetricResults(metricsContainers);
     MetricQueryResults metricQueryResults =
         metricResults.queryMetrics(MetricsFilter.builder().addStep(stepName).build());
     updateCounters(metricQueryResults.getCounters());

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/MetricsAccumulator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/MetricsAccumulator.java
@@ -21,7 +21,11 @@ import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.SimpleAccumulator;
 
-/** Accumulator of {@link MetricsContainerStepMap}. */
+/**
+ * Accumulator of {@link MetricsContainerStepMap}. This accumulator will only be reported to Flink
+ * when the job ends. This avoids the runtime overhead for accumulators which are continously sent
+ * to the job manager.
+ */
 public class MetricsAccumulator implements SimpleAccumulator<MetricsContainerStepMap> {
 
   private MetricsContainerStepMap metricsContainers = new MetricsContainerStepMap();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDoFnFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDoFnFunction.java
@@ -72,6 +72,7 @@ public class FlinkDoFnFunction<InputT, OutputT>
   private final Map<String, PCollectionView<?>> sideInputMapping;
 
   private transient DoFnInvoker<InputT, OutputT> doFnInvoker;
+  private transient FlinkMetricContainer metricContainer;
 
   public FlinkDoFnFunction(
       DoFn<InputT, OutputT> doFn,
@@ -133,12 +134,7 @@ public class FlinkDoFnFunction<InputT, OutputT>
 
     FlinkPipelineOptions pipelineOptions = serializedOptions.get().as(FlinkPipelineOptions.class);
     if (!pipelineOptions.getDisableMetrics()) {
-      doFnRunner =
-          new DoFnRunnerWithMetricsUpdate<>(
-              stepName,
-              doFnRunner,
-              new FlinkMetricContainer(
-                  getRuntimeContext(), pipelineOptions.getDisableMetricAccumulator()));
+      doFnRunner = new DoFnRunnerWithMetricsUpdate<>(stepName, doFnRunner, metricContainer);
     }
 
     doFnRunner.startBundle();
@@ -157,11 +153,13 @@ public class FlinkDoFnFunction<InputT, OutputT>
     // options where they are needed.
     FileSystems.setDefaultPipelineOptions(serializedOptions.get());
     doFnInvoker = DoFnInvokers.tryInvokeSetupFor(doFn);
+    metricContainer = new FlinkMetricContainer(getRuntimeContext());
   }
 
   @Override
   public void close() throws Exception {
     try {
+      metricContainer.registerMetricsForPipelineResult();
       Optional.ofNullable(doFnInvoker).ifPresent(DoFnInvoker::invokeTeardown);
     } finally {
       FlinkClassloading.deleteStaticCaches();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -439,8 +439,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
     doFnRunner = createWrappingDoFnRunner(doFnRunner);
 
     if (!options.getDisableMetrics()) {
-      flinkMetricContainer =
-          new FlinkMetricContainer(getRuntimeContext(), options.getDisableMetricAccumulator());
+      flinkMetricContainer = new FlinkMetricContainer(getRuntimeContext());
       doFnRunner = new DoFnRunnerWithMetricsUpdate<>(stepName, doFnRunner, flinkMetricContainer);
     }
 
@@ -481,6 +480,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
   @Override
   public void close() throws Exception {
     try {
+      flinkMetricContainer.registerMetricsForPipelineResult();
       // This is our last change to block shutdown of this operator while
       // there are still remaining processing-time timers. Flink will ignore pending
       // processing-time timers when upstream operators have shut down and will also

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
@@ -92,7 +92,6 @@ public class FlinkPipelineOptionsTest {
     assertThat(options.getSavepointPath(), is(nullValue()));
     assertThat(options.getAllowNonRestoredState(), is(false));
     assertThat(options.getDisableMetrics(), is(false));
-    assertThat(options.getDisableMetricAccumulator(), is(false));
   }
 
   @Test(expected = Exception.class)

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
@@ -21,8 +21,6 @@ import static org.apache.beam.runners.flink.metrics.FlinkMetricContainer.getFlin
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.runners.Parameterized.Parameter;
-import static org.junit.runners.Parameterized.Parameters;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.argThat;
@@ -59,27 +57,17 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link FlinkMetricContainer}. */
-@RunWith(Parameterized.class)
 public class FlinkMetricContainerTest {
-
-  @Parameter public boolean useMetricAccumulator;
 
   @Mock private RuntimeContext runtimeContext;
   @Mock private MetricGroup metricGroup;
 
   FlinkMetricContainer container;
-
-  @Parameters(name = "useMetricAccumulator: {0}")
-  public static Object[] data() {
-    return new Object[] {true, false};
-  }
 
   @Before
   public void beforeTest() {
@@ -88,7 +76,7 @@ public class FlinkMetricContainerTest {
             anyString()))
         .thenReturn(new MetricsAccumulator());
     when(runtimeContext.getMetricGroup()).thenReturn(metricGroup);
-    container = new FlinkMetricContainer(runtimeContext, !useMetricAccumulator);
+    container = new FlinkMetricContainer(runtimeContext);
   }
 
   @Test

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkDoFnFunctionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkDoFnFunctionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.functions;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.beam.runners.flink.metrics.FlinkMetricContainer;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.configuration.Configuration;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+
+/** Tests for {@link FlinkDoFnFunction}. */
+public class FlinkDoFnFunctionTest {
+
+  @Test
+  public void testAccumulatorRegistrationOnOperatorClose() throws Exception {
+    FlinkDoFnFunction doFnFunction =
+        new TestDoFnFunction(
+            "step",
+            WindowingStrategy.globalDefault(),
+            Collections.emptyMap(),
+            PipelineOptionsFactory.create(),
+            Collections.emptyMap(),
+            new TupleTag<>(),
+            null,
+            Collections.emptyMap(),
+            DoFnSchemaInformation.create(),
+            Collections.emptyMap());
+
+    doFnFunction.open(new Configuration());
+
+    String metricContainerFieldName = "metricContainer";
+    FlinkMetricContainer monitoredContainer =
+        Mockito.spy(
+            (FlinkMetricContainer)
+                Whitebox.getInternalState(doFnFunction, metricContainerFieldName));
+    Whitebox.setInternalState(doFnFunction, metricContainerFieldName, monitoredContainer);
+
+    doFnFunction.close();
+    Mockito.verify(monitoredContainer).registerMetricsForPipelineResult();
+  }
+
+  private static class TestDoFnFunction extends FlinkDoFnFunction {
+
+    public TestDoFnFunction(
+        String stepName,
+        WindowingStrategy windowingStrategy,
+        Map sideInputs,
+        PipelineOptions options,
+        Map outputMap,
+        TupleTag mainOutputTag,
+        Coder inputCoder,
+        Map outputCoderMap,
+        DoFnSchemaInformation doFnSchemaInformation,
+        Map sideInputMapping) {
+      super(
+          new IdentityFn(),
+          stepName,
+          windowingStrategy,
+          sideInputs,
+          options,
+          outputMap,
+          mainOutputTag,
+          inputCoder,
+          outputCoderMap,
+          doFnSchemaInformation,
+          sideInputMapping);
+    }
+
+    @Override
+    public RuntimeContext getRuntimeContext() {
+      return Mockito.mock(RuntimeContext.class);
+    }
+
+    private static class IdentityFn<T> extends DoFn<T, T> {
+      @ProcessElement
+      public void processElement(ProcessContext c) {
+        c.output(c.element());
+      }
+    }
+  }
+}

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkStatefulDoFnFunctionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkStatefulDoFnFunctionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.functions;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.beam.runners.flink.metrics.FlinkMetricContainer;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.configuration.Configuration;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+
+/** Tests for {@link FlinkStatefulDoFnFunction}. */
+public class FlinkStatefulDoFnFunctionTest {
+
+  @Test
+  public void testAccumulatorRegistrationOnOperatorClose() throws Exception {
+    FlinkStatefulDoFnFunction doFnFunction =
+        new TestDoFnFunction(
+            "step",
+            WindowingStrategy.globalDefault(),
+            Collections.emptyMap(),
+            PipelineOptionsFactory.create(),
+            Collections.emptyMap(),
+            new TupleTag<>(),
+            null,
+            Collections.emptyMap(),
+            DoFnSchemaInformation.create(),
+            Collections.emptyMap());
+
+    doFnFunction.open(new Configuration());
+
+    String metricContainerFieldName = "metricContainer";
+    FlinkMetricContainer monitoredContainer =
+        Mockito.spy(
+            (FlinkMetricContainer)
+                Whitebox.getInternalState(doFnFunction, metricContainerFieldName));
+    Whitebox.setInternalState(doFnFunction, metricContainerFieldName, monitoredContainer);
+
+    doFnFunction.close();
+    Mockito.verify(monitoredContainer).registerMetricsForPipelineResult();
+  }
+
+  private static class TestDoFnFunction extends FlinkStatefulDoFnFunction {
+
+    public TestDoFnFunction(
+        String stepName,
+        WindowingStrategy windowingStrategy,
+        Map sideInputs,
+        PipelineOptions options,
+        Map outputMap,
+        TupleTag mainOutputTag,
+        Coder inputCoder,
+        Map outputCoderMap,
+        DoFnSchemaInformation doFnSchemaInformation,
+        Map sideInputMapping) {
+      super(
+          new IdentityFn(),
+          stepName,
+          windowingStrategy,
+          sideInputs,
+          options,
+          outputMap,
+          mainOutputTag,
+          inputCoder,
+          outputCoderMap,
+          doFnSchemaInformation,
+          sideInputMapping);
+    }
+
+    @Override
+    public RuntimeContext getRuntimeContext() {
+      return Mockito.mock(RuntimeContext.class);
+    }
+
+    private static class IdentityFn<T> extends DoFn<T, T> {
+      @ProcessElement
+      public void processElement(ProcessContext c) {
+        c.output(c.element());
+      }
+    }
+  }
+}

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormatTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormatTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers;
+
+import org.apache.beam.runners.flink.metrics.FlinkMetricContainer;
+import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.io.CountingSource;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+
+/** Tests for {@link SourceInputFormat}. */
+public class SourceInputFormatTest {
+
+  @Test
+  public void testAccumulatorRegistrationOnOperatorClose() throws Exception {
+    SourceInputFormat<Long> sourceInputFormat =
+        new TestSourceInputFormat<>(
+            "step", CountingSource.upTo(10), PipelineOptionsFactory.create());
+
+    sourceInputFormat.open(sourceInputFormat.createInputSplits(1)[0]);
+
+    String metricContainerFieldName = "metricContainer";
+    FlinkMetricContainer monitoredContainer =
+        Mockito.spy(
+            (FlinkMetricContainer)
+                Whitebox.getInternalState(sourceInputFormat, metricContainerFieldName));
+    Whitebox.setInternalState(sourceInputFormat, metricContainerFieldName, monitoredContainer);
+
+    sourceInputFormat.close();
+    Mockito.verify(monitoredContainer).registerMetricsForPipelineResult();
+  }
+
+  private static class TestSourceInputFormat<T> extends SourceInputFormat<T> {
+
+    public TestSourceInputFormat(
+        String stepName, BoundedSource initialSource, PipelineOptions options) {
+      super(stepName, initialSource, options);
+    }
+
+    @Override
+    public RuntimeContext getRuntimeContext() {
+      return Mockito.mock(RuntimeContext.class);
+    }
+  }
+}

--- a/website/src/_includes/flink_java_pipeline_options.html
+++ b/website/src/_includes/flink_java_pipeline_options.html
@@ -48,11 +48,6 @@ which should be called before running the tests.
   <td>Default: <code>EXACTLY_ONCE</code></td>
 </tr>
 <tr>
-  <td><code>disableMetricAccumulator</code></td>
-  <td>By default, uses Flink accumulators to store the metrics which allows to query metrics from the PipelineResult. If set to true, metrics will still be reported but can't be queried via PipelineResult. This saves network and memory.</td>
-  <td>Default: <code>false</code></td>
-</tr>
-<tr>
   <td><code>disableMetrics</code></td>
   <td>Disable Beam metrics in Flink Runner</td>
   <td>Default: <code>false</code></td>

--- a/website/src/_includes/flink_python_pipeline_options.html
+++ b/website/src/_includes/flink_python_pipeline_options.html
@@ -48,11 +48,6 @@ which should be called before running the tests.
   <td>Default: <code>EXACTLY_ONCE</code></td>
 </tr>
 <tr>
-  <td><code>disable_metric_accumulator</code></td>
-  <td>By default, uses Flink accumulators to store the metrics which allows to query metrics from the PipelineResult. If set to true, metrics will still be reported but can't be queried via PipelineResult. This saves network and memory.</td>
-  <td>Default: <code>false</code></td>
-</tr>
-<tr>
   <td><code>disable_metrics</code></td>
   <td>Disable Beam metrics in Flink Runner</td>
   <td>Default: <code>false</code></td>


### PR DESCRIPTION
To avoid the runtime overhead of continuously reporting accumulators from the
TaskManagers to the JobManager, we can defer the reporting of the metrics
accumulator until the pipeline shuts down. A final snapshot of the accumulators
will be reported then.

This means the metrics will still be available in the PipelineResult. Of course,
the metrics reporting via Flink is not affected by this change.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
