### PR TITLE
[BEAM-9000] Java Test Assertions without toString for GenericJson subclasses

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -492,6 +492,7 @@ class BeamModulePlugin implements Plugin<Project> {
         jackson_module_scala                        : "com.fasterxml.jackson.module:jackson-module-scala_2.11:$jackson_version",
         jaxb_api                                    : "javax.xml.bind:jaxb-api:$jaxb_api_version",
         joda_time                                   : "joda-time:joda-time:2.10.3",
+        jsonassert                                  : "org.skyscreamer:jsonassert:1.5.0",
         jsr305                                      : "com.google.code.findbugs:jsr305:3.0.2",
         junit                                       : "junit:junit:4.13-beta-3",
         kafka                                       : "org.apache.kafka:kafka_2.11:$kafka_version",

--- a/runners/google-cloud-dataflow-java/worker/build.gradle
+++ b/runners/google-cloud-dataflow-java/worker/build.gradle
@@ -104,6 +104,7 @@ dependencies {
   shadowTest project(path: ":runners:direct-java", configuration: "shadow")
   shadowTest library.java.hamcrest_core
   shadowTest library.java.hamcrest_library
+  shadowTest library.java.jsonassert
   shadowTest library.java.junit
   shadowTest library.java.mockito_core
 }

--- a/runners/google-cloud-dataflow-java/worker/legacy-worker/build.gradle
+++ b/runners/google-cloud-dataflow-java/worker/legacy-worker/build.gradle
@@ -78,6 +78,7 @@ def excluded_dependencies = [
         library.java.hamcrest_core,                  // Test only
         library.java.hamcrest_library,               // Test only
         library.java.junit,                          // Test only
+        library.java.jsonassert                      // Test only
 ]
 
 applyJavaNature(
@@ -224,6 +225,7 @@ dependencies {
     shadowTest project(path: ":sdks:java:core", configuration: "shadowTest")
     shadowTest library.java.hamcrest_core
     shadowTest library.java.hamcrest_library
+    shadowTest library.java.jsonassert
     shadowTest library.java.junit
     shadowTest library.java.mockito_core
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/ElementCountMonitoringInfoToCounterUpdateTransformerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/ElementCountMonitoringInfoToCounterUpdateTransformerTest.java
@@ -17,8 +17,9 @@
  */
 package org.apache.beam.runners.dataflow.worker.fn.control;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.apache.beam.runners.dataflow.worker.testing.GenericJsonAssert.assertEqualsAsJson;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -56,7 +57,7 @@ public class ElementCountMonitoringInfoToCounterUpdateTransformerTest {
             mockSpecValidator, pcollectionNameMapping);
     Optional<String> error = Optional.of("Error text");
     when(mockSpecValidator.validate(any())).thenReturn(error);
-    assertEquals(null, testObject.transform(null));
+    assertNull(testObject.transform(null));
   }
 
   @Test
@@ -85,7 +86,7 @@ public class ElementCountMonitoringInfoToCounterUpdateTransformerTest {
         new ElementCountMonitoringInfoToCounterUpdateTransformer(
             mockSpecValidator, pcollectionNameMapping);
     when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
-    assertEquals(null, testObject.transform(monitoringInfo));
+    assertNull(testObject.transform(monitoringInfo));
   }
 
   @Test
@@ -106,12 +107,12 @@ public class ElementCountMonitoringInfoToCounterUpdateTransformerTest {
     when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
 
     CounterUpdate result = testObject.transform(monitoringInfo);
-    assertNotEquals(null, result);
+    assertNotNull(result);
 
-    assertEquals(
-        "{cumulative=true, integer={highBits=0, lowBits=0}, "
-            + "nameAndKind={kind=SUM, "
-            + "name=transformedValue-ElementCount}}",
-        result.toString());
+    assertEqualsAsJson(
+        "{cumulative:true, integer:{highBits:0, lowBits:0}, "
+            + "nameAndKind:{kind:'SUM', "
+            + "name:'transformedValue-ElementCount'}}",
+        result);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/FnApiMonitoringInfoToCounterUpdateTransformerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/FnApiMonitoringInfoToCounterUpdateTransformerTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.dataflow.worker.fn.control;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
@@ -86,6 +87,6 @@ public class FnApiMonitoringInfoToCounterUpdateTransformerTest {
 
     CounterUpdate result = testObject.transform(monitoringInfo);
 
-    assertSame(null, result);
+    assertNull(result);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/MSecMonitoringInfoToCounterUpdateTransformerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/MSecMonitoringInfoToCounterUpdateTransformerTest.java
@@ -17,8 +17,10 @@
  */
 package org.apache.beam.runners.dataflow.worker.fn.control;
 
+import static org.apache.beam.runners.dataflow.worker.testing.GenericJsonAssert.assertEqualsAsJson;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,7 +70,7 @@ public class MSecMonitoringInfoToCounterUpdateTransformerTest {
         MonitoringInfo.newBuilder()
             .setUrn("beam:metric:pardo_execution_time:start_bundle_msecs:v1:invalid")
             .build();
-    assertEquals(null, testObject.transform(monitoringInfo));
+    assertNull(testObject.transform(monitoringInfo));
   }
 
   @Test
@@ -142,14 +144,13 @@ public class MSecMonitoringInfoToCounterUpdateTransformerTest {
     CounterUpdate result = testObject.transform(monitoringInfo);
 
     // Validate
-    assertNotEquals(null, result);
-
-    assertEquals(
-        "{cumulative=true, integer={highBits=0, lowBits=0}, "
-            + "structuredNameAndMetadata={metadata={kind=SUM}, "
-            + "name={executionStepName=anyStageName, name=supportedCounter, origin=SYSTEM, "
-            + "originalStepName=anyOriginalName}}}",
-        result.toString());
+    assertNotNull(result);
+    assertEqualsAsJson(
+        "{cumulative:true, integer:{highBits:0, lowBits:0}, "
+            + "structuredNameAndMetadata:{metadata:{kind:'SUM'}, "
+            + "name:{executionStepName:'anyStageName', name:'supportedCounter', origin:'SYSTEM', "
+            + "originalStepName:'anyOriginalName'}}}",
+        result);
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/MeanByteCountMonitoringInfoToCounterUpdateTransformerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/MeanByteCountMonitoringInfoToCounterUpdateTransformerTest.java
@@ -17,8 +17,9 @@
  */
 package org.apache.beam.runners.dataflow.worker.fn.control;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.apache.beam.runners.dataflow.worker.testing.GenericJsonAssert.assertEqualsAsJson;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -56,7 +57,7 @@ public class MeanByteCountMonitoringInfoToCounterUpdateTransformerTest {
             mockSpecValidator, pcollectionNameMapping);
     Optional<String> error = Optional.of("Error text");
     when(mockSpecValidator.validate(any())).thenReturn(error);
-    assertEquals(null, testObject.transform(null));
+    assertNull(testObject.transform(null));
   }
 
   @Test
@@ -85,7 +86,7 @@ public class MeanByteCountMonitoringInfoToCounterUpdateTransformerTest {
         new MeanByteCountMonitoringInfoToCounterUpdateTransformer(
             mockSpecValidator, pcollectionNameMapping);
     when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
-    assertEquals(null, testObject.transform(monitoringInfo));
+    assertNull(testObject.transform(monitoringInfo));
   }
 
   @Test
@@ -107,12 +108,12 @@ public class MeanByteCountMonitoringInfoToCounterUpdateTransformerTest {
 
     CounterUpdate result = testObject.transform(monitoringInfo);
 
-    assertNotEquals(null, result);
-    assertEquals(
-        "{cumulative=true, integerMean={count={highBits=0, lowBits=0}, "
-            + "sum={highBits=0, lowBits=0}}, "
-            + "nameAndKind={kind=MEAN, "
-            + "name=transformedValue-MeanByteCount}}",
-        result.toString());
+    assertNotNull(result);
+    assertEqualsAsJson(
+        "{cumulative:true, integerMean:{count:{highBits:0, lowBits:0}, "
+            + "sum:{highBits:0, lowBits:0}}, "
+            + "nameAndKind:{kind:'MEAN', "
+            + "name:'transformedValue-MeanByteCount'}}",
+        result);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/UserDistributionMonitoringInfoToCounterUpdateTransformerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/UserDistributionMonitoringInfoToCounterUpdateTransformerTest.java
@@ -17,8 +17,9 @@
  */
 package org.apache.beam.runners.dataflow.worker.fn.control;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.apache.beam.runners.dataflow.worker.testing.GenericJsonAssert.assertEqualsAsJson;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,7 +59,7 @@ public class UserDistributionMonitoringInfoToCounterUpdateTransformerTest {
             mockSpecValidator, stepContextMapping);
     Optional<String> error = Optional.of("Error text");
     when(mockSpecValidator.validate(any())).thenReturn(error);
-    assertEquals(null, testObject.transform(null));
+    assertNull(testObject.transform(null));
   }
 
   @Test
@@ -89,7 +90,7 @@ public class UserDistributionMonitoringInfoToCounterUpdateTransformerTest {
         new UserDistributionMonitoringInfoToCounterUpdateTransformer(
             mockSpecValidator, stepContextMapping);
     when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
-    assertEquals(null, testObject.transform(monitoringInfo));
+    assertNull(testObject.transform(monitoringInfo));
   }
 
   @Test
@@ -114,15 +115,15 @@ public class UserDistributionMonitoringInfoToCounterUpdateTransformerTest {
     when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
 
     CounterUpdate result = testObject.transform(monitoringInfo);
-    assertNotEquals(null, result);
+    assertNotNull(result);
 
-    assertEquals(
-        "{cumulative=true, distribution={count={highBits=0, lowBits=0}, "
-            + "max={highBits=0, lowBits=0}, min={highBits=0, lowBits=0}, "
-            + "sum={highBits=0, lowBits=0}}, "
-            + "structuredNameAndMetadata={metadata={kind=DISTRIBUTION}, "
-            + "name={name=anyName, origin=USER, originNamespace=anyNamespace, "
-            + "originalStepName=anyOriginalName}}}",
-        result.toString());
+    assertEqualsAsJson(
+        "{cumulative:true, distribution:{count:{highBits:0, lowBits:0}, "
+            + "max:{highBits:0, lowBits:0}, min:{highBits:0, lowBits:0}, "
+            + "sum:{highBits:0, lowBits:0}}, "
+            + "structuredNameAndMetadata:{metadata:{kind:'DISTRIBUTION'}, "
+            + "name:{name:'anyName', origin:'USER', originNamespace:'anyNamespace', "
+            + "originalStepName:'anyOriginalName'}}}",
+        result);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/UserMonitoringInfoToCounterUpdateTransformerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/UserMonitoringInfoToCounterUpdateTransformerTest.java
@@ -17,8 +17,9 @@
  */
 package org.apache.beam.runners.dataflow.worker.fn.control;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.apache.beam.runners.dataflow.worker.testing.GenericJsonAssert.assertEqualsAsJson;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -57,7 +58,7 @@ public class UserMonitoringInfoToCounterUpdateTransformerTest {
         new UserMonitoringInfoToCounterUpdateTransformer(mockSpecValidator, stepContextMapping);
     Optional<String> error = Optional.of("Error text");
     when(mockSpecValidator.validate(any())).thenReturn(error);
-    assertEquals(null, testObject.transform(null));
+    assertNull(testObject.transform(null));
   }
 
   @Test
@@ -86,7 +87,7 @@ public class UserMonitoringInfoToCounterUpdateTransformerTest {
     UserMonitoringInfoToCounterUpdateTransformer testObject =
         new UserMonitoringInfoToCounterUpdateTransformer(mockSpecValidator, stepContextMapping);
     when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
-    assertEquals(null, testObject.transform(monitoringInfo));
+    assertNull(testObject.transform(monitoringInfo));
   }
 
   @Test
@@ -110,13 +111,13 @@ public class UserMonitoringInfoToCounterUpdateTransformerTest {
     when(mockSpecValidator.validate(any())).thenReturn(Optional.empty());
 
     CounterUpdate result = testObject.transform(monitoringInfo);
-    assertNotEquals(null, result);
+    assertNotNull(result);
 
-    assertEquals(
-        "{cumulative=true, integer={highBits=0, lowBits=0}, "
-            + "structuredNameAndMetadata={metadata={kind=SUM}, "
-            + "name={name=anyName, origin=USER, originNamespace=anyNamespace, "
-            + "originalStepName=anyOriginalName}}}",
-        result.toString());
+    assertEqualsAsJson(
+        "{cumulative:true, integer:{highBits:0, lowBits:0}, "
+            + "structuredNameAndMetadata:{metadata:{kind:'SUM'}, "
+            + "name:{name:'anyName', origin:'USER', originNamespace:'anyNamespace', "
+            + "originalStepName:'anyOriginalName'}}}",
+        result);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonAssert.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonAssert.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.testing;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+/** Assertions on {@link GenericJson} class. */
+public class GenericJsonAssert {
+
+  private static final JacksonFactory jacksonFactory = JacksonFactory.getDefaultInstance();
+
+  /**
+   * Asserts that {@code actual} has the same JSON representation as {@code expectedJsonText}.
+   *
+   * @param expectedJsonText expected JSON string.
+   * @param actual actual object to compare its JSON representation.
+   */
+  public static void assertEqualsAsJson(String expectedJsonText, GenericJson actual) {
+    actual.setFactory(jacksonFactory);
+
+    String actualJsonText = actual.toString();
+    try {
+      JSONAssert.assertEquals(expectedJsonText, actualJsonText, true);
+    } catch (JSONException ex) {
+      throw new IllegalArgumentException("Could not parse JSON", ex);
+    }
+  }
+}


### PR DESCRIPTION
Implementaiton of Option 3 "Check JSON equality via JSONassert" in
https://issues.apache.org/jira/projects/BEAM/issues/BEAM-9000

As of now, there are many tests that assert on `toString()` of GenericJson subclasses.

```
    CounterUpdate result = testObject.transform(monitoringInfo);
    assertEquals(
        "{cumulative=true, integer={highBits=0, lowBits=0}, "
            + "nameAndKind={kind=SUM, "
            + "name=transformedValue-ElementCount}}",
        result.toString());
```

This style is prone to unnecessary maintenance of the test code when upgrading dependencies. Dependencies may change the internal ordering of fields and trivial change in `toString()`. In fact,  [BEAM-8695](https://issues.apache.org/jira/browse/BEAM-8695) is suspended partly because of these tests.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
