### PR TITLE
[BEAM-8951] Stop using nose in load tests

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Python.groovy
@@ -28,7 +28,7 @@ String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def scenarios = { datasetName, sdkHarnessImageTag -> [
         [
                 title          : 'Combine Python Load test: 2GB 10 byte records',
-                test           : 'apache_beam.testing.load_tests.combine_test:CombineTest.testCombineGlobally',
+                test           : 'apache_beam.testing.load_tests.combine_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : 'load-tests-python-flink-batch-combine-1-' + now,
@@ -49,7 +49,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'Combine Python Load test: 2GB Fanout 4',
-                test           : 'apache_beam.testing.load_tests.combine_test:CombineTest.testCombineGlobally',
+                test           : 'apache_beam.testing.load_tests.combine_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : 'load-tests-python-flink-batch-combine-4-' + now,
@@ -71,7 +71,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'Combine Python Load test: 2GB Fanout 8',
-                test           : 'apache_beam.testing.load_tests.combine_test:CombineTest.testCombineGlobally',
+                test           : 'apache_beam.testing.load_tests.combine_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : 'load-tests-python-flink-batch-combine-5-' + now,

--- a/.test-infra/jenkins/job_LoadTests_Combine_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Python.groovy
@@ -25,7 +25,7 @@ def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def loadTestConfigurations = { datasetName -> [
         [
                 title          : 'Combine Python Load test: 2GB 10 byte records',
-                test           : 'apache_beam.testing.load_tests.combine_test:CombineTest.testCombineGlobally',
+                test           : 'apache_beam.testing.load_tests.combine_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-combine-1-' + now,
@@ -45,7 +45,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'Combine Python Load test: 2GB Fanout 4',
-                test           : 'apache_beam.testing.load_tests.combine_test:CombineTest.testCombineGlobally',
+                test           : 'apache_beam.testing.load_tests.combine_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-combine-4-' + now,
@@ -66,7 +66,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'Combine Python Load test: 2GB Fanout 8',
-                test           : 'apache_beam.testing.load_tests.combine_test:CombineTest.testCombineGlobally',
+                test           : 'apache_beam.testing.load_tests.combine_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-combine-5-' + now,

--- a/.test-infra/jenkins/job_LoadTests_GBK_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Flink_Python.groovy
@@ -28,7 +28,7 @@ String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def scenarios = { datasetName, sdkHarnessImageTag -> [
         [
                 title          : 'Load test: 2GB of 10B records',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_1_${now}",
@@ -47,7 +47,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'Load test: 2GB of 100B records',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_2_${now}",
@@ -66,7 +66,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'Load test: fanout 4 times with 2GB 10-byte records total',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_4_${now}",
@@ -85,7 +85,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'Load test: fanout 8 times with 2GB 10-byte records total',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_5_${now}",
@@ -104,7 +104,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'Load test: reiterate 4 times 10kB values',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name            : "load_tests_Python_Flink_Batch_GBK_6_${now}",

--- a/.test-infra/jenkins/job_LoadTests_GBK_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Python.groovy
@@ -24,7 +24,7 @@ def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def loadTestConfigurations = { datasetName -> [
         [
                 title          : 'GroupByKey Python Load test: 2GB of 10B records',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-gbk-1-' + now,
@@ -44,7 +44,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'GroupByKey Python Load test: 2GB of 100B records',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-gbk-2-' + now,
@@ -64,7 +64,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'GroupByKey Python Load test: 2GB of 100kB records',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-gbk-3-' + now,
@@ -84,7 +84,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'GroupByKey Python Load test: fanout 4 times with 2GB 10-byte records total',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-gbk-4-' + now,
@@ -104,7 +104,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'GroupByKey Python Load test: fanout 8 times with 2GB 10-byte records total',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-gbk-5-' + now,

--- a/.test-infra/jenkins/job_LoadTests_GBK_Python_reiterate.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Python_reiterate.groovy
@@ -27,7 +27,7 @@ def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def loadTestConfigurations = { datasetName -> [
         [
                 title          : 'GroupByKey Python Load test: reiterate 4 times 10kB values',
-                test           :  'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           :  'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',
@@ -49,7 +49,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'GroupByKey Python Load test: reiterate 4 times 2MB values',
-                test           :  'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           :  'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Flink_Python.groovy
@@ -28,7 +28,7 @@ String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def scenarios = { datasetName, sdkHarnessImageTag -> [
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 10 times',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-flink-batch-pardo-1-' + now,
@@ -51,7 +51,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 200 times',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-flink-batch-pardo-2-' + now,
@@ -74,7 +74,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 10 counters',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-flink-batch-pardo-3-' + now,
@@ -97,7 +97,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 100 counters',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-flink-batch-pardo-4-' + now,

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Python.groovy
@@ -25,7 +25,7 @@ def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def loadTestConfigurations = { datasetName -> [
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 10 times',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-pardo-1-' + now,
@@ -47,7 +47,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 200 times',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-pardo-2-' + now,
@@ -69,7 +69,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 10 counters',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-pardo-3-' + now,
@@ -91,7 +91,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 100 counters',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python-dataflow-batch-pardo-4-' + now,

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Python_37.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Python_37.groovy
@@ -25,7 +25,7 @@ def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def loadTestConfigurations = { datasetName -> [
         [
                 title          : 'ParDo Python Load test: 2GB 100 byte records 10 times',
-                test           : 'apache_beam.testing.load_tests.pardo_test:ParDoTest.testParDo',
+                test           : 'apache_beam.testing.load_tests.pardo_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name             : 'load-tests-python37-dataflow-batch-pardo-1-' + now,

--- a/.test-infra/jenkins/job_LoadTests_Python_Smoke.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Python_Smoke.groovy
@@ -24,7 +24,7 @@ def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def smokeTestConfigurations = { datasetName -> [
         [
                 title          : 'GroupByKey Python load test Direct',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DIRECT,
                 pipelineOptions: [
                         publish_to_big_query: true,
@@ -39,7 +39,7 @@ def smokeTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'GroupByKey Python load test Dataflow',
-                test           : 'apache_beam.testing.load_tests.group_by_key_test:GroupByKeyTest.testGroupByKey',
+                test           : 'apache_beam.testing.load_tests.group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         job_name            : 'load-tests-python-dataflow-batch-gbk-smoke-' + now,

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Python.groovy
@@ -28,7 +28,7 @@ String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def scenarios = { datasetName, sdkHarnessImageTag -> [
         [
                 title          : 'CoGroupByKey Python Load test: 2GB of 100B records with a single key',
-                test           : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                test           : 'apache_beam.testing.load_tests.co_group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',
@@ -58,7 +58,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'CoGroupByKey Python Load test: 2GB of 100B records with multiple keys',
-                test           : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                test           : 'apache_beam.testing.load_tests.co_group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',
@@ -88,7 +88,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'CoGroupByKey Python Load test: reiterate 4 times 10kB values',
-                test           : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                test           : 'apache_beam.testing.load_tests.co_group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',
@@ -118,7 +118,7 @@ def scenarios = { datasetName, sdkHarnessImageTag -> [
         ],
         [
                 title          : 'CoGroupByKey Python Load test: reiterate 4 times 2MB values',
-                test           : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                test           : 'apache_beam.testing.load_tests.co_group_by_key_test',
                 runner         : CommonTestProperties.Runner.PORTABLE,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Python.groovy
@@ -27,7 +27,7 @@ def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 def loadTestConfigurations = { datasetName -> [
         [
                 title          : 'CoGroupByKey Python Load test: 2GB of 100B records with a single key',
-                test           : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                test           : 'apache_beam.testing.load_tests.co_group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',
@@ -55,7 +55,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'CoGroupByKey Python Load test: 2GB of 100B records with multiple keys',
-                test           : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                test           : 'apache_beam.testing.load_tests.co_group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',
@@ -83,7 +83,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'CoGroupByKey Python Load test: reiterate 4 times 10kB values',
-                test           : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                test           : 'apache_beam.testing.load_tests.co_group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',
@@ -111,7 +111,7 @@ def loadTestConfigurations = { datasetName -> [
         ],
         [
                 title          : 'CoGroupByKey Python Load test: reiterate 4 times 2MB values',
-                test           : 'apache_beam.testing.load_tests.co_group_by_key_test:CoGroupByKeyTest.testCoGroupByKey',
+                test           : 'apache_beam.testing.load_tests.co_group_by_key_test',
                 runner         : CommonTestProperties.Runner.DATAFLOW,
                 pipelineOptions: [
                         project              : 'apache-beam-testing',

--- a/.test-infra/jenkins/job_PerformanceTests_BigQueryIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_BigQueryIO_Python.groovy
@@ -24,7 +24,7 @@ def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
 def bqio_read_test = [
         title          : 'BigQueryIO Read Performance Test Python 10 GB',
-        test           : 'apache_beam.io.gcp.bigquery_read_perf_test:BigQueryReadPerfTest.test',
+        test           : 'apache_beam.io.gcp.bigquery_read_perf_test',
         runner         : CommonTestProperties.Runner.DATAFLOW,
         pipelineOptions: [
                 job_name             : 'performance-tests-bqio-read-python-10gb' + now,
@@ -46,7 +46,7 @@ def bqio_read_test = [
 
 def bqio_write_test = [
         title          : 'BigQueryIO Write Performance Test Python Batch 10 GB',
-        test           : 'apache_beam.io.gcp.bigquery_write_perf_test:BigQueryWritePerfTest.test',
+        test           : 'apache_beam.io.gcp.bigquery_write_perf_test',
         runner         : CommonTestProperties.Runner.DATAFLOW,
         pipelineOptions: [
                 job_name             : 'performance-tests-bqio-write-python-batch-10gb' + now,

--- a/sdks/python/apache_beam/io/gcp/bigquery_read_perf_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_read_perf_test.py
@@ -55,8 +55,6 @@ from __future__ import absolute_import
 
 import base64
 import logging
-import os
-import unittest
 
 from apache_beam import Map
 from apache_beam import ParDo
@@ -82,15 +80,10 @@ except ImportError:
   HttpError = None
 # pylint: enable=wrong-import-order, wrong-import-position
 
-load_test_enabled = False
-if os.environ.get('LOAD_TEST_ENABLED') == 'true':
-  load_test_enabled = True
 
-
-@unittest.skipIf(not load_test_enabled, 'Enabled only for phrase triggering.')
 class BigQueryReadPerfTest(LoadTest):
-  def setUp(self):
-    super(BigQueryReadPerfTest, self).setUp()
+  def __init__(self):
+    super(BigQueryReadPerfTest, self).__init__()
     self.input_dataset = self.pipeline.get_option('input_dataset')
     self.input_table = self.pipeline.get_option('input_table')
     self._check_for_input_data()
@@ -118,8 +111,7 @@ class BigQueryReadPerfTest(LoadTest):
       return {'data': base64.b64encode(record[1])}
 
     with TestPipeline() as p:
-      # pylint: disable=expression-not-assigned
-      (
+      (  # pylint: disable=expression-not-assigned
           p
           | 'Produce rows' >> Read(
               SyntheticSource(self.parseTestPipelineOptions()))
@@ -143,5 +135,5 @@ class BigQueryReadPerfTest(LoadTest):
 
 
 if __name__ == '__main__':
-  logging.getLogger().setLevel(logging.INFO)
-  unittest.main()
+  logging.basicConfig(level=logging.INFO)
+  BigQueryReadPerfTest().run()

--- a/sdks/python/apache_beam/io/gcp/bigquery_read_perf_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_read_perf_test.py
@@ -29,7 +29,7 @@ key_size - required option, but its value has no meaning.
 
 Example test run on DataflowRunner:
 
-python setup.py nosetests \
+python -m apache_beam.io.gcp.bigquery_read_perf_test \
     --test-pipeline-options="
     --runner=TestDataflowRunner
     --project=...
@@ -45,8 +45,7 @@ python setup.py nosetests \
     \"num_records\": 1024,
     \"key_size\": 1,
     \"value_size\": 1024,
-    }'" \
-    --tests apache_beam.io.gcp.bigquery_read_perf_test
+    }'"
 """
 
 # pytype: skip-file

--- a/sdks/python/apache_beam/io/gcp/bigquery_write_perf_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_write_perf_test.py
@@ -27,7 +27,7 @@ key_size - required option, but its value has no meaning.
 
 Example test run on DataflowRunner:
 
-python setup.py nosetests \
+python -m apache_beam.io.gcp.bigquery_write_perf_test \
     --test-pipeline-options="
     --runner=TestDataflowRunner
     --project=...
@@ -43,8 +43,7 @@ python setup.py nosetests \
     \"num_records\": 1024,
     \"key_size\": 1,
     \"value_size\": 1024,
-    }'" \
-    --tests apache_beam.io.gcp.bigquery_write_perf_test
+    }'"
 
 This setup will result in a table of 1MB size.
 """

--- a/sdks/python/apache_beam/testing/load_tests/build.gradle
+++ b/sdks/python/apache_beam/testing/load_tests/build.gradle
@@ -42,10 +42,8 @@ task run(type: Exec, dependsOn: installGcpTest) {
         loadTestArgs +=" --sdk_location=${files(configurations.distTarBall.files).singleFile}"
     }
 
-    environment "LOAD_TEST_ENABLED", 'true'
     setWorkingDir "${project.rootDir}/sdks/python"
-
-    commandLine 'sh', '-c', "${project.ext.envdir}/bin/python setup.py nosetests --test-pipeline-options=\"${parseOptions(loadTestArgs)}\" --tests ${mainClass} --ignore-files \'.*py3\\d?\\.py\$\'"
+    commandLine 'sh', '-c', "${project.ext.envdir}/bin/python -m ${mainClass} --test-pipeline-options=\"${parseOptions(loadTestArgs)}\" --ignore-files \'.*py3\\d?\\.py\$\'"
     ignoreExitValue true
 
     doLast {

--- a/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
@@ -149,8 +149,6 @@ from __future__ import absolute_import
 
 import json
 import logging
-import os
-import unittest
 
 import apache_beam as beam
 from apache_beam.testing import synthetic_pipeline
@@ -160,15 +158,10 @@ from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
 INPUT_TAG = 'pc1'
 CO_INPUT_TAG = 'pc2'
 
-load_test_enabled = False
-if os.environ.get('LOAD_TEST_ENABLED') == 'true':
-  load_test_enabled = True
 
-
-@unittest.skipIf(not load_test_enabled, 'Enabled only for phrase triggering.')
 class CoGroupByKeyTest(LoadTest):
-  def setUp(self):
-    super(CoGroupByKeyTest, self).setUp()
+  def __init__(self):
+    super(CoGroupByKeyTest, self).__init__()
     self.co_input_options = json.loads(
         self.pipeline.get_option('co_input_options'))
     self.iterations = self.get_option_or_default('iterations', 1)
@@ -191,7 +184,7 @@ class CoGroupByKeyTest(LoadTest):
         self.pipeline
         | 'Read ' + INPUT_TAG >> beam.io.Read(
             synthetic_pipeline.SyntheticSource(
-                self.parseTestPipelineOptions(self.input_options)))
+                self.parse_synthetic_source_options()))
         | 'Make ' + INPUT_TAG + ' iterable' >> beam.Map(lambda x: (x, x))
         | 'Measure time: Start pc1' >> beam.ParDo(
             MeasureTime(self.metrics_namespace)))
@@ -200,7 +193,7 @@ class CoGroupByKeyTest(LoadTest):
         self.pipeline
         | 'Read ' + CO_INPUT_TAG >> beam.io.Read(
             synthetic_pipeline.SyntheticSource(
-                self.parseTestPipelineOptions(self.co_input_options)))
+                self.parse_synthetic_source_options(self.co_input_options)))
         | 'Make ' + CO_INPUT_TAG + ' iterable' >> beam.Map(lambda x: (x, x))
         | 'Measure time: Start pc2' >> beam.ParDo(
             MeasureTime(self.metrics_namespace)))
@@ -215,5 +208,5 @@ class CoGroupByKeyTest(LoadTest):
 
 
 if __name__ == '__main__':
-  logging.getLogger().setLevel(logging.INFO)
-  unittest.main()
+  logging.basicConfig(level=logging.INFO)
+  CoGroupByKeyTest().run()

--- a/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
@@ -31,9 +31,9 @@ will be stored,
 * iterations - number of reiterations over per-key-grouped values to perform
 (default: 1).
 
-Example test run on DirectRunner:
+Example test run:
 
-python setup.py nosetests \
+python -m apache_beam.testing.load_tests.co_group_by_key_test \
     --test-pipeline-options="
       --project=big-query-project
       --publish_to_big_query=true
@@ -43,18 +43,13 @@ python setup.py nosetests \
       --input_options='{
         \"num_records\": 1000,
         \"key_size\": 5,
-        \"value_size\":15,
-        \"bundle_size_distribution_type\": \"const\",
-        \"bundle_size_distribution_param\": 1,
-        \"force_initial_num_bundles\":0}'
-        --co_input_options='{
+        \"value_size\": 15
+        }'
+      --co_input_options='{
         \"num_records\": 1000,
         \"key_size\": 5,
-        \"value_size\":15,
-        \"bundle_size_distribution_type\": \"const\",
-        \"bundle_size_distribution_param\": 1,
-        \"force_initial_num_bundles\":0}'" \
-    --tests apache_beam.testing.load_tests.co_group_by_key_test
+        \"value_size\": 15
+        }'"
 
 or:
 
@@ -67,80 +62,14 @@ or:
     --input_options=\'
       {"num_records": 1,
       "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
+      "value_size": 1}\'
      --co_input_options=\'{
         "num_records": 1,
         "key_size": 1,
-        "value_size": 1,
-        "bundle_size_distribution_type": "const",
-        "bundle_size_distribution_param": 1,
-        "force_initial_num_bundles":0}\'
+        "value_size": 1}\'
     --runner=DirectRunner' \
--PloadTest.mainClass=
-apache_beam.testing.load_tests.co_group_by_key_test \
--Prunner=DirectRunner :sdks:python:apache_beam:testing:load-tests:run
-
-To run test on other runner (ex. Dataflow):
-
-python setup.py nosetests \
-    --test-pipeline-options="
-        --runner=TestDataflowRunner
-        --project=...
-        --staging_location=gs://...
-        --temp_location=gs://...
-        --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
-        --publish_to_big_query=true
-        --metrics_dataset=python_load_tests
-        --metrics_table=co_gbk
-        --iterations=1
-        --input_options='{
-        \"num_records\": 1000,
-        \"key_size\": 5,
-        \"value_size\":15,
-        \"bundle_size_distribution_type\": \"const\",
-        \"bundle_size_distribution_param\": 1,
-        \"force_initial_num_bundles\":0
-        }'
-        --co_input_options='{
-        \"num_records\": 1000,
-        \"key_size\": 5,
-        \"value_size\":15,
-        \"bundle_size_distribution_type\": \"const\",
-        \"bundle_size_distribution_param\": 1,
-        \"force_initial_num_bundles\":0
-        }'" \
-    --tests apache_beam.testing.load_tests.co_group_by_key_test
-
-or:
-
-./gradlew -PloadTest.args='
-    --publish_to_big_query=true
-    --project=...
-    --metrics_dataset=python_load_tests
-    --metrics_table=co_gbk
-    --iterations=1
-    --temp_location=gs://...
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
-    --co_input_options=\'{
-      "num_records": 1,
-      "key_size": 1,
-      "value_size": 1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles":0}\'
-    --runner=TestDataflowRunner' \
--PloadTest.mainClass=
-apache_beam.testing.load_tests.co_group_by_key_test \
--Prunner=TestDataflowRunner :sdks:python:apache_beam:testing:load-tests:run
+-PloadTest.mainClass=apache_beam.testing.load_tests.co_group_by_key_test \
+-Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """
 
 # pytype: skip-file

--- a/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
@@ -53,21 +53,21 @@ python -m apache_beam.testing.load_tests.co_group_by_key_test \
 
 or:
 
-./gradlew -PloadTest.args='
+./gradlew -PloadTest.args="
     --publish_to_big_query=true
     --project=...
     --metrics_dataset=python_load_tests
     --metrics_table=co_gbk
     --iterations=1
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size": 1}\'
-     --co_input_options=\'{
-        "num_records": 1,
-        "key_size": 1,
-        "value_size": 1}\'
-    --runner=DirectRunner' \
+    --input_options='{
+      \"num_records\": 1,
+      \"key_size\": 1,
+      \"value_size\": 1}'
+    --co_input_options='{
+      \"num_records\": 1,
+      \"key_size\": 1,
+      \"value_size\": 1}'
+    --runner=DirectRunner" \
 -PloadTest.mainClass=apache_beam.testing.load_tests.co_group_by_key_test \
 -Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """

--- a/sdks/python/apache_beam/testing/load_tests/combine_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/combine_test.py
@@ -48,16 +48,16 @@ python -m apache_beam.testing.load_tests.combine_test \
 
 or:
 
-./gradlew -PloadTest.args='
+./gradlew -PloadTest.args="
     --publish_to_big_query=true
     --project=...
-    --metrics_dataset=python_load_test
+    --metrics_dataset=python_load_tests
     --metrics_table=combine
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size": 1}\'
-    --runner=DirectRunner' \
+    --input_options='{
+      \"num_records\": 1,
+      \"key_size\": 1,
+      \"value_size\": 1}'
+    --runner=DirectRunner" \
 -PloadTest.mainClass=apache_beam.testing.load_tests.combine_test \
 -Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """

--- a/sdks/python/apache_beam/testing/load_tests/combine_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/combine_test.py
@@ -30,9 +30,9 @@ will be stored,
 will be stored,
 * input_options - options for Synthetic Sources.
 
-Example test run on DirectRunner:
+Example test run:
 
-python setup.py nosetests \
+python -m apache_beam.testing.load_tests.combine_test \
     --test-pipeline-options="
     --project=big-query-project
     --publish_to_big_query=true
@@ -43,12 +43,8 @@ python setup.py nosetests \
     --input_options='{
     \"num_records\": 300,
     \"key_size\": 5,
-    \"value_size\":15,
-    \"bundle_size_distribution_type\": \"const\",
-    \"bundle_size_distribution_param\": 1,
-    \"force_initial_num_bundles\": 0
-    }'" \
-    --tests apache_beam.testing.load_tests.combine_test
+    \"value_size\": 15
+    }'"
 
 or:
 
@@ -60,62 +56,10 @@ or:
     --input_options=\'
       {"num_records": 1,
       "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
-    --runner=DirectRunner
-    --fanout=1
-    --top_count=1000' \
+      "value_size": 1}\'
+    --runner=DirectRunner' \
 -PloadTest.mainClass=apache_beam.testing.load_tests.combine_test \
--Prunner=DirectRunner :sdks:python:apache_beam:testing:load-tests:run
-
-To run test on other runner (ex. Dataflow):
-
-python setup.py nosetests \
-    --test-pipeline-options="
-        --runner=TestDataflowRunner
-        --fanout=1
-        --top_count=1000
-        --project=...
-        --staging_location=gs://...
-        --temp_location=gs://...
-        --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
-        --publish_to_big_query=true
-        --metrics_dataset=python_load_tests
-        --metrics_table=combine
-        --input_options='{
-        \"num_records\": 1000,
-        \"key_size\": 5,
-        \"value_size\":15,
-        \"bundle_size_distribution_type\": \"const\",
-        \"bundle_size_distribution_param\": 1,
-        \"force_initial_num_bundles\": 0
-        }'" \
-    --tests apache_beam.testing.load_tests.combine_test
-
-or:
-
-./gradlew -PloadTest.args='
-    --publish_to_big_query=true
-    --project=...
-    --metrics_dataset=python_load_tests
-    --metrics_table=combine
-    --temp_location=gs://...
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
-    --runner=TestDataflowRunner
-    --fanout=1
-    --top_count=1000' \
--PloadTest.mainClass=
-apache_beam.testing.load_tests.combine_test \
--Prunner=
-TestDataflowRunner :sdks:python:apache_beam:testing:load-tests:run
+-Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """
 
 # pytype: skip-file

--- a/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
@@ -31,9 +31,9 @@ will be stored,
 will be stored,
 * input_options - options for Synthetic Sources.
 
-Example test run on DirectRunner:
+Example test run:
 
-python setup.py nosetests \
+python -m apache_beam.testing.load_tests.group_by_key_test \
     --test-pipeline-options="
     --project=big-query-project
     --publish_to_big_query=true
@@ -44,12 +44,8 @@ python setup.py nosetests \
     --input_options='{
     \"num_records\": 300,
     \"key_size\": 5,
-    \"value_size\":15,
-    \"bundle_size_distribution_type\": \"const\",
-    \"bundle_size_distribution_param\": 1,
-    \"force_initial_num_bundles\": 0
-    }'" \
-    --tests apache_beam.testing.load_tests.group_by_key_test
+    \"value_size\": 15
+    }'"
 
 or:
 
@@ -63,60 +59,10 @@ or:
     --input_options=\'
       {"num_records": 1,
       "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
+      "value_size": 1}\'
     --runner=DirectRunner' \
--PloadTest.mainClass=
-apache_beam.testing.load_tests.group_by_key_test \
--Prunner=DirectRunner :sdks:python:apache_beam:testing:load-tests:run
-
-To run test on other runner (ex. Dataflow):
-
-python setup.py nosetests \
-    --test-pipeline-options="
-        --runner=TestDataflowRunner
-        --project=...
-        --staging_location=gs://...
-        --temp_location=gs://...
-        --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
-        --publish_to_big_query=true
-        --metrics_dataset=python_load_tests
-        --metrics_table=gbk
-        --fanout=1
-        --iterations=1
-        --input_options='{
-        \"num_records\": 1000,
-        \"key_size\": 5,
-        \"value_size\":15,
-        \"bundle_size_distribution_type\": \"const\",
-        \"bundle_size_distribution_param\": 1,
-        \"force_initial_num_bundles\": 0
-        }'" \
-    --tests apache_beam.testing.load_tests.group_by_key_test
-
-or:
-
-./gradlew -PloadTest.args='
-    --publish_to_big_query=true
-    --project=...
-    --metrics_dataset=python_load_tests
-    --metrics_table=gbk
-    --temp_location=gs://...
-    --fanout=1
-    --iterations=1
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
-    --runner=TestDataflowRunner' \
--PloadTest.mainClass=
-apache_beam.testing.load_tests.group_by_key_test \
--Prunner=TestDataflowRunner :sdks:python:apache_beam:testing:load-tests:run
+-PloadTest.mainClass=apache_beam.testing.load_tests.group_by_key_test \
+-Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """
 
 # pytype: skip-file

--- a/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
@@ -49,18 +49,18 @@ python -m apache_beam.testing.load_tests.group_by_key_test \
 
 or:
 
-./gradlew -PloadTest.args='
+./gradlew -PloadTest.args="
     --publish_to_big_query=true
     --project=...
     --metrics_dataset=python_load_tests
     --metrics_table=gbk
     --fanout=1
     --iterations=1
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size": 1}\'
-    --runner=DirectRunner' \
+    --input_options='{
+      \"num_records\": 1,
+      \"key_size\": 1,
+      \"value_size\": 1}'
+    --runner=DirectRunner" \
 -PloadTest.mainClass=apache_beam.testing.load_tests.group_by_key_test \
 -Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """

--- a/sdks/python/apache_beam/testing/load_tests/load_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/load_test.py
@@ -33,8 +33,8 @@ class LoadTest(object):
     self.project_id = self.pipeline.get_option('project')
     self.metrics_namespace = self.pipeline.get_option('metrics_table')
     self._metrics_monitor = MetricsReader(
-        publish_to_bq=self.pipeline.get_option('publish_to_big_query') ==
-        'true',
+        publish_to_bq=self.pipeline.get_option('publish_to_big_query')
+        .lower() == 'true',
         project_name=self.project_id,
         bq_table=self.metrics_namespace,
         bq_dataset=self.pipeline.get_option('metrics_dataset'),

--- a/sdks/python/apache_beam/testing/load_tests/pardo_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/pardo_test.py
@@ -123,30 +123,23 @@ or:
 from __future__ import absolute_import
 
 import logging
-import os
-import unittest
 
 import apache_beam as beam
 from apache_beam.metrics import Metrics
-from apache_beam.testing import synthetic_pipeline
 from apache_beam.testing.load_tests.load_test import LoadTest
 from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
-
-load_test_enabled = False
-if os.environ.get('LOAD_TEST_ENABLED') == 'true':
-  load_test_enabled = True
+from apache_beam.testing.synthetic_pipeline import SyntheticSource
 
 
-@unittest.skipIf(not load_test_enabled, 'Enabled only for phrase triggering.')
 class ParDoTest(LoadTest):
-  def setUp(self):
-    super(ParDoTest, self).setUp()
+  def __init__(self):
+    super(ParDoTest, self).__init__()
     self.iterations = self.get_option_or_default('iterations')
     self.number_of_counters = self.get_option_or_default('number_of_counters')
     self.number_of_operations = self.get_option_or_default(
         'number_of_counter_operations')
 
-  def testParDo(self):
+  def test(self):
     class CounterOperation(beam.DoFn):
       def __init__(self, number_of_counters, number_of_operations):
         self.number_of_operations = number_of_operations
@@ -164,7 +157,7 @@ class ParDoTest(LoadTest):
     pc = (
         self.pipeline
         | 'Read synthetic' >> beam.io.Read(
-            synthetic_pipeline.SyntheticSource(self.parseTestPipelineOptions()))
+            SyntheticSource(self.parse_synthetic_source_options()))
         | 'Measure time: Start' >> beam.ParDo(
             MeasureTime(self.metrics_namespace)))
 
@@ -183,5 +176,5 @@ class ParDoTest(LoadTest):
 
 
 if __name__ == '__main__':
-  logging.getLogger().setLevel(logging.INFO)
-  unittest.main()
+  logging.basicConfig(level=logging.INFO)
+  ParDoTest().run()

--- a/sdks/python/apache_beam/testing/load_tests/pardo_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/pardo_test.py
@@ -33,9 +33,9 @@ will be stored,
 will be stored,
 * input_options - options for Synthetic Sources.
 
-Example test run on DirectRunner:
+Example test run:
 
-python setup.py nosetests \
+python -m apache_beam.testing.load_tests.pardo_test \
     --test-pipeline-options="
     --iterations=1000
     --number_of_counters=1
@@ -47,12 +47,8 @@ python setup.py nosetests \
     --input_options='{
     \"num_records\": 300,
     \"key_size\": 5,
-    \"value_size\":15,
-    \"bundle_size_distribution_type\": \"const\",
-    \"bundle_size_distribution_param\": 1,
-    \"force_initial_num_bundles\": 0
-    }'" \
-    --tests apache_beam.testing.load_tests.pardo_test
+    \"value_size\": 15
+    }'"
 
 or:
 
@@ -64,58 +60,10 @@ or:
     --input_options=\'
       {"num_records": 1,
       "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
+      "value_size": 1}\'
     --runner=DirectRunner' \
 -PloadTest.mainClass=apache_beam.testing.load_tests.pardo_test \
--Prunner=DirectRunner :sdks:python:apache_beam:testing:load-tests:run
-
-
-To run test on other runner (ex. Dataflow):
-
-python setup.py nosetests \
-    --test-pipeline-options="
-        --runner=TestDataflowRunner
-        --project=...
-        --staging_location=gs://...
-        --temp_location=gs://...
-        --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
-        --iterations=1000
-        --number_of_counters=1
-        --number_of_counter_operations=1
-        --publish_to_big_query=true
-        --metrics_dataset=python_load_tests
-        --metrics_table=pardo
-        --input_options='{
-        \"num_records\": 1000,
-        \"key_size\": 5,
-        \"value_size\":15,
-        \"bundle_size_distribution_type\": \"const\",
-        \"bundle_size_distribution_param\": 1,
-        \"force_initial_num_bundles\": 0
-        }'" \
-    --tests apache_beam.testing.load_tests.pardo_test
-
-or:
-
-./gradlew -PloadTest.args='
-    --publish_to_big_query=true
-    --project=...
-    --metrics_dataset=python_load_tests
-    --metrics_table=pardo
-    --temp_location=gs://...
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
-    --runner=TestDataflowRunner' \
--PloadTest.mainClass=apache_beam.testing.load_tests.pardo_test \
--Prunner=TestDataflowRunner :sdks:python:apache_beam:testing:load-tests:run
+-Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """
 
 # pytype: skip-file

--- a/sdks/python/apache_beam/testing/load_tests/pardo_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/pardo_test.py
@@ -37,7 +37,7 @@ Example test run:
 
 python -m apache_beam.testing.load_tests.pardo_test \
     --test-pipeline-options="
-    --iterations=1000
+    --iterations=1
     --number_of_counters=1
     --number_of_counter_operations=1
     --project=big-query-project
@@ -52,16 +52,16 @@ python -m apache_beam.testing.load_tests.pardo_test \
 
 or:
 
-./gradlew -PloadTest.args='
+./gradlew -PloadTest.args="
     --publish_to_big_query=true
     --project=...
     --metrics_dataset=python_load_tests
     --metrics_table=pardo
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size": 1}\'
-    --runner=DirectRunner' \
+    --input_options='{
+      \"num_records\": 1,
+      \"key_size\": 1,
+      \"value_size\": 1}'
+    --runner=DirectRunner" \
 -PloadTest.mainClass=apache_beam.testing.load_tests.pardo_test \
 -Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """

--- a/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
@@ -29,9 +29,9 @@ will be stored,
 will be stored,
 * input_options - options for Synthetic Sources.
 
-To run test on DirectRunner
+Example test run:
 
-python setup.py nosetests \
+python -m apache_beam.testing.load_tests.sideinput_test \
     --test-pipeline-options="
     --project=big-query-project
     --publish_to_big_query=true
@@ -41,13 +41,8 @@ python setup.py nosetests \
     --input_options='{
     \"num_records\": 300,
     \"key_size\": 5,
-    \"value_size\":15,
-    \"bundle_size_distribution_type\": \"const\",
-    \"bundle_size_distribution_param\": 1,
-    \"force_initial_num_bundles\": 0
-    }'
-   " \
-    --tests apache_beam.testing.load_tests.sideinput_test
+    \"value_size\": 15
+    }'"
 
 or:
 
@@ -59,58 +54,10 @@ or:
     --input_options=\'
       {"num_records": 1,
       "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
+      "value_size": 1}\'
     --runner=DirectRunner' \
--PloadTest.mainClass=
-apache_beam.testing.load_tests.sideinput_test \
--Prunner=DirectRunner :sdks:python:apache_beam:testing:load-tests:run
-
-To run test on other runner (ex. Dataflow):
-
-python setup.py nosetests \
-    --test-pipeline-options="
-        --runner=TestDataflowRunner
-        --project=...
-        --publish_to_big_query=true
-        --metrics_dataset=python_load_tests
-        --metrics_table=side_input
-        --staging_location=gs://...
-        --temp_location=gs://...
-        --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
-        --number_of_counter_operations=1000
-        --input_options='{
-        \"num_records\": 1,
-        \"key_size\": 1,
-        \"value_size\":1,
-        \"bundle_size_distribution_type\": \"const\",
-        \"bundle_size_distribution_param\": 1,
-        \"force_initial_num_bundles\": 0
-        }'
-        " \
-    --tests apache_beam.testing.load_tests.sideinput_test
-
-or:
-
-./gradlew -PloadTest.args='
-    --publish_to_big_query=true
-    --project=...
-    --metrics_dataset=python_load_tests
-    --metrics_table=side_input
-    --temp_location=gs://...
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size":1,
-      "bundle_size_distribution_type": "const",
-      "bundle_size_distribution_param": 1,
-      "force_initial_num_bundles": 1}\'
-    --runner=TestDataflowRunner' \
--PloadTest.mainClass=
-apache_beam.testing.load_tests.sideinput_test:SideInputTest.testSideInput \
--Prunner=TestDataflowRunner :sdks:python:apache_beam:testing:load-tests:run
+-PloadTest.mainClass=apache_beam.testing.load_tests.sideinput_test \
+-Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """
 
 # pytype: skip-file

--- a/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/sideinput_test.py
@@ -46,16 +46,16 @@ python -m apache_beam.testing.load_tests.sideinput_test \
 
 or:
 
-./gradlew -PloadTest.args='
+./gradlew -PloadTest.args="
     --publish_to_big_query=true
     --project=...
     --metrics_dataset=python_load_tests
     --metrics_table=side_input
-    --input_options=\'
-      {"num_records": 1,
-      "key_size": 1,
-      "value_size": 1}\'
-    --runner=DirectRunner' \
+    --input_options='{
+      \"num_records\": 1,
+      \"key_size\": 1,
+      \"value_size\": 1}'
+    --runner=DirectRunner" \
 -PloadTest.mainClass=apache_beam.testing.load_tests.sideinput_test \
 -Prunner=DirectRunner :sdks:python:apache_beam:testing:load_tests:run
 """

--- a/sdks/python/apache_beam/testing/load_tests/streaming/group_by_key_streaming_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/streaming/group_by_key_streaming_test.py
@@ -45,19 +45,12 @@ import uuid
 from hamcrest.core.core.allof import all_of
 
 from apache_beam.io.gcp.tests.pubsub_matcher import PubSubMessageMatcher
-from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.testing import test_utils
 from apache_beam.testing.load_tests.load_test import LoadTest
 from apache_beam.testing.load_tests.streaming import group_by_key_streaming_pipeline
 
 DEFAULT_TIMEOUT = 800
 WAIT_UNTIL_FINISH_DURATION = 1 * 60 * 1000
-
-
-class TestOptions(PipelineOptions):
-  @classmethod
-  def _add_argparse_args(cls, parser):
-    parser.add_argument('--test-pipeline-options')
 
 
 class GroupByKeyStreamingTest(LoadTest):


### PR DESCRIPTION
Beam is moving away from nose. We could change the way of running Python load tests: instead of being subclasses of `unittest.TestCase`, they could be plain Python scripts, just like wordcount examples.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
