### PR TITLE
[BEAM-9186] Allow injection of custom equality function.

### DIFF
--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -164,12 +164,13 @@ def equal_to(expected, equals_fn=None):
     # collection. It can also raise false negatives for types that don't have
     # a deterministic sort order, like pyarrow Tables as of 0.14.1
     if not equals_fn:
+      equals_fn = lambda e, a: e == a
       try:
         sorted_expected = sorted(expected)
         sorted_actual = sorted(actual)
         if sorted_expected == sorted_actual:
           return
-      except (BeamAssertException, TypeError):
+      except TypeError:
         pass
     # Slower method, used in two cases:
     # 1) If sorted expected != actual, use this method to verify the inequality.
@@ -177,8 +178,6 @@ def equal_to(expected, equals_fn=None):
     #    have a deterministic sort order.
     # 2) As a fallback if we encounter a TypeError in python 3. this method
     #    works on collections that have different types.
-    if not equals_fn:
-      equals_fn = lambda e, a: e == a
     unexpected = []
     for element in actual:
       found = False

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -155,11 +155,9 @@ def equal_to_per_window(expected_window_to_elements):
 # other. However, only permutations of the top level are checked. Therefore
 # [1,2] and [2,1] are considered equal and [[1,2]] and [[2,1]] are not.
 def equal_to(expected, equals_fn=None):
-  equal_to.equals_fn=equals_fn
 
-  def _equal(actual):
+  def _equal(actual, equals_fn=equals_fn):
     expected_list = list(expected)
-    equals_fn = equal_to.equals_fn
 
     # Try to compare actual and expected by sorting. This fails with a
     # TypeError in Python 3 if different types are present in the same

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -96,6 +96,11 @@ class UtilTest(unittest.TestCase):
         assert_that(p | Create(['a', 'b', 'c']),
                     equal_to(['a', 'b', 'd']))
 
+  def test_assert_with_custom_comparator(self):
+    with TestPipeline() as p:
+      assert_that(p | Create([1, 2, 3]), equal_to(
+          ['1', '2', '3'], equals_fn=lambda e, a: int(e) == int(a)))
+
   def test_reified_value_passes(self):
     expected = [TestWindowedValue(v, MIN_TIMESTAMP, [GlobalWindow()])
                 for v in [1, 2, 3]]


### PR DESCRIPTION
Testing complex object equality in beam tests is currently hard. This allows constructions like

```
assert_that(p | Create([1, 2, 3]), equal_to(
    ['1', '2', '3'], equals_fn=lambda e, a: int(e) == int(a)))
```