### PR TITLE
Update Beam Katas Python to use Python3

### DIFF
--- a/learning/katas/python/Common Transforms/Aggregation/Count/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Count/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -29,5 +30,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Aggregation/Largest/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Largest/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -29,5 +30,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Aggregation/Mean/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Mean/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -29,5 +30,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Aggregation/Smallest/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Smallest/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_answer_placeholders_text_deleted, test_is_not_empty
 
 
 def test_output():
@@ -29,5 +30,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Aggregation/Sum/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Sum/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -29,5 +30,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Filter/Filter/tests.py
+++ b/learning/katas/python/Common Transforms/Filter/Filter/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_filter():
@@ -39,6 +41,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_filter()
     test_output()

--- a/learning/katas/python/Common Transforms/Filter/ParDo/tests.py
+++ b/learning/katas/python/Common Transforms/Filter/ParDo/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -29,5 +30,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Core Transforms/Branching/Branching/tests.py
+++ b/learning/katas/python/Core Transforms/Branching/Branching/tests.py
@@ -14,7 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -39,5 +40,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Core Transforms/CoGroupByKey/CoGroupByKey/tests.py
+++ b/learning/katas/python/Core Transforms/CoGroupByKey/CoGroupByKey/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -33,5 +34,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Core Transforms/Combine/Combine PerKey/tests.py
+++ b/learning/katas/python/Core Transforms/Combine/Combine PerKey/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_combine_placeholders():
@@ -35,7 +37,7 @@ def test_output():
     PLAYER_3 = 'Player 3'
 
     answers = [str((PLAYER_1, 115)), str((PLAYER_2, 85)), str((PLAYER_3, 25))]
-    print answers
+    print(answers)
 
     if all(num in output for num in answers):
         passed()
@@ -44,6 +46,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_combine_placeholders()
     test_output()

--- a/learning/katas/python/Core Transforms/Combine/CombineFn/tests.py
+++ b/learning/katas/python/Core Transforms/Combine/CombineFn/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_combine_placeholders():
@@ -39,6 +41,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_combine_placeholders()
     test_output()

--- a/learning/katas/python/Core Transforms/Combine/Simple Function/tests.py
+++ b/learning/katas/python/Core Transforms/Combine/Simple Function/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_combine_placeholders():
@@ -39,6 +41,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_combine_placeholders()
     test_output()

--- a/learning/katas/python/Core Transforms/Composite Transform/Composite Transform/tests.py
+++ b/learning/katas/python/Core Transforms/Composite Transform/Composite Transform/tests.py
@@ -14,7 +14,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_composite_expand_method():
@@ -39,6 +41,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_composite_expand_method()
     test_output()

--- a/learning/katas/python/Core Transforms/Flatten/Flatten/tests.py
+++ b/learning/katas/python/Core Transforms/Flatten/Flatten/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_flatten():
@@ -39,6 +41,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_flatten()
     test_output()

--- a/learning/katas/python/Core Transforms/GroupByKey/GroupByKey/tests.py
+++ b/learning/katas/python/Core Transforms/GroupByKey/GroupByKey/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -31,5 +32,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Core Transforms/Map/FlatMap/tests.py
+++ b/learning/katas/python/Core Transforms/Map/FlatMap/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_flatmap():
@@ -39,6 +41,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_flatmap()
     test_output()

--- a/learning/katas/python/Core Transforms/Map/Map/tests.py
+++ b/learning/katas/python/Core Transforms/Map/Map/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_map():
@@ -39,6 +41,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_map()
     test_output()

--- a/learning/katas/python/Core Transforms/Map/ParDo OneToMany/tests.py
+++ b/learning/katas/python/Core Transforms/Map/ParDo OneToMany/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_dofn_process_method():
@@ -49,7 +51,8 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_dofn_process_method()
     test_pardo()
     test_output()

--- a/learning/katas/python/Core Transforms/Map/ParDo/tests.py
+++ b/learning/katas/python/Core Transforms/Map/ParDo/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_dofn_process_method():
@@ -49,7 +51,8 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_dofn_process_method()
     test_pardo()
     test_output()

--- a/learning/katas/python/Core Transforms/Partition/Partition/tests.py
+++ b/learning/katas/python/Core Transforms/Partition/Partition/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_partition():
@@ -48,6 +50,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_partition()
     test_output()

--- a/learning/katas/python/Core Transforms/Side Input/Side Input/tests.py
+++ b/learning/katas/python/Core Transforms/Side Input/Side Input/tests.py
@@ -22,8 +22,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, \
-    get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_dofn_process_method():
@@ -64,7 +65,8 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_dofn_process_method()
     test_pardo()
     test_output()

--- a/learning/katas/python/Core Transforms/Side Output/Side Output/tests.py
+++ b/learning/katas/python/Core Transforms/Side Output/Side Output/tests.py
@@ -14,8 +14,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, \
-    get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_dofn_process_method():
@@ -59,7 +60,8 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_dofn_process_method()
     test_pardo()
     test_output()

--- a/learning/katas/python/Examples/Word Count/Word Count/task-info.yaml
+++ b/learning/katas/python/Examples/Word Count/Word Count/task-info.yaml
@@ -1,29 +1,10 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-
 type: edu
 files:
 - name: task.py
   visible: true
   placeholders:
   - offset: 1021
-    length: 133
+    length: 136
     placeholder_text: TODO()
 - name: tests.py
   visible: false

--- a/learning/katas/python/Examples/Word Count/Word Count/task-info.yaml
+++ b/learning/katas/python/Examples/Word Count/Word Count/task-info.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 type: edu
 files:
 - name: task.py

--- a/learning/katas/python/Examples/Word Count/Word Count/task.html
+++ b/learning/katas/python/Examples/Word Count/Word Count/task.html
@@ -33,4 +33,8 @@
 <div class="hint">
   Refer to your katas above.
 </div>
+<div class="hint">
+  Use <a href="https://beam.apache.org/releases/pydoc/current/apache_beam.transforms.core.html#apache_beam.transforms.core.MapTuple">
+  MapTuple</a> to unpack key-value pair into different function arguments.
+</div>
 </html>

--- a/learning/katas/python/Examples/Word Count/Word Count/task.py
+++ b/learning/katas/python/Examples/Word Count/Word Count/task.py
@@ -29,7 +29,7 @@ p = beam.Pipeline()
 
    | beam.FlatMap(lambda sentence: sentence.split())
    | beam.combiners.Count.PerElement()
-   | beam.Map(lambda (k, v): k + ":" + str(v))
+   | beam.MapTuple(lambda k, v: k + ":" + str(v))
 
    | LogElements())
 

--- a/learning/katas/python/Examples/Word Count/Word Count/tests.py
+++ b/learning/katas/python/Examples/Word Count/Word Count/tests.py
@@ -14,7 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_file_output
+from test_helper import failed, passed, get_file_output, \
+    test_is_not_empty, test_answer_placeholders_text_deleted
 
 
 def test_output():
@@ -35,5 +36,6 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/IO/Built-in IOs/Built-in IOs/task-info.yaml
+++ b/learning/katas/python/IO/Built-in IOs/Built-in IOs/task-info.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-type: edu
+type: theory
 files:
 - name: task.py
   visible: true

--- a/learning/katas/python/IO/Built-in IOs/Built-in IOs/task.html
+++ b/learning/katas/python/IO/Built-in IOs/Built-in IOs/task.html
@@ -27,7 +27,6 @@
   Transforms</a> page for a list of the currently available I/O transforms.
 </p>
 <p>
-  <b>Note:</b> There is no kata for this task. Please click the "Check" button and
-  proceed to the next task.
+  <b>Note:</b> There is no kata for this task. Please proceed to the next task.
 </p>
 </html>

--- a/learning/katas/python/IO/TextIO/ReadFromText/tests.py
+++ b/learning/katas/python/IO/TextIO/ReadFromText/tests.py
@@ -14,7 +14,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_readfromtext_method():
@@ -50,6 +52,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_readfromtext_method()
     test_output()

--- a/learning/katas/python/Introduction/Hello Beam/Hello Beam/tests.py
+++ b/learning/katas/python/Introduction/Hello Beam/Hello Beam/tests.py
@@ -14,7 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import run_common_tests, failed, passed, get_answer_placeholders, get_file_output
+from test_helper import failed, passed, \
+    get_answer_placeholders, get_file_output, test_is_not_empty, \
+    test_answer_placeholders_text_deleted
 
 
 def test_answer_placeholders():
@@ -36,6 +38,7 @@ def test_output():
 
 
 if __name__ == '__main__':
-    run_common_tests()
+    test_is_not_empty()
+    test_answer_placeholders_text_deleted()
     test_answer_placeholders()
     test_output()

--- a/learning/katas/python/course-info.yaml
+++ b/learning/katas/python/course-info.yaml
@@ -22,7 +22,7 @@ language: English
 summary: "This course provides a series of katas to get familiar with Apache Beam.\
   \ \n\nApache Beam website – https://beam.apache.org/"
 programming_language: Python
-programming_language_version: 2.7
+programming_language_version: 3.7
 content:
 - Introduction
 - Core Transforms

--- a/learning/katas/python/course-remote-info.yaml
+++ b/learning/katas/python/course-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 54532
-update_date: Wed, 19 Jun 2019 10:36:17 UTC
+update_date: Mon, 20 Jan 2020 15:20:43 UTC

--- a/learning/katas/python/log_elements.py
+++ b/learning/katas/python/log_elements.py
@@ -26,7 +26,7 @@ class LogElements(beam.PTransform):
             self.prefix = prefix
 
         def process(self, element, **kwargs):
-            print self.prefix + str(element)
+            print(self.prefix + str(element))
             yield element
 
     def __init__(self, label=None, prefix=''):

--- a/learning/katas/python/requirements.txt
+++ b/learning/katas/python/requirements.txt
@@ -14,5 +14,5 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-apache-beam==2.13.0
-apache-beam[test]==2.13.0
+apache-beam==2.17.0
+apache-beam[test]==2.17.0


### PR DESCRIPTION
Update Beam Katas to support Python 3, and also updated Beam version to 2.17.0

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
