### PR TITLE
[BEAM-9083] Cherry-pick PR10610: Exclude testOutputTimestamp from flink streaming tests.

### DIFF
--- a/runners/flink/job-server/flink_job_server.gradle
+++ b/runners/flink/job-server/flink_job_server.gradle
@@ -151,6 +151,7 @@ def portableValidatesRunnerTask(String name, Boolean streaming) {
       if (streaming) {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime'
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithMultipleStages'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithOutputTimestamp'
       } else {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
       }


### PR DESCRIPTION
cherry picked from commit b0f1dcc50f10c647dfda0f4a2a545331bf9d789f: PR10610

R: @aaltay 