### PR TITLE
Beam-2535: Support timer output timestamps in the flink runner

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Timer.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Timer.java
@@ -47,12 +47,7 @@ public abstract class Timer<T> {
 
   /** Returns a timer for the given timestamp with a user specified payload. */
   public static <T> Timer<T> of(Instant timestamp, @Nullable T payload) {
-    return new AutoValue_Timer(timestamp, timestamp, payload);
-  }
-
-  /** Returns a timer for the given timestamp with a user specified payload and outputTimestamp. */
-  public static <T> Timer<T> of(Instant timestamp, Instant outputTimestamp, @Nullable T payload) {
-    return new AutoValue_Timer(timestamp, outputTimestamp, payload);
+    return new AutoValue_Timer(timestamp, payload);
   }
 
   /**
@@ -62,9 +57,6 @@ public abstract class Timer<T> {
    * org.apache.beam.model.pipeline.v1.RunnerApi.TimerSpec} that is associated with this timer.
    */
   public abstract Instant getTimestamp();
-
-  /* Returns the outputTimestamps  */
-  public abstract Instant getOutputTimestamp();
 
   /** A user supplied payload. */
   @Nullable

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -214,7 +214,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     OnTimerArgumentProvider argumentProvider =
-        new OnTimerArgumentProvider(timerId, window, effectiveTimestamp, timeDomain);
+        new OnTimerArgumentProvider(timerId, window, timestamp, effectiveTimestamp, timeDomain);
     invoker.invokeOnTimer(timerId, timerFamilyId, argumentProvider);
   }
 
@@ -774,6 +774,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
   private class OnTimerArgumentProvider extends DoFn<InputT, OutputT>.OnTimerContext
       implements DoFnInvoker.ArgumentProvider<InputT, OutputT> {
     private final BoundedWindow window;
+    private final Instant fireTimestamp;
     private final Instant timestamp;
     private final TimeDomain timeDomain;
     private final String timerId;
@@ -796,10 +797,15 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     private OnTimerArgumentProvider(
-        String timerId, BoundedWindow window, Instant timestamp, TimeDomain timeDomain) {
+        String timerId,
+        BoundedWindow window,
+        Instant fireTimestamp,
+        Instant timestamp,
+        TimeDomain timeDomain) {
       fn.super();
       this.timerId = timerId;
       this.window = window;
+      this.fireTimestamp = fireTimestamp;
       this.timestamp = timestamp;
       this.timeDomain = timeDomain;
     }
@@ -807,6 +813,11 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     @Override
     public Instant timestamp() {
       return timestamp;
+    }
+
+    @Override
+    public Instant fireTimestamp() {
+      return fireTimestamp;
     }
 
     @Override

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -199,7 +199,6 @@ def createValidatesRunnerTask(Map m) {
     maxParallelForks 2
     useJUnit {
       includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithOutputTimestamp'
       excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
       excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
       excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -679,7 +679,7 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
       WindowedValue<KV<Object, Timer>> timerValue =
           WindowedValue.of(
               KV.of(timerKey, Timer.of(timestamp, new byte[0])),
-              timestamp,
+              outputTimestamp,
               Collections.singleton(window),
               PaneInfo.NO_FIRING);
       try {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -159,7 +159,7 @@ public class SplittableDoFnOperator<InputT, OutputT, RestrictionT>
 
   @Override
   protected void fireTimer(InternalTimer<ByteBuffer, TimerInternals.TimerData> timer) {
-    timerInternals.cleanupPendingTimer(timer.getNamespace());
+    timerInternals.cleanupPendingTimer(timer.getNamespace(), true);
     if (timer.getNamespace().getDomain().equals(TimeDomain.EVENT_TIME)) {
       // ignore this, it can only be a state cleanup timers from StatefulDoFnRunner and ProcessFn
       // does its own state cleanup and should never set event-time timers.

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
@@ -126,7 +126,7 @@ public class WindowDoFnOperator<K, InputT, OutputT>
 
   @Override
   protected void fireTimer(InternalTimer<ByteBuffer, TimerData> timer) {
-    timerInternals.cleanupPendingTimer(timer.getNamespace());
+    timerInternals.cleanupPendingTimer(timer.getNamespace(), true);
     doFnRunner.processElement(
         WindowedValue.valueInGlobalWindow(
             KeyedWorkItems.timersWorkItem(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/TimerReceiver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/TimerReceiver.java
@@ -120,7 +120,7 @@ public class TimerReceiver {
 
         TimerInternals timerInternals = stepContext.namespacedToUser().timerInternals();
         timerInternals.setTimer(
-            namespace, timerId, "", timer.getTimestamp(), timer.getOutputTimestamp(), timeDomain);
+            namespace, timerId, "", timer.getTimestamp(), windowedValue.getTimestamp(), timeDomain);
 
         timerIdToKey.put(timerId, windowedValue.getValue().getKey());
         timerIdToPayload.put(timerId, timer.getPayload());
@@ -144,7 +144,7 @@ public class TimerReceiver {
               KV.of(
                   timerIdToKey.get(timerData.getTimerId()),
                   Timer.of(timerData.getTimestamp(), timerIdToPayload.get(timerData.getTimerId()))),
-              timerData.getTimestamp(),
+              timerData.getOutputTimestamp(),
               Collections.singleton(window),
               PaneInfo.NO_FIRING);
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/TimerReceiverTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/TimerReceiverTest.java
@@ -234,7 +234,9 @@ public class TimerReceiverTest implements Serializable {
     long testTimerOffset = 123456;
     // Arbitrary key.
     Object timer = timerBytes("X", testTimerOffset);
-    Object windowedTimer = WindowedValue.valueInGlobalWindow(timer);
+    Object windowedTimer =
+        WindowedValue.timestampedValueInGlobalWindow(
+            timer, BoundedWindow.TIMESTAMP_MIN_VALUE.plus(testTimerOffset));
 
     // Simulate the SDK Harness sending a timer element to the Runner Harness.
     assertTrue(timerReceiver.receive(timerOutputPCollection, windowedTimer));
@@ -349,10 +351,14 @@ public class TimerReceiverTest implements Serializable {
     long testTimerOffset = 123456;
     // Arbitrary key.
     Object timer1 = timerBytes("X", testTimerOffset);
-    Object windowedTimer1 = WindowedValue.valueInGlobalWindow(timer1);
+    Object windowedTimer1 =
+        WindowedValue.timestampedValueInGlobalWindow(
+            timer1, BoundedWindow.TIMESTAMP_MIN_VALUE.plus(testTimerOffset));
 
     Object timer2 = timerBytes("Y", testTimerOffset);
-    Object windowedTimer2 = WindowedValue.valueInGlobalWindow(timer2);
+    Object windowedTimer2 =
+        WindowedValue.timestampedValueInGlobalWindow(
+            timer2, BoundedWindow.TIMESTAMP_MIN_VALUE.plus(testTimerOffset));
 
     // Simulate the SDK Harness sending a timer element to the Runner Harness.
     assertTrue(

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/JobInvocation.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/JobInvocation.java
@@ -57,7 +57,6 @@ public class JobInvocation {
   private final List<JobMessage> messageHistory;
   private final List<Consumer<JobStateEvent>> stateObservers;
   private final List<Consumer<JobMessage>> messageObservers;
-
   private JobApi.MetricResults metrics;
   private PortablePipelineResult resultHandle;
   @Nullable private ListenableFuture<PortablePipelineResult> invocationFuture;

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/translation/PipelineTranslatorUtils.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/translation/PipelineTranslatorUtils.java
@@ -139,10 +139,11 @@ public final class PipelineTranslatorUtils {
     Preconditions.checkArgument(namespace instanceof StateNamespaces.WindowNamespace);
     BoundedWindow window = ((StateNamespaces.WindowNamespace) namespace).getWindow();
     Instant timestamp = timer.getTimestamp();
+    Instant outputTimestamp = timer.getOutputTimestamp();
     WindowedValue<KV<Object, Timer>> timerValue =
         WindowedValue.of(
             KV.of(currentTimerKey, Timer.of(timestamp, new byte[0])),
-            timestamp,
+            outputTimestamp,
             Collections.singleton(window),
             PaneInfo.NO_FIRING);
     timerConsumer.accept(timer.getTimerId(), timerValue);

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -1016,7 +1016,9 @@ public class RemoteExecutionTest implements Serializable {
                       @TimerId("event") Timer eventTimeTimer,
                       @TimerId("processing") Timer processingTimeTimer) {
                     context.output(KV.of("main" + context.element().getKey(), ""));
-                    eventTimeTimer.set(context.timestamp().plus(1L));
+                    eventTimeTimer
+                        .withOutputTimestamp(context.timestamp())
+                        .set(context.timestamp().plus(1L));
                     processingTimeTimer.offset(Duration.millis(2L));
                     processingTimeTimer.setRelative();
                   }
@@ -1027,7 +1029,9 @@ public class RemoteExecutionTest implements Serializable {
                       @TimerId("event") Timer eventTimeTimer,
                       @TimerId("processing") Timer processingTimeTimer) {
                     context.output(KV.of("event", ""));
-                    eventTimeTimer.set(context.timestamp().plus(11L));
+                    eventTimeTimer
+                        .withOutputTimestamp(context.timestamp())
+                        .set(context.timestamp().plus(11L));
                     processingTimeTimer.offset(Duration.millis(12L));
                     processingTimeTimer.setRelative();
                   }
@@ -1038,7 +1042,9 @@ public class RemoteExecutionTest implements Serializable {
                       @TimerId("event") Timer eventTimeTimer,
                       @TimerId("processing") Timer processingTimeTimer) {
                     context.output(KV.of("processing", ""));
-                    eventTimeTimer.set(context.timestamp().plus(21L));
+                    eventTimeTimer
+                        .withOutputTimestamp(context.timestamp())
+                        .set(context.timestamp().plus(21L));
                     processingTimeTimer.offset(Duration.millis(22L));
                     processingTimeTimer.setRelative();
                   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -279,6 +279,9 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
     /** Returns the timestamp of the current timer. */
     public abstract Instant timestamp();
 
+    /** Returns the output timestamp of the current timer. */
+    public abstract Instant fireTimestamp();
+
     /** Returns the window in which the timer is firing. */
     public abstract BoundedWindow window();
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -805,6 +805,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
     private final Instant currentTimestamp;
     private final Duration allowedLateness;
     private final WindowedValue<?> currentElementOrTimer;
+    private Instant currentOutputTimestamp = null;
 
     private Duration period = Duration.ZERO;
     private Duration offset = Duration.ZERO;
@@ -897,7 +898,16 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
 
     @Override
     public org.apache.beam.sdk.state.Timer withOutputTimestamp(Instant outputTime) {
-      throw new UnsupportedOperationException("TODO: Add support for timers");
+      Instant windowExpiry = LateDataUtils.garbageCollectionTime(currentWindow, allowedLateness);
+      checkArgument(
+          !outputTime.isAfter(windowExpiry),
+          "Attempted to set timer with output timestamp %s but that is after"
+              + " the expiration of window %s",
+          outputTime,
+          windowExpiry);
+
+      this.currentOutputTimestamp = outputTime;
+      return this;
     }
 
     /**
@@ -919,7 +929,20 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
       Collection<FnDataReceiver<WindowedValue<KV<Object, Timer>>>> consumers =
           (Collection) context.localNameToConsumer.get(timerId);
 
-      outputTo(consumers, currentElementOrTimer.withValue(KV.of(key, Timer.of(scheduledTime))));
+      if (currentOutputTimestamp == null) {
+        if (TimeDomain.EVENT_TIME.equals(timeDomain)) {
+          currentOutputTimestamp = scheduledTime;
+        } else {
+          currentOutputTimestamp = currentElementOrTimer.getTimestamp();
+        }
+      }
+      outputTo(
+          consumers,
+          WindowedValue.of(
+              KV.of(key, Timer.of(scheduledTime)),
+              currentOutputTimestamp,
+              currentElementOrTimer.getWindows(),
+              currentElementOrTimer.getPane()));
     }
   }
 
@@ -1317,6 +1340,11 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
     @Override
     public TimeDomain timeDomain() {
       return currentTimeDomain;
+    }
+
+    @Override
+    public Instant fireTimestamp() {
+      return currentTimer.getValue().getValue().getTimestamp();
     }
 
     @Override

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
 import org.apache.beam.fn.harness.data.PCollectionConsumerRegistry;
@@ -805,7 +806,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
     private final Instant currentTimestamp;
     private final Duration allowedLateness;
     private final WindowedValue<?> currentElementOrTimer;
-    private Instant currentOutputTimestamp = null;
+    @Nullable private Instant currentOutputTimestamp;
 
     private Duration period = Duration.ZERO;
     private Duration offset = Duration.ZERO;

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -934,9 +934,9 @@ public class FnApiDoFnRunnerTest implements Serializable {
             timerInGlobalWindow("A", new Instant(1400L), new Instant(2411L)),
             timerInGlobalWindow("B", new Instant(1500L), new Instant(2511L)),
             timerInGlobalWindow("A", new Instant(1600L), new Instant(2611L)),
-            timerInGlobalWindow("X", new Instant(2700L), new Instant(2721L)),
-            timerInGlobalWindow("C", new Instant(2800L), new Instant(2821L)),
-            timerInGlobalWindow("B", new Instant(2900L), new Instant(2921L))));
+            timerInGlobalWindow("X", new Instant(1700L), new Instant(1721L)),
+            timerInGlobalWindow("C", new Instant(1800L), new Instant(1821L)),
+            timerInGlobalWindow("B", new Instant(1900L), new Instant(1921L))));
     assertThat(
         processingTimerOutputValues,
         contains(

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -744,7 +744,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
         @TimerId("processing") Timer processingTimeTimer) {
       context.output("main" + context.element().getKey() + Iterables.toString(bagState.read()));
       bagState.add(context.element().getValue());
-      eventTimeTimer.set(context.timestamp().plus(1L));
+      eventTimeTimer.withOutputTimestamp(context.timestamp()).set(context.timestamp().plus(1L));
       processingTimeTimer.offset(Duration.millis(2L));
       processingTimeTimer.setRelative();
     }
@@ -757,7 +757,9 @@ public class FnApiDoFnRunnerTest implements Serializable {
         @TimerId("processing") Timer processingTimeTimer) {
       context.output("event" + Iterables.toString(bagState.read()));
       bagState.add("event");
-      eventTimeTimer.set(context.timestamp().plus(11L));
+      eventTimeTimer
+          .withOutputTimestamp(context.timestamp())
+          .set(context.fireTimestamp().plus(11L));
       processingTimeTimer.offset(Duration.millis(12L));
       processingTimeTimer.setRelative();
     }
@@ -770,7 +772,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
         @TimerId("processing") Timer processingTimeTimer) {
       context.output("processing" + Iterables.toString(bagState.read()));
       bagState.add("processing");
-      eventTimeTimer.set(context.timestamp().plus(21L));
+      eventTimeTimer.withOutputTimestamp(context.timestamp()).set(context.timestamp().plus(21L));
       processingTimeTimer.offset(Duration.millis(22L));
       processingTimeTimer.setRelative();
     }
@@ -929,12 +931,12 @@ public class FnApiDoFnRunnerTest implements Serializable {
             timerInGlobalWindow("Y", new Instant(1100L), new Instant(1101L)),
             timerInGlobalWindow("X", new Instant(1200L), new Instant(1201L)),
             timerInGlobalWindow("Y", new Instant(1300L), new Instant(1301L)),
-            timerInGlobalWindow("A", new Instant(1400L), new Instant(1411L)),
-            timerInGlobalWindow("B", new Instant(1500L), new Instant(1511L)),
-            timerInGlobalWindow("A", new Instant(1600L), new Instant(1611L)),
-            timerInGlobalWindow("X", new Instant(1700L), new Instant(1721L)),
-            timerInGlobalWindow("C", new Instant(1800L), new Instant(1821L)),
-            timerInGlobalWindow("B", new Instant(1900L), new Instant(1921L))));
+            timerInGlobalWindow("A", new Instant(1400L), new Instant(2411L)),
+            timerInGlobalWindow("B", new Instant(1500L), new Instant(2511L)),
+            timerInGlobalWindow("A", new Instant(1600L), new Instant(2611L)),
+            timerInGlobalWindow("X", new Instant(2700L), new Instant(2721L)),
+            timerInGlobalWindow("C", new Instant(2800L), new Instant(2821L)),
+            timerInGlobalWindow("B", new Instant(2900L), new Instant(2921L))));
     assertThat(
         processingTimerOutputValues,
         contains(


### PR DESCRIPTION
Adds the appropriate watermark holds in the flink runner