### PR TITLE
[BEAM-9167] Reduce Go SDK metric overhead

### DIFF
--- a/sdks/go/pkg/beam/core/metrics/metrics.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics.go
@@ -49,10 +49,13 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/ioutilx"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
 	"github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 	"github.com/golang/protobuf/ptypes"
@@ -64,22 +67,57 @@ import (
 // using metrics requires the PTransform have a context.Context
 // argument.
 
+// perBundle is a struct that retains per transform countersets.
+// TODO(lostluck): Migrate the exec package to use these to extract
+// metric data for export to runner, rather than the global store.
+type perBundle struct {
+	mu  sync.Mutex
+	css []*ptCounterSet
+}
+
+type nameHash uint64
+
+// ptCounterSet is the internal tracking struct for a single ptransform
+// in a single bundle for all counter types.
+type ptCounterSet struct {
+	// We store the user path access to the cells in metric type segregated
+	// maps. At present, caching the name hash,
+	counters      map[nameHash]*counter
+	distributions map[nameHash]*distribution
+	gauges        map[nameHash]*gauge
+}
+
 type ctxKey string
 
-const bundleKey ctxKey = "beam:bundle"
-const ptransformKey ctxKey = "beam:ptransform"
+const (
+	bundleKey     ctxKey = "beam:bundle"
+	ptransformKey ctxKey = "beam:ptransform"
+	counterSetKey ctxKey = "beam:counterset"
+)
 
 // beamCtx is a caching context for IDs necessary to place metric updates.
-//  Allocating contexts and searching for PTransformIDs for every element
+// Allocating contexts and searching for PTransformIDs for every element
 // is expensive, so we avoid it if possible.
 type beamCtx struct {
 	context.Context
 	bundleID, ptransformID string
+	bs                     *perBundle
+	cs                     *ptCounterSet
 }
 
-// Value lifts the beam contLift the keys value for faster lookups when not available.
+// Value implements context.Value for beamCtx, and lifts the
+// values for metrics keys for value for faster lookups.
 func (ctx *beamCtx) Value(key interface{}) interface{} {
 	switch key {
+	case counterSetKey:
+		if ctx.cs == nil {
+			if cs := ctx.Context.Value(key); cs != nil {
+				ctx.cs = cs.(*ptCounterSet)
+			} else {
+				return nil
+			}
+		}
+		return ctx.cs
 	case bundleKey:
 		if ctx.bundleID == "" {
 			if id := ctx.Context.Value(key); id != nil {
@@ -102,24 +140,30 @@ func (ctx *beamCtx) Value(key interface{}) interface{} {
 	return ctx.Context.Value(key)
 }
 
+func (ctx *beamCtx) String() string {
+	return fmt.Sprintf("beamCtx[%s;%s]", ctx.bundleID, ctx.ptransformID)
+}
+
 // SetBundleID sets the id of the current Bundle.
 func SetBundleID(ctx context.Context, id string) context.Context {
 	// Checking for *beamCtx is an optimization, so we don't dig deeply
 	// for ids if not necessary.
 	if bctx, ok := ctx.(*beamCtx); ok {
-		return &beamCtx{Context: bctx.Context, bundleID: id, ptransformID: bctx.ptransformID}
+		return &beamCtx{Context: bctx.Context, bundleID: id, bs: &perBundle{}, ptransformID: bctx.ptransformID}
 	}
-	return &beamCtx{Context: ctx, bundleID: id}
+	return &beamCtx{Context: ctx, bundleID: id, bs: &perBundle{}}
 }
 
 // SetPTransformID sets the id of the current PTransform.
+// Must only be called on a context returened by SetBundleID.
 func SetPTransformID(ctx context.Context, id string) context.Context {
 	// Checking for *beamCtx is an optimization, so we don't dig deeply
 	// for ids if not necessary.
 	if bctx, ok := ctx.(*beamCtx); ok {
-		return &beamCtx{Context: bctx.Context, bundleID: bctx.bundleID, ptransformID: id}
+		return &beamCtx{Context: bctx.Context, bundleID: bctx.bundleID, bs: bctx.bs, ptransformID: id}
 	}
-	return &beamCtx{Context: ctx, ptransformID: id}
+	panic(fmt.Sprintf("SetPTransformID called before SetBundleID for %v", id))
+	return nil // never runs.
 }
 
 const (
@@ -138,9 +182,55 @@ func getContextKey(ctx context.Context, n name) key {
 	return key
 }
 
+func getCounterSet(ctx context.Context) *ptCounterSet {
+	if id := ctx.Value(counterSetKey); id != nil {
+		return id.(*ptCounterSet)
+	}
+	// It's not set anywhere and wasn't hoisted, so create it.
+	if bctx, ok := ctx.(*beamCtx); ok {
+		bctx.bs.mu.Lock()
+		cs := &ptCounterSet{
+			counters:      make(map[nameHash]*counter),
+			distributions: make(map[nameHash]*distribution),
+			gauges:        make(map[nameHash]*gauge),
+		}
+		bctx.bs.css = append(bctx.bs.css, cs)
+		bctx.cs = cs
+		bctx.bs.mu.Unlock()
+		return cs
+	}
+	panic("counterSet missing, beam isn't set up properly.")
+	return nil // never runs.
+}
+
+type kind uint8
+
+const (
+	kindUnknown kind = iota
+	kindSumCounter
+	kindDistribution
+	kindGauge
+)
+
+func (t kind) String() string {
+	switch t {
+	case kindSumCounter:
+		return "Counter"
+	case kindDistribution:
+		return "Distribution"
+	case kindGauge:
+		return "Gauge"
+	default:
+		panic(fmt.Sprintf("Unknown metric type value: %v", uint8(t)))
+	}
+}
+
 // userMetric knows how to convert it's value to a Metrics_User proto.
+// TODO(lostluck): Move proto translation to the harness package to
+// avoid the proto dependency outside of the harness.
 type userMetric interface {
 	toProto() *fnexecution_v1.Metrics_User
+	kind() kind
 }
 
 // name is a pair of strings identifying a specific metric.
@@ -159,43 +249,87 @@ func newName(ns, n string) name {
 	return name{namespace: ns, name: n}
 }
 
+// We hash the name to a uint64 so we avoid using go's native string hashing for
+// every use of a metrics. uint64s have faster lookup than strings as a result.
+// Collisions are possible, but statistically unlikely as namespaces and names
+// are usually short enough to avoid this.
+var (
+	hasherMu sync.Mutex
+	hasher   = fnv.New64a()
+)
+
+func hashName(ns, n string) nameHash {
+	hasherMu.Lock()
+	hasher.Reset()
+	var buf [64]byte
+	b := buf[:]
+	hashString(ns, b)
+	hashString(n, b)
+	h := hasher.Sum64()
+	hasherMu.Unlock()
+	return nameHash(h)
+}
+
+// hashString hashes a string with the package level hasher
+// and requires posession of the hasherMu lock. The byte
+// slice is assumed to be backed by a [64]byte.
+func hashString(s string, b []byte) {
+	l := len(s)
+	i := 0
+	for len(s)-i > 64 {
+		n := i + 64
+		copy(b, s[i:n])
+		ioutilx.WriteUnsafe(hasher, b)
+		i = n
+	}
+	n := l - i
+	copy(b, s[i:])
+	ioutilx.WriteUnsafe(hasher, b[:n])
+}
+
 type key struct {
 	name               name
 	bundle, ptransform string
 }
 
 var (
-	// mu protects access to store
+	// mu protects access to the global store
 	mu sync.RWMutex
 	// store is a map of BundleIDs to PtransformIDs to userMetrics.
 	// it permits us to extract metric protos for runners per data Bundle, and
 	// per PTransform.
+	// TODO(lostluck): Migrate exec/plan.go to manage it's own perBundle counter stores.
+	// Note: This is safe to use to read the metrics concurrently with user modification
+	// in bundles, as only initial use modifies this map, and only contains the resulting
+	// metrics.
 	store = make(map[string]map[string]map[name]userMetric)
-
-	// We store the user path access to the cells in metric type segregated
-	// sync.Maps. Using sync.Maps lets metrics with disjoint keys have concurrent
-	// access to the cells, and using separate sync.Map per metric type
-	// simplifies code understanding, since each only contains a single type of
-	// cell.
-
-	countersMu      sync.RWMutex
-	counters        = make(map[key]*counter)
-	distributionsMu sync.RWMutex
-	distributions   = make(map[key]*distribution)
-	gaugesMu        sync.RWMutex
-	gauges          = make(map[key]*gauge)
 )
 
-// TODO(lostluck): 2018/03/05 Use a common internal beam now() instead, once that exists.
-var now = time.Now
+// storeMetric stores a metric away on its first use so it may be retrieved later on.
+// In the event of a name collision, storeMetric can panic, so it's prudent to release
+// locks if they are no longer required.
+func storeMetric(key key, m userMetric) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, ok := store[key.bundle]; !ok {
+		store[key.bundle] = make(map[string]map[name]userMetric)
+	}
+	if _, ok := store[key.bundle][key.ptransform]; !ok {
+		store[key.bundle][key.ptransform] = make(map[name]userMetric)
+	}
+	if ms, ok := store[key.bundle][key.ptransform][key.name]; ok {
+		if ms.kind() != m.kind() {
+			panic(fmt.Sprintf("metric name %s being reused for a second metric in a single PTransform", key.name))
+		}
+		return
+	}
+	store[key.bundle][key.ptransform][key.name] = m
+}
 
 // Counter is a simple counter for incrementing and decrementing a value.
 type Counter struct {
 	name name
-	// The following are a fast cache of the key and storage
-	mu sync.Mutex
-	k  key
-	c  *counter
+	hash nameHash
 }
 
 func (m *Counter) String() string {
@@ -204,38 +338,26 @@ func (m *Counter) String() string {
 
 // NewCounter returns the Counter with the given namespace and name.
 func NewCounter(ns, n string) *Counter {
-	mn := newName(ns, n)
 	return &Counter{
-		name: mn,
+		name: newName(ns, n),
+		hash: hashName(ns, n),
 	}
 }
 
 // Inc increments the counter within the given PTransform context by v.
 func (m *Counter) Inc(ctx context.Context, v int64) {
-	key := getContextKey(ctx, m.name)
-	cs := &counter{
-		value: v,
-	}
-	m.mu.Lock()
-	if m.k == key {
-		m.c.inc(v)
-		m.mu.Unlock()
-		return
-	}
-	m.k = key
-	countersMu.Lock()
-	if c, loaded := counters[key]; loaded {
-		m.c = c
-		countersMu.Unlock()
-		m.mu.Unlock()
+	cs := getCounterSet(ctx)
+	if c, ok := cs.counters[m.hash]; ok {
 		c.inc(v)
 		return
 	}
-	m.c = cs
-	counters[key] = cs
-	countersMu.Unlock()
-	m.mu.Unlock()
-	storeMetric(key, cs)
+	// We're the first to create this metric!
+	c := &counter{
+		value: v,
+	}
+	cs.counters[m.hash] = c
+	key := getContextKey(ctx, m.name)
+	storeMetric(key, c)
 }
 
 // Dec decrements the counter within the given PTransform context by v.
@@ -246,13 +368,10 @@ func (m *Counter) Dec(ctx context.Context, v int64) {
 // counter is a metric cell for counter values.
 type counter struct {
 	value int64
-	mu    sync.Mutex
 }
 
 func (m *counter) inc(v int64) {
-	m.mu.Lock()
-	m.value += v
-	m.mu.Unlock()
+	atomic.AddInt64(&m.value, v)
 }
 
 func (m *counter) String() string {
@@ -262,25 +381,23 @@ func (m *counter) String() string {
 // toProto returns a Metrics_User populated with the Data messages, but not the name. The
 // caller needs to populate with the metric's name.
 func (m *counter) toProto() *fnexecution_v1.Metrics_User {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	return &fnexecution_v1.Metrics_User{
 		Data: &fnexecution_v1.Metrics_User_CounterData_{
 			CounterData: &fnexecution_v1.Metrics_User_CounterData{
-				Value: m.value,
+				Value: atomic.LoadInt64(&m.value),
 			},
 		},
 	}
 }
 
+func (m *counter) kind() kind {
+	return kindSumCounter
+}
+
 // Distribution is a simple distribution of values.
 type Distribution struct {
 	name name
-
-	// The following are a fast cache of the key and storage
-	mu sync.Mutex
-	k  key
-	d  *distribution
+	hash nameHash
 }
 
 func (m *Distribution) String() string {
@@ -289,41 +406,29 @@ func (m *Distribution) String() string {
 
 // NewDistribution returns the Distribution with the given namespace and name.
 func NewDistribution(ns, n string) *Distribution {
-	mn := newName(ns, n)
 	return &Distribution{
-		name: mn,
+		name: newName(ns, n),
+		hash: hashName(ns, n),
 	}
 }
 
 // Update updates the distribution within the given PTransform context with v.
 func (m *Distribution) Update(ctx context.Context, v int64) {
-	key := getContextKey(ctx, m.name)
-	ds := &distribution{
+	cs := getCounterSet(ctx)
+	if d, ok := cs.distributions[m.hash]; ok {
+		d.update(v)
+		return
+	}
+	// We're the first to create this metric!
+	d := &distribution{
 		count: 1,
 		sum:   v,
 		min:   v,
 		max:   v,
 	}
-	m.mu.Lock()
-	if m.k == key {
-		m.d.update(v)
-		m.mu.Unlock()
-		return
-	}
-	m.k = key
-	distributionsMu.Lock()
-	if d, loaded := distributions[key]; loaded {
-		m.d = d
-		distributionsMu.Unlock()
-		m.mu.Unlock()
-		d.update(v)
-		return
-	}
-	m.d = ds
-	distributions[key] = ds
-	distributionsMu.Unlock()
-	m.mu.Unlock()
-	storeMetric(key, ds)
+	cs.distributions[m.hash] = d
+	key := getContextKey(ctx, m.name)
+	storeMetric(key, d)
 }
 
 // distribution is a metric cell for distribution values.
@@ -366,14 +471,14 @@ func (m *distribution) toProto() *fnexecution_v1.Metrics_User {
 	}
 }
 
+func (m *distribution) kind() kind {
+	return kindDistribution
+}
+
 // Gauge is a time, value pair metric.
 type Gauge struct {
 	name name
-
-	// The following are a fast cache of the key and storage
-	mu sync.Mutex
-	k  key
-	g  *gauge
+	hash nameHash
 }
 
 func (m *Gauge) String() string {
@@ -382,57 +487,30 @@ func (m *Gauge) String() string {
 
 // NewGauge returns the Gauge with the given namespace and name.
 func NewGauge(ns, n string) *Gauge {
-	mn := newName(ns, n)
 	return &Gauge{
-		name: mn,
+		name: newName(ns, n),
+		hash: hashName(ns, n),
 	}
 }
+
+// TODO(lostluck): 2018/03/05 Use a common internal beam now() instead, once that exists.
+var now = time.Now
 
 // Set sets the gauge to the given value, and associates it with the current time on the clock.
 func (m *Gauge) Set(ctx context.Context, v int64) {
-	key := getContextKey(ctx, m.name)
-	gs := &gauge{
-		t: now(),
-		v: v,
-	}
-	m.mu.Lock()
-	if m.k == key {
-		m.g.set(v)
-		m.mu.Unlock()
-		return
-	}
-	m.k = key
-	gaugesMu.Lock()
-	if g, loaded := gauges[key]; loaded {
-		m.g = g
-		gaugesMu.Unlock()
-		m.mu.Unlock()
+	cs := getCounterSet(ctx)
+	if g, ok := cs.gauges[m.hash]; ok {
 		g.set(v)
 		return
 	}
-	m.g = gs
-	gauges[key] = gs
-	gaugesMu.Unlock()
-	m.mu.Unlock()
-	storeMetric(key, gs)
-}
-
-// storeMetric stores a metric away on its first use so it may be retrieved later on.
-// In the event of a name collision, storeMetric can panic, so it's prudent to release
-// locks if they are no longer required.
-func storeMetric(key key, m userMetric) {
-	mu.Lock()
-	defer mu.Unlock()
-	if _, ok := store[key.bundle]; !ok {
-		store[key.bundle] = make(map[string]map[name]userMetric)
+	// We're the first to create this metric!
+	g := &gauge{
+		t: now(),
+		v: v,
 	}
-	if _, ok := store[key.bundle][key.ptransform]; !ok {
-		store[key.bundle][key.ptransform] = make(map[name]userMetric)
-	}
-	if _, ok := store[key.bundle][key.ptransform][key.name]; ok {
-		panic(fmt.Sprintf("metric name %s being reused for a second metric in a single PTransform", key.name))
-	}
-	store[key.bundle][key.ptransform][key.name] = m
+	cs.gauges[m.hash] = g
+	key := getContextKey(ctx, m.name)
+	storeMetric(key, g)
 }
 
 // gauge is a metric cell for gauge values.
@@ -466,8 +544,12 @@ func (m *gauge) toProto() *fnexecution_v1.Metrics_User {
 	}
 }
 
+func (m *gauge) kind() kind {
+	return kindGauge
+}
+
 func (m *gauge) String() string {
-	return fmt.Sprintf("time: %s value: %d", m.t, m.v)
+	return fmt.Sprintf("%v time: %s value: %d", m.kind(), m.t, m.v)
 }
 
 // ToProto exports all collected metrics for the given BundleID and PTransform ID pair.
@@ -505,23 +587,19 @@ func DumpToOut() {
 func dumpTo(p func(format string, args ...interface{})) {
 	mu.RLock()
 	defer mu.RUnlock()
-	countersMu.RLock()
-	defer countersMu.RUnlock()
-	distributionsMu.RLock()
-	defer distributionsMu.RUnlock()
-	gaugesMu.RLock()
-	defer gaugesMu.RUnlock()
 	var bs []string
 	for b := range store {
 		bs = append(bs, b)
 	}
 	sort.Strings(bs)
+
 	for _, b := range bs {
 		var pts []string
 		for pt := range store[b] {
 			pts = append(pts, pt)
 		}
 		sort.Strings(pts)
+
 		for _, pt := range pts {
 			var ns []name
 			for n := range store[b][pt] {
@@ -537,17 +615,10 @@ func dumpTo(p func(format string, args ...interface{})) {
 				return false
 			})
 			p("Bundle: %q - PTransformID: %q", b, pt)
+
 			for _, n := range ns {
-				key := key{name: n, bundle: b, ptransform: pt}
-				if m, ok := counters[key]; ok {
-					p("\t%s - %s", key.name, m)
-				}
-				if m, ok := distributions[key]; ok {
-					p("\t%s - %s", key.name, m)
-				}
-				if m, ok := gauges[key]; ok {
-					p("\t%s - %s", key.name, m)
-				}
+				m := store[b][pt][n]
+				p("\t%s - %s", n, m)
 			}
 		}
 	}
@@ -558,9 +629,6 @@ func dumpTo(p func(format string, args ...interface{})) {
 func Clear() {
 	mu.Lock()
 	store = make(map[string]map[string]map[name]userMetric)
-	counters = make(map[key]*counter)
-	distributions = make(map[key]*distribution)
-	gauges = make(map[key]*gauge)
 	mu.Unlock()
 }
 
@@ -570,21 +638,6 @@ func ClearBundleData(b string) {
 	// No concurrency races since mu guards all access to store,
 	// and the metric cell sync.Maps are goroutine safe.
 	mu.Lock()
-	pts := store[b]
-	countersMu.Lock()
-	distributionsMu.Lock()
-	gaugesMu.Lock()
-	for pt, m := range pts {
-		for n := range m {
-			key := key{name: n, bundle: b, ptransform: pt}
-			delete(counters, key)
-			delete(distributions, key)
-			delete(gauges, key)
-		}
-	}
-	countersMu.Unlock()
-	distributionsMu.Unlock()
-	gaugesMu.Unlock()
 	delete(store, b)
 	mu.Unlock()
 }

--- a/sdks/go/pkg/beam/core/metrics/metrics_test.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics_test.go
@@ -25,194 +25,150 @@ import (
 // bID is a bundleId to use in the tests, if nothing more specific is needed.
 const bID = "bID"
 
-// TestRobustness validates metrics not panicking if the context doesn't
-// have the bundle or transform ID.
-func TestRobustness(t *testing.T) {
-	m := NewCounter("Test", "myCount")
-	m.Inc(context.Background(), 3)
-	ptCtx := SetPTransformID(context.Background(), "MY_TRANSFORM")
-	m.Inc(ptCtx, 3)
-	bCtx := SetBundleID(context.Background(), bID)
-	m.Inc(bCtx, 3)
-}
-
-func TestBeamContext(t *testing.T) {
-	t.Run("ptransformID", func(t *testing.T) {
-		ptID := "MY_TRANSFORM"
-		ctx := SetPTransformID(context.Background(), ptID)
-		key := getContextKey(ctx, name{})
-		if key.bundle != bundleIDUnset {
-			t.Errorf("bundleId = %q, want %q", key.bundle, bundleIDUnset)
-		}
-		if key.ptransform != ptID {
-			t.Errorf("ptransformId = %q, want %q", key.ptransform, ptID)
-		}
-
-	})
-
-	t.Run("bundleID", func(t *testing.T) {
-		ctx := SetBundleID(context.Background(), bID)
-		key := getContextKey(ctx, name{})
-		if key.bundle != bID {
-			t.Errorf("bundleId = %q, want %q", key.bundle, bID)
-		}
-		if key.ptransform != ptransformIDUnset {
-			t.Errorf("ptransformId = %q, want %q", key.ptransform, ptransformIDUnset)
-		}
-	})
-}
-
 func ctxWith(b, pt string) context.Context {
 	ctx := context.Background()
-	ctx = SetPTransformID(ctx, pt)
 	ctx = SetBundleID(ctx, b)
+	ctx = SetPTransformID(ctx, pt)
 	return ctx
 }
 
 func TestCounter_Inc(t *testing.T) {
+	ctxA := ctxWith(bID, "A")
+	ctxB := ctxWith(bID, "B")
+
 	tests := []struct {
-		ns, n, key string // Counter name and PTransform context
-		inc        int64
-		value      int64 // Internal variable to check
+		ns, n string // Counter name
+		ctx   context.Context
+		inc   int64
+		value int64 // Internal variable to check
 	}{
-		{ns: "inc1", n: "count", key: "A", inc: 1, value: 1},
-		{ns: "inc1", n: "count", key: "A", inc: 1, value: 2},
-		{ns: "inc1", n: "ticker", key: "A", inc: 1, value: 1},
-		{ns: "inc1", n: "ticker", key: "A", inc: 2, value: 3},
-		{ns: "inc1", n: "count", key: "B", inc: 1, value: 1},
-		{ns: "inc1", n: "count", key: "B", inc: 1, value: 2},
-		{ns: "inc1", n: "ticker", key: "B", inc: 1, value: 1},
-		{ns: "inc1", n: "ticker", key: "B", inc: 2, value: 3},
-		{ns: "inc2", n: "count", key: "A", inc: 1, value: 1},
-		{ns: "inc2", n: "count", key: "A", inc: 1, value: 2},
-		{ns: "inc2", n: "ticker", key: "A", inc: 1, value: 1},
-		{ns: "inc2", n: "ticker", key: "A", inc: 2, value: 3},
-		{ns: "inc2", n: "count", key: "B", inc: 1, value: 1},
-		{ns: "inc2", n: "count", key: "B", inc: 1, value: 2},
-		{ns: "inc2", n: "ticker", key: "B", inc: 1, value: 1},
-		{ns: "inc2", n: "ticker", key: "B", inc: 2, value: 3},
+		{ns: "inc1", n: "count", ctx: ctxA, inc: 1, value: 1},
+		{ns: "inc1", n: "count", ctx: ctxA, inc: 1, value: 2},
+		{ns: "inc1", n: "ticker", ctx: ctxA, inc: 1, value: 1},
+		{ns: "inc1", n: "ticker", ctx: ctxA, inc: 2, value: 3},
+		{ns: "inc1", n: "count", ctx: ctxB, inc: 1, value: 1},
+		{ns: "inc1", n: "count", ctx: ctxB, inc: 1, value: 2},
+		{ns: "inc1", n: "ticker", ctx: ctxB, inc: 1, value: 1},
+		{ns: "inc1", n: "ticker", ctx: ctxB, inc: 2, value: 3},
+		{ns: "inc2", n: "count", ctx: ctxA, inc: 1, value: 1},
+		{ns: "inc2", n: "count", ctx: ctxA, inc: 1, value: 2},
+		{ns: "inc2", n: "ticker", ctx: ctxA, inc: 1, value: 1},
+		{ns: "inc2", n: "ticker", ctx: ctxA, inc: 2, value: 3},
+		{ns: "inc2", n: "count", ctx: ctxB, inc: 1, value: 1},
+		{ns: "inc2", n: "count", ctx: ctxB, inc: 1, value: 2},
+		{ns: "inc2", n: "ticker", ctx: ctxB, inc: 1, value: 1},
+		{ns: "inc2", n: "ticker", ctx: ctxB, inc: 2, value: 3},
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("add %d to %s.%s[%q] value: %d", test.inc, test.ns, test.n, test.key, test.value),
+		t.Run(fmt.Sprintf("add %d to %s.%s[%v] value: %d", test.inc, test.ns, test.n, test.ctx, test.value),
 			func(t *testing.T) {
 				m := NewCounter(test.ns, test.n)
-				ctx := ctxWith(bID, test.key)
-				m.Inc(ctx, test.inc)
+				m.Inc(test.ctx, test.inc)
 
-				key := key{name: name{namespace: test.ns, name: test.n}, bundle: bID, ptransform: test.key}
-				countersMu.Lock()
-				c, ok := counters[key]
-				countersMu.Unlock()
-				if !ok {
-					t.Fatalf("Unable to find Counter for key %v", key)
-				}
+				cs := getCounterSet(test.ctx)
+				c := cs.counters[m.hash]
 				if got, want := c.value, test.value; got != want {
-					t.Errorf("GetCounter(%q,%q).Inc(%s, %d) c.value got %v, want %v", test.ns, test.n, test.key, test.inc, got, want)
+					t.Errorf("GetCounter(%q,%q).Inc(%v, %d) c.value got %v, want %v", test.ns, test.n, test.ctx, test.inc, got, want)
 				}
 			})
 	}
 }
 
 func TestCounter_Dec(t *testing.T) {
+	ctxA := ctxWith(bID, "A")
+	ctxB := ctxWith(bID, "B")
+
 	tests := []struct {
-		ns, n, key string // Counter name and PTransform context
-		dec        int64
-		value      int64 // Internal variable to check
+		ns, n string // Counter name
+		ctx   context.Context
+		dec   int64
+		value int64 // Internal variable to check
 	}{
-		{ns: "dec1", n: "count", key: "A", dec: 1, value: -1},
-		{ns: "dec1", n: "count", key: "A", dec: 1, value: -2},
-		{ns: "dec1", n: "ticker", key: "A", dec: 1, value: -1},
-		{ns: "dec1", n: "ticker", key: "A", dec: 2, value: -3},
-		{ns: "dec1", n: "count", key: "B", dec: 1, value: -1},
-		{ns: "dec1", n: "count", key: "B", dec: 1, value: -2},
-		{ns: "dec1", n: "ticker", key: "B", dec: 1, value: -1},
-		{ns: "dec1", n: "ticker", key: "B", dec: 2, value: -3},
-		{ns: "dec2", n: "count", key: "A", dec: 1, value: -1},
-		{ns: "dec2", n: "count", key: "A", dec: 1, value: -2},
-		{ns: "dec2", n: "ticker", key: "A", dec: 1, value: -1},
-		{ns: "dec2", n: "ticker", key: "A", dec: 2, value: -3},
-		{ns: "dec2", n: "count", key: "B", dec: 1, value: -1},
-		{ns: "dec2", n: "count", key: "B", dec: 1, value: -2},
-		{ns: "dec2", n: "ticker", key: "B", dec: 1, value: -1},
-		{ns: "dec2", n: "ticker", key: "B", dec: 2, value: -3},
+		{ns: "dec1", n: "count", ctx: ctxA, dec: 1, value: -1},
+		{ns: "dec1", n: "count", ctx: ctxA, dec: 1, value: -2},
+		{ns: "dec1", n: "ticker", ctx: ctxA, dec: 1, value: -1},
+		{ns: "dec1", n: "ticker", ctx: ctxA, dec: 2, value: -3},
+		{ns: "dec1", n: "count", ctx: ctxB, dec: 1, value: -1},
+		{ns: "dec1", n: "count", ctx: ctxB, dec: 1, value: -2},
+		{ns: "dec1", n: "ticker", ctx: ctxB, dec: 1, value: -1},
+		{ns: "dec1", n: "ticker", ctx: ctxB, dec: 2, value: -3},
+		{ns: "dec2", n: "count", ctx: ctxA, dec: 1, value: -1},
+		{ns: "dec2", n: "count", ctx: ctxA, dec: 1, value: -2},
+		{ns: "dec2", n: "ticker", ctx: ctxA, dec: 1, value: -1},
+		{ns: "dec2", n: "ticker", ctx: ctxA, dec: 2, value: -3},
+		{ns: "dec2", n: "count", ctx: ctxB, dec: 1, value: -1},
+		{ns: "dec2", n: "count", ctx: ctxB, dec: 1, value: -2},
+		{ns: "dec2", n: "ticker", ctx: ctxB, dec: 1, value: -1},
+		{ns: "dec2", n: "ticker", ctx: ctxB, dec: 2, value: -3},
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("subtract %d to %s.%s[%q] value: %d", test.dec, test.ns, test.n, test.key, test.value),
+		t.Run(fmt.Sprintf("subtract %d to %s.%s[%v] value: %d", test.dec, test.ns, test.n, test.ctx, test.value),
 			func(t *testing.T) {
 				m := NewCounter(test.ns, test.n)
-				ctx := ctxWith(bID, test.key)
-				m.Dec(ctx, test.dec)
+				m.Dec(test.ctx, test.dec)
 
-				key := key{name: name{namespace: test.ns, name: test.n}, bundle: bID, ptransform: test.key}
-				countersMu.Lock()
-				c, ok := counters[key]
-				countersMu.Unlock()
-				if !ok {
-					t.Fatalf("Unable to find Counter for key %v", key)
-				}
+				cs := getCounterSet(test.ctx)
+				c := cs.counters[m.hash]
 				if got, want := c.value, test.value; got != want {
-					t.Errorf("GetCounter(%q,%q).Dec(%s, %d) c.value got %v, want %v", test.ns, test.n, test.key, test.dec, got, want)
+					t.Errorf("GetCounter(%q,%q).Dec(%v, %d) c.value got %v, want %v", test.ns, test.n, test.ctx, test.dec, got, want)
 				}
 			})
 	}
 }
 
 func TestDistribution_Update(t *testing.T) {
+	ctxA := ctxWith(bID, "A")
+	ctxB := ctxWith(bID, "B")
 	tests := []struct {
-		ns, n, key           string // Gauge name and PTransform context
+		ns, n                string // Counter name
+		ctx                  context.Context
 		v                    int64
 		count, sum, min, max int64 // Internal variables to check
 	}{
-		{ns: "update1", n: "latency", key: "A", v: 1, count: 1, sum: 1, min: 1, max: 1},
-		{ns: "update1", n: "latency", key: "A", v: 1, count: 2, sum: 2, min: 1, max: 1},
-		{ns: "update1", n: "latency", key: "A", v: 1, count: 3, sum: 3, min: 1, max: 1},
-		{ns: "update1", n: "size", key: "A", v: 1, count: 1, sum: 1, min: 1, max: 1},
-		{ns: "update1", n: "size", key: "A", v: 2, count: 2, sum: 3, min: 1, max: 2},
-		{ns: "update1", n: "size", key: "A", v: 3, count: 3, sum: 6, min: 1, max: 3},
-		{ns: "update1", n: "size", key: "A", v: -4, count: 4, sum: 2, min: -4, max: 3},
-		{ns: "update1", n: "size", key: "A", v: 1, count: 5, sum: 3, min: -4, max: 3},
-		{ns: "update1", n: "latency", key: "B", v: 1, count: 1, sum: 1, min: 1, max: 1},
-		{ns: "update1", n: "latency", key: "B", v: 1, count: 2, sum: 2, min: 1, max: 1},
-		{ns: "update1", n: "size", key: "B", v: 1, count: 1, sum: 1, min: 1, max: 1},
-		{ns: "update1", n: "size", key: "B", v: 2, count: 2, sum: 3, min: 1, max: 2},
-		{ns: "update2", n: "latency", key: "A", v: 1, count: 1, sum: 1, min: 1, max: 1},
-		{ns: "update2", n: "latency", key: "A", v: 1, count: 2, sum: 2, min: 1, max: 1},
-		{ns: "update2", n: "size", key: "A", v: 1, count: 1, sum: 1, min: 1, max: 1},
-		{ns: "update2", n: "size", key: "A", v: 2, count: 2, sum: 3, min: 1, max: 2},
-		{ns: "update2", n: "latency", key: "B", v: 1, count: 1, sum: 1, min: 1, max: 1},
-		{ns: "update2", n: "latency", key: "B", v: 1, count: 2, sum: 2, min: 1, max: 1},
-		{ns: "update2", n: "size", key: "B", v: 1, count: 1, sum: 1, min: 1, max: 1},
-		{ns: "update2", n: "size", key: "B", v: 2, count: 2, sum: 3, min: 1, max: 2},
-		{ns: "update1", n: "size", key: "A", v: 1, count: 6, sum: 4, min: -4, max: 3},
+		{ns: "update1", n: "latency", ctx: ctxA, v: 1, count: 1, sum: 1, min: 1, max: 1},
+		{ns: "update1", n: "latency", ctx: ctxA, v: 1, count: 2, sum: 2, min: 1, max: 1},
+		{ns: "update1", n: "latency", ctx: ctxA, v: 1, count: 3, sum: 3, min: 1, max: 1},
+		{ns: "update1", n: "size", ctx: ctxA, v: 1, count: 1, sum: 1, min: 1, max: 1},
+		{ns: "update1", n: "size", ctx: ctxA, v: 2, count: 2, sum: 3, min: 1, max: 2},
+		{ns: "update1", n: "size", ctx: ctxA, v: 3, count: 3, sum: 6, min: 1, max: 3},
+		{ns: "update1", n: "size", ctx: ctxA, v: -4, count: 4, sum: 2, min: -4, max: 3},
+		{ns: "update1", n: "size", ctx: ctxA, v: 1, count: 5, sum: 3, min: -4, max: 3},
+		{ns: "update1", n: "latency", ctx: ctxB, v: 1, count: 1, sum: 1, min: 1, max: 1},
+		{ns: "update1", n: "latency", ctx: ctxB, v: 1, count: 2, sum: 2, min: 1, max: 1},
+		{ns: "update1", n: "size", ctx: ctxB, v: 1, count: 1, sum: 1, min: 1, max: 1},
+		{ns: "update1", n: "size", ctx: ctxB, v: 2, count: 2, sum: 3, min: 1, max: 2},
+		{ns: "update2", n: "latency", ctx: ctxA, v: 1, count: 1, sum: 1, min: 1, max: 1},
+		{ns: "update2", n: "latency", ctx: ctxA, v: 1, count: 2, sum: 2, min: 1, max: 1},
+		{ns: "update2", n: "size", ctx: ctxA, v: 1, count: 1, sum: 1, min: 1, max: 1},
+		{ns: "update2", n: "size", ctx: ctxA, v: 2, count: 2, sum: 3, min: 1, max: 2},
+		{ns: "update2", n: "latency", ctx: ctxB, v: 1, count: 1, sum: 1, min: 1, max: 1},
+		{ns: "update2", n: "latency", ctx: ctxB, v: 1, count: 2, sum: 2, min: 1, max: 1},
+		{ns: "update2", n: "size", ctx: ctxB, v: 1, count: 1, sum: 1, min: 1, max: 1},
+		{ns: "update2", n: "size", ctx: ctxB, v: 2, count: 2, sum: 3, min: 1, max: 2},
+		{ns: "update1", n: "size", ctx: ctxA, v: 1, count: 6, sum: 4, min: -4, max: 3},
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("add %d to %s.%s[%q] count: %d sum: %d", test.v, test.ns, test.n, test.key, test.count, test.sum),
+		t.Run(fmt.Sprintf("add %d to %s.%s[%q] count: %d sum: %d", test.v, test.ns, test.n, test.ctx, test.count, test.sum),
 			func(t *testing.T) {
 				m := NewDistribution(test.ns, test.n)
-				ctx := ctxWith(bID, test.key)
-				m.Update(ctx, test.v)
+				m.Update(test.ctx, test.v)
 
-				key := key{name: name{namespace: test.ns, name: test.n}, bundle: bID, ptransform: test.key}
-				distributionsMu.Lock()
-				d, ok := distributions[key]
-				distributionsMu.Unlock()
-				if !ok {
-					t.Fatalf("Unable to find Distribution for key %v", key)
-				}
+				cs := getCounterSet(test.ctx)
+				d := cs.distributions[m.hash]
 				if got, want := d.count, test.count; got != want {
-					t.Errorf("GetDistribution(%q,%q).Update(%s, %d) d.count got %v, want %v", test.ns, test.n, test.key, test.v, got, want)
+					t.Errorf("GetDistribution(%q,%q).Update(%v, %d) d.count got %v, want %v", test.ns, test.n, test.ctx, test.v, got, want)
 				}
 				if got, want := d.sum, test.sum; got != want {
-					t.Errorf("GetDistribution(%q,%q).Update(%s, %d) d.sum got %v, want %v", test.ns, test.n, test.key, test.v, got, want)
+					t.Errorf("GetDistribution(%q,%q).Update(%v, %d) d.sum got %v, want %v", test.ns, test.n, test.ctx, test.v, got, want)
 				}
 				if got, want := d.min, test.min; got != want {
-					t.Errorf("GetDistribution(%q,%q).Update(%s, %d) d.min got %v, want %v", test.ns, test.n, test.key, test.v, got, want)
+					t.Errorf("GetDistribution(%q,%q).Update(%v, %d) d.min got %v, want %v", test.ns, test.n, test.ctx, test.v, got, want)
 				}
 				if got, want := d.max, test.max; got != want {
-					t.Errorf("GetDistribution(%q,%q).Update(%s, %d) d.max got %v, want %v", test.ns, test.n, test.key, test.v, got, want)
+					t.Errorf("GetDistribution(%q,%q).Update(%v, %d) d.max got %v, want %v", test.ns, test.n, test.ctx, test.v, got, want)
 				}
 			})
 	}
@@ -223,74 +179,51 @@ func testclock(t time.Time) func() time.Time {
 }
 
 func TestGauge_Set(t *testing.T) {
+	ctxA := ctxWith(bID, "A")
+	ctxB := ctxWith(bID, "B")
 	tests := []struct {
-		ns, n, key string // Gauge name and PTransform context
-		v          int64
-		t          time.Time
+		ns, n string // Counter name
+		ctx   context.Context
+		v     int64
+		t     time.Time
 	}{
-		{ns: "set1", n: "load", key: "A", v: 1, t: time.Unix(0, 0)},
-		{ns: "set1", n: "load", key: "A", v: 1, t: time.Unix(0, 0)},
-		{ns: "set1", n: "speed", key: "A", v: 1, t: time.Unix(0, 0)},
-		{ns: "set1", n: "speed", key: "A", v: 2, t: time.Unix(0, 0)},
-		{ns: "set1", n: "load", key: "B", v: 1, t: time.Unix(0, 0)},
-		{ns: "set1", n: "load", key: "B", v: 1, t: time.Unix(0, 0)},
-		{ns: "set1", n: "speed", key: "B", v: 1, t: time.Unix(0, 0)},
-		{ns: "set1", n: "speed", key: "B", v: 2, t: time.Unix(0, 0)},
-		{ns: "set2", n: "load", key: "A", v: 1, t: time.Unix(0, 0)},
-		{ns: "set2", n: "load", key: "A", v: 1, t: time.Unix(0, 0)},
-		{ns: "set2", n: "speed", key: "A", v: 1, t: time.Unix(0, 0)},
-		{ns: "set2", n: "speed", key: "A", v: 2, t: time.Unix(0, 0)},
-		{ns: "set2", n: "load", key: "B", v: 1, t: time.Unix(0, 0)},
-		{ns: "set2", n: "load", key: "B", v: 1, t: time.Unix(0, 0)},
-		{ns: "set2", n: "speed", key: "B", v: 1, t: time.Unix(0, 0)},
-		{ns: "set2", n: "speed", key: "B", v: 2, t: time.Unix(0, 0)},
+		{ns: "set1", n: "load", ctx: ctxA, v: 1, t: time.Unix(0, 0)},
+		{ns: "set1", n: "load", ctx: ctxA, v: 1, t: time.Unix(0, 0)},
+		{ns: "set1", n: "speed", ctx: ctxA, v: 1, t: time.Unix(0, 0)},
+		{ns: "set1", n: "speed", ctx: ctxA, v: 2, t: time.Unix(0, 0)},
+		{ns: "set1", n: "load", ctx: ctxB, v: 1, t: time.Unix(0, 0)},
+		{ns: "set1", n: "load", ctx: ctxB, v: 1, t: time.Unix(0, 0)},
+		{ns: "set1", n: "speed", ctx: ctxB, v: 1, t: time.Unix(0, 0)},
+		{ns: "set1", n: "speed", ctx: ctxB, v: 2, t: time.Unix(0, 0)},
+		{ns: "set2", n: "load", ctx: ctxA, v: 1, t: time.Unix(0, 0)},
+		{ns: "set2", n: "load", ctx: ctxA, v: 1, t: time.Unix(0, 0)},
+		{ns: "set2", n: "speed", ctx: ctxA, v: 1, t: time.Unix(0, 0)},
+		{ns: "set2", n: "speed", ctx: ctxA, v: 2, t: time.Unix(0, 0)},
+		{ns: "set2", n: "load", ctx: ctxB, v: 1, t: time.Unix(0, 0)},
+		{ns: "set2", n: "load", ctx: ctxB, v: 1, t: time.Unix(0, 0)},
+		{ns: "set2", n: "speed", ctx: ctxB, v: 1, t: time.Unix(0, 0)},
+		{ns: "set2", n: "speed", ctx: ctxB, v: 2, t: time.Unix(0, 0)},
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("set %s.%s[%q] to %d at %v", test.ns, test.n, test.key, test.v, test.t),
+		t.Run(fmt.Sprintf("set %s.%s[%v] to %d at %v", test.ns, test.n, test.ctx, test.v, test.t),
 			func(t *testing.T) {
 				m := NewGauge(test.ns, test.n)
-				ctx := ctxWith(bID, test.key)
 				now = testclock(test.t)
-				m.Set(ctx, test.v)
+				m.Set(test.ctx, test.v)
 
-				key := key{name: name{namespace: test.ns, name: test.n}, bundle: bID, ptransform: test.key}
-				gaugesMu.Lock()
-				g, ok := gauges[key]
-				gaugesMu.Unlock()
-				if !ok {
-					t.Fatalf("Unable to find Gauge for key %v", key)
-				}
+				cs := getCounterSet(test.ctx)
+				g := cs.gauges[m.hash]
 				if got, want := g.v, test.v; got != want {
-					t.Errorf("GetGauge(%q,%q).Set(%s, %d) g.v got %v, want %v", test.ns, test.n, test.key, test.v, got, want)
+					t.Errorf("GetGauge(%q,%q).Set(%v, %d) g.v got %v, want %v", test.ns, test.n, test.ctx, test.v, got, want)
 				}
 				if got, want := g.t, test.t; got != want {
-					t.Errorf("GetGauge(%q,%q).Set(%s, %d) t.t got %v, want %v", test.ns, test.n, test.key, test.v, got, want)
+					t.Errorf("GetGauge(%q,%q).Set(%v, %d) t.t got %v, want %v", test.ns, test.n, test.ctx, test.v, got, want)
 				}
 			})
 	}
 }
 
-type metricType uint8
-
-const (
-	counterType metricType = iota
-	distributionType
-	gaugeType
-)
-
-func (t metricType) String() string {
-	switch t {
-	case counterType:
-		return "Counter"
-	case distributionType:
-		return "Distribution"
-	case gaugeType:
-		return "Gauge"
-	default:
-		panic(fmt.Sprintf("Unknown metric type value: %v", uint8(t)))
-	}
-}
 func TestNameCollisions(t *testing.T) {
 	ns, c, d, g := "collisions", "counter", "distribution", "gauge"
 	// Checks that user code panics if a counter attempts to be defined in the same PTransform
@@ -302,17 +235,17 @@ func TestNameCollisions(t *testing.T) {
 	NewDistribution(ns, d).Update(ctxWith(bID, d), 1)
 	NewGauge(ns, g).Set(ctxWith(bID, g), 1)
 	tests := []struct {
-		existing, new metricType
+		existing, new kind
 	}{
-		{existing: counterType, new: counterType},
-		{existing: counterType, new: distributionType},
-		{existing: counterType, new: gaugeType},
-		{existing: distributionType, new: counterType},
-		{existing: distributionType, new: distributionType},
-		{existing: distributionType, new: gaugeType},
-		{existing: gaugeType, new: counterType},
-		{existing: gaugeType, new: distributionType},
-		{existing: gaugeType, new: gaugeType},
+		{existing: kindSumCounter, new: kindSumCounter},
+		{existing: kindSumCounter, new: kindDistribution},
+		{existing: kindSumCounter, new: kindGauge},
+		{existing: kindDistribution, new: kindSumCounter},
+		{existing: kindDistribution, new: kindDistribution},
+		{existing: kindDistribution, new: kindGauge},
+		{existing: kindGauge, new: kindSumCounter},
+		{existing: kindGauge, new: kindDistribution},
+		{existing: kindGauge, new: kindGauge},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s name collides with %s", test.existing, test.new),
@@ -325,26 +258,26 @@ func TestNameCollisions(t *testing.T) {
 						}
 						t.Error("panic expected")
 					} else {
-						t.Log("reusing names is fine when the metrics the same type:", test.existing, test.new)
+						t.Log("reusing names is fine when the metric is the same type:", test.existing, test.new)
 					}
 				}()
 				var name string
 				switch test.existing {
-				case counterType:
+				case kindSumCounter:
 					name = c
-				case distributionType:
+				case kindDistribution:
 					name = d
-				case gaugeType:
+				case kindGauge:
 					name = g
 				default:
 					t.Fatalf("unknown existing metricType with value: %v", int(test.existing))
 				}
 				switch test.new {
-				case counterType:
+				case kindSumCounter:
 					NewCounter(ns, name).Inc(ctxWith(bID, name), 1)
-				case distributionType:
+				case kindDistribution:
 					NewDistribution(ns, name).Update(ctxWith(bID, name), 1)
-				case gaugeType:
+				case kindGauge:
 					NewGauge(ns, name).Set(ctxWith(bID, name), 1)
 				default:
 					t.Fatalf("unknown new metricType with value: %v", int(test.new))
@@ -398,14 +331,16 @@ func TestClearBundleData(t *testing.T) {
 	}
 }
 
-// Run on @lostluck's desktop:
+// Run on @lostluck's desktop (2020/01/21) go1.13.4
 //
-// BenchmarkMetrics/counter_inplace-12         	 5000000	       243 ns/op	     128 B/op	       2 allocs/op
-// BenchmarkMetrics/distribution_inplace-12    	 5000000	       252 ns/op	     160 B/op	       2 allocs/op
-// BenchmarkMetrics/gauge_inplace-12           	 5000000	       266 ns/op	     160 B/op	       2 allocs/op
-// BenchmarkMetrics/counter_predeclared-12     	20000000	        74.3 ns/op	      16 B/op	       1 allocs/op
-// BenchmarkMetrics/distribution_predeclared-12         	20000000	        79.6 ns/op	      48 B/op	       1 allocs/op
-// BenchmarkMetrics/gauge_predeclared-12                	20000000	        92.9 ns/op	      48 B/op	       1 allocs/op
+// Allocs & bytes should be consistetn within go versions, but ns/op is relative to the running machine.
+//
+// BenchmarkMetrics/counter_inplace-12              4814373               243 ns/op              48 B/op          1 allocs/op
+// BenchmarkMetrics/distribution_inplace-12         4455957               273 ns/op              48 B/op          1 allocs/op
+// BenchmarkMetrics/gauge_inplace-12                4605908               265 ns/op              48 B/op          1 allocs/op
+// BenchmarkMetrics/counter_predeclared-12         75339600                15.5 ns/op             0 B/op          0 allocs/op
+// BenchmarkMetrics/distribution_predeclared-12            49202775                24.4 ns/op             0 B/op          0 allocs/op
+// BenchmarkMetrics/gauge_predeclared-12                   46614810                28.3 ns/op             0 B/op          0 allocs/op
 func BenchmarkMetrics(b *testing.B) {
 	Clear()
 	pt, c, d, g := "bench.bundle.data", "counter", "distribution", "gauge"

--- a/sdks/go/pkg/beam/metrics.go
+++ b/sdks/go/pkg/beam/metrics.go
@@ -21,8 +21,15 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/metrics"
 )
 
+// Implementation Note: The wrapping of the embedded methods
+// is to allow better GoDocs for the methods on the proxy types.
+
 // Counter is a metric that can be incremented and decremented,
 // and is aggregated by the sum.
+//
+// Counters are safe to use in multiple bundles simultaneously, but
+// not generally threadsafe. Your DoFn needs to manage the thread
+// safety of Beam metrics for any additional concurrency it uses.
 type Counter struct {
 	*metrics.Counter
 }
@@ -44,6 +51,10 @@ func NewCounter(namespace, name string) Counter {
 
 // Distribution is a metric that records various statistics about the distribution
 // of reported values.
+//
+// Distributions are safe to use in multiple bundles simultaneously, but
+// not generally threadsafe. Your DoFn needs to manage the thread
+// safety of Beam metrics for any additional concurrency it uses.
 type Distribution struct {
 	*metrics.Distribution
 }
@@ -60,6 +71,10 @@ func NewDistribution(namespace, name string) Distribution {
 
 // Gauge is a metric that can have its new value set, and is aggregated by taking
 // the last reported value.
+//
+// Gauge are safe to use in multiple bundles simultaneously, but
+// not generally threadsafe. Your DoFn needs to manage the thread
+// safety of Beam metrics for any additional concurrency it uses.
 type Gauge struct {
 	*metrics.Gauge
 }

--- a/sdks/go/pkg/beam/metrics_test.go
+++ b/sdks/go/pkg/beam/metrics_test.go
@@ -29,8 +29,8 @@ var ctx = context.Background()
 
 func ctxWithPtransformID(id string) context.Context {
 	ctx := context.Background()
-	ctx = metrics.SetPTransformID(ctx, id)
 	ctx = metrics.SetBundleID(ctx, "exampleBundle")
+	ctx = metrics.SetPTransformID(ctx, id)
 	return ctx
 }
 
@@ -69,7 +69,7 @@ func Example_metricsDeclaredAnywhere() {
 
 func Example_metricsReusable() {
 
-	// Metrics can be used in multiple DoFns
+	// Metric proxies can be used in multiple DoFns
 	c := beam.NewCounter("example.reusable", "count")
 
 	extractWordsDofn := func(ctx context.Context, line string, emit func(string)) {


### PR DESCRIPTION
This PR dramatically reduces the overhead of metrics in the Go SDK.

A contemporary side by side comparison of the benchmark in the metrics package on my current machine:
```
benchmark                                        old ns/op     new ns/op     delta
BenchmarkMetrics/counter_inplace-12              585           249           -57.44%
BenchmarkMetrics/distribution_inplace-12         622           270           -56.59%
BenchmarkMetrics/gauge_inplace-12                812           311           -61.70%
BenchmarkMetrics/counter_predeclared-12          227           15.8          -93.04%
BenchmarkMetrics/distribution_predeclared-12     282           24.0          -91.49%
BenchmarkMetrics/gauge_predeclared-12            389           63.7          -83.62%

benchmark                                        old allocs     new allocs     delta
BenchmarkMetrics/counter_inplace-12              4              1              -75.00%
BenchmarkMetrics/distribution_inplace-12         4              1              -75.00%
BenchmarkMetrics/gauge_inplace-12                4              1              -75.00%
BenchmarkMetrics/counter_predeclared-12          3              0              -100.00%
BenchmarkMetrics/distribution_predeclared-12     3              0              -100.00%
BenchmarkMetrics/gauge_predeclared-12            3              0              -100.00%

benchmark                                        old bytes     new bytes     delta
BenchmarkMetrics/counter_inplace-12              160           48            -70.00%
BenchmarkMetrics/distribution_inplace-12         192           48            -75.00%
BenchmarkMetrics/gauge_inplace-12                192           48            -75.00%
BenchmarkMetrics/counter_predeclared-12          48            0             -100.00%
BenchmarkMetrics/distribution_predeclared-12     80            0             -100.00%
BenchmarkMetrics/gauge_predeclared-12            80            0             -100.00%
```

In particular this PR moves away from a global datastore for all metrics towards a perBundle based countersets. This allows for the removal of the per layer locks and the global lock that needed to be checked since all bundles had to check the same datastore. Now they only store a metric cell in the global store on first creation (still stored per bundle and per ptransform).

A subsequent change will remove the global store altogether in favour of better exposing the metrics per bundle, and allowing a callback visitor to thread-safely access the data inside each metric. This will also permit removing the dependency on the protos from the package, which was a mistake I made when I first wrote the package.

Further, Counters now use atomic operations rather than locks, which additional speeds them up vs the previous mutex approach.

Counter "names" are hashed ahead of time and the hash value cached in the proxy to increase the speed of subsequent lookups using the same proxy object.

This does make the proxies unsafe to use concurrently within the same bundle prior to first use, but this matches the general rule of Beam runners managing the concurrency for efficient processing, and that framework constructs are not safe for concurrent use by user code, without user managed locks.

As an exploration, I did try using sync.Map to avoid the above restriction, but the overhead for the additional interface wraping and unwraping was significant enough that this approach was worthwhile. 
This may be worth revisiting if Go gains Generics, as that would probably avoid this cost.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
