### PR TITLE
[BEAM-8999] Respect timestamp combiners in PGBKCVOperation.

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_transforms.py
@@ -681,13 +681,7 @@ def lift_combiners(stages, context):
         context.components.pcollections[
             only_element(list(combine_per_key_transform.inputs.values()))
         ].windowing_strategy_id]
-    if windowing.output_time != beam_runner_api_pb2.OutputTime.END_OF_WINDOW:
-      # This depends on the spec of PartialGroupByKey.
-      return False
-    elif not is_compatible_with_combiner_lifting(windowing.trigger):
-      return False
-    else:
-      return True
+    return is_compatible_with_combiner_lifting(windowing.trigger)
 
   def make_stage(base_stage, transform):
     # type: (Stage, beam_runner_api_pb2.PTransform) -> Stage

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -1098,6 +1098,12 @@ class BeamTransformFactory(object):
     # type: (beam_runner_api_pb2.PTransform) -> coders.Coder
     return only_element(list(self.get_input_coders(transform_proto).values()))
 
+  def get_input_windowing(self, transform_proto):
+    pcoll_id = only_element(transform_proto.inputs.values())
+    windowing_strategy_id = self.descriptor.pcollections[
+        pcoll_id].windowing_strategy_id
+    return self.context.windowing_strategies.get_by_id(windowing_strategy_id)
+
   # TODO(robertwb): Update all operations to take these in the constructor.
   @staticmethod
   def augment_oldstyle_op(op,  # type: OperationT
@@ -1485,7 +1491,8 @@ def create(factory, transform_id, transform_proto, payload, consumers):
               None,
               [factory.get_only_output_coder(transform_proto)]),
           factory.counter_factory,
-          factory.state_sampler),
+          factory.state_sampler,
+          factory.get_input_windowing(transform_proto)),
       transform_proto.unique_name,
       consumers)
 

--- a/sdks/python/apache_beam/runners/worker/operations.pxd
+++ b/sdks/python/apache_beam/runners/worker/operations.pxd
@@ -117,7 +117,7 @@ cdef class PGBKCVOperation(Operation):
   cdef long max_keys
   cdef long key_count
 
-  cpdef output_key(self, tuple wkey, value, timestamp)
+  cpdef output_key(self, wkey, value, timestamp)
 
 
 cdef class FlattenOperation(Operation):

--- a/sdks/python/apache_beam/runners/worker/operations.pxd
+++ b/sdks/python/apache_beam/runners/worker/operations.pxd
@@ -111,11 +111,13 @@ cdef class PGBKCVOperation(Operation):
   cdef public object combine_fn
   cdef public object combine_fn_add_input
   cdef public object combine_fn_compact
+  cdef public bint is_default_windowing
+  cdef public object timestamp_combiner
   cdef dict table
   cdef long max_keys
   cdef long key_count
 
-  cpdef output_key(self, tuple wkey, value)
+  cpdef output_key(self, tuple wkey, value, timestamp)
 
 
 cdef class FlattenOperation(Operation):

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -58,6 +58,7 @@ from apache_beam.transforms import sideinputs as apache_sideinputs
 from apache_beam.transforms import combiners
 from apache_beam.transforms import core
 from apache_beam.transforms import userstate
+from apache_beam.transforms import window
 from apache_beam.transforms.combiners import PhasedCombineFnExecutor
 from apache_beam.transforms.combiners import curry_combine_fn
 from apache_beam.transforms.window import GlobalWindows
@@ -888,7 +889,8 @@ class PGBKOperation(Operation):
 
 class PGBKCVOperation(Operation):
 
-  def __init__(self, name_context, spec, counter_factory, state_sampler):
+  def __init__(
+      self, name_context, spec, counter_factory, state_sampler, windowing=None):
     super(PGBKCVOperation, self).__init__(
         name_context, spec, counter_factory, state_sampler)
     # Combiners do not accept deferred side-inputs (the ignored fourth
@@ -904,6 +906,15 @@ class PGBKCVOperation(Operation):
       self.combine_fn_compact = None
     else:
       self.combine_fn_compact = self.combine_fn.compact
+    if windowing:
+      self.is_default_windowing = windowing.is_default()
+      tsc_type = windowing.timestamp_combiner
+      self.timestamp_combiner = (
+          None if tsc_type == window.TimestampCombiner.OUTPUT_AT_EOW
+          else window.TimestampCombiner.get_impl(tsc_type, windowing.windowfn))
+    else:
+      self.is_default_windowing = False  # unknown
+      self.timestamp_combiner = None
     # Optimization for the (known tiny accumulator, often wide keyspace)
     # combine functions.
     # TODO(b/36567833): Bound by in-memory size rather than key count.
@@ -923,8 +934,8 @@ class PGBKCVOperation(Operation):
       key, value = wkv.value
       # pylint: disable=unidiomatic-typecheck
       # Optimization for the global window case.
-      if len(wkv.windows) == 1 and type(wkv.windows[0]) is _global_window_type:
-        wkey = 0, key  # type: Tuple[Hashable, Any]
+      if self.is_default_windowing:
+        wkey = key  # type: Hashable
       else:
         wkey = tuple(wkv.windows), key
       entry = self.table.get(wkey, None)
@@ -935,7 +946,7 @@ class PGBKCVOperation(Operation):
           # TODO(robertwb): Use an LRU cache?
           for old_wkey, old_wvalue in self.table.items():
             old_wkeys.append(old_wkey)  # Can't mutate while iterating.
-            self.output_key(old_wkey, old_wvalue[0])
+            self.output_key(old_wkey, old_wvalue[0], old_wvalue[1])
             self.key_count -= 1
             if self.key_count <= target:
               break
@@ -944,26 +955,33 @@ class PGBKCVOperation(Operation):
         self.key_count += 1
         # We save the accumulator as a one element list so we can efficiently
         # mutate when new values are added without searching the cache again.
-        entry = self.table[wkey] = [self.combine_fn.create_accumulator()]
+        entry = self.table[wkey] = [self.combine_fn.create_accumulator(), None]
+        if not self.is_default_windowing:
+          # Conditional as the timestamp attribute is lazily initialized.
+          entry[1] = wkv.timestamp
       entry[0] = self.combine_fn_add_input(entry[0], value)
+      if not self.is_default_windowing and self.timestamp_combiner:
+        entry[1] = self.timestamp_combiner.combine(entry[1], wkv.timestamp)
 
   def finish(self):
     for wkey, value in self.table.items():
-      self.output_key(wkey, value[0])
+      self.output_key(wkey, value[0], value[1])
     self.table = {}
     self.key_count = 0
 
-  def output_key(self, wkey, accumulator):
-    windows, key = wkey
+  def output_key(self, wkey, accumulator, timestamp):
     if self.combine_fn_compact is None:
       value = accumulator
     else:
       value = self.combine_fn_compact(accumulator)
-    if windows == 0:
-      self.output(_globally_windowed_value.with_value((key, value)))
+
+    if self.is_default_windowing:
+      self.output(_globally_windowed_value.with_value((wkey, value)))
     else:
-      self.output(
-          WindowedValue((key, value), windows[0].max_timestamp(), windows))
+      windows, key = wkey
+      if self.timestamp_combiner is None:
+        timestamp = windows[0].max_timestamp()
+      self.output(WindowedValue((key, value), timestamp, windows))
 
 
 class FlattenOperation(Operation):

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -30,7 +30,6 @@ from builtins import filter
 from builtins import object
 from builtins import zip
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import DefaultDict
 from typing import Dict
 from typing import FrozenSet
@@ -38,7 +37,6 @@ from typing import Hashable
 from typing import Iterator
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 
 from apache_beam import pvalue


### PR DESCRIPTION
This fixes a correctness issue on non-direct runners.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
