### PR TITLE
[BEAM-9178] Support all ZetaSQL TIMESTAMP functions

### DIFF
--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/SqlStdOperatorMappingTable.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/SqlStdOperatorMappingTable.java
@@ -18,19 +18,19 @@
 package org.apache.beam.sdk.extensions.sql.zetasql;
 
 import com.google.zetasql.ZetaSQLFunction.FunctionSignatureId;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlOperator;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 
 /** SqlStdOperatorMappingTable. */
 @Internal
 public class SqlStdOperatorMappingTable {
   static final List<FunctionSignatureId> ZETASQL_BUILTIN_FUNCTION_WHITELIST =
-      Arrays.asList(
+      ImmutableList.of(
           FunctionSignatureId.FN_AND,
           FunctionSignatureId.FN_OR,
           FunctionSignatureId.FN_NOT,
@@ -78,8 +78,6 @@ public class SqlStdOperatorMappingTable {
           FunctionSignatureId.FN_MOD_NUMERIC,
           FunctionSignatureId.FN_CASE_NO_VALUE,
           FunctionSignatureId.FN_CASE_WITH_VALUE,
-          FunctionSignatureId.FN_TIMESTAMP_ADD,
-          // TODO: FunctionSignatureId.FN_TIMESTAMP_SUB,
           FunctionSignatureId.FN_FLOOR_DOUBLE,
           FunctionSignatureId.FN_FLOOR_NUMERIC,
           FunctionSignatureId.FN_CEIL_DOUBLE,
@@ -92,13 +90,34 @@ public class SqlStdOperatorMappingTable {
           FunctionSignatureId.FN_IF,
           FunctionSignatureId.FN_IFNULL,
           FunctionSignatureId.FN_NULLIF,
+
+          // Timestamp functions
+          FunctionSignatureId.FN_CURRENT_TIMESTAMP, // current_timestamp
+          FunctionSignatureId.FN_EXTRACT_FROM_TIMESTAMP, // $extract
+          FunctionSignatureId.FN_STRING_FROM_TIMESTAMP, // string
+          FunctionSignatureId.FN_TIMESTAMP_FROM_STRING, // timestamp
+          FunctionSignatureId.FN_TIMESTAMP_FROM_DATE, // timestamp
+          // FunctionSignatureId.FN_TIMESTAMP_FROM_DATETIME // timestamp
+          FunctionSignatureId.FN_TIMESTAMP_ADD, // timestamp_add
+          FunctionSignatureId.FN_TIMESTAMP_SUB, // timestamp_sub
+          FunctionSignatureId.FN_TIMESTAMP_DIFF, // timestamp_diff
+          FunctionSignatureId.FN_TIMESTAMP_TRUNC, // timestamp_trunc
+          FunctionSignatureId.FN_FORMAT_TIMESTAMP, // format_timestamp
+          FunctionSignatureId.FN_PARSE_TIMESTAMP, // parse_timestamp
+          FunctionSignatureId.FN_TIMESTAMP_FROM_INT64_SECONDS, // timestamp_seconds
+          FunctionSignatureId.FN_TIMESTAMP_FROM_INT64_MILLIS, // timestamp_millis
+          // FunctionSignatureId.FN_TIMESTAMP_FROM_INT64_MICROS, // timestamp_micros
+          FunctionSignatureId.FN_UNIX_SECONDS_FROM_TIMESTAMP, // unix_seconds
+          FunctionSignatureId.FN_UNIX_MILLIS_FROM_TIMESTAMP, // unix_millis
+          // FunctionSignatureId.FN_UNIX_MICROS_FROM_TIMESTAMP, // unix_micros
+          FunctionSignatureId.FN_TIMESTAMP_FROM_UNIX_SECONDS_INT64, // timestamp_from_unix_seconds
+          FunctionSignatureId.FN_TIMESTAMP_FROM_UNIX_MILLIS_INT64, // timestamp_from_unix_millis
+          // FunctionSignatureId.FN_TIMESTAMP_FROM_UNIX_MICROS_INT64, // timestamp_from_unix_micros
+
+          // Date/Time/Datetime functions
           FunctionSignatureId.FN_EXTRACT_FROM_DATE,
           FunctionSignatureId.FN_EXTRACT_FROM_DATETIME,
           FunctionSignatureId.FN_EXTRACT_FROM_TIME,
-          FunctionSignatureId.FN_EXTRACT_FROM_TIMESTAMP,
-          FunctionSignatureId.FN_TIMESTAMP_FROM_STRING,
-          FunctionSignatureId.FN_TIMESTAMP_FROM_DATE,
-          // TODO: FunctionSignatureId.FN_TIMESTAMP_FROM_DATETIME
           FunctionSignatureId.FN_DATE_FROM_YEAR_MONTH_DAY
           // TODO: FunctionSignatureId.FN_DATE_FROM_TIMESTAMP
           );
@@ -106,7 +125,7 @@ public class SqlStdOperatorMappingTable {
   // todo: Some of operators defined here are later overridden in ZetaSQLPlannerImpl.
   // We should remove them from this table and add generic way to provide custom
   // implementation. (Ex.: timestamp_add)
-  public static final ImmutableMap<String, SqlOperator> ZETASQL_FUNCTION_TO_CALCITE_SQL_OPERATOR =
+  public static final Map<String, SqlOperator> ZETASQL_FUNCTION_TO_CALCITE_SQL_OPERATOR =
       ImmutableMap.<String, SqlOperator>builder()
           // grouped window function
           .put("TUMBLE", SqlStdOperatorTable.TUMBLE)
@@ -304,10 +323,6 @@ public class SqlStdOperatorMappingTable {
           // .put("time_sub", SqlStdOperatorTable.MINUS_DATE)
 
           // timestamp functions
-          .put(
-              "timestamp_add",
-              SqlStdOperatorTable.DATETIME_PLUS) // overridden in ZetaSQLPlannerImpl
-          // .put("timestamp_sub", SqlStdOperatorTable.MINUS_DATE)
           .put("$extract", SqlStdOperatorTable.EXTRACT)
           .put("timestamp", SqlOperators.TIMESTAMP_OP)
 
@@ -335,19 +350,7 @@ public class SqlStdOperatorMappingTable {
           .put("nullif", SqlStdOperatorTable.CASE)
           .build();
 
-  // argument one and two should compose of a interval.
-  public static final ImmutableSet<String> FUNCTION_FAMILY_DATE_ADD =
-      ImmutableSet.of(
-          "date_add",
-          "date_sub",
-          "datetime_add",
-          "datetime_sub",
-          "time_add",
-          "time_sub",
-          "timestamp_add",
-          "timestamp_sub");
-
-  public static final ImmutableMap<String, SqlOperatorRewriter>
+  public static final Map<String, SqlOperatorRewriter>
       ZETASQL_FUNCTION_TO_CALCITE_SQL_OPERATOR_REWRITER =
           ImmutableMap.<String, SqlOperatorRewriter>builder()
               .put("$case_with_value", new SqlCaseWithValueOperatorRewriter())

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
@@ -33,10 +33,16 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.math.LongMath;
 import org.joda.time.Instant;
 
-/** Utility methods for ZetaSQL related operations. */
+/**
+ * Utility methods for ZetaSQL related operations.
+ *
+ * <p>Unsupported ZetaSQL types: INT32, UINT32, UINT64, FLOAT, ENUM, PROTO, GEOGRAPHY
+ * TODO[BEAM-8630]: support ZetaSQL types: DATE, TIME, DATETIME
+ */
 @Internal
 public final class ZetaSqlUtils {
 
@@ -44,8 +50,28 @@ public final class ZetaSqlUtils {
 
   private ZetaSqlUtils() {}
 
-  // Unsupported ZetaSQL types: INT32, UINT32, UINT64, FLOAT, ENUM, PROTO, GEOGRAPHY
-  // TODO[BEAM-8630]: support ZetaSQL types: DATE, TIME, DATETIME
+  public static SqlTypeName zetaSqlTypeToCalciteType(TypeKind zetaSqlType) {
+    switch (zetaSqlType) {
+      case TYPE_INT64:
+        return SqlTypeName.BIGINT;
+      case TYPE_NUMERIC:
+        return SqlTypeName.DECIMAL;
+      case TYPE_DOUBLE:
+        return SqlTypeName.DOUBLE;
+      case TYPE_STRING:
+        return SqlTypeName.VARCHAR;
+      case TYPE_TIMESTAMP:
+        return SqlTypeName.TIMESTAMP;
+      case TYPE_BOOL:
+        return SqlTypeName.BOOLEAN;
+      case TYPE_BYTES:
+        return SqlTypeName.VARBINARY;
+        // TODO[BEAM-9179] Add conversion code for ARRAY and ROW types
+      default:
+        throw new IllegalArgumentException("Unsupported ZetaSQL type: " + zetaSqlType.name());
+    }
+  }
+
   public static Type beamFieldTypeToZetaSqlType(FieldType fieldType) {
     switch (fieldType.getTypeName()) {
       case INT64:

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
@@ -2227,12 +2227,45 @@ public class ZetaSQLDialectSpecTest {
     pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
   }
 
+  // TODO[BEAM-9166]: Add a test for CURRENT_TIMESTAMP function ("SELECT CURRENT_TIMESTAMP()")
+
   @Test
-  @Ignore("[BEAM-9178] Full TIMESTAMP function support will be added in PR10634")
-  public void testTimestampAddSub() {
+  public void testTimestampFromString() {
+    String sql = "SELECT TIMESTAMP(\"2008-12-25 15:30:00\", \"America/Los_Angeles\")";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(Schema.builder().addDateTimeField("f_timestamp").build())
+                .addValues(parseTimestampWithTimeZone("2008-12-25 15:30:00-08"))
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testStringFromTimestamp() {
+    String sql = "SELECT STRING(TIMESTAMP \"2008-12-25 15:30:00\", \"America/Los_Angeles\")";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(Schema.builder().addStringField("f_timestamp_string").build())
+                .addValues("2008-12-25 07:30:00-08")
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testTimestampAdd() {
     String sql =
         "SELECT "
-            + "TIMESTAMP_ADD(TIMESTAMP '2008-12-25 15:30:00 UTC', INTERVAL 10 MINUTE), "
+            + "TIMESTAMP_ADD(TIMESTAMP '2008-12-25 15:30:00 UTC', INTERVAL 5+5 MINUTE), "
             + "TIMESTAMP_ADD(TIMESTAMP '2008-12-25 15:30:00+07:30', INTERVAL 10 MINUTE)";
 
     ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
@@ -2243,12 +2276,192 @@ public class ZetaSQLDialectSpecTest {
         .containsInAnyOrder(
             Row.withSchema(
                     Schema.builder()
-                        .addDateTimeField("f_timestamp_plus")
-                        .addDateTimeField("f_timestamp_with_time_zone_plus")
+                        .addDateTimeField("f_timestamp_add")
+                        .addDateTimeField("f_timestamp_with_time_zone_add")
                         .build())
                 .addValues(
                     DateTimeUtils.parseTimestampWithUTCTimeZone("2008-12-25 15:40:00"),
                     parseTimestampWithTimeZone("2008-12-25 15:40:00+0730"))
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testTimestampSub() {
+    String sql =
+        "SELECT "
+            + "TIMESTAMP_SUB(TIMESTAMP '2008-12-25 15:30:00 UTC', INTERVAL 5+5 MINUTE), "
+            + "TIMESTAMP_SUB(TIMESTAMP '2008-12-25 15:30:00+07:30', INTERVAL 10 MINUTE)";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(
+                    Schema.builder()
+                        .addDateTimeField("f_timestamp_sub")
+                        .addDateTimeField("f_timestamp_with_time_zone_sub")
+                        .build())
+                .addValues(
+                    DateTimeUtils.parseTimestampWithUTCTimeZone("2008-12-25 15:20:00"),
+                    parseTimestampWithTimeZone("2008-12-25 15:20:00+0730"))
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testTimestampDiff() {
+    String sql =
+        "SELECT TIMESTAMP_DIFF("
+            + "TIMESTAMP \"2018-10-14 15:30:00.000 UTC\", "
+            + "TIMESTAMP \"2018-08-14 15:05:00.001 UTC\", "
+            + "MILLISECOND)";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(Schema.builder().addInt64Field("f_timestamp_diff").build())
+                .addValues((61L * 24 * 60 + 25) * 60 * 1000 - 1)
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testTimestampDiffNegativeResult() {
+    String sql = "SELECT TIMESTAMP_DIFF(TIMESTAMP \"2018-08-14\", TIMESTAMP \"2018-10-14\", DAY)";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(Schema.builder().addInt64Field("f_timestamp_diff").build())
+                .addValues(-61L)
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testTimestampTrunc() {
+    String sql = "SELECT TIMESTAMP_TRUNC(TIMESTAMP '2017-11-06 00:00:00+12', ISOWEEK, 'UTC')";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(Schema.builder().addDateTimeField("f_timestamp_trunc").build())
+                .addValues(DateTimeUtils.parseTimestampWithUTCTimeZone("2017-10-30 00:00:00"))
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testFormatTimestamp() {
+    String sql =
+        "SELECT FORMAT_TIMESTAMP(\"%D %T\", TIMESTAMP \"2018-10-14 15:30:00.123+00\", \"UTC\")";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(Schema.builder().addStringField("f_timestamp_str").build())
+                .addValues("10/14/18 15:30:00")
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testParseTimestamp() {
+    String sql = "SELECT PARSE_TIMESTAMP(\"%m-%d-%y %T\", \"10-14-18 15:30:00\", \"UTC\")";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(Schema.builder().addDateTimeField("f_timestamp").build())
+                .addValues(DateTimeUtils.parseTimestampWithUTCTimeZone("2018-10-14 15:30:00"))
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testTimestampFromInt64() {
+    String sql = "SELECT " + "TIMESTAMP_SECONDS(1230219000), " + "TIMESTAMP_MILLIS(1230219000123) ";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(
+                    Schema.builder()
+                        .addDateTimeField("f_timestamp_seconds")
+                        .addDateTimeField("f_timestamp_millis")
+                        .build())
+                .addValues(
+                    DateTimeUtils.parseTimestampWithUTCTimeZone("2008-12-25 15:30:00"),
+                    DateTimeUtils.parseTimestampWithUTCTimeZone("2008-12-25 15:30:00.123"))
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testTimestampToUnixInt64() {
+    String sql =
+        "SELECT "
+            + "UNIX_SECONDS(TIMESTAMP \"2008-12-25 15:30:00 UTC\"), "
+            + "UNIX_MILLIS(TIMESTAMP \"2008-12-25 15:30:00.123 UTC\")";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(
+                    Schema.builder()
+                        .addInt64Field("f_unix_seconds")
+                        .addInt64Field("f_unix_millis")
+                        .build())
+                .addValues(1230219000L, 1230219000123L)
+                .build());
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
+  }
+
+  @Test
+  public void testTimestampFromUnixInt64() {
+    String sql =
+        "SELECT "
+            + "TIMESTAMP_FROM_UNIX_SECONDS(1230219000), "
+            + "TIMESTAMP_FROM_UNIX_MILLIS(1230219000123) ";
+
+    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
+    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
+    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
+
+    PAssert.that(stream)
+        .containsInAnyOrder(
+            Row.withSchema(
+                    Schema.builder()
+                        .addDateTimeField("f_timestamp_seconds")
+                        .addDateTimeField("f_timestamp_millis")
+                        .build())
+                .addValues(
+                    DateTimeUtils.parseTimestampWithUTCTimeZone("2008-12-25 15:30:00"),
+                    DateTimeUtils.parseTimestampWithUTCTimeZone("2008-12-25 15:30:00.123"))
                 .build());
     pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
   }
@@ -2884,7 +3097,7 @@ public class ZetaSQLDialectSpecTest {
   }
 
   @Test
-  public void testTimeStampLiteralWithoutTimeZone() {
+  public void testTimestampLiteralWithoutTimeZone() {
     String sql = "SELECT TIMESTAMP '2016-12-25 05:30:00'";
     ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
     BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
@@ -2900,7 +3113,7 @@ public class ZetaSQLDialectSpecTest {
   }
 
   @Test
-  public void testTimeStampLiteralWithNonUTCTimeZone() {
+  public void testTimestampLiteralWithNonUTCTimeZone() {
     String sql = "SELECT TIMESTAMP '2016-12-25 05:30:00+05'";
     ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
     BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
@@ -3465,8 +3678,7 @@ public class ZetaSQLDialectSpecTest {
   }
 
   @Test
-  @Ignore("")
-  public void testTimestampAddWithParameter() {
+  public void testTimestampAddWithParameter1() {
     String sql = "SELECT TIMESTAMP_ADD(@p0, INTERVAL @p1 MILLISECOND)";
     ImmutableMap<String, Value> params =
         ImmutableMap.of(
@@ -3487,8 +3699,7 @@ public class ZetaSQLDialectSpecTest {
   }
 
   @Test
-  @Ignore("[BEAM-9178] Full TIMESTAMP function support will be added in PR10634")
-  public void testTimeStampAddWithParameter() {
+  public void testTimestampAddWithParameter2() {
     String sql = "SELECT TIMESTAMP_ADD(@p0, INTERVAL @p1 MINUTE)";
     ImmutableMap<String, Value> params =
         ImmutableMap.of(
@@ -3797,14 +4008,16 @@ public class ZetaSQLDialectSpecTest {
   public void testExtractTimestamp() {
     String sql =
         "WITH Timestamps AS (\n"
-            + "  SELECT TIMESTAMP '2005-01-03 12:34:56' AS timestamp UNION ALL\n"
-            + "  SELECT TIMESTAMP '2017-05-26'\n"
+            + "  SELECT TIMESTAMP '2007-12-31 12:34:56' AS timestamp UNION ALL\n"
+            + "  SELECT TIMESTAMP '2009-12-31'\n"
             + ")\n"
             + "SELECT\n"
-            + "  timestamp,\n"
             + "  EXTRACT(ISOYEAR FROM timestamp) AS isoyear,\n"
             + "  EXTRACT(YEAR FROM timestamp) AS year,\n"
             + "  EXTRACT(ISOWEEK FROM timestamp) AS week,\n"
+            // TODO[BEAM-9178]: Add tests for TIMESTAMP_TRUNC and EXTRACT with "week with weekday"
+            //  date parts once they are supported
+            // + "  EXTRACT(WEEK FROM timestamp) AS week,\n"
             + "  EXTRACT(MINUTE FROM timestamp) AS minute\n"
             + "FROM Timestamps\n";
 
@@ -3815,25 +4028,16 @@ public class ZetaSQLDialectSpecTest {
 
     final Schema schema =
         Schema.builder()
-            .addDateTimeField("ts")
             .addField("isoyear", FieldType.INT64)
             .addField("year", FieldType.INT64)
-            .addField("week", FieldType.INT64)
+            .addField("isoweek", FieldType.INT64)
+            // .addField("week", FieldType.INT64)
             .addField("minute", FieldType.INT64)
             .build();
     PAssert.that(stream)
         .containsInAnyOrder(
-            Row.withSchema(schema)
-                .addValues(
-                    DateTimeUtils.parseTimestampWithUTCTimeZone("2005-01-03 12:34:56"),
-                    2005L,
-                    2005L,
-                    1L,
-                    34L)
-                .build(),
-            Row.withSchema(schema)
-                .addValues(parseDate("2017-05-26"), 2017L, 2017L, 21L, 0L)
-                .build());
+            Row.withSchema(schema).addValues(2008L, 2007L, 1L /* , 53L */, 34L).build(),
+            Row.withSchema(schema).addValues(2009L, 2009L, 53L /* , 52L */, 0L).build());
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
   }


### PR DESCRIPTION
This PR adds support of **all** ZetaSQL ([BigQuery Standard SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions)) TIMESTAMP functions to BeamSQL:

- CURRENT_TIMESTAMP
- EXTRACT (extracting DATE and WEEK not supported)
- STRING
- TIMESTAMP (constructing TIMESTAMP from DATE or DATETIME not supported)
- TIMESTAMP_ADD
- TIMESTAMP_SUB
- TIMESTAMP_DIFF
- TIMESTAMP_TRUNC (truncating WEEK not supported)
- FORMAT_TIMESTAMP
- PARSE_TIMESTAMP
- TIMESTAMP_SECONDS and TIMESTAMP_MILLIS (TIMESTAMP_MICROS not supported)
- UNIX_SECONDS and UNIX_MILLIS (UNIX_MICROS not supported)
- TIMESTAMP_FROM_UNIX_SECONDS and TIMESTAMP_FROM_UNIX_MILLIS (TIMESTAMP_FROM_UNIX_MICROS not supported)

(Exception: the known precision and timezone issue)

r: @apilloud @kennknowles 
cc: @amaliujia @TheNeuralBit 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
