### PR TITLE
[BEAM-9062] Improve assertion error for equal_to

### DIFF
--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -179,11 +179,11 @@ def equal_to(expected):
           expected_list.remove(element)
         except ValueError:
           raise BeamAssertException(
-              'Failed assert: %r == %r, right side missing at least element'
+              'Failed assert: %r == %r, left side missing at least element'
               ' %r' % (expected, actual, element))
       if expected_list:
         raise BeamAssertException(
-            'Failed assert: %r == %r, left side missing elements %r' %
+            'Failed assert: %r == %r, right side missing elements %r' %
             (expected, actual, expected_list))
 
   return _equal

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -179,8 +179,8 @@ def equal_to(expected):
           expected_list.remove(element)
         except ValueError:
           raise BeamAssertException(
-              'Failed assert: %r == %r, right side missing at least element %r' %
-              (expected, actual, element))
+              'Failed assert: %r == %r, right side missing at least element'
+              ' %r' % (expected, actual, element))
       if expected_list:
         raise BeamAssertException(
             'Failed assert: %r == %r, left side missing elements %r' %

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -174,17 +174,19 @@ def equal_to(expected):
     # 2) As a fallback if we encounter a TypeError in python 3. this method
     #    works on collections that have different types.
     except (BeamAssertException, TypeError):
+      left_missing = []
       for element in actual:
         try:
           expected_list.remove(element)
         except ValueError:
-          raise BeamAssertException(
-              'Failed assert: %r == %r, left side missing at least element'
-              ' %r' % (expected, actual, element))
-      if expected_list:
-        raise BeamAssertException(
-            'Failed assert: %r == %r, right side missing elements %r' %
-            (expected, actual, expected_list))
+          left_missing.append(element)
+      if left_missing or expected_list:
+        msg = 'Failed assert: %r == %r' % (expected, actual)
+        if left_missing:
+          msg = msg + ', left side missing elements %r' % left_missing
+        if expected_list:
+          msg = msg + ', right side missing elements %r' % expected_list
+        raise BeamAssertException(msg)
 
   return _equal
 

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -179,7 +179,7 @@ def equal_to(expected):
           expected_list.remove(element)
         except ValueError:
           raise BeamAssertException(
-              'Failed assert: %r == %r, expected missing %r' %
+              'Failed assert: %r == %r, expected missing element %r' %
               (expected, actual, element))
       if expected_list:
         raise BeamAssertException('Failed assert: %r == %r, actual missing %r' %

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -179,11 +179,12 @@ def equal_to(expected):
           expected_list.remove(element)
         except ValueError:
           raise BeamAssertException(
-              'Failed assert: %r == %r, expected missing element %r' %
+              'Failed assert: %r == %r, right side missing at least element %r' %
               (expected, actual, element))
       if expected_list:
-        raise BeamAssertException('Failed assert: %r == %r, actual missing %r' %
-                                  (expected, actual, expected_list))
+        raise BeamAssertException(
+            'Failed assert: %r == %r, left side missing elements %r' %
+            (expected, actual, expected_list))
 
   return _equal
 

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -179,10 +179,11 @@ def equal_to(expected):
           expected_list.remove(element)
         except ValueError:
           raise BeamAssertException(
-              'Failed assert: %r == %r' % (expected, actual))
+              'Failed assert: %r == %r, expected missing %r' %
+              (expected, actual, element))
       if expected_list:
-        raise BeamAssertException(
-            'Failed assert: %r == %r' % (expected, actual))
+        raise BeamAssertException('Failed assert: %r == %r, actual missing %r' %
+                                  (expected, actual, expected_list))
 
   return _equal
 

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -166,7 +166,7 @@ def equal_to(expected):
       sorted_actual = sorted(actual)
       if sorted_expected != sorted_actual:
         raise BeamAssertException(
-            'Failed assert: %r == %r' % (sorted_actual, sorted_expected))
+            'Failed assert: %r == %r' % (sorted_expected, sorted_actual))
     # Slower method, used in two cases:
     # 1) If sorted expected != actual, use this method to verify the inequality.
     #    This ensures we don't raise any false negatives for types that don't
@@ -174,18 +174,18 @@ def equal_to(expected):
     # 2) As a fallback if we encounter a TypeError in python 3. this method
     #    works on collections that have different types.
     except (BeamAssertException, TypeError):
-      left_missing = []
+      unexpected = []
       for element in actual:
         try:
           expected_list.remove(element)
         except ValueError:
-          left_missing.append(element)
-      if left_missing or expected_list:
-        msg = 'Failed assert: %r == %r' % (actual, expected)
-        if left_missing:
-          msg = msg + ', left side missing elements %r' % left_missing
+          unexpected.append(element)
+      if unexpected or expected_list:
+        msg = 'Failed assert: %r == %r' % (expected, actual)
+        if unexpected:
+          msg = msg + ', unexpected elements %r' % unexpected
         if expected_list:
-          msg = msg + ', right side missing elements %r' % expected_list
+          msg = msg + ', missing elements %r' % expected_list
         raise BeamAssertException(msg)
 
   return _equal

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -166,7 +166,7 @@ def equal_to(expected):
       sorted_actual = sorted(actual)
       if sorted_expected != sorted_actual:
         raise BeamAssertException(
-            'Failed assert: %r == %r' % (sorted_expected, sorted_actual))
+            'Failed assert: %r == %r' % (sorted_actual, sorted_expected))
     # Slower method, used in two cases:
     # 1) If sorted expected != actual, use this method to verify the inequality.
     #    This ensures we don't raise any false negatives for types that don't
@@ -181,7 +181,7 @@ def equal_to(expected):
         except ValueError:
           left_missing.append(element)
       if left_missing or expected_list:
-        msg = 'Failed assert: %r == %r' % (expected, actual)
+        msg = 'Failed assert: %r == %r' % (actual, expected)
         if left_missing:
           msg = msg + ', left side missing elements %r' % left_missing
         if expected_list:

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -67,23 +67,22 @@ class UtilTest(unittest.TestCase):
       with TestPipeline() as p:
         assert_that(p | Create([1, 10, 100]), equal_to([1, 2, 3]))
 
-  def test_assert_missing_right(self):
+  def test_assert_missing(self):
     with self.assertRaisesRegexp(Exception,
-                                 "right side missing elements \['c'\]"):
+                                 "missing elements \['c'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b']), equal_to(['a', 'b', 'c']))
 
-  def test_assert_missing_left(self):
+  def test_assert_unexpected(self):
     with self.assertRaisesRegexp(Exception,
-                                 "left side missing elements \['c'\]"):
+                                 "unexpected elements \['c', 'd'\]"):
       with TestPipeline() as p:
-        assert_that(p | Create(['a', 'b', 'c']), equal_to(['a', 'b']))
+        assert_that(p | Create(['a', 'b', 'c', 'd']), equal_to(['a', 'b']))
 
-  def test_assert_missing_left_and_right(self):
+  def test_assert_missing_missing_and_unexpected(self):
     with self.assertRaisesRegexp(
         Exception,
-        "left side missing elements \['c'\].*"
-        "right side missing elements \['d'\]"):
+        "unexpected elements \['c'\].*missing elements \['d'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b', 'c']),
                     equal_to(['a', 'b', 'd']))

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -43,10 +43,10 @@ from apache_beam.utils.timestamp import MIN_TIMESTAMP
 class UtilTest(unittest.TestCase):
 
   def setUp(self):
-    try:                    # Python 2
+    try:                    # Python 3
+      _ = self.assertRaisesRegex
+    except AttributeError:  # Python 2
       self.assertRaisesRegex = self.assertRaisesRegexp
-    except AttributeError:  # Python 3
-      pass
 
   def test_assert_that_passes(self):
     with TestPipeline() as p:
@@ -81,7 +81,8 @@ class UtilTest(unittest.TestCase):
 
   def test_assert_unexpected(self):
     with self.assertRaisesRegex(BeamAssertException,
-                                r"unexpected elements \['c', 'd'\]"):
+                                r"unexpected elements \['c', 'd'\]|"
+                                r"unexpected elements \['d', 'c'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b', 'c', 'd']), equal_to(['a', 'b']))
 

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -67,7 +67,6 @@ class UtilTest(unittest.TestCase):
       with TestPipeline() as p:
         assert_that(p | Create([1, 10, 100]), equal_to([1, 2, 3]))
 
-<<<<<<< HEAD
   def test_assert_missing_right(self):
     with self.assertRaisesRegexp(Exception,
                                  "right side missing elements \['c'\]"):
@@ -88,22 +87,6 @@ class UtilTest(unittest.TestCase):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b', 'c']),
                     equal_to(['a', 'b', 'd']))
-=======
-  def test_assert_that_produces_correct_error_messages(self):
-    with self.assertRaisesRegex(
-        Exception,
-        r"Failed assert: \[1\] == \[1, 2\], left side missing elements "
-        r"\[2\].*"):
-      with TestPipeline() as p:
-        assert_that(p | Create([1]), equal_to([1, 2]))
-
-    with self.assertRaisesRegex(
-        Exception,
-        r"Failed assert: \[1, 2\] == \[1\], right side missing at least "
-        r"element 2.*"):
-      with TestPipeline() as p:
-        assert_that(p | Create([1, 2]), equal_to([1]))
->>>>>>> f7c426a35f20a154e31d0ff281ba6fba96a5ef17
 
   def test_reified_value_passes(self):
     expected = [TestWindowedValue(v, MIN_TIMESTAMP, [GlobalWindow()])

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -67,6 +67,27 @@ class UtilTest(unittest.TestCase):
       with TestPipeline() as p:
         assert_that(p | Create([1, 10, 100]), equal_to([1, 2, 3]))
 
+  def test_assert_missing_right(self):
+    with self.assertRaisesRegexp(Exception,
+                                 "right side missing elements \['c'\]"):
+      with TestPipeline() as p:
+        assert_that(p | Create(['a', 'b']), equal_to(['a', 'b', 'c']))
+
+  def test_assert_missing_left(self):
+    with self.assertRaisesRegexp(Exception,
+                                 "left side missing elements \['c'\]"):
+      with TestPipeline() as p:
+        assert_that(p | Create(['a', 'b', 'c']), equal_to(['a', 'b']))
+
+  def test_assert_missing_left_and_right(self):
+    with self.assertRaisesRegexp(
+        Exception,
+        "left side missing elements \['c'\].*"
+        "right side missing elements \['d'\]"):
+      with TestPipeline() as p:
+        assert_that(p | Create(['a', 'b', 'c']),
+                    equal_to(['a', 'b', 'd']))
+
   def test_reified_value_passes(self):
     expected = [TestWindowedValue(v, MIN_TIMESTAMP, [GlobalWindow()])
                 for v in [1, 2, 3]]

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -42,6 +42,12 @@ from apache_beam.utils.timestamp import MIN_TIMESTAMP
 
 class UtilTest(unittest.TestCase):
 
+  def setUp(self):
+    try:                    # Python 2
+      self.assertRaisesRegex = self.assertRaisesRegexp
+    except AttributeError:  # Python 3
+      pass
+
   def test_assert_that_passes(self):
     with TestPipeline() as p:
       assert_that(p | Create([1, 2, 3]), equal_to([1, 2, 3]))
@@ -68,20 +74,20 @@ class UtilTest(unittest.TestCase):
         assert_that(p | Create([1, 10, 100]), equal_to([1, 2, 3]))
 
   def test_assert_missing(self):
-    with self.assertRaisesRegexp(Exception,
-                                 r"missing elements \['c'\]"):
+    with self.assertRaisesRegex(BeamAssertException,
+                                r"missing elements \['c'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b']), equal_to(['a', 'b', 'c']))
 
   def test_assert_unexpected(self):
-    with self.assertRaisesRegexp(Exception,
-                                 r"unexpected elements \['c', 'd'\]"):
+    with self.assertRaisesRegex(BeamAssertException,
+                                r"unexpected elements \['c', 'd'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b', 'c', 'd']), equal_to(['a', 'b']))
 
   def test_assert_missing_and_unexpected(self):
-    with self.assertRaisesRegexp(
-        Exception,
+    with self.assertRaisesRegex(
+        BeamAssertException,
         r"unexpected elements \['c'\].*missing elements \['d'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b', 'c']),

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -69,20 +69,20 @@ class UtilTest(unittest.TestCase):
 
   def test_assert_missing(self):
     with self.assertRaisesRegexp(Exception,
-                                 "missing elements \['c'\]"):
+                                 r"missing elements \['c'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b']), equal_to(['a', 'b', 'c']))
 
   def test_assert_unexpected(self):
     with self.assertRaisesRegexp(Exception,
-                                 "unexpected elements \['c', 'd'\]"):
+                                 r"unexpected elements \['c', 'd'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b', 'c', 'd']), equal_to(['a', 'b']))
 
-  def test_assert_missing_missing_and_unexpected(self):
+  def test_assert_missing_and_unexpected(self):
     with self.assertRaisesRegexp(
         Exception,
-        "unexpected elements \['c'\].*missing elements \['d'\]"):
+        r"unexpected elements \['c'\].*missing elements \['d'\]"):
       with TestPipeline() as p:
         assert_that(p | Create(['a', 'b', 'c']),
                     equal_to(['a', 'b', 'd']))


### PR DESCRIPTION
Now lists the first element found in actual not found in expected, or all of the elements from actual. Only effects the exception error message, which is not covered by any unit tests.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
