### PR TITLE
[BEAM-8335] Revert PR #9953

### DIFF
--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -80,7 +80,7 @@ class SwitchingDirectRunner(PipelineRunner):
     from apache_beam.pipeline import PipelineVisitor
     from apache_beam.runners.dataflow.native_io.iobase import NativeSource
     from apache_beam.runners.dataflow.native_io.iobase import _NativeWrite
-    from apache_beam.testing.test_stream import _TestStream
+    from apache_beam.testing.test_stream import TestStream
 
     class _FnApiRunnerSupportVisitor(PipelineVisitor):
       """Visitor determining if a Pipeline can be run on the FnApiRunner."""
@@ -93,7 +93,7 @@ class SwitchingDirectRunner(PipelineRunner):
       def visit_transform(self, applied_ptransform):
         transform = applied_ptransform.transform
         # The FnApiRunner does not support streaming execution.
-        if isinstance(transform, _TestStream):
+        if isinstance(transform, TestStream):
           self.supported_by_fnapi_runner = False
         # The FnApiRunner does not support reads from NativeSources.
         if (isinstance(transform, beam.io.Read) and
@@ -360,7 +360,7 @@ class BundleBasedDirectRunner(PipelineRunner):
     from apache_beam.runners.direct.executor import Executor
     from apache_beam.runners.direct.transform_evaluator import \
       TransformEvaluatorRegistry
-    from apache_beam.testing.test_stream import _TestStream
+    from apache_beam.testing.test_stream import TestStream
 
     # Performing configured PTransform overrides.
     pipeline.replace_all(_get_transform_overrides(options))
@@ -373,7 +373,7 @@ class BundleBasedDirectRunner(PipelineRunner):
         self.uses_test_stream = False
 
       def visit_transform(self, applied_ptransform):
-        if isinstance(applied_ptransform.transform, _TestStream):
+        if isinstance(applied_ptransform.transform, TestStream):
           self.uses_test_stream = True
 
     visitor = _TestStreamUsageVisitor()

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -228,7 +228,7 @@ class TestStream(PTransform):
     self._add(ElementEvent(timestamped_values))
     return self
 
-  def advance_watermark_to(self, new_watermark):
+  def advance_watermark_to(self, new_watermark, tag=None):
     """Advance the watermark to a given Unix timestamp.
 
     The Unix timestamp value used must be later than the previous watermark
@@ -238,9 +238,9 @@ class TestStream(PTransform):
     self._add(WatermarkEvent(new_watermark))
     return self
 
-  def advance_watermark_to_infinity(self):
+  def advance_watermark_to_infinity(self, tag=None):
     """Advance the watermark to the end of time, completing this TestStream."""
-    self.advance_watermark_to(timestamp.MAX_TIMESTAMP)
+    self.advance_watermark_to(timestamp.MAX_TIMESTAMP, tag)
     return self
 
   def advance_processing_time(self, advance_by):

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -201,7 +201,7 @@ class TestStream(PTransform):
       raise ValueError('Unknown event: %s' % event)
     self.events.append(event)
 
-  def add_elements(self, elements):
+  def add_elements(self, elements, tag=None, event_timestamp=None):
     """Add elements to the TestStream.
 
     Elements added to the TestStream will be produced during pipeline execution.

--- a/sdks/python/apache_beam/testing/test_stream_test.py
+++ b/sdks/python/apache_beam/testing/test_stream_test.py
@@ -55,7 +55,7 @@ class TestStreamTest(unittest.TestCase):
                    .add_elements(['d'])
                    .advance_watermark_to_infinity())
     self.assertEqual(
-        test_stream._events,
+        test_stream.events,
         [
             WatermarkEvent(0),
             ElementEvent([
@@ -124,136 +124,6 @@ class TestStreamTest(unittest.TestCase):
         ('e', timestamp.Timestamp(20)),
         ('late', timestamp.Timestamp(12)),
         ('last', timestamp.Timestamp(310)),]))
-
-    p.run()
-
-  def test_multiple_outputs(self):
-    """Tests that the TestStream supports emitting to multiple PCollections."""
-    letters_elements = [
-        TimestampedValue('a', 6),
-        TimestampedValue('b', 7),
-        TimestampedValue('c', 8),
-    ]
-    numbers_elements = [
-        TimestampedValue('1', 11),
-        TimestampedValue('2', 12),
-        TimestampedValue('3', 13),
-    ]
-    test_stream = (TestStream()
-                   .advance_watermark_to(5, tag='letters')
-                   .add_elements(letters_elements, tag='letters')
-                   .advance_watermark_to(10, tag='numbers')
-                   .add_elements(numbers_elements, tag='numbers'))
-
-    class RecordFn(beam.DoFn):
-      def process(self, element=beam.DoFn.ElementParam,
-                  timestamp=beam.DoFn.TimestampParam):
-        yield (element, timestamp)
-
-    options = StandardOptions(streaming=True)
-    p = TestPipeline(options=options)
-
-    main = p | test_stream
-    letters = main['letters'] | 'record letters' >> beam.ParDo(RecordFn())
-    numbers = main['numbers'] | 'record numbers' >> beam.ParDo(RecordFn())
-
-    assert_that(letters, equal_to([
-        ('a', Timestamp(6)),
-        ('b', Timestamp(7)),
-        ('c', Timestamp(8))]), label='assert letters')
-
-    assert_that(numbers, equal_to([
-        ('1', Timestamp(11)),
-        ('2', Timestamp(12)),
-        ('3', Timestamp(13))]), label='assert numbers')
-
-    p.run()
-
-  def test_multiple_outputs_with_watermark_advancement(self):
-    """Tests that the TestStream can independently control output watermarks."""
-
-    # Purposely set the watermark of numbers to 20 then letters to 5 to test
-    # that the watermark advancement is per PCollection.
-    #
-    # This creates two PCollections, (a, b, c) and (1, 2, 3). These will be
-    # emitted at different times so that they will have different windows. The
-    # watermark advancement is checked by checking their windows. If the
-    # watermark does not advance, then the windows will be [-inf, -inf). If the
-    # windows do not advance separately, then the PCollections will both
-    # windowed in [15, 30).
-    letters_elements = [
-        TimestampedValue('a', 6),
-        TimestampedValue('b', 7),
-        TimestampedValue('c', 8),
-    ]
-    numbers_elements = [
-        TimestampedValue('1', 21),
-        TimestampedValue('2', 22),
-        TimestampedValue('3', 23),
-    ]
-    test_stream = (TestStream()
-                   .advance_watermark_to(0, tag='letters')
-                   .advance_watermark_to(0, tag='numbers')
-                   .advance_watermark_to(20, tag='numbers')
-                   .advance_watermark_to(5, tag='letters')
-                   .add_elements(letters_elements, tag='letters')
-                   .advance_watermark_to(10, tag='letters')
-                   .add_elements(numbers_elements, tag='numbers')
-                   .advance_watermark_to(30, tag='numbers'))
-
-    options = StandardOptions(streaming=True)
-    p = TestPipeline(options=options)
-
-    main = p | test_stream
-
-    # Use an AfterWatermark trigger with an early firing to test that the
-    # watermark is advancing properly and that the element is being emitted in
-    # the correct window.
-    letters = (main['letters']
-               | 'letter windows' >> beam.WindowInto(
-                   FixedWindows(15),
-                   trigger=trigger.AfterWatermark(early=trigger.AfterCount(1)),
-                   accumulation_mode=trigger.AccumulationMode.DISCARDING)
-               | 'letter with key' >> beam.Map(lambda x: ('k', x))
-               | 'letter gbk' >> beam.GroupByKey())
-
-    numbers = (main['numbers']
-               | 'number windows' >> beam.WindowInto(
-                   FixedWindows(15),
-                   trigger=trigger.AfterWatermark(early=trigger.AfterCount(1)),
-                   accumulation_mode=trigger.AccumulationMode.DISCARDING)
-               | 'number with key' >> beam.Map(lambda x: ('k', x))
-               | 'number gbk' >> beam.GroupByKey())
-
-    # The letters were emitted when the watermark was at 5, thus we expect to
-    # see the elements in the [0, 15) window. We used an early trigger to make
-    # sure that the ON_TIME empty pane was also emitted with a TestStream.
-    # This pane has no data because of the early trigger causes the elements to
-    # fire before the end of the window and because the accumulation mode
-    # discards any data after the trigger fired.
-    expected_letters = {
-        window.IntervalWindow(0, 15): [
-            ('k', ['a', 'b', 'c']),
-            ('k', []),
-        ],
-    }
-
-    # Same here, except the numbers were emitted at watermark = 20, thus they
-    # are in the [15, 30) window.
-    expected_numbers = {
-        window.IntervalWindow(15, 30): [
-            ('k', ['1', '2', '3']),
-            ('k', []),
-        ],
-    }
-    assert_that(
-        letters,
-        equal_to_per_window(expected_letters),
-        label='letters assert per window')
-    assert_that(
-        numbers,
-        equal_to_per_window(expected_numbers),
-        label='numbers assert per window')
 
     p.run()
 


### PR DESCRIPTION
Result in test failures.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
