### PR TITLE
[BEAM-9184] Add ToSet combiner

### DIFF
--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -31,6 +31,7 @@ from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Set
 from typing import Tuple
 from typing import TypeVar
 from typing import Union
@@ -55,6 +56,7 @@ __all__ = [
     'Top',
     'ToDict',
     'ToList',
+    'ToSet',
     'Latest'
     ]
 
@@ -797,6 +799,35 @@ class ToDictCombineFn(core.CombineFn):
     for a in accumulators:
       result.update(a)
     return result
+
+  def extract_output(self, accumulator):
+    return accumulator
+
+
+class ToSet(ptransform.PTransform):
+  """A global CombineFn that condenses a PCollection into a set."""
+
+  def __init__(self, label='ToSet'):  # pylint: disable=useless-super-delegation
+    super(ToSet, self).__init__(label)
+
+  def expand(self, pcoll):
+    return pcoll | self.label >> core.CombineGlobally(ToSetCombineFn())
+
+
+@with_input_types(T)
+@with_output_types(Set[T])
+class ToSetCombineFn(core.CombineFn):
+  """CombineFn for ToSet."""
+
+  def create_accumulator(self):
+    return set()
+
+  def add_input(self, accumulator, element):
+    accumulator.add(element)
+    return accumulator
+
+  def merge_accumulators(self, accumulators):
+    return set.union(*accumulators)
 
   def extract_output(self, accumulator):
     return accumulator

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -350,7 +350,7 @@ class CombineTest(unittest.TestCase):
     pipeline = TestPipeline()
     the_list = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
     pcoll = pipeline | 'start' >> Create(the_list)
-    result = pcoll | 'to list' >> combine.ToSet()
+    result = pcoll | 'to set' >> combine.ToSet()
 
     def matcher(expected):
       def match(actual):

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -346,6 +346,18 @@ class CombineTest(unittest.TestCase):
     assert_that(result, matcher())
     pipeline.run()
 
+  def test_to_set(self):
+    pipeline = TestPipeline()
+    the_list = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
+    pcoll = pipeline | 'start' >> Create(the_list)
+    result = pcoll | 'to list' >> combine.ToSet()
+
+    def matcher(expected):
+      def match(actual):
+        equal_to(expected[0])(actual[0])
+      return match
+    assert_that(result, matcher(set(the_list)))
+
   def test_combine_globally_with_default(self):
     with TestPipeline() as p:
       assert_that(p | Create([]) | CombineGlobally(sum), equal_to([0]))


### PR DESCRIPTION
Adds ToSet(), following from ToList() and ToDict(). For lists with many duplicates, ToList() will not combine well. Pairing with an empty value to use ToDict() seems unnecessarily complicated.