### PR TITLE
[BEAM-9027] [SQL] Fix ZetaSql unparsing bugs

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
@@ -28,12 +28,15 @@ public class BeamSqlUnparseContext extends SqlImplementor.SimpleContext {
   public SqlNode toSql(RexProgram program, RexNode rex) {
     if (rex.getKind().equals(SqlKind.LITERAL)) {
       final RexLiteral literal = (RexLiteral) rex;
-      if (literal.getTypeName().getFamily().equals(SqlTypeFamily.BINARY)) {
-        BitString bitString = BitString.createFromBytes(literal.getValueAs(byte[].class));
-        return new SqlByteStringLiteral(bitString, POS);
-      } else if (literal.getTypeName().getFamily().equals(SqlTypeFamily.CHARACTER)) {
-        String escaped = StringEscapeUtils.escapeJava(literal.getValueAs(String.class));
-        return SqlLiteral.createCharString(escaped, POS);
+      SqlTypeFamily family = literal.getTypeName().getFamily();
+      if (family != null) {
+        if (family.equals(SqlTypeFamily.BINARY)) {
+          BitString bitString = BitString.createFromBytes(literal.getValueAs(byte[].class));
+          return new SqlByteStringLiteral(bitString, POS);
+        } else if (family.equals(SqlTypeFamily.CHARACTER)) {
+          String escaped = StringEscapeUtils.escapeJava(literal.getValueAs(String.class));
+          return SqlLiteral.createCharString(escaped, POS);
+        }
       }
     }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
@@ -24,7 +24,6 @@ import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rel.rel2sql.Sql
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rex.RexLiteral;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rex.RexNode;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rex.RexProgram;
-import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlDialect;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlKind;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlLiteral;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlNode;
@@ -37,8 +36,8 @@ import org.apache.beam.vendor.calcite.v1_20_0.org.apache.commons.lang.StringEsca
 
 public class BeamSqlUnparseContext extends SqlImplementor.SimpleContext {
 
-  public BeamSqlUnparseContext(SqlDialect dialect, IntFunction<SqlNode> field) {
-    super(dialect, field);
+  public BeamSqlUnparseContext(IntFunction<SqlNode> field) {
+    super(BeamBigQuerySqlDialect.DEFAULT, field);
   }
 
   @Override
@@ -46,14 +45,12 @@ public class BeamSqlUnparseContext extends SqlImplementor.SimpleContext {
     if (rex.getKind().equals(SqlKind.LITERAL)) {
       final RexLiteral literal = (RexLiteral) rex;
       SqlTypeFamily family = literal.getTypeName().getFamily();
-      if (family != null) {
-        if (family.equals(SqlTypeFamily.BINARY)) {
-          BitString bitString = BitString.createFromBytes(literal.getValueAs(byte[].class));
-          return new SqlByteStringLiteral(bitString, POS);
-        } else if (family.equals(SqlTypeFamily.CHARACTER)) {
-          String escaped = StringEscapeUtils.escapeJava(literal.getValueAs(String.class));
-          return SqlLiteral.createCharString(escaped, POS);
-        }
+      if (SqlTypeFamily.BINARY.equals(family)) {
+        BitString bitString = BitString.createFromBytes(literal.getValueAs(byte[].class));
+        return new SqlByteStringLiteral(bitString, POS);
+      } else if (SqlTypeFamily.CHARACTER.equals(family)) {
+        String escaped = StringEscapeUtils.escapeJava(literal.getValueAs(String.class));
+        return SqlLiteral.createCharString(escaped, POS);
       }
     }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.sdk.extensions.sql.meta.provider.bigquery;
 
 import static org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rel.rel2sql.SqlImplementor.POS;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
@@ -1,0 +1,63 @@
+package org.apache.beam.sdk.extensions.sql.meta.provider.bigquery;
+
+import static org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rel.rel2sql.SqlImplementor.POS;
+
+import java.util.function.IntFunction;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rel.rel2sql.SqlImplementor;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rex.RexLiteral;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rex.RexNode;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.rex.RexProgram;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlDialect;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlKind;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlLiteral;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlNode;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlWriter;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.util.BitString;
+
+public class BeamSqlUnparseContext extends SqlImplementor.SimpleContext {
+
+  public BeamSqlUnparseContext(SqlDialect dialect, IntFunction<SqlNode> field) {
+    super(dialect, field);
+  }
+
+  @Override
+  public SqlNode toSql(RexProgram program, RexNode rex) {
+    if (rex.getKind().equals(SqlKind.LITERAL)) {
+      final RexLiteral literal = (RexLiteral) rex;
+      if (literal.getTypeName().getFamily().equals(SqlTypeFamily.BINARY)) {
+
+        return new SqlByteStringLiteral(BitString.createFromBytes(literal.getValueAs(byte[].class)), POS);
+      }
+    }
+
+    return super.toSql(program, rex);
+  }
+
+  private class SqlByteStringLiteral extends SqlLiteral {
+
+    SqlByteStringLiteral(BitString bytes, SqlParserPos pos) {
+      super(bytes, SqlTypeName.BINARY, pos);
+    }
+
+    @Override
+    public SqlByteStringLiteral clone(SqlParserPos pos) {
+      return new SqlByteStringLiteral((BitString)this.value, pos);
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+      assert this.value instanceof BitString;
+
+      StringBuilder builder = new StringBuilder("B'");
+      for (byte b : ((BitString) this.value).getAsByteArray()) {
+        builder.append(String.format("\\x%02X", b));
+      }
+      builder.append("'");
+
+      writer.literal(builder.toString());
+    }
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryTable.java
@@ -188,8 +188,7 @@ class BigQueryTable extends SchemaBaseBeamTable implements Serializable {
 
     // TODO: BigQuerySqlDialectWithTypeTranslation can be replaced with BigQuerySqlDialect after
     // updating vendor Calcite version.
-    SqlImplementor.SimpleContext context =
-        new SqlImplementor.SimpleContext(BeamBigQuerySqlDialect.DEFAULT, field);
+    SqlImplementor.Context context = new BeamSqlUnparseContext(field);
 
     // Create a single SqlNode from a list of RexNodes
     SqlNode andSqlNode = null;

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
@@ -74,7 +74,7 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
         i ->
             new SqlIdentifier(
                 getProgram().getInputRowType().getFieldList().get(i).getName(), SqlParserPos.ZERO);
-    context = new BeamSqlUnparseContext(DIALECT, fn);
+    context = new BeamSqlUnparseContext(fn);
   }
 
   @Override

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
@@ -32,6 +32,7 @@ import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.impl.rel.AbstractBeamCalcRel;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.extensions.sql.meta.provider.bigquery.BeamBigQuerySqlDialect;
+import org.apache.beam.sdk.extensions.sql.meta.provider.bigquery.BeamSqlUnparseContext;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -73,7 +74,7 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
         i ->
             new SqlIdentifier(
                 getProgram().getInputRowType().getFieldList().get(i).getName(), SqlParserPos.ZERO);
-    context = new SqlImplementor.SimpleContext(DIALECT, fn);
+    context = new BeamSqlUnparseContext(DIALECT, fn);
   }
 
   @Override

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLQueryPlanner.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLQueryPlanner.java
@@ -73,8 +73,8 @@ public class ZetaSQLQueryPlanner implements QueryPlanner {
 
   public static RuleSet[] getZetaSqlRuleSets() {
     // TODO[BEAM-8630]: uncomment the next line once we have fully migrated to BeamZetaSqlCalcRel
-    // return replaceBeamCalcRule(BeamRuleSets.getRuleSets());
-    return BeamRuleSets.getRuleSets();
+    return replaceBeamCalcRule(BeamRuleSets.getRuleSets());
+    //return BeamRuleSets.getRuleSets();
   }
 
   private static RuleSet[] replaceBeamCalcRule(RuleSet[] ruleSets) {

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLQueryPlanner.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLQueryPlanner.java
@@ -73,8 +73,8 @@ public class ZetaSQLQueryPlanner implements QueryPlanner {
 
   public static RuleSet[] getZetaSqlRuleSets() {
     // TODO[BEAM-8630]: uncomment the next line once we have fully migrated to BeamZetaSqlCalcRel
-    return replaceBeamCalcRule(BeamRuleSets.getRuleSets());
-    //return BeamRuleSets.getRuleSets();
+    // return replaceBeamCalcRule(BeamRuleSets.getRuleSets());
+    return BeamRuleSets.getRuleSets();
   }
 
   private static RuleSet[] replaceBeamCalcRule(RuleSet[] ruleSets) {

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
@@ -158,6 +158,8 @@ public final class ZetaSqlUtils {
       case DECIMAL:
         return value.getNumericValue();
       case DOUBLE:
+        // Floats with a floating part equal to zero are treated as whole (INT64).
+        // Cast to double when that happens.
         if (value.getType().getKind().equals(TypeKind.TYPE_INT64)) {
           return (double) value.getInt64Value();
         }

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
@@ -158,6 +158,9 @@ public final class ZetaSqlUtils {
       case DECIMAL:
         return value.getNumericValue();
       case DOUBLE:
+        if (value.getType().getKind().equals(TypeKind.TYPE_INT64)) {
+          return (double) value.getInt64Value();
+        }
         return value.getDoubleValue();
       case STRING:
         return value.getStringValue();

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
@@ -141,16 +141,13 @@ public class ZetaSQLDialectSpecTest {
   }
 
   @Test
-  // TODO: update test name to something more accurate.
-  public void testCeil() {
+  public void testByteString() {
     String sql = "SELECT @p0 IS NULL AS ColA";
 
-    ByteString byteString = ByteString.copyFrom(new byte[] { 0x62 });
+    ByteString byteString = ByteString.copyFrom(new byte[] {0x62});
 
     ImmutableMap<String, Value> params =
-        ImmutableMap.<String, Value>builder()
-            .put("p0", Value.createBytesValue(byteString))
-            .build();
+        ImmutableMap.<String, Value>builder().put("p0", Value.createBytesValue(byteString)).build();
 
     ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
     BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql, params);
@@ -158,8 +155,7 @@ public class ZetaSQLDialectSpecTest {
 
     final Schema schema = Schema.builder().addNullableField("ColA", FieldType.BOOLEAN).build();
 
-    PAssert.that(stream)
-        .containsInAnyOrder(Row.withSchema(schema).addValues(false).build());
+    PAssert.that(stream).containsInAnyOrder(Row.withSchema(schema).addValues(false).build());
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
   }
@@ -174,8 +170,7 @@ public class ZetaSQLDialectSpecTest {
 
     final Schema schema = Schema.builder().addNullableField("ColA", FieldType.DOUBLE).build();
 
-    PAssert.that(stream)
-        .containsInAnyOrder(Row.withSchema(schema).addValues(3.0).build());
+    PAssert.that(stream).containsInAnyOrder(Row.withSchema(schema).addValues(3.0).build());
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
   }
@@ -190,8 +185,7 @@ public class ZetaSQLDialectSpecTest {
 
     final Schema schema = Schema.builder().addNullableField("ColA", FieldType.STRING).build();
 
-    PAssert.that(stream)
-        .containsInAnyOrder(Row.withSchema(schema).addValues("abc\n").build());
+    PAssert.that(stream).containsInAnyOrder(Row.withSchema(schema).addValues("abc\n").build());
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
   }

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
@@ -164,6 +164,22 @@ public class ZetaSQLDialectSpecTest {
   }
 
   @Test
+  public void testFloat() {
+    String sql = "SELECT 3.0";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    final Schema schema = Schema.builder().addNullableField("ColA", FieldType.DOUBLE).build();
+
+    PAssert.that(stream)
+        .containsInAnyOrder(Row.withSchema(schema).addValues(3.0).build());
+
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
   public void testEQ1() {
     String sql = "SELECT @p0 = @p1 AS ColA";
 

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
@@ -141,6 +141,29 @@ public class ZetaSQLDialectSpecTest {
   }
 
   @Test
+  public void testCeil() {
+    String sql = "SELECT @p0 IS NULL AS ColA";
+
+    ByteString byteString = ByteString.copyFrom(new byte[] { 0x62 });
+
+    ImmutableMap<String, Value> params =
+        ImmutableMap.<String, Value>builder()
+            .put("p0", Value.createBytesValue(byteString))
+            .build();
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql, params);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    final Schema schema = Schema.builder().addNullableField("ColA", FieldType.BOOLEAN).build();
+
+    PAssert.that(stream)
+        .containsInAnyOrder(Row.withSchema(schema).addValues(false).build());
+
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
   public void testEQ1() {
     String sql = "SELECT @p0 = @p1 AS ColA";
 

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
@@ -141,6 +141,7 @@ public class ZetaSQLDialectSpecTest {
   }
 
   @Test
+  // TODO: update test name to something more accurate.
   public void testCeil() {
     String sql = "SELECT @p0 IS NULL AS ColA";
 
@@ -175,6 +176,22 @@ public class ZetaSQLDialectSpecTest {
 
     PAssert.that(stream)
         .containsInAnyOrder(Row.withSchema(schema).addValues(3.0).build());
+
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testStringLiterals() {
+    String sql = "SELECT 'abc\\n'";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    final Schema schema = Schema.builder().addNullableField("ColA", FieldType.STRING).build();
+
+    PAssert.that(stream)
+        .containsInAnyOrder(Row.withSchema(schema).addValues("abc\n").build());
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
   }


### PR DESCRIPTION
Create a `BeamSqlUnparseContext` to cover `ZetaSQL` specific unparsing syntax.
- Implement custom unparsing for `SqlTypeFamily#BINARY`
  - Unparse binary string to the following format: `B'\x01\x62'`
- Floats with a floating part equal to zero are treated as whole (`INT64`). Cast to double when that happens.
- Literal strings should escape `\` when unparsed.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
