### PR TITLE
[BEAM-9151] Fix misconfigured legacy dataflow tests.

### DIFF
--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -56,7 +56,7 @@ def commonConfig = { dataflowWorkerJar, workerHarnessContainerImage = '', additi
                "--tempRoot=${gcsTempRoot}",
                "--runner=TestDataflowRunner",
                "--dataflowWorkerJar=${dataflowWorkerJar}",
-               workerHarnessContainerImage.isEmpty() ?'':"--workerHarnessContainerImage=${workerHarnessContainerImage}"
+               "--workerHarnessContainerImage=${workerHarnessContainerImage}"
                ] + additionalOptions
        systemProperty "beamTestPipelineOptions", JsonOutput.toJson(preCommitBeamTestPipelineOptions)
      }


### PR DESCRIPTION
R: @lukecwik 
When `dataflowWorkerJar` is provided, the `workerHarnessContainerImage` should be set to empty explicitly, otherwise, the dataflow service will ignore worker jar and still pick harness container

I'll cherry-pick it into 2.19.0 release branch to fix non-expected failures.