### PR TITLE
[BEAM-9041, BEAM-9042] SchemaCoder equals should not rely on from/toRowFunction equality

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
@@ -102,7 +102,8 @@ public class SchemaCoder<T> extends CustomCoder<T> {
 
   /**
    * Returns a {@link SchemaCoder} for the specified class. If no schema is registered for this
-   * class, then throws {@link NoSuchSchemaException}.
+   * class, then throws {@link NoSuchSchemaException}. The parameter functions to convert from and
+   * to Rows <b>must</b> implement the equals contract.
    */
   public static <T> SchemaCoder<T> of(
       Schema schema,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -504,7 +504,10 @@ public class AvroUtils {
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
       final String avroSchemaAsString = (String) in.readObject();
-      avroSchema = new org.apache.avro.Schema.Parser().parse(avroSchemaAsString);
+      avroSchema =
+          (avroSchemaAsString == null)
+              ? null
+              : new org.apache.avro.Schema.Parser().parse(avroSchemaAsString);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -20,6 +20,9 @@ package org.apache.beam.sdk.schemas.utils;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -466,7 +469,7 @@ public class AvroUtils {
   }
 
   private static class RowToGenericRecordFn implements SerializableFunction<Row, GenericRecord> {
-    private final org.apache.avro.Schema avroSchema;
+    private transient org.apache.avro.Schema avroSchema;
 
     RowToGenericRecordFn(@Nullable org.apache.avro.Schema avroSchema) {
       this.avroSchema = avroSchema;
@@ -492,6 +495,16 @@ public class AvroUtils {
     @Override
     public int hashCode() {
       return Objects.hash(avroSchema);
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+      final String avroSchemaAsString = (avroSchema == null) ? null : avroSchema.toString();
+      out.writeObject(avroSchemaAsString);
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+      final String avroSchemaAsString = (String) in.readObject();
+      avroSchema = new org.apache.avro.Schema.Parser().parse(avroSchemaAsString);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -422,7 +423,37 @@ public class AvroUtils {
    */
   public static SerializableFunction<GenericRecord, Row> getGenericRecordToRowFunction(
       @Nullable Schema schema) {
-    return g -> toBeamRowStrict(g, schema);
+    return new GenericRecordToRowFn(schema);
+  }
+
+  private static class GenericRecordToRowFn implements SerializableFunction<GenericRecord, Row> {
+    private final Schema schema;
+
+    GenericRecordToRowFn(Schema schema) {
+      this.schema = schema;
+    }
+
+    @Override
+    public Row apply(GenericRecord input) {
+      return toBeamRowStrict(input, schema);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (other == null || getClass() != other.getClass()) {
+        return false;
+      }
+      GenericRecordToRowFn that = (GenericRecordToRowFn) other;
+      return schema.equals(that.schema);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(schema);
+    }
   }
 
   /**
@@ -431,7 +462,37 @@ public class AvroUtils {
    */
   public static SerializableFunction<Row, GenericRecord> getRowToGenericRecordFunction(
       @Nullable org.apache.avro.Schema avroSchema) {
-    return g -> toGenericRecord(g, avroSchema);
+    return new RowToGenericRecordFn(avroSchema);
+  }
+
+  private static class RowToGenericRecordFn implements SerializableFunction<Row, GenericRecord> {
+    private final org.apache.avro.Schema avroSchema;
+
+    RowToGenericRecordFn(@Nullable org.apache.avro.Schema avroSchema) {
+      this.avroSchema = avroSchema;
+    }
+
+    @Override
+    public GenericRecord apply(Row input) {
+      return toGenericRecord(input, avroSchema);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (other == null || getClass() != other.getClass()) {
+        return false;
+      }
+      RowToGenericRecordFn that = (RowToGenericRecordFn) other;
+      return avroSchema.equals(that.avroSchema);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(avroSchema);
+    }
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/AvroUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/AvroUtilsTest.java
@@ -48,6 +48,7 @@ import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.utils.AvroGenerators.RecordSchemaGenerator;
 import org.apache.beam.sdk.schemas.utils.AvroUtils.TypeWithNullability;
+import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
@@ -533,6 +534,7 @@ public class AvroUtilsTest {
     assertFalse(records.hasSchema());
     records.setCoder(AvroUtils.schemaCoder(schema));
     assertTrue(records.hasSchema());
+    CoderProperties.coderSerializable(records.getCoder());
 
     AvroGeneratedUser user = new AvroGeneratedUser("foo", 42, "green");
     PCollection<AvroGeneratedUser> users =
@@ -540,6 +542,7 @@ public class AvroUtilsTest {
     assertFalse(users.hasSchema());
     users.setCoder(AvroUtils.schemaCoder((AvroCoder<AvroGeneratedUser>) users.getCoder()));
     assertTrue(users.hasSchema());
+    CoderProperties.coderSerializable(users.getCoder());
   }
 
   public static ContainsField containsField(Function<org.apache.avro.Schema, Boolean> predicate) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/AvroUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/AvroUtilsTest.java
@@ -50,6 +50,7 @@ import org.apache.beam.sdk.schemas.utils.AvroGenerators.RecordSchemaGenerator;
 import org.apache.beam.sdk.schemas.utils.AvroUtils.TypeWithNullability;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -502,6 +503,12 @@ public class AvroUtilsTest {
   }
 
   @Test
+  public void testRowToGenericRecordFunction() {
+    SerializableUtils.ensureSerializable(AvroUtils.getRowToGenericRecordFunction(NULL_SCHEMA));
+    SerializableUtils.ensureSerializable(AvroUtils.getRowToGenericRecordFunction(null));
+  }
+
+  @Test
   public void testGenericRecordToBeamRow() {
     GenericRecord genericRecord = getGenericRecord();
     Row row = AvroUtils.toBeamRowStrict(getGenericRecord(), null);
@@ -511,6 +518,12 @@ public class AvroUtilsTest {
     genericRecord.put("timestampMillis", new DateTime(genericRecord.get("timestampMillis")));
     row = AvroUtils.toBeamRowStrict(getGenericRecord(), null);
     assertEquals(getBeamRow(), row);
+  }
+
+  @Test
+  public void testGenericRecordToRowFunction() {
+    SerializableUtils.ensureSerializable(AvroUtils.getGenericRecordToRowFunction(Schema.of()));
+    SerializableUtils.ensureSerializable(AvroUtils.getGenericRecordToRowFunction(null));
   }
 
   @Test


### PR DESCRIPTION
This PR fixes both issues because (1) one fix depends on the other, and (2) to make it easier to validate/cherry pick into 2.18.0's branch.

BEAM-9041: Don't rely on equality for the from/to functions in `SchemaCoder` because nobody implements equals on `SerializableFunction`. I tried to do this with byte equality, maybe there is a better way to do it but I could not think of another.
BEAM-9042: Since Avro's `Schema` class is not `Serializable` I made it `transient`. Another approach could have been to transform the Schema into a String (not sure if this is needed but I can change it if you think it is worth).

R: @TheNeuralBit 