### PR TITLE
[BEAM-7951]  Improve the docs for `beam_runner_api.proto` and `WindowedValue.java`

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -679,12 +679,12 @@ message StandardCoders {
 
     // A windowed value coder with parameterized timestamp, windows and pane info.
     // Encodes an element with only the value of the windowed value.
-    // Decodes the value and assign the parameterized timestamp, windows and PaneInfo to the
-    // windowed value
+    // Decodes the value and assigns the parameterized timestamp, windows and pane info to the
+    // windowed value.
     // Components: The element coder and the window coder, in that order
     // The payload of this coder is an encoded windowed value using the
-    // beam:coder:windowed_value:v1 coder parameterized by beam:coder:bytes:v1
-    // elements coder and the window coder that this param_windowed_value uses.
+    // beam:coder:windowed_value:v1 coder parameterized by a beam:coder:bytes:v1
+    // element coder and the window coder that this param_windowed_value coder uses.
     PARAM_WINDOWED_VALUE = 14 [(beam_urn) = "beam:coder:param_windowed_value:v1"];
 
     // Encodes an iterable of elements, some of which may be stored elsewhere.
@@ -1089,8 +1089,8 @@ message WireCoderSetting {
   // the URN is beam:coder:windowed_value:v1, this may be omitted. If the URN is
   // beam:coder:param_windowed_value:v1, the payload is an encoded windowed
   // value using the beam:coder:windowed_value:v1 coder parameterized by
-  // beam:coder:bytes:v1 elements coder and the window coder that this
-  // param_windowed_value uses.
+  // a beam:coder:bytes:v1 element coder and the window coder that this
+  // param_windowed_value coder uses.
   bytes payload = 2;
 }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
@@ -648,7 +648,7 @@ public abstract class WindowedValue<T> {
    * <p>A {@code ValueOnlyWindowedValueCoder} only encodes and decodes the value. It drops timestamp
    * and windows for encoding, and uses defaults timestamp, and windows for decoding.
    *
-   * @deprecated Use ParamWindowedValueCoder instead it is general purpose implementation of the
+   * @deprecated Use ParamWindowedValueCoder instead, it is a general purpose implementation of the
    *     same concept but makes timestamp, windows and pane info configurable.
    */
   @Deprecated
@@ -709,7 +709,7 @@ public abstract class WindowedValue<T> {
   }
 
   /**
-   * A parameterized Coder for {@code WindowedValue}.
+   * A parameterized coder for {@code WindowedValue}.
    *
    * <p>A {@code ParamWindowedValueCoder} only encodes and decodes the value. It drops timestamp,
    * windows, and pane info during encoding, and uses the supplied parameterized timestamp, windows
@@ -726,8 +726,8 @@ public abstract class WindowedValue<T> {
     private static final byte[] EMPTY_BYTES = new byte[0];
 
     /**
-     * Returns the {@link ParamWindowedValueCoder} from the given valueCoder, windowCoder and the
-     * supplied parameterized timestamp, windows and pane info for {@link WindowedValue}.
+     * Returns the {@link ParamWindowedValueCoder} for the given valueCoder and windowCoder using
+     * the supplied parameterized timestamp, windows and pane info for {@link WindowedValue}.
      */
     public static <T> ParamWindowedValueCoder<T> of(
         Coder<T> valueCoder,
@@ -739,9 +739,9 @@ public abstract class WindowedValue<T> {
     }
 
     /**
-     * Returns the {@link ParamWindowedValueCoder} from the given valueCoder, windowCoder and the
-     * supplied parameterized {@link BoundedWindow#TIMESTAMP_MIN_VALUE}, {@link #GLOBAL_WINDOWS} and
-     * {@link PaneInfo#NO_FIRING} for {@link WindowedValue}.
+     * Returns the {@link ParamWindowedValueCoder} for the given valueCoder and windowCoder using
+     * {@link BoundedWindow#TIMESTAMP_MIN_VALUE} as the timestamp, {@link #GLOBAL_WINDOWS} as the
+     * window and {@link PaneInfo#NO_FIRING} as the pane info for parameters.
      */
     public static <T> ParamWindowedValueCoder<T> of(
         Coder<T> valueCoder, Coder<? extends BoundedWindow> windowCoder) {
@@ -754,10 +754,10 @@ public abstract class WindowedValue<T> {
     }
 
     /**
-     * Returns the {@link ParamWindowedValueCoder} from the given valueCoder, {@link
-     * GlobalWindow.Coder#INSTANCE} and the supplied parameterized {@link
-     * BoundedWindow#TIMESTAMP_MIN_VALUE}, {@link #GLOBAL_WINDOWS} and {@link PaneInfo#NO_FIRING}
-     * for {@link WindowedValue}.
+     * Returns the {@link ParamWindowedValueCoder} for the given valueCoder and {@link
+     * GlobalWindow.Coder#INSTANCE} using {@link BoundedWindow#TIMESTAMP_MIN_VALUE} as the
+     * timestamp, {@link #GLOBAL_WINDOWS} as the window and {@link PaneInfo#NO_FIRING} as the pane
+     * info for parameters.
      */
     public static <T> ParamWindowedValueCoder<T> of(Coder<T> valueCoder) {
       return ParamWindowedValueCoder.of(valueCoder, GlobalWindow.Coder.INSTANCE);


### PR DESCRIPTION
Fixes comments in beam_runner_api.proto and WindowedValue.java as suggested in [https://github.com/apache/beam/pull/9979#pullrequestreview-335982782](https://github.com/apache/beam/pull/9979#pullrequestreview-335982782)

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
