### PR TITLE
[BEAM-9019] Remove BeamCoderWrapper to avoid extra object allocation

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/SchemaHelpers.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/SchemaHelpers.java
@@ -24,14 +24,16 @@ import org.apache.spark.sql.types.StructType;
 
 /** A {@link SchemaHelpers} for the Spark Batch Runner. */
 public class SchemaHelpers {
+  private static final StructType BINARY_SCHEMA =
+      new StructType(
+          new StructField[] {
+            StructField.apply("binaryStructField", DataTypes.BinaryType, true, Metadata.empty())
+          });
+
   public static StructType binarySchema() {
     // we use a binary schema for now because:
     // using a empty schema raises a indexOutOfBoundsException
     // using a NullType schema stores null in the elements
-    StructField[] array = new StructField[1];
-    StructField binaryStructField =
-        StructField.apply("binaryStructField", DataTypes.BinaryType, true, Metadata.empty());
-    array[0] = binaryStructField;
-    return new StructType(array);
+    return BINARY_SCHEMA;
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/helpers/EncoderHelpers.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/helpers/EncoderHelpers.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.beam.runners.spark.structuredstreaming.translation.SchemaHelpers;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.spark.sql.Encoder;
@@ -98,19 +99,17 @@ public class EncoderHelpers {
       List<String> parts = new ArrayList<>();
       List<Object> args = new ArrayList<>();
       /*
-            CODE GENERATED
-            final ${javaType} ${ev.value} = (${input.isNull})
-                ? null
-                : org.apache.beam.runners.spark.structuredstreaming.translation.helpers.CoderHelpers.toByteArray(${input.value}, ${coder});
+        CODE GENERATED
+        final ${javaType} ${ev.value} = org.apache.beam.runners.spark.structuredstreaming.translation.helpers.EncoderHelpers.EncodeUsingBeamCoder.encode(${input.value}, ${coder});
       */
       parts.add("final ");
       args.add(javaType);
       parts.add(" ");
       args.add(ev.value());
-      parts.add(" = (");
-      args.add(input.isNull());
       parts.add(
-          ") ? null : org.apache.beam.runners.spark.structuredstreaming.translation.helpers.CoderHelpers.toByteArray(");
+          " = org.apache.beam.runners.spark.structuredstreaming.translation.helpers.EncoderHelpers.EncodeUsingBeamCoder.encode(");
+      args.add(input.isNull());
+      parts.add(", ");
       args.add(input.value());
       parts.add(", ");
       args.add(accessCode);
@@ -167,6 +166,14 @@ public class EncoderHelpers {
     public int hashCode() {
       return Objects.hash(super.hashCode(), child, coder);
     }
+
+    /**
+     * Convert value to byte array (invoked by generated code in {@link #doGenCode(CodegenContext,
+     * ExprCode)}).
+     */
+    public static <T> byte[] encode(boolean isNull, @Nullable T value, Coder<T> coder) {
+      return isNull ? null : CoderHelpers.toByteArray(value, coder);
+    }
   }
 
   /**
@@ -201,21 +208,19 @@ public class EncoderHelpers {
       List<String> parts = new ArrayList<>();
       List<Object> args = new ArrayList<>();
       /*
-            CODE GENERATED:
-            final ${javaType} ${ev.value} = (${input.isNull})
-                ? null
-                : (${javaType}) org.apache.beam.runners.spark.structuredstreaming.translation.helpers.CoderHelpers.fromByteArray(${input.value}, ${coder});
+        CODE GENERATED:
+        final ${javaType} ${ev.value} = (${javaType}) org.apache.beam.runners.spark.structuredstreaming.translation.helpers.EncoderHelpers.DecodeUsingBeamCoder.decode(${input.value}, ${coder});
       */
       parts.add("final ");
       args.add(javaType);
       parts.add(" ");
       args.add(ev.value());
       parts.add(" = (");
-      args.add(input.isNull());
-      parts.add(") ? null : (");
       args.add(javaType);
       parts.add(
-          ") org.apache.beam.runners.spark.structuredstreaming.translation.helpers.CoderHelpers.fromByteArray(");
+          ") org.apache.beam.runners.spark.structuredstreaming.translation.helpers.EncoderHelpers.DecodeUsingBeamCoder.decode(");
+      args.add(input.isNull());
+      parts.add(", ");
       args.add(input.value());
       parts.add(", ");
       args.add(accessCode);
@@ -272,6 +277,14 @@ public class EncoderHelpers {
     @Override
     public int hashCode() {
       return Objects.hash(super.hashCode(), child, classTag, coder);
+    }
+
+    /**
+     * Convert value from byte array (invoked by generated code in {@link #doGenCode(CodegenContext,
+     * ExprCode)}).
+     */
+    public static <T> T decode(boolean isNull, @Nullable byte[] serialized, Coder<T> coder) {
+      return isNull ? null : CoderHelpers.fromByteArray(serialized, coder);
     }
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/structuredstreaming/translation/helpers/EncoderHelpersTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/structuredstreaming/translation/helpers/EncoderHelpersTest.java
@@ -15,13 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.spark.structuredstreaming.utils;
+package org.apache.beam.runners.spark.structuredstreaming.translation.helpers;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import org.apache.beam.runners.spark.structuredstreaming.translation.helpers.EncoderHelpers;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.SparkSession;
@@ -31,7 +30,7 @@ import org.junit.runners.JUnit4;
 
 /** Test of the wrapping of Beam Coders as Spark ExpressionEncoders. */
 @RunWith(JUnit4.class)
-public class EncodersTest {
+public class EncoderHelpersTest {
 
   @Test
   public void beamCoderToSparkEncoderTest() {
@@ -40,13 +39,9 @@ public class EncodersTest {
             .appName("beamCoderToSparkEncoderTest")
             .master("local[4]")
             .getOrCreate();
-    List<Integer> data = new ArrayList<>();
-    data.add(1);
-    data.add(2);
-    data.add(3);
+    List<Integer> data = Arrays.asList(1, 2, 3);
     Dataset<Integer> dataset =
         sparkSession.createDataset(data, EncoderHelpers.fromBeamCoder(VarIntCoder.of()));
-    List<Integer> results = dataset.collectAsList();
-    assertEquals(data, results);
+    assertEquals(data, dataset.collectAsList());
   }
 }


### PR DESCRIPTION
It simplifies #10450 by removing the extra wrapper object allocation to instead reuse the already wrapped Coder and delegate the coding/decoding work to existing methods in `CoderHelpers`.

R: @echauchot 