### PR TITLE
[BEAM-9268] SpannerIO: Add more documentation and warnings for unknown tables.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationKeyEncoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationKeyEncoder.java
@@ -27,7 +27,6 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.Op;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
-import com.google.common.annotations.VisibleForTesting;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerSchema.KeyPart;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.MutableDateTime;
@@ -54,7 +54,7 @@ class MutationKeyEncoder {
 
   // Global single instance. Use Concurrent Map and AtomicInteger for thread-safety.
   @VisibleForTesting
-  static final Map<String, AtomicInteger> unknownTablesWarnings = new ConcurrentHashMap<>();
+  private static final Map<String, AtomicInteger> unknownTablesWarnings = new ConcurrentHashMap<>();
 
   public MutationKeyEncoder(SpannerSchema schema) {
     this.schema = schema;
@@ -227,5 +227,11 @@ class MutationKeyEncoder {
     jodaDate.setDate(date.getYear(), date.getMonth(), date.getDayOfMonth());
 
     return Days.daysBetween(MIN_DATE, jodaDate).getDays();
+  }
+
+  // Give tests access to the Unknown Tables Warning count.
+  @VisibleForTesting
+  static Map<String, AtomicInteger> getUnknownTablesWarningsMap() {
+    return unknownTablesWarnings;
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationKeyEncoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationKeyEncoder.java
@@ -27,24 +27,34 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.Op;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
+import com.google.common.annotations.VisibleForTesting;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerSchema.KeyPart;
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.MutableDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Given the Schema, Encodes the table name and Key into a lexicographically sortable {@code
  * byte[]}.
  */
 class MutationKeyEncoder {
-
+  private static final Logger LOG = LoggerFactory.getLogger(MutationKeyEncoder.class);
+  private static final int ROWS_PER_UNKNOWN_TABLE_LOG_MESSAGE = 10000;
   private static final DateTime MIN_DATE = new DateTime(1, 1, 1, 0, 0);
   private final SpannerSchema schema;
+
+  // Global single instance. Use Concurrent Map and AtomicInteger for thread-safety.
+  @VisibleForTesting
+  static final Map<String, AtomicInteger> unknownTablesWarnings = new ConcurrentHashMap<>();
 
   public MutationKeyEncoder(SpannerSchema schema) {
     this.schema = schema;
@@ -58,12 +68,30 @@ class MutationKeyEncoder {
    */
   public byte[] encodeTableNameAndKey(Mutation m) {
     OrderedCode orderedCode = new OrderedCode();
-    orderedCode.writeBytes(m.getTable().getBytes(StandardCharsets.UTF_8));
+    String tableName = m.getTable().toLowerCase();
+
+    if (schema.getColumns(tableName).isEmpty()) {
+      // Log an warning for an unknown table.
+      if (!unknownTablesWarnings.containsKey(tableName)) {
+        unknownTablesWarnings.putIfAbsent(tableName, new AtomicInteger(0));
+      }
+      // Only log every 10000 rows per table, or there will be way too much logging...
+      int numWarnings = unknownTablesWarnings.get(tableName).incrementAndGet();
+      if (1 == (numWarnings % ROWS_PER_UNKNOWN_TABLE_LOG_MESSAGE)) {
+        System.err.printf(
+            "Performance issue: Mutation references an unknown table: %s. "
+                + "See SpannerIO documentation section 'Database Schema Preparation' "
+                + "(At least %,d occurrences)\n",
+            tableName, numWarnings);
+      }
+    }
+
+    orderedCode.writeBytes(tableName.getBytes(StandardCharsets.UTF_8));
 
     if (m.getOperation() == Op.DELETE) {
       if (isPointDelete(m)) {
-        Key next = m.getKeySet().getKeys().iterator().next();
-        encodeKey(orderedCode, m.getTable(), next);
+        Key key = m.getKeySet().getKeys().iterator().next();
+        encodeKey(orderedCode, tableName, key);
       } else {
         // The key is left empty for non-point deletes, since there is no general way to batch them.
       }
@@ -114,8 +142,8 @@ class MutationKeyEncoder {
     }
   }
 
-  private void encodeKey(OrderedCode orderedCode, String table, Key key) {
-    List<SpannerSchema.KeyPart> parts = schema.getKeyParts(table);
+  private void encodeKey(OrderedCode orderedCode, String tableName, Key key) {
+    List<SpannerSchema.KeyPart> parts = schema.getKeyParts(tableName);
     Iterator<Object> it = key.getParts().iterator();
     for (SpannerSchema.KeyPart part : parts) {
       Object value = it.next();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationKeyEncoderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationKeyEncoderTest.java
@@ -513,10 +513,10 @@ public class MutationKeyEncoderTest {
                 .build());
 
     verifyEncodedOrdering(schema, sortedMutations);
-    Assert.assertEquals(3, MutationKeyEncoder.unknownTablesWarnings.size());
-    Assert.assertEquals(2, MutationKeyEncoder.unknownTablesWarnings.get("test2").get());
-    Assert.assertEquals(1, MutationKeyEncoder.unknownTablesWarnings.get("test3").get());
-    Assert.assertEquals(2, MutationKeyEncoder.unknownTablesWarnings.get("test4").get());
+    Assert.assertEquals(3, MutationKeyEncoder.getUnknownTablesWarningsMap().size());
+    Assert.assertEquals(2, MutationKeyEncoder.getUnknownTablesWarningsMap().get("test2").get());
+    Assert.assertEquals(1, MutationKeyEncoder.getUnknownTablesWarningsMap().get("test3").get());
+    Assert.assertEquals(2, MutationKeyEncoder.getUnknownTablesWarningsMap().get("test4").get());
   }
 
   private void verifyEncodedOrdering(SpannerSchema schema, List<Mutation> expectedMutations) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationKeyEncoderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationKeyEncoderTest.java
@@ -25,9 +25,9 @@ import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.TreeMultimap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.UnsignedBytes;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -471,6 +471,54 @@ public class MutationKeyEncoderTest {
     verifyEncodedOrdering(schema, sortedMutations);
   }
 
+  @Test
+  public void unknownTableOrdering() throws Exception {
+    SpannerSchema.Builder builder = SpannerSchema.builder();
+
+    builder.addColumn("test1", "key", "INT64");
+    builder.addKeyPart("test1", "key", false);
+
+    SpannerSchema schema = builder.build();
+
+    // Verify that the encoded keys are ordered by table name and column values (as text).
+    List<Mutation> sortedMutations =
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("test2")
+                .set("key")
+                .to("a")
+                .set("keydesc")
+                .to("a")
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("test2")
+                .set("key")
+                .to("a")
+                .set("keydesc")
+                .to("b")
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("test3")
+                .set("key")
+                .to("b")
+                // leave keydesc value unspecified --> maxvalue descending.
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("test4")
+                .set("key")
+                .to("b")
+                .set("keydesc")
+                .to("a")
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("test4")
+                // leave 'key' value unspecified -> maxvalue
+                .set("keydesc")
+                .to("a")
+                .build());
+
+    verifyEncodedOrdering(schema, sortedMutations);
+    Assert.assertEquals(3, MutationKeyEncoder.unknownTablesWarnings.size());
+    Assert.assertEquals(2, MutationKeyEncoder.unknownTablesWarnings.get("test2").get());
+    Assert.assertEquals(1, MutationKeyEncoder.unknownTablesWarnings.get("test3").get());
+    Assert.assertEquals(2, MutationKeyEncoder.unknownTablesWarnings.get("test4").get());
+  }
+
   private void verifyEncodedOrdering(SpannerSchema schema, List<Mutation> expectedMutations) {
     MutationKeyEncoder encoder = new MutationKeyEncoder(schema);
 
@@ -485,10 +533,11 @@ public class MutationKeyEncoderTest {
             expectedMutations.get(2),
             expectedMutations.get(0));
 
-    // use a Map to re-sort them by the encoded key order,
-    // This allows the original values to be reported on error,
-    Map<byte[], Mutation> mutationsByEncoding =
-        new TreeMap<>(UnsignedBytes.lexicographicalComparator());
+    // Use a map to sort the list by encoded table/key, then by Mutation contents to give a defined
+    // order when the same key is given, or if it is an unknown table.
+    TreeMultimap<byte[], Mutation> mutationsByEncoding =
+        TreeMultimap.create(
+            UnsignedBytes.lexicographicalComparator(), Comparator.comparing(Mutation::toString));
     for (Mutation m : unsortedMutations) {
       mutationsByEncoding.put(encoder.encodeTableNameAndKey(m), m);
     }


### PR DESCRIPTION
When a table is not known to SpannerIO, this causes performance issues because without knowlege of the table schema, the Mutations can not be sorted by primary key.

This change adds more information to the javadoc, and logs a warning
for every 10K mutations referencing an unknown table.

https://issues.apache.org/jira/browse/BEAM-9268

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
