### PR TITLE
[BEAM-9037] Instant and duration as logical type

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/NanosDuration.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/NanosDuration.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.logicaltypes;
+
+import java.time.Duration;
+import org.apache.beam.sdk.values.Row;
+
+/** A duration represented in nanoseconds. */
+public class NanosDuration extends NanosType<Duration> {
+  public static final String IDENTIFIER = "beam:logical_type:nanos_duration:v1";
+
+  public NanosDuration() {
+    super(IDENTIFIER);
+  }
+
+  @Override
+  public Row toBaseType(Duration input) {
+    return Row.withSchema(schema).addValues(input.getSeconds(), input.getNano()).build();
+  }
+
+  @Override
+  public Duration toInputType(Row row) {
+    return Duration.ofSeconds(row.getInt64(0), row.getInt32(1));
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/NanosInstant.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/NanosInstant.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.logicaltypes;
+
+import java.time.Instant;
+import org.apache.beam.sdk.values.Row;
+
+/** A timestamp represented as nanoseconds since the epoch. */
+public class NanosInstant extends NanosType<Instant> {
+  public static final String IDENTIFIER = "beam:logical_type:nanos_instant:v1";
+
+  public NanosInstant() {
+    super(IDENTIFIER);
+  }
+
+  @Override
+  public Row toBaseType(Instant input) {
+    return Row.withSchema(schema).addValues(input.getEpochSecond(), input.getNano()).build();
+  }
+
+  @Override
+  public Instant toInputType(Row row) {
+    return Instant.ofEpochSecond(row.getInt64(0), row.getInt32(1));
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/NanosType.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/NanosType.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.logicaltypes;
+
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+
+/** Base class for types representing timestamps or durations as nanoseconds. */
+abstract class NanosType<T> implements Schema.LogicalType<T, Row> {
+  private final String identifier;
+  protected final Schema schema;
+
+  NanosType(String identifier) {
+    this.identifier = identifier;
+    this.schema = Schema.builder().addInt64Field("seconds").addInt32Field("nanos").build();
+  }
+
+  @Override
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  @Override
+  public Schema.FieldType getArgumentType() {
+    return Schema.FieldType.STRING;
+  }
+
+  @Override
+  public String getArgument() {
+    return "";
+  }
+
+  @Override
+  public Schema.FieldType getBaseType() {
+    return Schema.FieldType.row(schema);
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
@@ -19,6 +19,8 @@ package org.apache.beam.sdk.schemas.logicaltypes;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
@@ -70,5 +72,29 @@ public class LogicalTypesTest {
     union = intOneOf.getLogicalTypeValue(0, OneOfType.Value.class);
     assertEquals("int32", union.getCaseType().toString());
     assertEquals(42, (int) union.getValue());
+  }
+
+  @Test
+  public void testNanosInstant() {
+    Schema rowSchema = new NanosInstant().getBaseType().getRowSchema();
+    Instant now = Instant.now();
+    Row nowAsRow = Row.withSchema(rowSchema).addValues(now.getEpochSecond(), now.getNano()).build();
+
+    Schema schema = Schema.builder().addLogicalTypeField("now", new NanosInstant()).build();
+    Row row = Row.withSchema(schema).addValues(now).build();
+    assertEquals(now, row.getLogicalTypeValue(0, NanosInstant.class));
+    assertEquals(nowAsRow, row.getValue(0));
+  }
+
+  @Test
+  public void testNanosDuration() {
+    Schema rowSchema = new NanosInstant().getBaseType().getRowSchema();
+    Duration duration = Duration.ofSeconds(123, 42);
+    Row durationAsRow = Row.withSchema(rowSchema).addValues(123L, 42).build();
+
+    Schema schema = Schema.builder().addLogicalTypeField("duration", new NanosDuration()).build();
+    Row row = Row.withSchema(schema).addValues(duration).build();
+    assertEquals(duration, row.getLogicalTypeValue(0, NanosDuration.class));
+    assertEquals(durationAsRow, row.getValue(0));
   }
 }

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoByteBuddyUtils.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoByteBuddyUtils.java
@@ -46,8 +46,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
-import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.DurationNanos;
-import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.TimestampNanos;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.FieldValueSetter;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
@@ -244,7 +242,7 @@ public class ProtoByteBuddyUtils {
         return new Compound(
             readValue,
             MethodInvocation.invoke(
-                new ForLoadedType(TimestampNanos.class)
+                new ForLoadedType(ProtoSchemaLogicalTypes.TimestampConvert.class)
                     .getDeclaredMethods()
                     .filter(ElementMatchers.named("toRow"))
                     .getOnly()));
@@ -252,7 +250,7 @@ public class ProtoByteBuddyUtils {
         return new Compound(
             readValue,
             MethodInvocation.invoke(
-                new ForLoadedType(DurationNanos.class)
+                new ForLoadedType(ProtoSchemaLogicalTypes.DurationConvert.class)
                     .getDeclaredMethods()
                     .filter(ElementMatchers.named("toRow"))
                     .getOnly()));
@@ -324,7 +322,7 @@ public class ProtoByteBuddyUtils {
         return new Compound(
             readValue,
             MethodInvocation.invoke(
-                new ForLoadedType(TimestampNanos.class)
+                new ForLoadedType(ProtoSchemaLogicalTypes.TimestampConvert.class)
                     .getDeclaredMethods()
                     .filter(ElementMatchers.named("toTimestamp"))
                     .getOnly()));
@@ -332,7 +330,7 @@ public class ProtoByteBuddyUtils {
         return new Compound(
             readValue,
             MethodInvocation.invoke(
-                new ForLoadedType(DurationNanos.class)
+                new ForLoadedType(ProtoSchemaLogicalTypes.DurationConvert.class)
                     .getDeclaredMethods()
                     .filter(ElementMatchers.named("toDuration"))
                     .getOnly()));

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaLogicalTypes.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaLogicalTypes.java
@@ -30,86 +30,31 @@ import org.apache.beam.sdk.values.Row;
 /** A set of {@link LogicalType} classes to represent protocol buffer types. */
 @Experimental(Kind.SCHEMAS)
 public class ProtoSchemaLogicalTypes {
-  /** Base class for types representing timestamps or durations as nanoseconds. */
-  public abstract static class NanosType<T> implements LogicalType<T, Row> {
-    private final String identifier;
 
-    private static final Schema SCHEMA =
-        Schema.builder().addInt64Field("seconds").addInt32Field("nanos").build();
+  /** Compatible schema with the row schema of NanosDuration and NanosInstant. */
+  private static final Schema SCHEMA =
+      Schema.builder().addInt64Field("seconds").addInt32Field("nanos").build();
 
-    protected NanosType(String identifier) {
-      this.identifier = identifier;
-    }
+  public static class TimestampConvert {
 
-    @Override
-    public String getIdentifier() {
-      return identifier;
-    }
-
-    @Override
-    public FieldType getArgumentType() {
-      return FieldType.STRING;
-    }
-
-    @Override
-    public FieldType getBaseType() {
-      return FieldType.row(SCHEMA);
-    }
-  }
-
-  /** A timestamp represented as nanoseconds since the epoch. */
-  public static class TimestampNanos extends NanosType<Timestamp> {
-    public static final String IDENTIFIER = "ProtoTimestamp";
-
-    public TimestampNanos() {
-      super(IDENTIFIER);
-    }
-
-    @Override
-    public Row toBaseType(Timestamp input) {
-      return toRow(input);
-    }
-
-    @Override
-    public Timestamp toInputType(Row base) {
-      return toTimestamp(base);
-    }
-
+    /** ByteBuddy conversion for Timestamp to NanosInstant base type. */
     public static Row toRow(Timestamp input) {
-      return Row.withSchema(NanosType.SCHEMA)
-          .addValues(input.getSeconds(), input.getNanos())
-          .build();
+      return Row.withSchema(SCHEMA).addValues(input.getSeconds(), input.getNanos()).build();
     }
 
+    /** ByteBuddy conversion for NanosInstant base type to Timestamp. */
     public static Timestamp toTimestamp(Row row) {
       return Timestamp.newBuilder().setSeconds(row.getInt64(0)).setNanos(row.getInt32(1)).build();
     }
   }
 
-  /** A duration represented in nanoseconds. */
-  public static class DurationNanos extends NanosType<Duration> {
-    public static final String IDENTIFIER = "ProtoTimestamp";
-
-    public DurationNanos() {
-      super(IDENTIFIER);
-    }
-
-    @Override
-    public Row toBaseType(Duration input) {
-      return toRow(input);
-    }
-
-    @Override
-    public Duration toInputType(Row base) {
-      return toDuration(base);
-    }
-
+  public static class DurationConvert {
+    /** ByteBuddy conversion for Duration to NanosDuration base type. */
     public static Row toRow(Duration input) {
-      return Row.withSchema(NanosType.SCHEMA)
-          .addValues(input.getSeconds(), input.getNanos())
-          .build();
+      return Row.withSchema(SCHEMA).addValues(input.getSeconds(), input.getNanos()).build();
     }
 
+    /** ByteBuddy conversion for NanosDuration base type to Duration. */
     public static Duration toDuration(Row row) {
       return Duration.newBuilder().setSeconds(row.getInt64(0)).setNanos(row.getInt32(1)).build();
     }

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -28,20 +28,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.DurationNanos;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed64;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SFixed32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SFixed64;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SInt32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SInt64;
-import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.TimestampNanos;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.UInt32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.UInt64;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
+import org.apache.beam.sdk.schemas.logicaltypes.NanosDuration;
+import org.apache.beam.sdk.schemas.logicaltypes.NanosInstant;
 import org.apache.beam.sdk.schemas.logicaltypes.OneOfType;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
@@ -244,7 +244,7 @@ public class ProtoSchemaTranslator {
         String fullName = protoFieldDescriptor.getMessageType().getFullName();
         switch (fullName) {
           case "google.protobuf.Timestamp":
-            fieldType = FieldType.logicalType(new TimestampNanos());
+            fieldType = FieldType.logicalType(new NanosInstant());
             break;
           case "google.protobuf.Int32Value":
           case "google.protobuf.UInt32Value":
@@ -261,7 +261,7 @@ public class ProtoSchemaTranslator {
                     .withNullable(true);
             break;
           case "google.protobuf.Duration":
-            fieldType = FieldType.logicalType(new DurationNanos());
+            fieldType = FieldType.logicalType(new NanosDuration());
             break;
           case "google.protobuf.Any":
             throw new RuntimeException("Any not yet supported");

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -43,19 +43,19 @@ import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OuterOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Primitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.RepeatPrimitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.WktMessage;
-import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.DurationNanos;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed64;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SFixed32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SFixed64;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SInt32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SInt64;
-import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.TimestampNanos;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.UInt32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.UInt64;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.logicaltypes.NanosDuration;
+import org.apache.beam.sdk.schemas.logicaltypes.NanosInstant;
 import org.apache.beam.sdk.schemas.logicaltypes.OneOfType;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -357,9 +357,9 @@ class TestProtoSchemas {
           .addNullableField("string", withFieldNumber(FieldType.STRING, 14))
           .addNullableField("bytes", withFieldNumber(FieldType.BYTES, 15))
           .addNullableField(
-              "timestamp", withFieldNumber(FieldType.logicalType(new TimestampNanos()), 16))
+              "timestamp", withFieldNumber(FieldType.logicalType(new NanosInstant()), 16))
           .addNullableField(
-              "duration", withFieldNumber(FieldType.logicalType(new DurationNanos()), 17))
+              "duration", withFieldNumber(FieldType.logicalType(new NanosDuration()), 17))
           .build();
   // A sample instance of the  row.
   static final Instant JAVA_NOW = Instant.now();
@@ -368,6 +368,8 @@ class TestProtoSchemas {
           .setSeconds(JAVA_NOW.getEpochSecond())
           .setNanos(JAVA_NOW.getNano())
           .build();
+  static final java.time.Duration JAVA_DURATION =
+      java.time.Duration.ofSeconds(JAVA_NOW.getEpochSecond(), JAVA_NOW.getNano());
   static final Duration PROTO_DURATION =
       Duration.newBuilder()
           .setSeconds(JAVA_NOW.getEpochSecond())
@@ -376,7 +378,7 @@ class TestProtoSchemas {
   static final Row WKT_MESSAGE_ROW =
       Row.withSchema(WKT_MESSAGE_SCHEMA)
           .addValues(
-              1.1, 2.2F, 32, 64L, 33, 65L, true, "horsey", BYTE_ARRAY, PROTO_NOW, PROTO_DURATION)
+              1.1, 2.2F, 32, 64L, 33, 65L, true, "horsey", BYTE_ARRAY, JAVA_NOW, JAVA_DURATION)
           .build();
 
   // A sample instance of the proto.


### PR DESCRIPTION
The proto schema includes Timestamp and Duration with nano precision.
The logical types should be promoted to the core logical types, so they
can be handled on various IO's as standard mandatory conversions.

This means that the logical type should use the proto specific Timestamp
and Duration but the java 8 Instant and Duration.

------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
