### PR TITLE
[BEAM-9020] LengthPrefixUnknownCodersTest to avoid relying on AbstractMap's equality

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/LengthPrefixUnknownCodersTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/LengthPrefixUnknownCodersTest.java
@@ -24,6 +24,9 @@ import static org.apache.beam.runners.dataflow.worker.graph.LengthPrefixUnknownC
 import static org.apache.beam.runners.dataflow.worker.graph.LengthPrefixUnknownCoders.forInstructionOutputNode;
 import static org.apache.beam.runners.dataflow.worker.graph.LengthPrefixUnknownCoders.forParallelInstruction;
 import static org.apache.beam.runners.dataflow.worker.testing.GenericJsonAssert.assertEqualsAsJson;
+import static org.apache.beam.runners.dataflow.worker.testing.GenericJsonMatcher.jsonOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
@@ -226,7 +229,7 @@ public class LengthPrefixUnknownCodersTest {
   }
 
   @Test
-  public void testLengthPrefixAndReplaceForRunnerNetwork() {
+  public void testLengthPrefixAndReplaceForRunnerNetwork() throws Exception {
     Node readNode = createReadNode("Read", "Source", windowedValueCoder);
     Edge readNodeEdge = DefaultEdge.create();
     Node readNodeOut = createInstructionOutputNode("Read.out", windowedValueCoder);
@@ -243,7 +246,6 @@ public class LengthPrefixUnknownCodersTest {
 
     MutableNetwork<Node, Edge> prefixedNetwork = andReplaceForRunnerNetwork(network);
 
-    // ImmutableSet keeps ordering
     ImmutableSet.Builder<GenericJson> prefixedInstructions = ImmutableSet.builder();
     for (Node node : prefixedNetwork.nodes()) {
       if (node instanceof ParallelInstructionNode) {
@@ -253,11 +255,11 @@ public class LengthPrefixUnknownCodersTest {
       }
     }
 
-    ImmutableSet<GenericJson> expectedInstructions =
-        ImmutableSet.of(
-            prefixedReadNodeOut.getInstructionOutput(), prefixedReadNode.getParallelInstruction());
-
-    assertEqualsAsJson(expectedInstructions, prefixedInstructions.build());
+    assertThat(
+        prefixedInstructions.build(),
+        containsInAnyOrder(
+            jsonOf(prefixedReadNodeOut.getInstructionOutput()),
+            jsonOf(prefixedReadNode.getParallelInstruction())));
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonAssert.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonAssert.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.dataflow.worker.testing;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import java.io.IOException;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -28,19 +29,23 @@ public class GenericJsonAssert {
   private static final JacksonFactory jacksonFactory = JacksonFactory.getDefaultInstance();
 
   /**
-   * Asserts that {@code actual} has the same JSON representation as {@code expectedJsonText}.
+   * Asserts that {@code actual} has the same JSON representation as {@code expected}.
    *
-   * @param expectedJsonText expected JSON string.
+   * @param expected expected JSON string, {@link GenericJson}, {@link java.util.Map}, or {@link
+   *     Iterable} of {@link GenericJson}.
    * @param actual actual object to compare its JSON representation.
    */
-  public static void assertEqualsAsJson(String expectedJsonText, GenericJson actual) {
-    actual.setFactory(jacksonFactory);
+  public static void assertEqualsAsJson(Object expected, Object actual) {
 
-    String actualJsonText = actual.toString();
     try {
+      String expectedJsonText =
+          expected instanceof String ? (String) expected : jacksonFactory.toString(expected);
+      String actualJsonText = jacksonFactory.toString(actual);
       JSONAssert.assertEquals(expectedJsonText, actualJsonText, true);
     } catch (JSONException ex) {
       throw new IllegalArgumentException("Could not parse JSON", ex);
+    } catch (IOException ex) {
+      throw new IllegalArgumentException("Could not generate JSON text", ex);
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcher.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcher.java
@@ -29,7 +29,7 @@ import org.skyscreamer.jsonassert.JSONCompareResult;
 
 /**
  * Matcher to compare {@link GenericJson}s using JSONassert's {@link JSONCompare}. This matcher does
- * not rely on {@link GenericJson#equals(Object)}.
+ * not rely on {@link GenericJson#equals(Object)}, which may use fields irrelevant to JSON values.
  */
 public final class GenericJsonMatcher extends TypeSafeMatcher<GenericJson> {
 
@@ -53,7 +53,6 @@ public final class GenericJsonMatcher extends TypeSafeMatcher<GenericJson> {
   protected boolean matchesSafely(GenericJson actual) {
     try {
       String actualJsonText = jacksonFactory.toString(actual);
-
       JSONCompareResult result =
           JSONCompare.compareJSON(expectedJsonText, actualJsonText, JSONCompareMode.STRICT);
       return result.passed();

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcher.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.testing;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import java.io.IOException;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONCompare;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.JSONCompareResult;
+
+/**
+ * Matcher to compare {@link GenericJson}s using JSONassert's {@link JSONCompare}. This matcher does
+ * not rely on {@link GenericJson#equals(Object)}.
+ */
+public final class GenericJsonMatcher extends TypeSafeMatcher<GenericJson> {
+
+  private String expectedJsonText;
+
+  private static final JacksonFactory jacksonFactory = JacksonFactory.getDefaultInstance();
+
+  private GenericJsonMatcher(GenericJson expected) {
+    try {
+      expectedJsonText = jacksonFactory.toString(expected);
+    } catch (IOException ex) {
+      throw new IllegalArgumentException("Could not parse JSON", ex);
+    }
+  }
+
+  public static GenericJsonMatcher jsonOf(GenericJson genericJson) {
+    return new GenericJsonMatcher(genericJson);
+  }
+
+  @Override
+  protected boolean matchesSafely(GenericJson actual) {
+    try {
+      String actualJsonText = jacksonFactory.toString(actual);
+
+      JSONCompareResult result =
+          JSONCompare.compareJSON(expectedJsonText, actualJsonText, JSONCompareMode.STRICT);
+      return result.passed();
+    } catch (IOException | JSONException ex) {
+      throw new IllegalArgumentException("Could not parse JSON", ex);
+    }
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    description.appendText(expectedJsonText);
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcherTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcherTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.testing;
+
+import static org.apache.beam.runners.dataflow.worker.testing.GenericJsonMatcher.jsonOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.google.api.client.json.GenericJson;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link GenericJsonMatcher}. */
+@RunWith(JUnit4.class)
+public class GenericJsonMatcherTest {
+
+  @Test
+  public void testMatch() {
+    GenericJson genericJson1 = new GenericJson();
+    genericJson1.set("foo", "bar");
+    GenericJson genericJson2 = new GenericJson();
+    genericJson2.set("foo", "bar");
+
+    assertThat(genericJson1, is(jsonOf(genericJson2)));
+  }
+
+  @Test
+  public void testMatchFailure() {
+
+    GenericJson genericJson1 = new GenericJson();
+    genericJson1.set("foo", "bar");
+    GenericJson genericJson2 = new GenericJson();
+    genericJson2.set("foo", "baz");
+
+    try {
+      assertThat(genericJson1, is(jsonOf(genericJson2)));
+    } catch (AssertionError ex) {
+      // pass
+      assertEquals("\nExpected: is {\"foo\":\"baz\"}\n     but: was <{foo=bar}>", ex.getMessage());
+      return;
+    }
+    fail();
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcherTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcherTest.java
@@ -34,29 +34,30 @@ public class GenericJsonMatcherTest {
 
   @Test
   public void testMatch() {
-    GenericJson genericJson1 = new GenericJson();
-    genericJson1.set("foo", "bar");
-    GenericJson genericJson2 = new GenericJson();
-    genericJson2.set("foo", "bar");
+    GenericJson expected = new GenericJson();
+    expected.set("foo", "bar");
+    GenericJson actual = new GenericJson();
+    actual.set("foo", "bar");
 
-    assertThat(genericJson1, is(jsonOf(genericJson2)));
+    assertThat(expected, is(jsonOf(actual)));
   }
 
   @Test
   public void testMatchFailure() {
-
-    GenericJson genericJson1 = new GenericJson();
-    genericJson1.set("foo", "bar");
-    GenericJson genericJson2 = new GenericJson();
-    genericJson2.set("foo", "baz");
+    GenericJson expected = new GenericJson();
+    expected.set("foo", "expected");
+    GenericJson actual = new GenericJson();
+    actual.set("foo", "actual");
 
     try {
-      assertThat(genericJson1, is(jsonOf(genericJson2)));
+      assertThat(actual, is(jsonOf(expected)));
     } catch (AssertionError ex) {
+      assertEquals(
+          "\nExpected: is {\"foo\":\"expected\"}\n     but: was <{foo=actual}>", ex.getMessage());
+
       // pass
-      assertEquals("\nExpected: is {\"foo\":\"baz\"}\n     but: was <{foo=bar}>", ex.getMessage());
       return;
     }
-    fail();
+    fail("The difference in JSON should raise AssertionError");
   }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/BEAM-9020 .

Attempt for BEAM-8695 LengthPrefixUnknownCodersTest failed when trying to upgrade google-http-client to v1.34.0, because LengthPrefixUnknownCodersTest relies on the equality of CloudObject with Map.

With that version, GenericData has its own equals method ([PR#589](https://github.com/googleapis/google-http-java-client/pull/589/files#diff-914cd7ff18143b3d2398149e1cfb4f45R218))  that checks classInfo and thus the comparisons between a CloudObject and a Map always fail.

Therefore LengthPrefixUnknownCodersTest should not rely on AbstractMap's equality.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
