### PR TITLE
Make SerializableUtils.deserializeFromByteArray generic

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CoderTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CoderTranslation.java
@@ -143,8 +143,7 @@ public class CoderTranslation {
   }
 
   private static Coder<?> fromCustomCoder(RunnerApi.Coder protoCoder) throws IOException {
-    return (Coder<?>)
-        SerializableUtils.deserializeFromByteArray(
-            protoCoder.getSpec().getPayload().toByteArray(), "Custom Coder Bytes");
+    return SerializableUtils.deserializeFromByteArray(
+        protoCoder.getSpec().getPayload().toByteArray(), "Custom Coder Bytes");
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslation.java
@@ -73,10 +73,8 @@ public class CreatePCollectionViewTranslation {
         application.getFullName(),
         transformProto.getSpec().getUrn());
 
-    return (PCollectionView<ViewT>)
-        SerializableUtils.deserializeFromByteArray(
-            transformProto.getSpec().getPayload().toByteArray(),
-            PCollectionView.class.getSimpleName());
+    return SerializableUtils.deserializeFromByteArray(
+        transformProto.getSpec().getPayload().toByteArray(), PCollectionView.class.getSimpleName());
   }
 
   /**

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PCollectionViewTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PCollectionViewTranslation.java
@@ -83,9 +83,8 @@ public class PCollectionViewTranslation {
         "Can't deserialize unknown %s type %s",
         ViewFn.class.getSimpleName(),
         spec.getUrn());
-    return (ViewFn<?, ?>)
-        SerializableUtils.deserializeFromByteArray(
-            spec.getPayload().toByteArray(), "Custom ViewFn");
+    return SerializableUtils.deserializeFromByteArray(
+        spec.getPayload().toByteArray(), "Custom ViewFn");
   }
 
   /**
@@ -100,8 +99,7 @@ public class PCollectionViewTranslation {
         "Can't deserialize unknown %s type %s",
         WindowMappingFn.class.getSimpleName(),
         spec.getUrn());
-    return (WindowMappingFn<?>)
-        SerializableUtils.deserializeFromByteArray(
-            spec.getPayload().toByteArray(), "Custom WinodwMappingFn");
+    return SerializableUtils.deserializeFromByteArray(
+        spec.getPayload().toByteArray(), "Custom WinodwMappingFn");
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -537,10 +537,8 @@ public class ParDoTranslation {
         }
 
         Combine.CombineFn<?, ?, ?> combineFn =
-            (Combine.CombineFn<?, ?, ?>)
-                SerializableUtils.deserializeFromByteArray(
-                    combineFnSpec.getPayload().toByteArray(),
-                    Combine.CombineFn.class.getSimpleName());
+            SerializableUtils.deserializeFromByteArray(
+                combineFnSpec.getPayload().toByteArray(), Combine.CombineFn.class.getSimpleName());
 
         // Rawtype coder cast because it is required to be a valid accumulator coder
         // for the CombineFn, by construction
@@ -618,9 +616,8 @@ public class ParDoTranslation {
         FunctionSpec.class.getSimpleName(),
         CUSTOM_JAVA_DO_FN_URN,
         fnSpec.getUrn());
-    byte[] serializedFn = fnSpec.getPayload().toByteArray();
-    return (DoFnWithExecutionInformation)
-        SerializableUtils.deserializeFromByteArray(serializedFn, "Custom DoFn With Execution Info");
+    return SerializableUtils.deserializeFromByteArray(
+        fnSpec.getPayload().toByteArray(), "Custom DoFn With Execution Info");
   }
 
   /**

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ReadTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ReadTranslation.java
@@ -85,9 +85,8 @@ public class ReadTranslation {
   public static BoundedSource<?> boundedSourceFromProto(ReadPayload payload)
       throws InvalidProtocolBufferException {
     checkArgument(payload.getIsBounded().equals(IsBounded.Enum.BOUNDED));
-    return (BoundedSource<?>)
-        SerializableUtils.deserializeFromByteArray(
-            payload.getSource().getPayload().toByteArray(), "BoundedSource");
+    return SerializableUtils.deserializeFromByteArray(
+        payload.getSource().getPayload().toByteArray(), "BoundedSource");
   }
 
   public static <T> BoundedSource<T> boundedSourceFromTransform(
@@ -122,9 +121,8 @@ public class ReadTranslation {
 
   public static UnboundedSource<?, ?> unboundedSourceFromProto(ReadPayload payload) {
     checkArgument(payload.getIsBounded().equals(IsBounded.Enum.UNBOUNDED));
-    return (UnboundedSource<?, ?>)
-        SerializableUtils.deserializeFromByteArray(
-            payload.getSource().getPayload().toByteArray(), "UnboundedSource");
+    return SerializableUtils.deserializeFromByteArray(
+        payload.getSource().getPayload().toByteArray(), "UnboundedSource");
   }
 
   public static PCollection.IsBounded sourceIsBounded(AppliedPTransform<?, ?, ?> transform) {

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WindowingStrategyTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WindowingStrategyTranslation.java
@@ -363,9 +363,8 @@ public class WindowingStrategyTranslation implements Serializable {
         return Sessions.withGapDuration(
             Duration.millis(Durations.toMillis(sessionParams.getGapSize())));
       } else if (s.equals(SERIALIZED_JAVA_WINDOWFN_URN)) {
-        return (WindowFn<?, ?>)
-            SerializableUtils.deserializeFromByteArray(
-                windowFnSpec.getPayload().toByteArray(), "WindowFn");
+        return SerializableUtils.deserializeFromByteArray(
+            windowFnSpec.getPayload().toByteArray(), "WindowFn");
       } else {
         throw new IllegalArgumentException(
             "Unknown or unsupported WindowFn: " + windowFnSpec.getUrn());

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WriteFilesTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WriteFilesTranslation.java
@@ -114,12 +114,8 @@ public class WriteFilesTranslation {
         FileBasedSink.class.getSimpleName(),
         FunctionSpec.class.getSimpleName(),
         sinkProto.getUrn());
-
-    byte[] serializedSink = sinkProto.getPayload().toByteArray();
-
-    return (FileBasedSink<?, ?, ?>)
-        SerializableUtils.deserializeFromByteArray(
-            serializedSink, FileBasedSink.class.getSimpleName());
+    return SerializableUtils.deserializeFromByteArray(
+        sinkProto.getPayload().toByteArray(), FileBasedSink.class.getSimpleName());
   }
 
   public static <UserT, DestinationT, OutputT> FileBasedSink<UserT, DestinationT, OutputT> getSink(

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslationTest.java
@@ -90,9 +90,8 @@ public class CreatePCollectionViewTranslationTest {
 
     // Checks that the payload is what it should be
     PCollectionView<?> deserializedView =
-        (PCollectionView<?>)
-            SerializableUtils.deserializeFromByteArray(
-                payload.getPayload().toByteArray(), PCollectionView.class.getSimpleName());
+        SerializableUtils.deserializeFromByteArray(
+            payload.getPayload().toByteArray(), PCollectionView.class.getSimpleName());
 
     assertThat(deserializedView, Matchers.equalTo(createViewTransform.getView()));
   }
@@ -117,9 +116,8 @@ public class CreatePCollectionViewTranslationTest {
 
     // Checks that the payload is what it should be
     PCollectionView<?> deserializedView =
-        (PCollectionView<?>)
-            SerializableUtils.deserializeFromByteArray(
-                payload.getPayload().toByteArray(), PCollectionView.class.getSimpleName());
+        SerializableUtils.deserializeFromByteArray(
+            payload.getPayload().toByteArray(), PCollectionView.class.getSimpleName());
 
     assertThat(deserializedView, Matchers.equalTo(createViewTransform.getView()));
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DoFnLifecycleManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DoFnLifecycleManager.java
@@ -98,9 +98,8 @@ class DoFnLifecycleManager {
     @Override
     public DoFn<?, ?> load(Thread key) throws Exception {
       DoFn<?, ?> fn =
-          (DoFn<?, ?>)
-              SerializableUtils.deserializeFromByteArray(
-                  original, "DoFn Copy in thread " + key.getName());
+          SerializableUtils.deserializeFromByteArray(
+              original, "DoFn Copy in thread " + key.getName());
       DoFnInvokers.tryInvokeSetupFor(fn);
       return fn;
     }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/CloudObjectTranslators.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/CloudObjectTranslators.java
@@ -355,9 +355,8 @@ class CloudObjectTranslators {
       public Coder fromCloudObject(CloudObject cloudObject) {
         String serializedCoder = Structs.getString(cloudObject, CODER_FIELD);
         String type = Structs.getString(cloudObject, TYPE_FIELD);
-        return (Coder<?>)
-            SerializableUtils.deserializeFromByteArray(
-                StringUtils.jsonStringToByteArray(serializedCoder), type);
+        return SerializableUtils.deserializeFromByteArray(
+            StringUtils.jsonStringToByteArray(serializedCoder), type);
       }
 
       @Override

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
@@ -68,23 +68,17 @@ public class SchemaCoderCloudObjectTranslator implements CloudObjectTranslator<S
   public SchemaCoder fromCloudObject(CloudObject cloudObject) {
     try {
       TypeDescriptor typeDescriptor =
-          (TypeDescriptor)
-              SerializableUtils.deserializeFromByteArray(
-                  StringUtils.jsonStringToByteArray(
-                      Structs.getString(cloudObject, TYPE_DESCRIPTOR)),
-                  "typeDescriptor");
+          SerializableUtils.deserializeFromByteArray(
+              StringUtils.jsonStringToByteArray(Structs.getString(cloudObject, TYPE_DESCRIPTOR)),
+              "typeDescriptor");
       SerializableFunction toRowFunction =
-          (SerializableFunction)
-              SerializableUtils.deserializeFromByteArray(
-                  StringUtils.jsonStringToByteArray(
-                      Structs.getString(cloudObject, TO_ROW_FUNCTION)),
-                  "toRowFunction");
+          SerializableUtils.deserializeFromByteArray(
+              StringUtils.jsonStringToByteArray(Structs.getString(cloudObject, TO_ROW_FUNCTION)),
+              "toRowFunction");
       SerializableFunction fromRowFunction =
-          (SerializableFunction)
-              SerializableUtils.deserializeFromByteArray(
-                  StringUtils.jsonStringToByteArray(
-                      Structs.getString(cloudObject, FROM_ROW_FUNCTION)),
-                  "fromRowFunction");
+          SerializableUtils.deserializeFromByteArray(
+              StringUtils.jsonStringToByteArray(Structs.getString(cloudObject, FROM_ROW_FUNCTION)),
+              "fromRowFunction");
       SchemaApi.Schema protoSchema =
           SchemaApi.Schema.parseFrom(
               StringUtils.jsonStringToByteArray(Structs.getString(cloudObject, SCHEMA)));

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -713,11 +713,10 @@ public class DataflowPipelineTranslatorTest implements Serializable {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     DoFnInfo<String, Integer> fnInfo =
-        (DoFnInfo<String, Integer>)
-            SerializableUtils.deserializeFromByteArray(
-                jsonStringToByteArray(
-                    getString(processKeyedStep.getProperties(), PropertyNames.SERIALIZED_FN)),
-                "DoFnInfo");
+        SerializableUtils.deserializeFromByteArray(
+            jsonStringToByteArray(
+                getString(processKeyedStep.getProperties(), PropertyNames.SERIALIZED_FN)),
+            "DoFnInfo");
     assertThat(fnInfo.getDoFn(), instanceOf(TestSplittableFn.class));
     assertThat(
         fnInfo.getWindowingStrategy().getWindowFn(),

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DoFnInstanceManagers.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DoFnInstanceManagers.java
@@ -75,8 +75,7 @@ public class DoFnInstanceManagers {
     }
 
     private DoFnInfo<?, ?> deserializeCopy() throws Exception {
-      DoFnInfo<?, ?> fn;
-      fn = (DoFnInfo<?, ?>) SerializableUtils.deserializeFromByteArray(serializedFnInfo, null);
+      DoFnInfo<?, ?> fn = SerializableUtils.deserializeFromByteArray(serializedFnInfo, null);
       DoFnInvokers.invokerFor(fn.getDoFn()).invokeSetup();
       return fn;
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PartialGroupByKeyParDoFns.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PartialGroupByKeyParDoFns.java
@@ -71,12 +71,10 @@ public class PartialGroupByKeyParDoFns {
       sideInputReader = NullSideInputReader.empty();
       stepContext = null;
     } else {
-      Object deserializedFn =
+      AppliedCombineFn<K, InputT, AccumT, ?> combineFnUnchecked =
           SerializableUtils.deserializeFromByteArray(
               getBytes(cloudUserFn, PropertyNames.SERIALIZED_FN), "serialized combine fn");
-      @SuppressWarnings("unchecked")
-      AppliedCombineFn<K, InputT, AccumT, ?> combineFnUnchecked =
-          ((AppliedCombineFn<K, InputT, AccumT, ?>) deserializedFn);
+
       combineFn = combineFnUnchecked;
 
       sideInputReader =

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PubsubReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PubsubReader.java
@@ -94,8 +94,7 @@ class PubsubReader<T> extends NativeReader<WindowedValue<T>> {
       // special case of a zero-length array allows pass-through of the raw protobuf.
       if (attributesFnBytes != null && attributesFnBytes.length > 0) {
         parseFn =
-            (SimpleFunction<PubsubMessage, Object>)
-                SerializableUtils.deserializeFromByteArray(attributesFnBytes, "serialized fn info");
+            SerializableUtils.deserializeFromByteArray(attributesFnBytes, "serialized fn info");
       }
       return new PubsubReader<>(
           typedCoder, (StreamingModeExecutionContext) executionContext, parseFn);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PubsubSink.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PubsubSink.java
@@ -111,9 +111,7 @@ class PubsubSink<T> extends Sink<WindowedValue<T>> {
         withAttributes = true;
         if (attributesFnBytes.length > 0) {
           formatFn =
-              (SimpleFunction<Object, PubsubMessage>)
-                  SerializableUtils.deserializeFromByteArray(
-                      attributesFnBytes, "serialized fn info");
+              SerializableUtils.deserializeFromByteArray(attributesFnBytes, "serialized fn info");
         }
       }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/SplittableProcessFnFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/SplittableProcessFnFactory.java
@@ -72,9 +72,8 @@ class SplittableProcessFnFactory {
     @Override
     public DoFnInfo<?, ?> getDoFnInfo(CloudObject cloudUserFn) throws Exception {
       DoFnInfo<?, ?> doFnInfo =
-          (DoFnInfo<?, ?>)
-              deserializeFromByteArray(
-                  getBytes(cloudUserFn, PropertyNames.SERIALIZED_FN), "Serialized DoFnInfo");
+          deserializeFromByteArray(
+              getBytes(cloudUserFn, PropertyNames.SERIALIZED_FN), "Serialized DoFnInfo");
       Coder restrictionCoder =
           coderFromCloudObject(
               fromSpec(getObject(cloudUserFn, WorkerPropertyNames.RESTRICTION_CODER)));

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/UserParDoFnFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/UserParDoFnFactory.java
@@ -58,9 +58,8 @@ class UserParDoFnFactory implements ParDoFnFactory {
   private static class UserDoFnExtractor implements DoFnExtractor {
     @Override
     public DoFnInfo<?, ?> getDoFnInfo(CloudObject cloudUserFn) {
-      return (DoFnInfo<?, ?>)
-          SerializableUtils.deserializeFromByteArray(
-              getBytes(cloudUserFn, PropertyNames.SERIALIZED_FN), "Serialized DoFnInfo");
+      return SerializableUtils.deserializeFromByteArray(
+          getBytes(cloudUserFn, PropertyNames.SERIALIZED_FN), "Serialized DoFnInfo");
     }
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
@@ -574,9 +574,7 @@ public class WorkerCustomSources {
   @VisibleForTesting
   static Source<?> deserializeFromCloudSource(Map<String, Object> spec) throws Exception {
     Source<?> source =
-        (Source<?>)
-            deserializeFromByteArray(
-                Base64.decodeBase64(getString(spec, SERIALIZED_SOURCE)), "Source");
+        deserializeFromByteArray(Base64.decodeBase64(getString(spec, SERIALIZED_SOURCE)), "Source");
     try {
       source.validate();
     } catch (Exception e) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -250,9 +250,8 @@ public class SchemaTranslation {
           return FieldType.DECIMAL;
         } else if (urn.equals(URN_BEAM_LOGICAL_JAVASDK)) {
           return FieldType.logicalType(
-              (LogicalType)
-                  SerializableUtils.deserializeFromByteArray(
-                      protoFieldType.getLogicalType().getPayload().toByteArray(), "logicalType"));
+              SerializableUtils.deserializeFromByteArray(
+                  protoFieldType.getLogicalType().getPayload().toByteArray(), "logicalType"));
         } else {
           throw new IllegalArgumentException("Encountered unsupported logical type URN: " + urn);
         }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/MatcherDeserializer.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/MatcherDeserializer.java
@@ -34,8 +34,7 @@ class MatcherDeserializer extends JsonDeserializer<SerializableMatcher<?>> {
       throws IOException, JsonProcessingException {
     ObjectNode node = jsonParser.readValueAsTree();
     String matcher = node.get("matcher").asText();
-    byte[] in = BaseEncoding.base64().decode(matcher);
-    return (SerializableMatcher<?>)
-        SerializableUtils.deserializeFromByteArray(in, "SerializableMatcher");
+    return SerializableUtils.deserializeFromByteArray(
+        BaseEncoding.base64().decode(matcher), "SerializableMatcher");
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -704,9 +704,8 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
       fn = origFn;
     } else {
       fn =
-          (DoFn<InputT, OutputT>)
-              SerializableUtils.deserializeFromByteArray(
-                  SerializableUtils.serializeToByteArray(origFn), origFn.toString());
+          SerializableUtils.deserializeFromByteArray(
+              SerializableUtils.serializeToByteArray(origFn), origFn.toString());
     }
     fnInvoker = DoFnInvokers.invokerFor(fn);
     fnInvoker.invokeSetup();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/SerializableUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/SerializableUtils.java
@@ -63,12 +63,12 @@ public class SerializableUtils {
    * @throws IllegalArgumentException if there are errors when deserializing, using the provided
    *     description to identify what was being deserialized
    */
-  public static Object deserializeFromByteArray(byte[] encodedValue, String description) {
+  public static <T> T deserializeFromByteArray(byte[] encodedValue, String description) {
     try {
       try (ObjectInputStream ois =
           new ContextualObjectInputStream(
               new SnappyInputStream(new ByteArrayInputStream(encodedValue)))) {
-        return ois.readObject();
+        return (T) ois.readObject();
       }
     } catch (IOException | ClassNotFoundException exn) {
       throw new IllegalArgumentException("unable to deserialize " + description, exn);
@@ -107,10 +107,9 @@ public class SerializableUtils {
       loader = tccl; // will likely fail but the best we can do
     }
     thread.setContextClassLoader(loader);
-    @SuppressWarnings("unchecked")
     final T copy;
     try {
-      copy = (T) deserializeFromByteArray(serializeToByteArray(value), value.toString());
+      copy = deserializeFromByteArray(serializeToByteArray(value), value.toString());
     } finally {
       thread.setContextClassLoader(tccl);
     }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BoundedSourceRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BoundedSourceRunner.java
@@ -133,7 +133,7 @@ public class BoundedSourceRunner<InputT extends BoundedSource<OutputT>, OutputT>
         byte[] bytes = definition.getPayload().toByteArray();
         @SuppressWarnings("unchecked")
         InputT boundedSource0 =
-            (InputT) SerializableUtils.deserializeFromByteArray(bytes, definition.toString());
+            SerializableUtils.deserializeFromByteArray(bytes, definition.toString());
         boundedSource = boundedSource0;
       } else if (definition.getUrn().equals(PTransformTranslation.READ_TRANSFORM_URN)) {
         ReadPayload readPayload = ReadPayload.parseFrom(definition.getPayload());

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
@@ -154,9 +154,8 @@ public class CombineRunners {
 
       CombinePayload combinePayload = CombinePayload.parseFrom(pTransform.getSpec().getPayload());
       CombineFn<InputT, AccumT, ?> combineFn =
-          (CombineFn)
-              SerializableUtils.deserializeFromByteArray(
-                  combinePayload.getCombineFn().getPayload().toByteArray(), "CombineFn");
+          SerializableUtils.deserializeFromByteArray(
+              combinePayload.getCombineFn().getPayload().toByteArray(), "CombineFn");
       Coder<AccumT> accumCoder =
           (Coder<AccumT>) rehydratedComponents.getCoder(combinePayload.getAccumulatorCoderId());
 
@@ -187,9 +186,8 @@ public class CombineRunners {
               throws IOException {
     CombinePayload combinePayload = CombinePayload.parseFrom(pTransform.getSpec().getPayload());
     CombineFn<?, AccumT, ?> combineFn =
-        (CombineFn)
-            SerializableUtils.deserializeFromByteArray(
-                combinePayload.getCombineFn().getPayload().toByteArray(), "CombineFn");
+        SerializableUtils.deserializeFromByteArray(
+            combinePayload.getCombineFn().getPayload().toByteArray(), "CombineFn");
 
     return (KV<KeyT, Iterable<AccumT>> input) ->
         KV.of(input.getKey(), combineFn.mergeAccumulators(input.getValue()));
@@ -200,9 +198,8 @@ public class CombineRunners {
           String pTransformId, PTransform pTransform) throws IOException {
     CombinePayload combinePayload = CombinePayload.parseFrom(pTransform.getSpec().getPayload());
     CombineFn<?, AccumT, OutputT> combineFn =
-        (CombineFn)
-            SerializableUtils.deserializeFromByteArray(
-                combinePayload.getCombineFn().getPayload().toByteArray(), "CombineFn");
+        SerializableUtils.deserializeFromByteArray(
+            combinePayload.getCombineFn().getPayload().toByteArray(), "CombineFn");
 
     return (KV<KeyT, AccumT> input) ->
         KV.of(input.getKey(), combineFn.extractOutput(input.getValue()));
@@ -214,9 +211,8 @@ public class CombineRunners {
               throws IOException {
     CombinePayload combinePayload = CombinePayload.parseFrom(pTransform.getSpec().getPayload());
     CombineFn<InputT, AccumT, OutputT> combineFn =
-        (CombineFn)
-            SerializableUtils.deserializeFromByteArray(
-                combinePayload.getCombineFn().getPayload().toByteArray(), "CombineFn");
+        SerializableUtils.deserializeFromByteArray(
+            combinePayload.getCombineFn().getPayload().toByteArray(), "CombineFn");
 
     return (KV<KeyT, Iterable<InputT>> input) -> {
       return KV.of(input.getKey(), combineFn.apply(input.getValue()));


### PR DESCRIPTION
Did this little improvement as part of the ongoing work to get rid of commons-lang3 `SerializationUtils` but I prefer to keep it separated because this may introduce much noise in the other review (once finished). 
R: @lukecwik 