### PR TITLE
[BEAM-8335] On Unbounded Source change

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -125,7 +125,8 @@ def is_source_to_cache_changed(user_pipeline):
   """
   # By default gets empty set if the user_pipeline is first time seen because
   # we can treat it as adding transforms.
-  recorded_signature = ie.current_env().cached_source_signature(user_pipeline)
+  recorded_signature = ie.current_env().get_cached_source_signature(
+      user_pipeline)
   current_signature = extract_source_to_cache_signature(user_pipeline)
   is_changed = not current_signature.issubset(recorded_signature)
   # The computation of extract_unbounded_source_signature is expensive, track on

--- a/sdks/python/apache_beam/runners/interactive/display/pipeline_graph_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pipeline_graph_test.py
@@ -91,24 +91,24 @@ class PipelineGraphTest(unittest.TestCase):
          '}\n'),
         pipeline_graph.PipelineGraph(p).get_dot())
 
-  @patch('IPython.get_ipython', mock_get_ipython)
-  def test_get_dot_within_notebook(self):
+  @patch('IPython.get_ipython', new_callable=mock_get_ipython)
+  def test_get_dot_within_notebook(self, cell):
     # Assume a mocked ipython kernel and notebook frontend have been set up.
     ie.current_env()._is_in_ipython = True
     ie.current_env()._is_in_notebook = True
-    with mock_get_ipython():  # Cell 1
+    with cell:  # Cell 1
       p = beam.Pipeline(ir.InteractiveRunner())
       # Immediately track this local pipeline so that ipython prompts when
       # applying transforms will be tracked and used for labels.
       ib.watch(locals())
 
-    with mock_get_ipython():  # Cell 2
+    with cell:  # Cell 2
       init_pcoll = p | 'Init' >> beam.Create(range(10))
 
-    with mock_get_ipython():  # Cell 3
+    with cell:  # Cell 3
       squares = init_pcoll | 'Square' >> beam.Map(lambda x: x * x)
 
-    with mock_get_ipython():  # Cell 4
+    with cell:  # Cell 4
       cubes = init_pcoll | 'Cube' >> beam.Map(lambda x: x ** 3)
 
     # Tracks all PCollections defined so far.

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -244,7 +244,7 @@ class InteractiveEnvironment(object):
   def set_cached_source_signature(self, pipeline, signature):
     self._cached_source_signature[pipeline] = signature
 
-  def cached_source_signature(self, pipeline):
+  def get_cached_source_signature(self, pipeline):
     return self._cached_source_signature.get(pipeline, set())
 
   def track_user_pipelines(self):

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -89,7 +89,7 @@ class InteractiveEnvironment(object):
     # the end user. The InteractiveRunner is responsible for populating this
     # dictionary implicitly when a background caching jobs is started.
     self._background_caching_pipeline_results = {}
-    self._unbounded_source_signature = {}
+    self._cached_source_signature = {}
     self._tracked_user_pipelines = set()
     # Always watch __main__ module.
     self.watch('__main__')
@@ -241,11 +241,11 @@ class InteractiveEnvironment(object):
       return runner.PipelineState.is_terminal(result.state)
     return True
 
-  def set_unbounded_source_signature(self, pipeline, signature):
-    self._unbounded_source_signature[pipeline] = signature
+  def set_cached_source_signature(self, pipeline, signature):
+    self._cached_source_signature[pipeline] = signature
 
-  def unbounded_source_signature(self, pipeline):
-    return self._unbounded_source_signature.get(pipeline, set())
+  def cached_source_signature(self, pipeline):
+    return self._cached_source_signature.get(pipeline, set())
 
   def track_user_pipelines(self):
     """Record references to all user-defined pipeline instances watched in

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -89,6 +89,7 @@ class InteractiveEnvironment(object):
     # the end user. The InteractiveRunner is responsible for populating this
     # dictionary implicitly when a background caching jobs is started.
     self._background_caching_pipeline_results = {}
+    self._unbounded_source_signature = {}
     self._tracked_user_pipelines = set()
     # Always watch __main__ module.
     self.watch('__main__')
@@ -239,6 +240,12 @@ class InteractiveEnvironment(object):
     if result:
       return runner.PipelineState.is_terminal(result.state)
     return True
+
+  def set_unbounded_source_signature(self, pipeline, signature):
+    self._unbounded_source_signature[pipeline] = signature
+
+  def unbounded_source_signature(self, pipeline):
+    return self._unbounded_source_signature.get(pipeline, set())
 
   def track_user_pipelines(self):
     """Record references to all user-defined pipeline instances watched in

--- a/sdks/python/apache_beam/runners/interactive/testing/mock_ipython.py
+++ b/sdks/python/apache_beam/runners/interactive/testing/mock_ipython.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 #
 
-# Mocked object returned by invoking get_ipython() in an ipython environment.
-_mocked_get_ipython = None
-
 
 def mock_get_ipython():
   """Mock an ipython environment w/o setting up real ipython kernel.
@@ -27,17 +24,20 @@ def mock_get_ipython():
 
   Examples::
 
-    # Usage, before each test function, append:
-    @patch('IPython.get_ipython', mock_get_ipython)
+    # Usage, before each test function, prepend:
+    @patch('IPython.get_ipython', new_callable=mock_get_ipython)
 
-    # Group lines of code into a cell:
-    with mock_get_ipython():
+    # In the test function's signature, add an argument for the patch, e.g.:
+    def some_test(self, cell):
+
+    # Group lines of code into a cell using the argument:
+    with cell:
       # arbitrary python code
       # ...
       # arbitrary python code
 
     # Next cell with prompt increased by one:
-    with mock_get_ipython():  # Auto-incremental
+    with cell:  # Auto-incremental
       # arbitrary python code
       # ...
       # arbitrary python code
@@ -47,6 +47,9 @@ def mock_get_ipython():
 
     def __init__(self):
       self._execution_count = 0
+
+    def __call__(self):
+      return self
 
     @property
     def execution_count(self):
@@ -61,7 +64,4 @@ def mock_get_ipython():
       """Marks exiting of a cell/prompt."""
       pass
 
-  global _mocked_get_ipython
-  if not _mocked_get_ipython:
-    _mocked_get_ipython = MockedGetIpython()
-  return _mocked_get_ipython
+  return MockedGetIpython()


### PR DESCRIPTION
1. Evict all cache when unbounded source changes in a pipeline executed
by the InteractiveRunner;
2. Invalidate existing background caching job on unbounded source
change;
3. Detects unbounded source addition/deletion/mutation through signature
generated from `to_runner_api`;
4. The change detection and following routines are carried out at
pipeline execution time.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
