### PR TITLE
Change access for the TableRowJsonCoder constructor

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowJsonCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowJsonCoder.java
@@ -73,7 +73,7 @@ public class TableRowJsonCoder extends AtomicCoder<TableRow> {
   private static final TableRowJsonCoder INSTANCE = new TableRowJsonCoder();
   private static final TypeDescriptor<TableRow> TYPE_DESCRIPTOR = new TypeDescriptor<TableRow>() {};
 
-  private TableRowJsonCoder() {}
+  protected TableRowJsonCoder() {}
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
The class TableRowJsonCoder is a singleton, which makes it impossible to subclass to tweak the behavior of the Mapper object in cases where non-standard behavior is desired.
Change the constructor of TableRowJsonCoder from private to protected to allow for subclassing.

R: lukecwik
