### PR TITLE
[BEAM-7746] Introduce a protocol to handle various types of partitioning buffers

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -53,6 +53,7 @@ from typing import Union
 from typing import overload
 
 import grpc
+from typing_extensions import Protocol
 
 import apache_beam as beam  # pylint: disable=ungrouped-imports
 from apache_beam import coders
@@ -262,7 +263,23 @@ class BeamFnControlServicer(beam_fn_api_pb2_grpc.BeamFnControlServicer):
                    in self._req_worker_mapping.items()])
 
 
-class _ListBuffer(list):
+class Buffer(Protocol):
+  def __iter__(self):
+    # type: () -> Iterator[bytes]
+    pass
+
+  def append(self, item):
+    # type: (bytes) -> None
+    pass
+
+
+class PartitionableBuffer(Buffer, Protocol):
+  def partition(self, n):
+    # type: (int) -> List[List[bytes]]
+    pass
+
+
+class _ListBuffer(List[bytes]):
   """Used to support parititioning of a list."""
   def partition(self, n):
     # type: (int) -> List[List[bytes]]
@@ -280,7 +297,7 @@ class _GroupingBuffer(object):
     self._key_coder = pre_grouped_coder.key_coder()
     self._pre_grouped_coder = pre_grouped_coder
     self._post_grouped_coder = post_grouped_coder
-    self._table = collections.defaultdict(list)  # type: Optional[DefaultDict[bytes, List[Any]]]
+    self._table = collections.defaultdict(list)  # type: DefaultDict[bytes, List[Any]]
     self._windowing = windowing
     self._grouped_output = None  # type: Optional[List[List[bytes]]]
 
@@ -339,7 +356,7 @@ class _GroupingBuffer(object):
           coder_impl.encode_to_stream(wkvs, output_stream_list[idx % n], True)
       for ix, output_stream in enumerate(output_stream_list):
         self._grouped_output[ix] = [output_stream.get()]
-      self._table = None
+      self._table.clear()
     return self._grouped_output
 
   def __iter__(self):
@@ -573,7 +590,7 @@ class FnApiRunner(runner.PipelineRunner):
 
     try:
       with self.maybe_profile():
-        pcoll_buffers = collections.defaultdict(_ListBuffer)  # type: DefaultDict[bytes, _ListBuffer]
+        pcoll_buffers = collections.defaultdict(_ListBuffer)  # type: DefaultDict[bytes, PartitionableBuffer]
         for stage in stages:
           stage_results = self._run_stage(
               worker_handler_manager.get_worker_handlers,
@@ -594,8 +611,10 @@ class FnApiRunner(runner.PipelineRunner):
                                   context,  # type: pipeline_context.PipelineContext
                                   pipeline_components,  # type: beam_runner_api_pb2.Components
                                   data_side_input,  # type: DataSideInput
-                                  pcoll_buffers,  # type: Mapping[bytes, _ListBuffer]
-                                  safe_coders):
+                                  pcoll_buffers,  # type: Mapping[bytes, PartitionableBuffer]
+                                  safe_coders
+                                 ):
+    # type: (...) -> None
     for (transform_id, tag), (buffer_id, si) in data_side_input.items():
       _, pcoll_id = split_buffer_id(buffer_id)
       value_coder = context.coders[safe_coders[
@@ -644,7 +663,7 @@ class FnApiRunner(runner.PipelineRunner):
       try:
         worker_handler.state.checkpoint()
         testing_bundle_manager = ParallelBundleManager(
-            worker_handler_list, lambda pcoll_id: [],
+            worker_handler_list, lambda pcoll_id: _ListBuffer(),
             get_input_coder_callable, process_bundle_descriptor,
             self._progress_frequency, k,
             num_workers=self._num_workers,
@@ -660,8 +679,9 @@ class FnApiRunner(runner.PipelineRunner):
       pipeline_components,  # type: beam_runner_api_pb2.Components
       stage,  # type: fn_api_runner_transforms.Stage
       get_buffer_callable,
-      deferred_inputs  # type: DefaultDict[str, _ListBuffer]
-      ):
+      deferred_inputs  # type: DefaultDict[str, PartitionableBuffer]
+  ):
+    # type: (...) -> None
 
     for transform_id, timer_writes in stage.timer_pcollections:
 
@@ -696,8 +716,9 @@ class FnApiRunner(runner.PipelineRunner):
       get_input_coder_callable,
       input_for_callable,
       last_sent,
-      deferred_inputs  # type: DefaultDict[str, _ListBuffer]
+      deferred_inputs  # type: DefaultDict[str, PartitionableBuffer]
   ):
+    # type: (...) -> None
 
     prev_stops = {}  # type: Dict[str, int]
     for split in splits:
@@ -738,11 +759,13 @@ class FnApiRunner(runner.PipelineRunner):
       stage,  # type: fn_api_runner_transforms.Stage
       pipeline_components,  # type: beam_runner_api_pb2.Components
       data_api_service_descriptor,
-      pcoll_buffers  # type: DefaultDict[bytes, _ListBuffer]
+      pcoll_buffers  # type: DefaultDict[bytes, PartitionableBuffer]
   ):
+    # type: (...) -> Tuple[Dict[Tuple[str, str], PartitionableBuffer], DataSideInput, Dict[Tuple[str, str], bytes]]
+
     # Returns maps of transform names to PCollection identifiers.
     # Also mutates IO stages to point to the data ApiServiceDescriptor.
-    data_input = {}
+    data_input = {}  # type: Dict[Tuple[str, str], PartitionableBuffer]
     data_side_input = {}   # type: DataSideInput
     data_output = {}    # type: Dict[Tuple[str, str], bytes]
     for transform in stage.transforms:
@@ -781,7 +804,7 @@ class FnApiRunner(runner.PipelineRunner):
                  worker_handler_factory,  # type: Callable[[Optional[str], int], List[WorkerHandler]]
                  pipeline_components,  # type: beam_runner_api_pb2.Components
                  stage,  # type: fn_api_runner_transforms.Stage
-                 pcoll_buffers,  # type: DefaultDict[bytes, _ListBuffer]
+                 pcoll_buffers,  # type: DefaultDict[bytes, PartitionableBuffer]
                  safe_coders
                 ):
     # type: (...) -> beam_fn_api_pb2.InstructionResponse
@@ -848,6 +871,7 @@ class FnApiRunner(runner.PipelineRunner):
                                      safe_coders)
 
     def get_buffer(buffer_id):
+      # type: (bytes) -> PartitionableBuffer
       """Returns the buffer for a given (operation_type, PCollection ID).
 
       For grouping-typed operations, we produce a ``_GroupingBuffer``. For
@@ -918,7 +942,7 @@ class FnApiRunner(runner.PipelineRunner):
     last_sent = data_input
 
     while True:
-      deferred_inputs = collections.defaultdict(_ListBuffer)  # type: DefaultDict[str, _ListBuffer]
+      deferred_inputs = collections.defaultdict(_ListBuffer)  # type: DefaultDict[str, PartitionableBuffer]
 
       self._collect_written_timers_and_add_to_deferred_inputs(
           context, pipeline_components, stage, get_buffer, deferred_inputs)
@@ -966,9 +990,9 @@ class FnApiRunner(runner.PipelineRunner):
   def _extract_endpoints(stage,  # type: fn_api_runner_transforms.Stage
                          pipeline_components,  # type: beam_runner_api_pb2.Components
                          data_api_service_descriptor, # type: Optional[endpoints_pb2.ApiServiceDescriptor]
-                         pcoll_buffers  # type: DefaultDict[bytes, _ListBuffer]
+                         pcoll_buffers  # type: DefaultDict[bytes, PartitionableBuffer]
                         ):
-    # type: (...) -> Tuple[Dict[str, _ListBuffer], DataSideInput, DataOutput]
+    # type: (...) -> Tuple[Dict[str, PartitionableBuffer], DataSideInput, DataOutput]
     """Returns maps of transform names to PCollection identifiers.
 
     Also mutates IO stages to point to the data ApiServiceDescriptor.
@@ -987,7 +1011,7 @@ class FnApiRunner(runner.PipelineRunner):
         PCollection buffer; `data_output` is a dictionary mapping
         (transform_name, output_name) to a PCollection ID.
     """
-    data_input = {}  # type: Dict[str, _ListBuffer]
+    data_input = {}  # type: Dict[str, PartitionableBuffer]
     data_side_input = {}  # type: DataSideInput
     data_output = {}  # type: DataOutput
     for transform in stage.transforms:
@@ -1028,10 +1052,12 @@ class FnApiRunner(runner.PipelineRunner):
 
     class CopyOnWriteState(object):
       def __init__(self, underlying):
+        # type: (DefaultDict[bytes, Buffer]) -> None
         self._underlying = underlying
-        self._overlay = {}
+        self._overlay = {}  # type: Dict[bytes, Buffer]
 
       def __getitem__(self, key):
+        # type: (bytes) -> Buffer
         if key in self._overlay:
           return self._overlay[key]
         else:
@@ -1043,11 +1069,17 @@ class FnApiRunner(runner.PipelineRunner):
         self._overlay[key] = []
 
       def commit(self):
+        # type: () -> DefaultDict[bytes, Buffer]
         self._underlying.update(self._overlay)
         return self._underlying
 
     class CopyOnWriteList(object):
-      def __init__(self, underlying, overlay, key):
+      def __init__(self,
+                   underlying,  # type: DefaultDict[bytes, Buffer]
+                   overlay,  # type: Dict[bytes, Buffer]
+                   key  # type: bytes
+                  ):
+        # type: (...) -> None
         self._underlying = underlying
         self._overlay = overlay
         self._key = key
@@ -1065,24 +1097,37 @@ class FnApiRunner(runner.PipelineRunner):
           self._overlay[self._key] = list(self._underlying[self._key])
         self._overlay[self._key].append(item)
 
+    StateType = Union[CopyOnWriteState,
+                      DefaultDict[bytes, Buffer]]
+
     def __init__(self):
+      # type: () -> None
       self._lock = threading.Lock()
-      self._state = collections.defaultdict(list)  # type: DefaultDict[bytes, List[bytes]]
-      self._checkpoint = None
+      self._state = collections.defaultdict(list)  # type: FnApiRunner.StateServicer.StateType
+      self._checkpoint = None  # type: Optional[FnApiRunner.StateServicer.StateType]
       self._use_continuation_tokens = False
-      self._continuations = {}
+      self._continuations = {}  # type: Dict[str, Tuple[bytes, ...]]
 
     def checkpoint(self):
-      assert self._checkpoint is None
+      # type: () -> None
+      assert self._checkpoint is None and not \
+        isinstance(self._state, FnApiRunner.StateServicer.CopyOnWriteState)
       self._checkpoint = self._state
       self._state = FnApiRunner.StateServicer.CopyOnWriteState(self._state)
 
     def commit(self):
+      # type: () -> None
+      assert isinstance(self._state,
+                        FnApiRunner.StateServicer.CopyOnWriteState) and \
+             isinstance(self._checkpoint,
+                        FnApiRunner.StateServicer.CopyOnWriteState)
       self._state.commit()
       self._state = self._checkpoint.commit()
       self._checkpoint = None
 
     def restore(self):
+      # type: () -> None
+      assert self._checkpoint is not None
       self._state = self._checkpoint
       self._checkpoint = None
 
@@ -1722,6 +1767,7 @@ class DockerSdkWorkerHandler(GrpcWorkerHandler):
            '--artifact_endpoint=%s' % self.control_address,
            '--provision_endpoint=%s' % self.control_address,
           ]).strip()
+      assert self._container_id is not None
       while True:
         status = subprocess.check_output([
             'docker',
@@ -1861,7 +1907,7 @@ class BundleManager(object):
 
   def __init__(self,
                worker_handler_list,  # type: Sequence[WorkerHandler]
-               get_buffer,  # type: Callable[[bytes], list]
+               get_buffer,  # type: Callable[[bytes], PartitionableBuffer]
                get_input_coder_impl,  # type: Callable[[str], CoderImpl]
                bundle_descriptor,  # type: beam_fn_api_pb2.ProcessBundleDescriptor
                progress_frequency=None,
@@ -1930,7 +1976,7 @@ class BundleManager(object):
 
   def _generate_splits_for_testing(self,
                                    split_manager,
-                                   inputs,  # type: Mapping[str, _ListBuffer]
+                                   inputs,  # type: Mapping[str, PartitionableBuffer]
                                    process_bundle_id):
     # type: (...) -> List[beam_fn_api_pb2.ProcessBundleSplitResponse]
     split_results = []  # type: List[beam_fn_api_pb2.ProcessBundleSplitResponse]
@@ -1992,7 +2038,7 @@ class BundleManager(object):
     return split_results
 
   def process_bundle(self,
-                     inputs,  # type: Mapping[str, _ListBuffer]
+                     inputs,  # type: Mapping[str, PartitionableBuffer]
                      expected_outputs  # type: DataOutput
                     ):
     # type: (...) -> BundleProcessResult
@@ -2065,7 +2111,7 @@ class ParallelBundleManager(BundleManager):
   def __init__(
       self,
       worker_handler_list,  # type: Sequence[WorkerHandler]
-      get_buffer,  # type: Callable[[bytes], list]
+      get_buffer,  # type: Callable[[bytes], PartitionableBuffer]
       get_input_coder_impl,  # type: Callable[[str], CoderImpl]
       bundle_descriptor,  # type: beam_fn_api_pb2.ProcessBundleDescriptor
       progress_frequency=None,
@@ -2080,7 +2126,7 @@ class ParallelBundleManager(BundleManager):
     self._num_workers = kwargs.pop('num_workers', 1)
 
   def process_bundle(self,
-                     inputs,  # type: Mapping[str, _ListBuffer]
+                     inputs,  # type: Mapping[str, PartitionableBuffer]
                      expected_outputs  # type: DataOutput
                     ):
     # type: (...) -> BundleProcessResult


### PR DESCRIPTION
This is a followup to #9056.

R: @robertwb 
R: @udim 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
