### PR TITLE
[BEAM-7427] Refactor JmsCheckpointMark to use SerializableCoder

### DIFF
--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
@@ -17,48 +17,55 @@
  */
 package org.apache.beam.sdk.io.jms;
 
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
 import javax.jms.Message;
-import org.apache.beam.sdk.coders.AvroCoder;
-import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.io.UnboundedSource;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Checkpoint for an unbounded JmsIO.Read. Consists of JMS destination name, and the latest message
- * ID consumed so far.
+ * Checkpoint for an unbounded JMS source. Consists of the JMS messages waiting to be acknowledged
+ * and oldest pending message timestamp.
  */
-@DefaultCoder(AvroCoder.class)
-public class JmsCheckpointMark implements UnboundedSource.CheckpointMark {
+@VisibleForTesting
+public class JmsCheckpointMark implements UnboundedSource.CheckpointMark, Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(JmsCheckpointMark.class);
 
-  private final State state = new State();
+  @VisibleForTesting Instant oldestMessageTimestamp = Instant.now();
+  @VisibleForTesting transient List<Message> messages = new ArrayList<>();
+
+  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
   public JmsCheckpointMark() {}
 
-  protected List<Message> getMessages() {
-    return state.getMessages();
+  public void add(Message message) throws Exception {
+    lock.writeLock().lock();
+    try {
+      Instant currentMessageTimestamp = new Instant(message.getJMSTimestamp());
+      if (currentMessageTimestamp.isBefore(oldestMessageTimestamp)) {
+        oldestMessageTimestamp = currentMessageTimestamp;
+      }
+      messages.add(message);
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
-  protected void addMessage(Message message) throws Exception {
-    Instant currentMessageTimestamp = new Instant(message.getJMSTimestamp());
-    state.atomicWrite(
-        () -> {
-          state.updateOldestPendingTimestampIf(currentMessageTimestamp, Instant::isBefore);
-          state.addMessage(message);
-        });
-  }
-
-  protected Instant getOldestPendingTimestamp() {
-    return state.getOldestPendingTimestamp();
+  public Instant getOldestMessageTimestamp() {
+    lock.readLock().lock();
+    try {
+      return this.oldestMessageTimestamp;
+    } finally {
+      lock.readLock().unlock();
+    }
   }
 
   /**
@@ -68,117 +75,44 @@ public class JmsCheckpointMark implements UnboundedSource.CheckpointMark {
    */
   @Override
   public void finalizeCheckpoint() {
-    State snapshot = state.snapshot();
-    for (Message message : snapshot.messages) {
-      try {
-        message.acknowledge();
-        Instant currentMessageTimestamp = new Instant(message.getJMSTimestamp());
-        snapshot.updateOldestPendingTimestampIf(currentMessageTimestamp, Instant::isAfter);
-      } catch (Exception e) {
-        LOG.error("Exception while finalizing message: {}", e);
+    lock.writeLock().lock();
+    try {
+      for (Message message : messages) {
+        try {
+          message.acknowledge();
+          Instant currentMessageTimestamp = new Instant(message.getJMSTimestamp());
+          if (currentMessageTimestamp.isAfter(oldestMessageTimestamp)) {
+            oldestMessageTimestamp = currentMessageTimestamp;
+          }
+        } catch (Exception e) {
+          LOG.error("Exception while finalizing message: {}", e);
+        }
       }
+      messages.clear();
+    } finally {
+      lock.writeLock().unlock();
     }
-    state.atomicWrite(
-        () -> {
-          state.removeMessages(snapshot.messages);
-          state.updateOldestPendingTimestampIf(snapshot.oldestPendingTimestamp, Instant::isAfter);
-        });
   }
 
-  /**
-   * Encapsulates the state of a checkpoint mark; the list of messages pending finalisation and the
-   * oldest pending timestamp. Read/write-exclusive access is provided throughout, and constructs
-   * allowing multiple operations to be performed atomically -- i.e. performed within the context of
-   * a single lock operation -- are made available.
-   */
-  private class State {
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+  // set an empty list to messages when deserialize
+  private void readObject(java.io.ObjectInputStream stream)
+      throws IOException, ClassNotFoundException {
+    stream.defaultReadObject();
+    messages = new ArrayList<>();
+  }
 
-    private final List<Message> messages;
-    private Instant oldestPendingTimestamp;
-
-    public State() {
-      this(new ArrayList<>(), BoundedWindow.TIMESTAMP_MIN_VALUE);
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof JmsCheckpointMark) {
+      JmsCheckpointMark that = (JmsCheckpointMark) other;
+      return Objects.equals(this.oldestMessageTimestamp, that.oldestMessageTimestamp);
+    } else {
+      return false;
     }
+  }
 
-    private State(List<Message> messages, Instant oldestPendingTimestamp) {
-      this.messages = messages;
-      this.oldestPendingTimestamp = oldestPendingTimestamp;
-    }
-
-    /**
-     * Create and return a copy of the current state.
-     *
-     * @return A new {@code State} instance which is a deep copy of the target instance at the time
-     *     of execution.
-     */
-    public State snapshot() {
-      return atomicRead(() -> new State(new ArrayList<>(messages), oldestPendingTimestamp));
-    }
-
-    public Instant getOldestPendingTimestamp() {
-      return atomicRead(() -> oldestPendingTimestamp);
-    }
-
-    public List<Message> getMessages() {
-      return atomicRead(() -> messages);
-    }
-
-    public void addMessage(Message message) {
-      atomicWrite(() -> messages.add(message));
-    }
-
-    public void removeMessages(List<Message> messages) {
-      atomicWrite(() -> this.messages.removeAll(messages));
-    }
-
-    /**
-     * Conditionally sets {@code oldestPendingTimestamp} to the value of the supplied {@code
-     * candidate}, iff the provided {@code check} yields true for the {@code candidate} when called
-     * with the existing {@code oldestPendingTimestamp} value.
-     *
-     * @param candidate The potential new value.
-     * @param check The comparison method to call on {@code candidate} passing the existing {@code
-     *     oldestPendingTimestamp} value as a parameter.
-     */
-    private void updateOldestPendingTimestampIf(
-        Instant candidate, BiFunction<Instant, Instant, Boolean> check) {
-      atomicWrite(
-          () -> {
-            if (check.apply(candidate, oldestPendingTimestamp)) {
-              oldestPendingTimestamp = candidate;
-            }
-          });
-    }
-
-    /**
-     * Call the provided {@link Supplier} under this State's read lock and return its result.
-     *
-     * @param operation The code to execute in the context of this State's read lock.
-     * @param <T> The return type of the provided {@link Supplier}.
-     * @return The value produced by the provided {@link Supplier}.
-     */
-    public <T> T atomicRead(Supplier<T> operation) {
-      lock.readLock().lock();
-      try {
-        return operation.get();
-      } finally {
-        lock.readLock().unlock();
-      }
-    }
-
-    /**
-     * Call the provided {@link Runnable} under this State's write lock.
-     *
-     * @param operation The code to execute in the context of this State's write lock.
-     */
-    public void atomicWrite(Runnable operation) {
-      lock.writeLock().lock();
-      try {
-        operation.run();
-      } finally {
-        lock.writeLock().unlock();
-      }
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(oldestMessageTimestamp, messages);
   }
 }

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -38,7 +38,6 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.Read.Unbounded;
@@ -406,7 +405,7 @@ public class JmsIO {
 
   /** An unbounded JMS source. */
   @VisibleForTesting
-  protected static class UnboundedJmsSource<T> extends UnboundedSource<T, JmsCheckpointMark> {
+  static class UnboundedJmsSource<T> extends UnboundedSource<T, JmsCheckpointMark> {
 
     private final Read<T> spec;
 
@@ -439,7 +438,7 @@ public class JmsIO {
 
     @Override
     public Coder<JmsCheckpointMark> getCheckpointMarkCoder() {
-      return AvroCoder.of(JmsCheckpointMark.class);
+      return SerializableCoder.of(JmsCheckpointMark.class);
     }
 
     @Override
@@ -516,7 +515,7 @@ public class JmsIO {
           return false;
         }
 
-        checkpointMark.addMessage(message);
+        checkpointMark.add(message);
 
         currentMessage = this.source.spec.getMessageMapper().mapMessage(message);
         currentTimestamp = new Instant(message.getJMSTimestamp());
@@ -537,7 +536,7 @@ public class JmsIO {
 
     @Override
     public Instant getWatermark() {
-      return checkpointMark.getOldestPendingTimestamp();
+      return checkpointMark.getOldestMessageTimestamp();
     }
 
     @Override

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -48,9 +48,11 @@ import org.apache.activemq.security.AuthenticationUser;
 import org.apache.activemq.security.SimpleAuthenticationPlugin;
 import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.activemq.util.Callback;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Count;
@@ -404,6 +406,16 @@ public class JmsIOTest {
     // Concurrency issues would cause an exception to be thrown before this method exits, failing
     // the test
     runner.join();
+  }
+
+  /** Test the checkpoint mark default coder, which is actually AvroCoder. */
+  @Test
+  public void testCheckpointMarkDefaultCoder() throws Exception {
+    JmsCheckpointMark jmsCheckpointMark = new JmsCheckpointMark();
+    jmsCheckpointMark.add(new ActiveMQMessage());
+    Coder coder = new JmsIO.UnboundedJmsSource(null).getCheckpointMarkCoder();
+    CoderProperties.coderSerializable(coder);
+    CoderProperties.coderDecodeEncodeEqual(coder, jmsCheckpointMark);
   }
 
   private int count(String queue) throws Exception {


### PR DESCRIPTION
This refactoring uses JmsCheckpointMark coder compatible.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
