### PR TITLE
[BEAM-5504] Introduce PubsubAvroTable

### DIFF
--- a/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/DataCatalogTableProvider.java
+++ b/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/DataCatalogTableProvider.java
@@ -40,7 +40,7 @@ import org.apache.beam.sdk.extensions.sql.meta.provider.FullNameTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.InvalidTableException;
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.bigquery.BigQueryTableProvider;
-import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubJsonTableProvider;
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.text.TextTableProvider;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableList;
@@ -53,7 +53,7 @@ public class DataCatalogTableProvider extends FullNameTableProvider implements A
   private static final TableFactory GCS_TABLE_FACTORY = new GcsTableFactory();
 
   private static final Map<String, TableProvider> DELEGATE_PROVIDERS =
-      Stream.of(new PubsubJsonTableProvider(), new BigQueryTableProvider(), new TextTableProvider())
+      Stream.of(new PubsubTableProvider(), new BigQueryTableProvider(), new TextTableProvider())
           .collect(toMap(TableProvider::getTableType, p -> p));
 
   private final DataCatalogClient dataCatalog;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/avro/GenericRecordWriteConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/avro/GenericRecordWriteConverter.java
@@ -59,7 +59,7 @@ public abstract class GenericRecordWriteConverter
   }
 
   @AutoValue.Builder
-  abstract static class Builder {
+  public abstract static class Builder {
     public abstract Builder beamSchema(Schema beamSchema);
 
     public abstract GenericRecordWriteConverter build();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/AvroPubsubMessageToRow.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/AvroPubsubMessageToRow.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubMessageToRow.FlatSchemaPubsubMessageToRow;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TupleTagList;
+
+/** Read side converter for {@link PubsubMessage} with Avro payload. */
+@Internal
+@Experimental
+@AutoValue
+public abstract class AvroPubsubMessageToRow extends PubsubMessageToRow implements Serializable {
+
+  @Override
+  public PCollectionTuple expand(PCollection<PubsubMessage> input) {
+    PCollectionTuple rows =
+        input.apply(
+            ParDo.of(new FlatSchemaAvroPubsubMessageToRow(messageSchema(), useDlq()))
+                .withOutputTags(
+                    MAIN_TAG, useDlq() ? TupleTagList.of(DLQ_TAG) : TupleTagList.empty()));
+    rows.get(MAIN_TAG).setRowSchema(messageSchema());
+    return rows;
+  }
+
+  public static Builder builder() {
+    return new AutoValue_AvroPubsubMessageToRow.Builder();
+  }
+
+  @Internal
+  private static class FlatSchemaAvroPubsubMessageToRow extends FlatSchemaPubsubMessageToRow {
+
+    private final Schema messageSchema;
+
+    private final boolean useDlq;
+
+    protected FlatSchemaAvroPubsubMessageToRow(Schema messageSchema, boolean useDlq) {
+      this.messageSchema = messageSchema;
+      this.useDlq = useDlq;
+    }
+
+    @Override
+    protected Schema getMessageSchema() {
+      return messageSchema;
+    }
+
+    @Override
+    protected boolean getUseDlq() {
+      return useDlq;
+    }
+
+    @Override
+    protected final Row parsePayload(PubsubMessage pubsubMessage) {
+      byte[] avroPayload = pubsubMessage.getPayload();
+
+      // Construct payload flat schema.
+      Schema payloadSchema =
+          new Schema(
+              getMessageSchema().getFields().stream()
+                  .filter(field -> !TIMESTAMP_FIELD.equals(field.getName()))
+                  .collect(Collectors.toList()));
+      org.apache.avro.Schema avroSchema = AvroUtils.toAvroSchema(payloadSchema);
+      return AvroUtils.toBeamRowStrict(AvroUtils.toGenericRecord(avroPayload, avroSchema), null);
+    }
+  }
+
+  @Override
+  public boolean useFlatSchema() {
+    return true;
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    public abstract Builder messageSchema(Schema messageSchema);
+
+    public abstract Builder useDlq(boolean useDlq);
+
+    public abstract AvroPubsubMessageToRow build();
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/JsonPubsubMessageToRow.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/JsonPubsubMessageToRow.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.beam.sdk.util.RowJsonUtils.newObjectMapperWith;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.util.RowJson.RowJsonDeserializer;
+import org.apache.beam.sdk.util.RowJson.UnsupportedRowJsonException;
+import org.apache.beam.sdk.util.RowJsonUtils;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.joda.time.Instant;
+
+/** Read side converter for {@link PubsubMessage} with JSON payload. */
+@Internal
+@Experimental
+@AutoValue
+public abstract class JsonPubsubMessageToRow extends PubsubMessageToRow implements Serializable {
+
+  @Override
+  public PCollectionTuple expand(PCollection<PubsubMessage> input) {
+    PCollectionTuple rows =
+        input.apply(
+            ParDo.of(
+                    useFlatSchema()
+                        ? new FlatSchemaJsonPubsubMessageToRoW(messageSchema(), useDlq())
+                        : new NestedSchemaPubsubMessageToRow(messageSchema(), useDlq()))
+                .withOutputTags(
+                    MAIN_TAG, useDlq() ? TupleTagList.of(DLQ_TAG) : TupleTagList.empty()));
+    rows.get(MAIN_TAG).setRowSchema(messageSchema());
+    return rows;
+  }
+
+  /**
+   * A {@link DoFn} to convert a flat schema{@link PubsubMessage} with JSON payload to {@link Row}.
+   */
+  @Internal
+  private static class FlatSchemaJsonPubsubMessageToRoW extends FlatSchemaPubsubMessageToRow {
+
+    private final Schema messageSchema;
+
+    private final boolean useDlq;
+
+    private transient volatile @Nullable ObjectMapper objectMapper;
+
+    protected FlatSchemaJsonPubsubMessageToRoW(Schema messageSchema, boolean useDlq) {
+      this.messageSchema = messageSchema;
+      this.useDlq = useDlq;
+    }
+
+    @Override
+    public Schema getMessageSchema() {
+      return messageSchema;
+    }
+
+    @Override
+    public boolean getUseDlq() {
+      return useDlq;
+    }
+
+    @Override
+    protected final Row parsePayload(PubsubMessage pubsubMessage) {
+      String payloadJson = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);
+      // Construct flat payload schema.
+      Schema payloadSchema =
+          new Schema(
+              messageSchema.getFields().stream()
+                  .filter(f -> !f.getName().equals(TIMESTAMP_FIELD))
+                  .collect(Collectors.toList()));
+
+      if (objectMapper == null) {
+        objectMapper = newObjectMapperWith(RowJsonDeserializer.forSchema(payloadSchema));
+      }
+
+      return RowJsonUtils.jsonToRow(objectMapper, payloadJson);
+    }
+  }
+
+  /**
+   * A {@link DoFn} to convert a nested schema {@link PubsubMessage} with JSON payload to {@link
+   * Row}.
+   */
+  @Internal
+  private static class NestedSchemaPubsubMessageToRow extends DoFn<PubsubMessage, Row> {
+
+    private final Schema messageSchema;
+
+    private final boolean useDlq;
+
+    private transient volatile @Nullable ObjectMapper objectMapper;
+
+    protected NestedSchemaPubsubMessageToRow(Schema messageSchema, boolean useDlq) {
+      this.messageSchema = messageSchema;
+      this.useDlq = useDlq;
+    }
+
+    /** Get the value for a field int the order they're specified in the nested schema. */
+    private Object getValueForFieldNestedSchema(
+        Schema.Field field, Instant timestamp, Map<String, String> attributeMap, Row payload) {
+      switch (field.getName()) {
+        case TIMESTAMP_FIELD:
+          return timestamp;
+        case ATTRIBUTES_FIELD:
+          return attributeMap;
+        case PAYLOAD_FIELD:
+          return payload;
+        default:
+          throw new IllegalArgumentException(
+              "Unexpected field '"
+                  + field.getName()
+                  + "' in top level schema"
+                  + " for Pubsub message. Top level schema should only contain "
+                  + "'timestamp', 'attributes', and 'payload' fields");
+      }
+    }
+
+    private Row parsePayload(PubsubMessage pubsubMessage) {
+      String payloadJson = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);
+      // Retrieve nested payload schema.
+      Schema payloadSchema = messageSchema.getField(PAYLOAD_FIELD).getType().getRowSchema();
+
+      if (objectMapper == null) {
+        objectMapper = newObjectMapperWith(RowJsonDeserializer.forSchema(payloadSchema));
+      }
+
+      return RowJsonUtils.jsonToRow(objectMapper, payloadJson);
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      try {
+        Row payload = parsePayload(context.element());
+        List<Object> values =
+            messageSchema.getFields().stream()
+                .map(
+                    field ->
+                        getValueForFieldNestedSchema(
+                            field,
+                            context.timestamp(),
+                            context.element().getAttributeMap(),
+                            payload))
+                .collect(toList());
+        context.output(Row.withSchema(messageSchema).addValues(values).build());
+      } catch (UnsupportedRowJsonException jsonException) {
+        if (useDlq) {
+          context.output(DLQ_TAG, context.element());
+        } else {
+          throw new RuntimeException("Error parsing message", jsonException);
+        }
+      }
+    }
+  }
+
+  public static Builder builder() {
+    return new AutoValue_JsonPubsubMessageToRow.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    public abstract Builder messageSchema(Schema messageSchema);
+
+    public abstract Builder useDlq(boolean useDlq);
+
+    public abstract Builder useFlatSchema(boolean useFlatSchema);
+
+    public abstract JsonPubsubMessageToRow build();
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOAvroTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOAvroTable.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubMessageToRow.DLQ_TAG;
+import static org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubMessageToRow.MAIN_TAG;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubTableProvider.PubsubIOTableConfiguration;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.POutput;
+import org.apache.beam.sdk.values.Row;
+
+@Internal
+@Experimental
+class PubsubIOAvroTable extends PubsubIOTable implements Serializable {
+
+  private final PubsubIOTableConfiguration config;
+
+  private PubsubIOAvroTable(PubsubIOTableConfiguration config) {
+    this.config = config;
+  }
+
+  @Override
+  protected PubsubIOTableConfiguration getConfig() {
+    return config;
+  }
+
+  static PubsubIOAvroTable withConfiguration(PubsubIOTableConfiguration config) {
+    return new PubsubIOAvroTable(config);
+  }
+
+  @Override
+  public Schema getSchema() {
+    return config.getSchema();
+  }
+
+  @Override
+  public PCollection<Row> buildIOReader(PBegin begin) {
+    PCollectionTuple rowsWithDlq =
+        begin
+            .apply("ReadFromPubsub", readMessagesWithAttributes())
+            .apply(
+                "AvroPubsubMessageToRow",
+                AvroPubsubMessageToRow.builder()
+                    .messageSchema(getSchema())
+                    .useDlq(config.useDlq())
+                    .build());
+
+    if (config.useDlq()) {
+      rowsWithDlq.get(DLQ_TAG).apply(writeMessagesToDlq());
+    }
+
+    return rowsWithDlq.get(MAIN_TAG);
+  }
+
+  @Override
+  public POutput buildIOWriter(PCollection<Row> input) {
+    if (!config.getUseFlatSchema()) {
+      throw new UnsupportedOperationException(
+          "Writing to a Pubsub topic is only supported for flattened schemas");
+    }
+    return input
+        .apply(RowToAvroPubsubMessage.fromTableConfig(config))
+        .apply(createPubsubMessageWrite());
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOTable.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.extensions.sql.impl.BeamTableStatistics;
+import org.apache.beam.sdk.extensions.sql.meta.BaseBeamTable;
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubTableProvider.PubsubIOTableConfiguration;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.values.PCollection.IsBounded;
+
+@Internal
+public abstract class PubsubIOTable extends BaseBeamTable {
+
+  protected abstract PubsubIOTableConfiguration getConfig();
+
+  @Override
+  public IsBounded isBounded() {
+    return IsBounded.UNBOUNDED;
+  }
+
+  @Override
+  public BeamTableStatistics getTableStatistics(PipelineOptions options) {
+    return BeamTableStatistics.UNBOUNDED_UNKNOWN;
+  }
+
+  protected PubsubIO.Read<PubsubMessage> readMessagesWithAttributes() {
+    PubsubIO.Read<PubsubMessage> read =
+        PubsubIO.readMessagesWithAttributes().fromTopic(getConfig().getTopic());
+
+    return getConfig().useTimestampAttribute()
+        ? read.withTimestampAttribute(getConfig().getTimestampAttribute())
+        : read;
+  }
+
+  protected PubsubIO.Write<PubsubMessage> createPubsubMessageWrite() {
+    PubsubIO.Write<PubsubMessage> write = PubsubIO.writeMessages().to(getConfig().getTopic());
+    if (getConfig().useTimestampAttribute()) {
+      write = write.withTimestampAttribute(getConfig().getTimestampAttribute());
+    }
+    return write;
+  }
+
+  protected PubsubIO.Write<PubsubMessage> writeMessagesToDlq() {
+    PubsubIO.Write<PubsubMessage> write =
+        PubsubIO.writeMessages().to(getConfig().getDeadLetterQueue());
+
+    return getConfig().useTimestampAttribute()
+        ? write.withTimestampAttribute(getConfig().getTimestampAttribute())
+        : write;
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRow.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRow.java
@@ -17,41 +17,27 @@
  */
 package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
 
-import static java.util.stream.Collectors.toList;
-import static org.apache.beam.sdk.util.RowJsonUtils.newObjectMapperWith;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.auto.value.AutoValue;
-import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.util.RowJson.RowJsonDeserializer;
-import org.apache.beam.sdk.util.RowJson.UnsupportedRowJsonException;
-import org.apache.beam.sdk.util.RowJsonUtils;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
-import org.apache.beam.sdk.values.TupleTagList;
 import org.joda.time.Instant;
 
-/** Read side converter for {@link PubsubMessage} with JSON payload. */
+/** Read side converter template for {@link PubsubMessage}. */
 @Internal
 @Experimental
-@AutoValue
 public abstract class PubsubMessageToRow
-    extends PTransform<PCollection<PubsubMessage>, PCollectionTuple> implements Serializable {
+    extends PTransform<PCollection<PubsubMessage>, PCollectionTuple> {
   static final String TIMESTAMP_FIELD = "event_timestamp";
   static final String ATTRIBUTES_FIELD = "attributes";
   static final String PAYLOAD_FIELD = "payload";
@@ -71,7 +57,8 @@ public abstract class PubsubMessageToRow
    *   <li>'payload' of type {@link TypeName#ROW ROW&lt;...&gt;}
    * </ul>
    *
-   * <p>Only UTF-8 JSON objects are supported.
+   * <p>UTF-8 JSON and Avro objects are supported via {@link JsonPubsubMessageToRow} and {@link
+   * AvroPubsubMessageToRow} respectively.
    */
   public abstract Schema messageSchema();
 
@@ -79,54 +66,19 @@ public abstract class PubsubMessageToRow
 
   public abstract boolean useFlatSchema();
 
-  public static Builder builder() {
-    return new AutoValue_PubsubMessageToRow.Builder();
-  }
+  protected abstract static class FlatSchemaPubsubMessageToRow extends DoFn<PubsubMessage, Row> {
 
-  @Override
-  public PCollectionTuple expand(PCollection<PubsubMessage> input) {
-    PCollectionTuple rows =
-        input.apply(
-            ParDo.of(
-                    useFlatSchema()
-                        ? new FlatSchemaPubsubMessageToRoW(messageSchema(), useDlq())
-                        : new NestedSchemaPubsubMessageToRow(messageSchema(), useDlq()))
-                .withOutputTags(
-                    MAIN_TAG, useDlq() ? TupleTagList.of(DLQ_TAG) : TupleTagList.empty()));
-    rows.get(MAIN_TAG).setRowSchema(messageSchema());
-    return rows;
-  }
+    protected abstract Row parsePayload(PubsubMessage message);
 
-  /**
-   * A {@link DoFn} to convert a flat schema{@link PubsubMessage} with JSON payload to {@link Row}.
-   */
-  @Internal
-  private static class FlatSchemaPubsubMessageToRoW extends DoFn<PubsubMessage, Row> {
+    protected abstract Schema getMessageSchema();
 
-    private final Schema messageSchema;
-
-    private final Schema payloadSchema;
-
-    private final boolean useDlq;
-
-    private transient volatile @Nullable ObjectMapper objectMapper;
-
-    protected FlatSchemaPubsubMessageToRoW(Schema messageSchema, boolean useDlq) {
-      this.messageSchema = messageSchema;
-      // Construct flat payload schema.
-      this.payloadSchema =
-          new Schema(
-              messageSchema.getFields().stream()
-                  .filter(f -> !f.getName().equals(TIMESTAMP_FIELD))
-                  .collect(Collectors.toList()));
-      this.useDlq = useDlq;
-    }
+    protected abstract boolean getUseDlq();
 
     /**
      * Get the value for a field from a given payload in the order they're specified in the flat
      * schema.
      */
-    private Object getValueForFieldFlatSchema(Schema.Field field, Instant timestamp, Row payload) {
+    protected Object getValueForFieldFlatSchema(Field field, Instant timestamp, Row payload) {
       String fieldName = field.getName();
       if (TIMESTAMP_FIELD.equals(fieldName)) {
         return timestamp;
@@ -135,115 +87,22 @@ public abstract class PubsubMessageToRow
       }
     }
 
-    private Row parsePayload(PubsubMessage pubsubMessage) {
-      String payloadJson = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);
-      if (objectMapper == null) {
-        objectMapper = newObjectMapperWith(RowJsonDeserializer.forSchema(payloadSchema));
-      }
-
-      return RowJsonUtils.jsonToRow(objectMapper, payloadJson);
-    }
-
     @ProcessElement
-    public void processElement(
-        @Element PubsubMessage element, @Timestamp Instant timestamp, MultiOutputReceiver o) {
+    public void processElement(ProcessContext context) {
       try {
-        Row payload = parsePayload(element);
+        Row payload = parsePayload(context.element());
         List<Object> values =
-            messageSchema.getFields().stream()
-                .map(field -> getValueForFieldFlatSchema(field, timestamp, payload))
-                .collect(toList());
-        o.get(MAIN_TAG).output(Row.withSchema(messageSchema).addValues(values).build());
-      } catch (UnsupportedRowJsonException jsonException) {
-        if (useDlq) {
-          o.get(DLQ_TAG).output(element);
+            getMessageSchema().getFields().stream()
+                .map(field -> getValueForFieldFlatSchema(field, context.timestamp(), payload))
+                .collect(Collectors.toList());
+        context.output(Row.withSchema(getMessageSchema()).addValues(values).build());
+      } catch (Exception exception) {
+        if (getUseDlq()) {
+          context.output(DLQ_TAG, context.element());
         } else {
-          throw new RuntimeException("Error parsing message", jsonException);
+          throw new RuntimeException("Error parsing message", exception);
         }
       }
     }
-  }
-
-  /**
-   * A {@link DoFn} to convert a nested schema {@link PubsubMessage} with JSON payload to {@link
-   * Row}.
-   */
-  @Internal
-  private static class NestedSchemaPubsubMessageToRow extends DoFn<PubsubMessage, Row> {
-
-    private final Schema messageSchema;
-
-    private final boolean useDlq;
-
-    private transient volatile @Nullable ObjectMapper objectMapper;
-
-    protected NestedSchemaPubsubMessageToRow(Schema messageSchema, boolean useDlq) {
-      this.messageSchema = messageSchema;
-      this.useDlq = useDlq;
-    }
-
-    /** Get the value for a field int the order they're specified in the nested schema. */
-    private Object getValueForFieldNestedSchema(
-        Schema.Field field, Instant timestamp, Map<String, String> attributeMap, Row payload) {
-      switch (field.getName()) {
-        case TIMESTAMP_FIELD:
-          return timestamp;
-        case ATTRIBUTES_FIELD:
-          return attributeMap;
-        case PAYLOAD_FIELD:
-          return payload;
-        default:
-          throw new IllegalArgumentException(
-              "Unexpected field '"
-                  + field.getName()
-                  + "' in top level schema"
-                  + " for Pubsub message. Top level schema should only contain "
-                  + "'timestamp', 'attributes', and 'payload' fields");
-      }
-    }
-
-    private Row parsePayload(PubsubMessage pubsubMessage) {
-      String payloadJson = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);
-      // Retrieve nested payload schema.
-      Schema payloadSchema = messageSchema.getField(PAYLOAD_FIELD).getType().getRowSchema();
-      if (objectMapper == null) {
-        objectMapper = newObjectMapperWith(RowJsonDeserializer.forSchema(payloadSchema));
-      }
-
-      return RowJsonUtils.jsonToRow(objectMapper, payloadJson);
-    }
-
-    @ProcessElement
-    public void processElement(
-        @Element PubsubMessage element, @Timestamp Instant timestamp, MultiOutputReceiver o) {
-      try {
-        Row payload = parsePayload(element);
-        List<Object> values =
-            messageSchema.getFields().stream()
-                .map(
-                    field ->
-                        getValueForFieldNestedSchema(
-                            field, timestamp, element.getAttributeMap(), payload))
-                .collect(toList());
-        o.get(MAIN_TAG).output(Row.withSchema(messageSchema).addValues(values).build());
-      } catch (UnsupportedRowJsonException jsonException) {
-        if (useDlq) {
-          o.get(DLQ_TAG).output(element);
-        } else {
-          throw new RuntimeException("Error parsing message", jsonException);
-        }
-      }
-    }
-  }
-
-  @AutoValue.Builder
-  abstract static class Builder {
-    public abstract Builder messageSchema(Schema messageSchema);
-
-    public abstract Builder useDlq(boolean useDlq);
-
-    public abstract Builder useFlatSchema(boolean useFlatSchema);
-
-    public abstract PubsubMessageToRow build();
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/RowToAvroPubsubMessage.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/RowToAvroPubsubMessage.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.extensions.sql.meta.provider.avro.GenericRecordWriteConverter;
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubTableProvider.PubsubIOTableConfiguration;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.transforms.DropFields;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.WithTimestamps;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableMap;
+
+/**
+ * A {@link PTransform} to convert {@link Row} to {@link PubsubMessage}.
+ *
+ * <p>Currently only supports writing a flat schema into a AVRO payload.
+ */
+@Experimental
+@Internal
+public class RowToAvroPubsubMessage
+    extends PTransform<PCollection<Row>, PCollection<PubsubMessage>> {
+  private final PubsubIOTableConfiguration config;
+
+  private static final String EVENT_TIMESTAMP = "event_timestamp";
+
+  private RowToAvroPubsubMessage(PubsubIOTableConfiguration config) {
+    checkArgument(
+        config.getUseFlatSchema(), "RowToAvroPubsubMessage only supports flattened schemas.");
+
+    this.config = config;
+  }
+
+  public static RowToAvroPubsubMessage fromTableConfig(PubsubIOTableConfiguration config) {
+    return new RowToAvroPubsubMessage(config);
+  }
+
+  @Override
+  public PCollection<PubsubMessage> expand(PCollection<Row> input) {
+    PCollection<Row> withTimestamp =
+        (config.useTimestampAttribute())
+            ? input.apply(WithTimestamps.of((row) -> row.getDateTime(EVENT_TIMESTAMP).toInstant()))
+            : input;
+
+    Schema payloadSchema =
+        new Schema(
+            config.getSchema().getFields().stream()
+                .filter(field -> !EVENT_TIMESTAMP.equals(field.getName()))
+                .collect(Collectors.toList()));
+
+    return withTimestamp
+        .apply(DropFields.fields(EVENT_TIMESTAMP))
+        .apply(GenericRecordWriteConverter.builder().beamSchema(payloadSchema).build())
+        .apply(
+            ParDo.of(
+                new DoFn<GenericRecord, PubsubMessage>() {
+                  @ProcessElement
+                  public void processElement(ProcessContext context) {
+                    context.output(
+                        new PubsubMessage(
+                            AvroUtils.toBytes(context.element()),
+                            ImmutableMap.of(),
+                            config.useTimestampAttribute()
+                                ? context.element().get(EVENT_TIMESTAMP).toString()
+                                : null));
+                  }
+                }));
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/RowToJsonPubsubMessage.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/RowToJsonPubsubMessage.java
@@ -38,23 +38,23 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  * <p>Currently only supports writing a flat schema into a JSON payload. This means that all Row
  * field values are written to the {@link PubsubMessage} JSON payload, except for {@code
  * event_timestamp}, which is either ignored or written to the message attributes, depending on
- * whether {@link PubsubJsonTableProvider.PubsubIOTableConfiguration#getTimestampAttribute()} is
- * set.
+ * whether {@link PubsubTableProvider.PubsubIOTableConfiguration#getTimestampAttribute()} is set.
  */
 @Experimental
-public class RowToPubsubMessage extends PTransform<PCollection<Row>, PCollection<PubsubMessage>> {
-  private final PubsubJsonTableProvider.PubsubIOTableConfiguration config;
+public class RowToJsonPubsubMessage
+    extends PTransform<PCollection<Row>, PCollection<PubsubMessage>> {
+  private final PubsubTableProvider.PubsubIOTableConfiguration config;
 
-  private RowToPubsubMessage(PubsubJsonTableProvider.PubsubIOTableConfiguration config) {
+  private RowToJsonPubsubMessage(PubsubTableProvider.PubsubIOTableConfiguration config) {
     checkArgument(
         config.getUseFlatSchema(), "RowToPubsubMessage is only supported for flattened schemas.");
 
     this.config = config;
   }
 
-  public static RowToPubsubMessage fromTableConfig(
-      PubsubJsonTableProvider.PubsubIOTableConfiguration config) {
-    return new RowToPubsubMessage(config);
+  public static RowToJsonPubsubMessage fromTableConfig(
+      PubsubTableProvider.PubsubIOTableConfiguration config) {
+    return new RowToJsonPubsubMessage(config);
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/PubsubToBigqueryIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/PubsubToBigqueryIT.java
@@ -27,7 +27,7 @@ import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.extensions.sql.meta.provider.bigquery.BigQueryTableProvider;
-import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubJsonTableProvider;
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubTableProvider;
 import org.apache.beam.sdk.io.gcp.bigquery.TestBigQuery;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.TestPubsub;
@@ -55,8 +55,7 @@ public class PubsubToBigqueryIT implements Serializable {
 
   @Test
   public void testSimpleInsert() throws Exception {
-    BeamSqlEnv sqlEnv =
-        BeamSqlEnv.inMemory(new PubsubJsonTableProvider(), new BigQueryTableProvider());
+    BeamSqlEnv sqlEnv = BeamSqlEnv.inMemory(new PubsubTableProvider(), new BigQueryTableProvider());
 
     String createTableString =
         "CREATE EXTERNAL TABLE pubsub_topic (\n"
@@ -113,8 +112,7 @@ public class PubsubToBigqueryIT implements Serializable {
 
   @Test
   public void testSimpleInsertFlat() throws Exception {
-    BeamSqlEnv sqlEnv =
-        BeamSqlEnv.inMemory(new PubsubJsonTableProvider(), new BigQueryTableProvider());
+    BeamSqlEnv sqlEnv = BeamSqlEnv.inMemory(new PubsubTableProvider(), new BigQueryTableProvider());
 
     String createTableString =
         "CREATE EXTERNAL TABLE pubsub_topic (\n"

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/AvroPubsubMessageToRowTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/AvroPubsubMessageToRowTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubMessageToRow.DLQ_TAG;
+import static org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubMessageToRow.MAIN_TAG;
+import static org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.Iterables.size;
+import static org.junit.Assert.assertEquals;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Unit tests for {@link AvroPubsubMessageToRow}. */
+public class AvroPubsubMessageToRowTest implements Serializable {
+
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testConvertsMessagesToFlatRow() throws Exception {
+
+    Schema payloadSchema =
+        Schema.builder()
+            .addNullableField("id", FieldType.INT32)
+            .addNullableField("name", FieldType.STRING)
+            .build();
+
+    Schema messageSchema =
+        Schema.builder()
+            .addDateTimeField("event_timestamp")
+            .addNullableField("id", FieldType.INT32)
+            .addNullableField("name", FieldType.STRING)
+            .build();
+
+    Map<String, Object> nullId = new HashMap<>();
+    nullId.put("id", null);
+    nullId.put("name", "Luke");
+    Map<String, Object> nullValues = new HashMap<>();
+    nullValues.put("id", null);
+    nullValues.put("name", null);
+
+    PCollectionTuple rows =
+        pipeline
+            .apply(
+                "create",
+                Create.timestamped(
+                    message(
+                        1,
+                        map("attr", "val"),
+                        getGenericRecord(payloadSchema, ImmutableMap.of("id", 1, "name", "Jack"))),
+                    message(
+                        2,
+                        map("attr", "val"),
+                        getGenericRecord(payloadSchema, ImmutableMap.of("name", "Paul", "id", 2))),
+                    message(
+                        3,
+                        map("attr", "val"),
+                        getGenericRecord(payloadSchema, ImmutableMap.of("id", 3, "name", "Bill"))),
+                    message(4, map("attr", "val"), getGenericRecord(payloadSchema, nullId)),
+                    message(3, map("attr", "val"), getGenericRecord(payloadSchema, nullValues))))
+            .apply(
+                "convert",
+                AvroPubsubMessageToRow.builder()
+                    .messageSchema(messageSchema)
+                    .useDlq(false)
+                    .build());
+
+    PAssert.that(rows.get(MAIN_TAG))
+        .containsInAnyOrder(
+            Row.withSchema(messageSchema).addValues(ts(1), 1, "Jack").build(),
+            Row.withSchema(messageSchema).addValues(ts(2), 2, "Paul").build(),
+            Row.withSchema(messageSchema).addValues(ts(3), 3, "Bill").build(),
+            Row.withSchema(messageSchema).addValues(ts(4), null, "Luke").build(),
+            Row.withSchema(messageSchema).addValues(ts(3), null, null).build());
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testSendsInvalidFlatMessageToDLQ() throws Exception {
+    Schema payloadSchema =
+        Schema.builder()
+            .addNullableField("id", FieldType.INT32)
+            .addNullableField("name", FieldType.STRING)
+            .build();
+
+    Schema invalidPayloadSchema = Schema.builder().addNullableField("id", FieldType.STRING).build();
+
+    Schema messageSchema =
+        Schema.builder()
+            .addNullableField("event_timestamp", FieldType.DATETIME)
+            .addNullableField("id", FieldType.INT32)
+            .addNullableField("name", FieldType.STRING)
+            .build();
+
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("id", null);
+    GenericRecord record = getGenericRecord(invalidPayloadSchema, fields);
+    TimestampedValue<PubsubMessage> message1 =
+        message(
+            1,
+            map("attr1", "val1"),
+            getGenericRecord(invalidPayloadSchema, ImmutableMap.of("id", "xyz")));
+    TimestampedValue<PubsubMessage> message2 = message(2, map("attr2", "val2"), record);
+
+    PCollectionTuple outputs =
+        pipeline
+            .apply(
+                "create",
+                Create.timestamped(
+                    message1,
+                    message2,
+                    message(
+                        6,
+                        map("attr", "val"),
+                        getGenericRecord(
+                            payloadSchema, ImmutableMap.of("id", 1, "name", "George"))),
+                    message(
+                        7,
+                        map("bttr", "vbl"),
+                        getGenericRecord(
+                            payloadSchema, ImmutableMap.of("id", 2, "name", "Lucas")))))
+            .apply(
+                "convert",
+                AvroPubsubMessageToRow.builder().messageSchema(messageSchema).useDlq(true).build());
+
+    PCollection<Row> rows = outputs.get(MAIN_TAG);
+    PCollection<PubsubMessage> dlqMessages = outputs.get(DLQ_TAG);
+
+    byte[] payload1 = message1.getValue().getPayload();
+    byte[] payload2 = message2.getValue().getPayload();
+
+    PAssert.that(dlqMessages)
+        .satisfies(
+            messages -> {
+              assertEquals(2, size(messages));
+              assertEquals(
+                  ImmutableSet.of(map("attr1", "val1"), map("attr2", "val2")),
+                  convertToSet(messages, m -> m.getAttributeMap()));
+
+              assertEquals(
+                  ImmutableSet.of(new String(payload1, UTF_8), new String(payload2, UTF_8)),
+                  convertToSet(messages, m -> new String(m.getPayload(), UTF_8)));
+              return null;
+            });
+
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            Row.withSchema(messageSchema).addValues(ts(6), 1, "George").build(),
+            Row.withSchema(messageSchema).addValues(ts(7), 2, "Lucas").build());
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testFlatSchemaMessageInvalidElement() throws Exception {
+    Schema messageSchema =
+        Schema.builder()
+            .addDateTimeField("event_timestamp")
+            .addInt32Field("id")
+            .addStringField("name")
+            .build();
+
+    Schema invalidPayloadSchema = Schema.builder().addNullableField("id", FieldType.STRING).build();
+
+    pipeline
+        .apply(
+            "create",
+            Create.timestamped(
+                message(
+                    1,
+                    map("attr1", "val1"),
+                    getGenericRecord(invalidPayloadSchema, ImmutableMap.of("id", "xyz")))))
+        .apply(
+            "convert",
+            JsonPubsubMessageToRow.builder()
+                .messageSchema(messageSchema)
+                .useDlq(false)
+                .useFlatSchema(true)
+                .build());
+
+    Exception exception = Assert.assertThrows(RuntimeException.class, () -> pipeline.run());
+    Assert.assertTrue(exception.getMessage().contains("Error parsing message"));
+  }
+
+  private GenericRecord getGenericRecord(Schema payloadSchema, Map<String, Object> pairs) {
+    GenericRecord record = new Record(AvroUtils.toAvroSchema(payloadSchema));
+    for (String key : pairs.keySet()) {
+      record.put(key, pairs.get(key));
+    }
+    return record;
+  }
+
+  private Map<String, String> map(String attr, String val) {
+    return ImmutableMap.of(attr, val);
+  }
+
+  private TimestampedValue<PubsubMessage> message(
+      int timestamp, Map<String, String> attributes, GenericRecord payload) throws Exception {
+
+    return TimestampedValue.of(
+        new PubsubMessage(AvroUtils.toBytes(payload), attributes), ts(timestamp));
+  }
+
+  private Instant ts(long epochMills) {
+    return new DateTime(epochMills).toInstant();
+  }
+
+  private static <V> Set<V> convertToSet(
+      Iterable<PubsubMessage> messages, Function<? super PubsubMessage, V> mapper) {
+
+    return StreamSupport.stream(messages.spliterator(), false).map(mapper).collect(toSet());
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/JsonPubsubMessageToRowTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/JsonPubsubMessageToRowTest.java
@@ -49,7 +49,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /** Unit tests for {@link PubsubMessageToRow}. */
-public class PubsubMessageToRowTest implements Serializable {
+public class JsonPubsubMessageToRowTest implements Serializable {
 
   @Rule public transient TestPipeline pipeline = TestPipeline.create();
 
@@ -80,7 +80,7 @@ public class PubsubMessageToRowTest implements Serializable {
                     message(4, map("dttr", "vdl"), "{ \"name\" : null, \"id\" : null }")))
             .apply(
                 "convert",
-                PubsubMessageToRow.builder()
+                JsonPubsubMessageToRow.builder()
                     .messageSchema(messageSchema)
                     .useDlq(false)
                     .useFlatSchema(false)
@@ -129,7 +129,7 @@ public class PubsubMessageToRowTest implements Serializable {
                     message(4, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }")))
             .apply(
                 "convert",
-                PubsubMessageToRow.builder()
+                JsonPubsubMessageToRow.builder()
                     .messageSchema(messageSchema)
                     .useDlq(true)
                     .useFlatSchema(false)
@@ -185,7 +185,7 @@ public class PubsubMessageToRowTest implements Serializable {
                     message(4, map("dttr", "vdl"), "{ \"name\" : null, \"id\" : null }")))
             .apply(
                 "convert",
-                PubsubMessageToRow.builder()
+                JsonPubsubMessageToRow.builder()
                     .messageSchema(messageSchema)
                     .useDlq(false)
                     .useFlatSchema(true)
@@ -232,7 +232,7 @@ public class PubsubMessageToRowTest implements Serializable {
                     message(4, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }")))
             .apply(
                 "convert",
-                PubsubMessageToRow.builder()
+                JsonPubsubMessageToRow.builder()
                     .messageSchema(messageSchema)
                     .useDlq(true)
                     .useFlatSchema(true)
@@ -284,7 +284,7 @@ public class PubsubMessageToRowTest implements Serializable {
                 message(2, map("attr1", "val1"), "{ \"invalid1\" : \"sdfsd\" }")))
         .apply(
             "convert",
-            PubsubMessageToRow.builder()
+            JsonPubsubMessageToRow.builder()
                 .messageSchema(messageSchema)
                 .useDlq(false)
                 .useFlatSchema(true)
@@ -313,7 +313,7 @@ public class PubsubMessageToRowTest implements Serializable {
                 message(2, map("attr1", "val1"), "{ \"invalid1\" : \"sdfsd\" }")))
         .apply(
             "convert",
-            PubsubMessageToRow.builder()
+            JsonPubsubMessageToRow.builder()
                 .messageSchema(messageSchema)
                 .useDlq(false)
                 .useFlatSchema(false)

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/RowToAvroPubsubMessageTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/RowToAvroPubsubMessageTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubTableProvider.PubsubIOTableConfiguration;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link
+ * org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.RowToAvroPubsubMessage}.
+ */
+public class RowToAvroPubsubMessageTest {
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
+
+  private static final String EVENT_TIMESTAMP = "event_timestamp";
+  private static final String TOPIC = "test";
+
+  private static final Schema beamSchema =
+      Schema.builder()
+          .addDateTimeField(EVENT_TIMESTAMP)
+          .addInt32Field("id")
+          .addNullableField("name", FieldType.STRING)
+          .build();
+
+  private static final Schema payloadSchema =
+      Schema.builder().addInt32Field("id").addNullableField("name", FieldType.STRING).build();
+
+  @Test
+  public void testConvertsRowToPubsubMessage() throws Exception {
+    PCollection<PubsubMessage> flatMessages =
+        pipeline
+            .apply(
+                "create",
+                Create.of(
+                    ImmutableList.of(
+                        Row.withSchema(beamSchema).addValues(ts(5), 1, "Jack").build(),
+                        Row.withSchema(beamSchema).addValues(ts(6), 3, "Paul").build(),
+                        Row.withSchema(beamSchema).addValues(ts(7), 5, null).build())))
+            .setRowSchema(beamSchema)
+            .apply(
+                RowToAvroPubsubMessage.fromTableConfig(
+                    PubsubIOTableConfiguration.builder()
+                        .setSchema(beamSchema)
+                        .setTopic(TOPIC)
+                        .setUseFlatSchema(true)
+                        .build()));
+
+    String payload1 =
+        new String(
+            AvroUtils.toBytes(
+                getGenericRecord(payloadSchema, ImmutableMap.of("id", 1, "name", "Jack"))),
+            UTF_8);
+    String payload2 =
+        new String(
+            AvroUtils.toBytes(
+                getGenericRecord(payloadSchema, ImmutableMap.of("id", 3, "name", "Paul"))),
+            UTF_8);
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("id", 5);
+    fields.put("name", null);
+    String payload3 = new String(AvroUtils.toBytes(getGenericRecord(payloadSchema, fields)), UTF_8);
+
+    PAssert.that(flatMessages)
+        .satisfies(
+            messages -> {
+              assertEquals(
+                  ImmutableSet.of(payload1, payload2, payload3),
+                  convertToSet(messages, message -> new String(message.getPayload(), UTF_8)));
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  // Construct an generic record.
+  private GenericRecord getGenericRecord(Schema payloadSchema, Map<String, Object> pairs) {
+    GenericRecord record = new Record(AvroUtils.toAvroSchema(payloadSchema));
+    for (String key : pairs.keySet()) {
+      record.put(key, pairs.get(key));
+    }
+    return record;
+  }
+
+  private Instant ts(long epochMills) {
+    return new DateTime(epochMills).toInstant();
+  }
+
+  private static <V> Set<V> convertToSet(
+      Iterable<PubsubMessage> messages, Function<? super PubsubMessage, V> mapper) {
+    return StreamSupport.stream(messages.spliterator(), false).map(mapper).collect(toSet());
+  }
+}


### PR DESCRIPTION
The PR introcduces AVRO support for PubsubTable.

The initial attempt is to make avro format a parity with the existing json format.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
