### PR TITLE
[BEAM-8749] Update cassandra-driver-core to version 3.8.0

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -362,7 +362,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def apex_malhar_version = "3.4.0"
     def aws_java_sdk_version = "1.11.519"
     def aws_java_sdk2_version = "2.5.71"
-    def cassandra_driver_version = "3.6.0"
+    def cassandra_driver_version = "3.8.0"
     def classgraph_version = "4.8.56"
     def generated_grpc_beta_version = "0.44.0"
     def generated_grpc_ga_version = "1.43.0"

--- a/sdks/java/io/hadoop-format/build.gradle
+++ b/sdks/java/io/hadoop-format/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   testCompile "commons-httpclient:commons-httpclient:3.1"
   testCompile library.java.cassandra_driver_core
   testCompile library.java.cassandra_driver_mapping
-  testCompile "org.apache.cassandra:cassandra-all:3.11.3"
+  testCompile "org.apache.cassandra:cassandra-all:3.11.5"
   testCompile library.java.postgres
   testCompile "org.apache.logging.log4j:log4j-core:$log4j_version"
   testCompile library.java.junit


### PR DESCRIPTION
A catch up on improvements PR for CassandraIO, it sets the dependencies in the latest released versions before 4.0. The 4.0 change is quite bigger so better let that for the future. (Also there is not a cassandra-all release not in alpha yet).

R: @aromanenko-dev 