### PR TITLE
[BEAM-9083] Exclude testOutputTimestamp from flink streaming tests.

### DIFF
--- a/runners/flink/job-server/flink_job_server.gradle
+++ b/runners/flink/job-server/flink_job_server.gradle
@@ -151,6 +151,7 @@ def portableValidatesRunnerTask(String name, Boolean streaming) {
       if (streaming) {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime'
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithMultipleStages'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithOutputTimestamp'
       } else {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
       }


### PR DESCRIPTION
Related failures: https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming