### PR TITLE
[BEAM-8335] Add the ReverseTestStream

### DIFF
--- a/sdks/python/apache_beam/runners/direct/clock.py
+++ b/sdks/python/apache_beam/runners/direct/clock.py
@@ -26,6 +26,8 @@ from __future__ import absolute_import
 import time
 from builtins import object
 
+from apache_beam.utils.timestamp import Timestamp
+
 
 class Clock(object):
   def time(self):
@@ -44,11 +46,11 @@ class RealClock(object):
 
 class TestClock(object):
   """Clock used for Testing"""
-  def __init__(self, current_time=0):
-    self._current_time = current_time
+  def __init__(self, current_time=None):
+    self._current_time = current_time if current_time else Timestamp()
 
   def time(self):
-    return self._current_time
+    return float(self._current_time)
 
   def advance_time(self, advance_by):
     self._current_time += advance_by

--- a/sdks/python/apache_beam/runners/direct/test_stream_impl.py
+++ b/sdks/python/apache_beam/runners/direct/test_stream_impl.py
@@ -136,6 +136,7 @@ class _TestStream(PTransform):
     self.coder = coder
     self._raw_events = events
     self._events = self._add_watermark_advancements(output_tags, events)
+    self.output_tags = output_tags
 
   def _watermark_starts(self, output_tags):
     """Sentinel values to hold the watermark of outputs to -inf.

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -26,19 +26,30 @@ from __future__ import absolute_import
 from abc import ABCMeta
 from abc import abstractmethod
 from builtins import object
+from enum import Enum
 from functools import total_ordering
 
 from future.utils import with_metaclass
 
+import apache_beam as beam
 from apache_beam import coders
 from apache_beam import pvalue
 from apache_beam.portability import common_urns
 from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.portability.api.beam_interactive_api_pb2 import TestStreamFileHeader
+from apache_beam.portability.api.beam_interactive_api_pb2 import TestStreamFileRecord
+from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 from apache_beam.transforms import PTransform
 from apache_beam.transforms import core
 from apache_beam.transforms import window
+from apache_beam.transforms.timeutil import TimeDomain
+from apache_beam.transforms.userstate import TimerSpec
+from apache_beam.transforms.userstate import on_timer
 from apache_beam.transforms.window import TimestampedValue
 from apache_beam.utils import timestamp
+from apache_beam.utils.timestamp import MIN_TIMESTAMP
+from apache_beam.utils.timestamp import Duration
+from apache_beam.utils.timestamp import Timestamp
 from apache_beam.utils.windowed_value import WindowedValue
 
 __all__ = [
@@ -107,6 +118,9 @@ class ElementEvent(Event):
     self.tag = tag
 
   def __eq__(self, other):
+    if not isinstance(other, ElementEvent):
+      return False
+
     return (
         self.timestamped_values == other.timestamped_values and
         self.tag == other.tag)
@@ -115,6 +129,9 @@ class ElementEvent(Event):
     return hash(self.timestamped_values)
 
   def __lt__(self, other):
+    if not isinstance(other, ElementEvent):
+      raise TypeError
+
     return self.timestamped_values < other.timestamped_values
 
   def to_runner_api(self, element_coder):
@@ -129,6 +146,11 @@ class ElementEvent(Event):
             ],
             tag=tag))
 
+  def __repr__(self):
+    return 'ElementEvent: <{}, {}>'.format([(e.value, e.timestamp)
+                                            for e in self.timestamped_values],
+                                           self.tag)
+
 
 class WatermarkEvent(Event):
   """Watermark-advancing test stream event."""
@@ -137,12 +159,18 @@ class WatermarkEvent(Event):
     self.tag = tag
 
   def __eq__(self, other):
+    if not isinstance(other, WatermarkEvent):
+      return False
+
     return self.new_watermark == other.new_watermark and self.tag == other.tag
 
   def __hash__(self):
     return hash(str(self.new_watermark) + str(self.tag))
 
   def __lt__(self, other):
+    if not isinstance(other, WatermarkEvent):
+      raise TypeError
+
     return self.new_watermark < other.new_watermark
 
   def to_runner_api(self, unused_element_coder):
@@ -156,25 +184,37 @@ class WatermarkEvent(Event):
         AdvanceWatermark(
             new_watermark=self.new_watermark.micros // 1000, tag=tag))
 
+  def __repr__(self):
+    return 'WatermarkEvent: <{}, {}>'.format(self.new_watermark, self.tag)
+
 
 class ProcessingTimeEvent(Event):
   """Processing time-advancing test stream event."""
   def __init__(self, advance_by):
-    self.advance_by = timestamp.Duration.of(advance_by)
+    self.advance_by = Duration.of(advance_by)
 
   def __eq__(self, other):
+    if not isinstance(other, ProcessingTimeEvent):
+      return False
+
     return self.advance_by == other.advance_by
 
   def __hash__(self):
     return hash(self.advance_by)
 
   def __lt__(self, other):
+    if not isinstance(other, ProcessingTimeEvent):
+      raise TypeError
+
     return self.advance_by < other.advance_by
 
   def to_runner_api(self, unused_element_coder):
     return beam_runner_api_pb2.TestStreamPayload.Event(
         processing_time_event=beam_runner_api_pb2.TestStreamPayload.Event.
         AdvanceProcessingTime(advance_duration=self.advance_by.micros // 1000))
+
+  def __repr__(self):
+    return 'ProcessingTimeEvent: <{}>'.format(self.advance_by)
 
 
 class TestStream(PTransform):
@@ -308,6 +348,8 @@ class TestStream(PTransform):
     return self
 
   def to_runner_api_parameter(self, context):
+    # Sort the output tags so that the order is deterministic and we are able
+    # to test equality on a roundtrip through the to/from proto apis.
     return (
         common_urns.primitives.TEST_STREAM.urn,
         beam_runner_api_pb2.TestStreamPayload(
@@ -326,3 +368,299 @@ class TestStream(PTransform):
         coder=coder,
         events=[Event.from_runner_api(e, coder) for e in payload.events],
         output_tags=output_tags)
+
+
+class TimingInfo(object):
+  def __init__(self, processing_time, watermark):
+    self._processing_time = timestamp.Timestamp.of(processing_time)
+    self._watermark = timestamp.Timestamp.of(watermark)
+
+  @property
+  def processing_time(self):
+    return self._processing_time
+
+  @property
+  def watermark(self):
+    return self._watermark
+
+  def __repr__(self):
+    return '({}, {})'.format(self.processing_time, self.watermark)
+
+
+class PairWithTiming(PTransform):
+  """Pairs the input element with timing information.
+
+  Input: element; output: KV(element, timing information)
+  Where timing information := (processing time, watermark)
+
+  This is used in the ReverseTestStream implementation to replay watermark
+  advancements.
+  """
+
+  URN = "beam:transform:pair_with_timing:v1"
+
+  def expand(self, pcoll):
+    return pvalue.PCollection.from_(pcoll)
+
+
+class OutputFormat(Enum):
+  TEST_STREAM_EVENTS = 1
+  TEST_STREAM_FILE_RECORDS = 2
+  SERIALIZED_TEST_STREAM_FILE_RECORDS = 3
+
+
+class ReverseTestStream(PTransform):
+  """A Transform that can create TestStream events from a stream of elements.
+
+  This currently assumes that this the pipeline being run on a single machine
+  and elements come in order and are outputted in the same order that they came
+  in.
+  """
+  def __init__(
+      self, sample_resolution_sec, output_tag, coder=None, output_format=None):
+    self._sample_resolution_sec = sample_resolution_sec
+    self._output_tag = output_tag
+    self._output_format = output_format if output_format \
+                          else OutputFormat.TEST_STREAM_EVENTS
+    self._coder = coder if coder else beam.coders.FastPrimitivesCoder()
+
+  def expand(self, pcoll):
+    ret = (
+        pcoll
+        | beam.WindowInto(beam.window.GlobalWindows())
+
+        # First get the initial timing information. This will be used to start
+        # the periodic timers which will generate processing time and watermark
+        # advancements every `sample_resolution_sec`.
+        | 'initial timing' >> PairWithTiming()
+
+        # Next, map every element to the same key so that only a single timer is
+        # started for this given ReverseTestStream.
+        | 'first key' >> beam.Map(lambda x: (0, x))
+
+        # Next, pass-through each element which will be paired with its timing
+        # info in the next step. Also, start the periodic timers. We use timers
+        # in this situation to capture watermark advancements that occur when
+        # there are no elements being produced upstream.
+        | beam.ParDo(
+            _TimingEventGenerator(
+                output_tag=self._output_tag,
+                sample_resolution_sec=self._sample_resolution_sec))
+
+        # Next, retrieve the timing information for watermark events that were
+        # generated in the previous step. This is because elements generated
+        # through the timers don't have their timing information yet.
+        | 'timing info for watermarks' >> PairWithTiming()
+
+        # Re-key to the same key to keep global state.
+        | 'second key' >> beam.Map(lambda x: (0, x))
+
+        # Format the events properly.
+        | beam.ParDo(_TestStreamFormatter(self._coder, self._output_format)))
+
+    if self._output_format == OutputFormat.SERIALIZED_TEST_STREAM_FILE_RECORDS:
+
+      def serializer(e):
+        return e.SerializeToString()
+
+      ret = ret | 'serializer' >> beam.Map(serializer)
+
+    return ret
+
+
+class _TimingEventGenerator(beam.DoFn):
+  """Generates ProcessingTimeEvents and WatermarkEvents at a regular cadence.
+
+  The runner keeps the state of the clock (which may be faked) and the
+  watermarks, which are inaccessible to SDKs. This DoFn generates
+  ProcessingTimeEvents and WatermarkEvents at a specified sampling rate to
+  capture any clock or watermark advancements between elements.
+  """
+
+  # Used to return the initial timing information.
+  EXECUTE_ONCE_STATE = beam.transforms.userstate.BagStateSpec(
+      name='execute_once_state', coder=beam.coders.FastPrimitivesCoder())
+
+  # A processing time timer in an infinite loop that generates the events that
+  # will be paired with the TimingInfo from the runner.
+  TIMING_SAMPLER = TimerSpec('timing_sampler', TimeDomain.REAL_TIME)
+
+  def __init__(self, output_tag, sample_resolution_sec=0.1):
+    self._output_tag = output_tag
+    self._sample_resolution_sec = sample_resolution_sec
+
+  @on_timer(TIMING_SAMPLER)
+  def on_timing_sampler(
+      self,
+      timestamp=beam.DoFn.TimestampParam,
+      window=beam.DoFn.WindowParam,
+      timing_sampler=beam.DoFn.TimerParam(TIMING_SAMPLER)):
+    """Yields an unbounded stream of ProcessingTimeEvents and WatermarkEvents.
+
+    The returned events will be paired with the TimingInfo. This loop's only
+    purpose is to generate these events even when there are no elements.
+    """
+    next_sample_time = (timestamp.micros * 1e-6) + self._sample_resolution_sec
+    timing_sampler.set(next_sample_time)
+
+    # Generate two events, the delta since the last sample and a place-holder
+    # WatermarkEvent. This is a placeholder because we can't otherwise add the
+    # watermark from the runner to the event.
+    yield ProcessingTimeEvent(self._sample_resolution_sec)
+    yield WatermarkEvent(MIN_TIMESTAMP)
+
+  def process(
+      self,
+      e,
+      timestamp=beam.DoFn.TimestampParam,
+      window=beam.DoFn.WindowParam,
+      timing_sampler=beam.DoFn.TimerParam(TIMING_SAMPLER),
+      execute_once_state=beam.DoFn.StateParam(EXECUTE_ONCE_STATE)):
+
+    _, (element, timing_info) = e
+
+    # Only set the timers once and only send the header once.
+    first_time = next(execute_once_state.read(), True)
+    if first_time:
+      # Generate the initial timing events.
+      execute_once_state.add(False)
+      now_sec = timing_info.processing_time.micros * 1e-6
+      timing_sampler.set(now_sec + self._sample_resolution_sec)
+
+      # Here we capture the initial time offset and initial watermark. This is
+      # where we emit the TestStreamFileHeader.
+      yield TestStreamFileHeader(tag=self._output_tag)
+      yield ProcessingTimeEvent(
+          Duration(micros=timing_info.processing_time.micros))
+      yield WatermarkEvent(MIN_TIMESTAMP)
+    yield element
+
+
+class _TestStreamFormatter(beam.DoFn):
+  """Formats the events to the specified output format.
+  """
+
+  # In order to generate the processing time deltas, we need to keep track of
+  # the previous clock time we got from the runner.
+  PREV_SAMPLE_TIME_STATE = beam.transforms.userstate.BagStateSpec(
+      name='prev_sample_time_state', coder=beam.coders.FastPrimitivesCoder())
+
+  def __init__(self, coder, output_format):
+    self._coder = coder
+    self._output_format = output_format
+
+  def start_bundle(self):
+    self.elements = []
+    self.timing_events = []
+    self.header = None
+
+  def finish_bundle(self):
+    """Outputs all the buffered elements.
+    """
+    if self._output_format == OutputFormat.TEST_STREAM_EVENTS:
+      return self._output_as_events()
+    return self._output_as_records()
+
+  def process(
+      self,
+      e,
+      timestamp=beam.DoFn.TimestampParam,
+      prev_sample_time_state=beam.DoFn.StateParam(PREV_SAMPLE_TIME_STATE)):
+    """Buffers elements until the end of the bundle.
+
+    This buffers elements instead of emitting them immediately to keep elements
+    that come in the same bundle to be outputted in the same bundle.
+    """
+    _, (element, timing_info) = e
+
+    if isinstance(element, TestStreamFileHeader):
+      self.header = element
+    elif isinstance(element, WatermarkEvent):
+      # WatermarkEvents come in with a watermark of MIN_TIMESTAMP. Fill in the
+      # correct watermark from the runner here.
+      element.new_watermark = timing_info.watermark.micros
+      if element not in self.timing_events:
+        self.timing_events.append(element)
+
+    elif isinstance(element, ProcessingTimeEvent):
+      # Because the runner holds the clock, calculate the processing time delta
+      # here. The TestStream may have faked out the clock, and thus the
+      # delta calculated in the SDK with time.time() will be wrong.
+      prev_sample = next(prev_sample_time_state.read(), Timestamp())
+      prev_sample_time_state.clear()
+      prev_sample_time_state.add(timing_info.processing_time)
+
+      advance_by = timing_info.processing_time - prev_sample
+
+      element.advance_by = advance_by
+      self.timing_events.append(element)
+    else:
+      self.elements.append(TimestampedValue(element, timestamp))
+
+  def _output_as_events(self):
+    """Outputs buffered elements as TestStream events.
+    """
+    if self.timing_events:
+      yield WindowedValue(
+          self.timing_events, timestamp=0, windows=[beam.window.GlobalWindow()])
+
+    if self.elements:
+      yield WindowedValue([ElementEvent(self.elements)],
+                          timestamp=0,
+                          windows=[beam.window.GlobalWindow()])
+
+  def _output_as_records(self):
+    """Outputs buffered elements as TestStreamFileRecords.
+    """
+    if self.header:
+      yield WindowedValue(
+          self.header, timestamp=0, windows=[beam.window.GlobalWindow()])
+
+    if self.timing_events:
+      timing_events = self._timing_events_to_records(self.timing_events)
+      for r in timing_events:
+        yield WindowedValue(
+            r, timestamp=0, windows=[beam.window.GlobalWindow()])
+
+    if self.elements:
+      elements = self._elements_to_record(self.elements)
+      yield WindowedValue(
+          elements, timestamp=0, windows=[beam.window.GlobalWindow()])
+
+  def _timing_events_to_records(self, timing_events):
+    """Returns given timing_events as TestStreamFileRecords.
+    """
+    records = []
+    for e in self.timing_events:
+      if isinstance(e, ProcessingTimeEvent):
+        processing_time_event = TestStreamPayload.Event.AdvanceProcessingTime(
+            advance_duration=e.advance_by.micros)
+        records.append(
+            TestStreamFileRecord(
+                recorded_event=TestStreamPayload.Event(
+                    processing_time_event=processing_time_event)))
+
+      elif isinstance(e, WatermarkEvent):
+        watermark_event = TestStreamPayload.Event.AdvanceWatermark(
+            new_watermark=int(e.new_watermark))
+        records.append(
+            TestStreamFileRecord(
+                recorded_event=TestStreamPayload.Event(
+                    watermark_event=watermark_event)))
+
+    return records
+
+  def _elements_to_record(self, elements):
+    """Returns elements as TestStreamFileRecords.
+    """
+    elements = []
+    for tv in self.elements:
+      element_timestamp = tv.timestamp.micros
+      element = beam_runner_api_pb2.TestStreamPayload.TimestampedElement(
+          encoded_element=self._coder.encode(tv.value),
+          timestamp=element_timestamp)
+      elements.append(element)
+
+    element_event = TestStreamPayload.Event.AddElements(elements=elements)
+    return TestStreamFileRecord(
+        recorded_event=TestStreamPayload.Event(element_event=element_event))


### PR DESCRIPTION
This adds the ReverseTestStream capabilities that takes in a stream of elements and emits the correct TestStreamPayloads to replay the stream. This relies on runners implementing a new primitive called the "PairWithTiming" transform. This takes an element as an input and outputs a new tuple of (element, timing information). Timing information contains the processing time timestamp and watermark.

#interactive
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
