### PR TITLE
[BEAM-5605] Migrate splittable DoFn methods to use "new" DoFn style argument providing.

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
@@ -51,6 +51,8 @@ import org.apache.beam.sdk.transforms.ParDo.MultiOutput;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
+import org.apache.beam.sdk.transforms.reflect.DoFnInvoker.ArgumentProvider;
+import org.apache.beam.sdk.transforms.reflect.DoFnInvoker.BaseArgumentProvider;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
@@ -461,7 +463,21 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
     @ProcessElement
     public void processElement(ProcessContext context) {
       context.output(
-          KV.of(context.element(), invoker.invokeGetInitialRestriction(context.element())));
+          KV.of(
+              context.element(),
+              invoker.invokeGetInitialRestriction(
+                  new BaseArgumentProvider<InputT, OutputT>() {
+                    @Override
+                    public InputT element(DoFn<InputT, OutputT> doFn) {
+                      return context.element();
+                    }
+
+                    @Override
+                    public String getErrorContext() {
+                      return PairWithRestrictionFn.class.getSimpleName()
+                          + ".invokeGetInitialRestriction";
+                    }
+                  })));
     }
 
     @Teardown
@@ -491,21 +507,40 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
 
     @ProcessElement
     public void processElement(final ProcessContext c) {
-      final InputT element = c.element().getKey();
       invoker.invokeSplitRestriction(
-          element,
-          c.element().getValue(),
-          new OutputReceiver<RestrictionT>() {
-            @Override
-            public void output(RestrictionT part) {
-              c.output(KV.of(element, part));
-            }
+          (ArgumentProvider)
+              new BaseArgumentProvider<InputT, RestrictionT>() {
+                @Override
+                public InputT element(DoFn<InputT, RestrictionT> doFn) {
+                  return c.element().getKey();
+                }
 
-            @Override
-            public void outputWithTimestamp(RestrictionT part, Instant timestamp) {
-              throw new UnsupportedOperationException();
-            }
-          });
+                @Override
+                public Object restriction() {
+                  return c.element().getValue();
+                }
+
+                @Override
+                public OutputReceiver<RestrictionT> outputReceiver(
+                    DoFn<InputT, RestrictionT> doFn) {
+                  return new OutputReceiver<RestrictionT>() {
+                    @Override
+                    public void output(RestrictionT part) {
+                      c.output(KV.of(c.element().getKey(), part));
+                    }
+
+                    @Override
+                    public void outputWithTimestamp(RestrictionT part, Instant timestamp) {
+                      throw new UnsupportedOperationException();
+                    }
+                  };
+                }
+
+                @Override
+                public String getErrorContext() {
+                  return SplitRestrictionFn.class.getSimpleName() + ".invokeSplitRestriction";
+                }
+              });
     }
 
     @Teardown

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -169,12 +169,12 @@ public class PTransformMatchersTest implements Serializable {
             ProcessContext context, RestrictionTracker<Void, Void> tracker) {}
 
         @GetInitialRestriction
-        public Void getInitialRestriction(KV<String, Integer> element) {
+        public Void getInitialRestriction(@Element KV<String, Integer> element) {
           return null;
         }
 
         @NewTracker
-        public SomeTracker newTracker(Void restriction) {
+        public SomeTracker newTracker(@Restriction Void restriction) {
           return null;
         }
       };

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ParDoTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ParDoTranslationTest.java
@@ -260,12 +260,12 @@ public class ParDoTranslationTest {
     }
 
     @GetInitialRestriction
-    public Integer restriction(KV<Long, String> elem) {
+    public Integer restriction(@Element KV<Long, String> elem) {
       return 42;
     }
 
     @NewTracker
-    public RestrictionTracker<Integer, ?> newTracker(Integer restriction) {
+    public RestrictionTracker<Integer, ?> newTracker(@Restriction Integer restriction) {
       throw new UnsupportedOperationException("Should never be called; only to test translation");
     }
 

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
@@ -83,7 +83,7 @@ public class SplittableParDoTest {
         ProcessContext context, RestrictionTracker<SomeRestriction, Void> tracker) {}
 
     @GetInitialRestriction
-    public SomeRestriction getInitialRestriction(Integer element) {
+    public SomeRestriction getInitialRestriction(@Element Integer element) {
       return null;
     }
   }
@@ -96,7 +96,7 @@ public class SplittableParDoTest {
     }
 
     @GetInitialRestriction
-    public SomeRestriction getInitialRestriction(Integer element) {
+    public SomeRestriction getInitialRestriction(@Element Integer element) {
       return null;
     }
   }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpanderTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpanderTest.java
@@ -59,13 +59,15 @@ public class SplittableParDoExpanderTest {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRange(String element) {
+    public OffsetRange getInitialRange(@Element String element) {
       return new OffsetRange(0, element.length());
     }
 
     @SplitRestriction
     public void splitRange(
-        String element, OffsetRange range, OutputReceiver<OffsetRange> receiver) {
+        @Element String element,
+        @Restriction OffsetRange range,
+        OutputReceiver<OffsetRange> receiver) {
       receiver.output(new OffsetRange(range.getFrom(), (range.getFrom() + range.getTo()) / 2));
       receiver.output(new OffsetRange((range.getFrom() + range.getTo()) / 2, range.getTo()));
     }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -118,6 +118,11 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
               }
 
               @Override
+              public Object restriction() {
+                return tracker.currentRestriction();
+              }
+
+              @Override
               public InputT element(DoFn<InputT, OutputT> doFn) {
                 return processContext.element();
               }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -359,6 +359,11 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
+    public Object restriction() {
+      throw new UnsupportedOperationException("@Restriction parameters are not supported.");
+    }
+
+    @Override
     public DoFn<InputT, OutputT>.OnTimerContext onTimerContext(DoFn<InputT, OutputT> doFn) {
       throw new UnsupportedOperationException(
           "Cannot access OnTimerContext outside of @OnTimer methods.");
@@ -488,6 +493,11 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     public MultiOutputReceiver taggedOutputReceiver(DoFn<InputT, OutputT> doFn) {
       throw new UnsupportedOperationException(
           "Cannot access outputReceiver in @FinishBundle method.");
+    }
+
+    @Override
+    public Object restriction() {
+      throw new UnsupportedOperationException("@Restriction parameters are not supported.");
     }
 
     @Override
@@ -720,6 +730,12 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
+    public Object restriction() {
+      throw new UnsupportedOperationException(
+          "@Restriction parameters are not supported. Only the RestrictionTracker is accessible.");
+    }
+
+    @Override
     public DoFn<InputT, OutputT>.OnTimerContext onTimerContext(DoFn<InputT, OutputT> doFn) {
       throw new UnsupportedOperationException(
           "Cannot access OnTimerContext outside of @OnTimer methods.");
@@ -900,6 +916,11 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     @Override
     public MultiOutputReceiver taggedOutputReceiver(DoFn<InputT, OutputT> doFn) {
       return DoFnOutputReceivers.windowedMultiReceiver(this, outputCoders);
+    }
+
+    @Override
+    public Object restriction() {
+      throw new UnsupportedOperationException("@Restriction parameters are not supported.");
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDoViaKeyedWorkItems.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDoViaKeyedWorkItems.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
+import org.apache.beam.sdk.transforms.reflect.DoFnInvoker.BaseArgumentProvider;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -376,7 +377,18 @@ public class SplittableParDoViaKeyedWorkItems {
       }
 
       final RestrictionTracker<RestrictionT, PositionT> tracker =
-          invoker.invokeNewTracker(elementAndRestriction.getValue());
+          invoker.invokeNewTracker(
+              new BaseArgumentProvider<InputT, OutputT>() {
+                @Override
+                public Object restriction() {
+                  return elementAndRestriction.getValue();
+                }
+
+                @Override
+                public String getErrorContext() {
+                  return ProcessFn.class.getSimpleName() + ".invokeNewTracker";
+                }
+              });
       SplittableProcessElementInvoker<InputT, OutputT, RestrictionT, PositionT>.Result result =
           processElementInvoker.invokeProcessElement(
               invoker, elementAndRestriction.getKey(), tracker);

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvokerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvokerTest.java
@@ -85,7 +85,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRestriction(Void element) {
+    public OffsetRange getInitialRestriction(@Element Void element) {
       throw new UnsupportedOperationException("Should not be called in this test");
     }
   }
@@ -195,7 +195,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
           }
 
           @GetInitialRestriction
-          public OffsetRange getInitialRestriction(Void element) {
+          public OffsetRange getInitialRestriction(@Element Void element) {
             throw new UnsupportedOperationException("Should not be called in this test");
           }
         };
@@ -214,7 +214,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
           }
 
           @GetInitialRestriction
-          public OffsetRange getInitialRestriction(Void element) {
+          public OffsetRange getInitialRestriction(@Element Void element) {
             throw new UnsupportedOperationException("Should not be called in this test");
           }
         };

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
@@ -276,7 +276,7 @@ public class SplittableParDoProcessFnTest {
     }
 
     @GetInitialRestriction
-    public SomeRestriction getInitialRestriction(Integer elem) {
+    public SomeRestriction getInitialRestriction(@Element Integer elem) {
       return new SomeRestriction();
     }
   }
@@ -327,12 +327,12 @@ public class SplittableParDoProcessFnTest {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRestriction(Instant elem) {
+    public OffsetRange getInitialRestriction(@Element Instant elem) {
       throw new IllegalStateException("Expected to be supplied explicitly in this test");
     }
 
     @NewTracker
-    public OffsetRangeTracker newTracker(OffsetRange range) {
+    public OffsetRangeTracker newTracker(@Restriction OffsetRange range) {
       return new OffsetRangeTracker(range);
     }
   }
@@ -375,7 +375,7 @@ public class SplittableParDoProcessFnTest {
     }
 
     @GetInitialRestriction
-    public SomeRestriction getInitialRestriction(Integer elem) {
+    public SomeRestriction getInitialRestriction(@Element Integer elem) {
       return new SomeRestriction();
     }
   }
@@ -437,7 +437,7 @@ public class SplittableParDoProcessFnTest {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRestriction(Integer elem) {
+    public OffsetRange getInitialRestriction(@Element Integer elem) {
       throw new UnsupportedOperationException("Expected to be supplied explicitly in this test");
     }
   }
@@ -559,7 +559,7 @@ public class SplittableParDoProcessFnTest {
     }
 
     @GetInitialRestriction
-    public SomeRestriction getInitialRestriction(Integer element) {
+    public SomeRestriction getInitialRestriction(@Element Integer element) {
       return new SomeRestriction();
     }
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -1069,7 +1069,7 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRange(String element) {
+    public OffsetRange getInitialRange(@Element String element) {
       return null;
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -40,6 +40,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.Sizes;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.Window;
@@ -569,13 +570,10 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * Annotation for the method to use for processing elements. A subclass of {@link DoFn} must have
    * a method with this annotation.
    *
-   * <p>The signature of this method must satisfy the following constraints:
+   * <p>If any of the arguments is a {@link RestrictionTracker} then see the specifications below
+   * about splittable {@link DoFn}, otherwise this method must satisfy the following constraints:
    *
    * <ul>
-   *   <li>If one of its arguments is a {@link RestrictionTracker}, then it is a <a
-   *       href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn} subject to the
-   *       separate requirements described below. Items below are assuming this is not a splittable
-   *       {@link DoFn}.
    *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
    *       passed the current element being processed; the argument type must match the input type
    *       of this DoFn.
@@ -614,45 +612,93 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <p>See <a href="https://s.apache.org/splittable-do-fn">the proposal</a> for an overview of the
    * involved concepts (<i>splittable DoFn</i>, <i>restriction</i>, <i>restriction tracker</i>).
    *
-   * <p>If a {@link DoFn} is splittable, the following constraints must be respected:
+   * <p>A splittable {@link DoFn} must obey the following constraints:
    *
    * <ul>
    *   <li>It <i>must</i> define a {@link GetInitialRestriction} method.
-   *   <li>It <i>may</i> define a {@link GetSize} method.
-   *   <li>It <i>may</i> define a {@link SplitRestriction} method.
+   *   <li>It <i>should</i> define a {@link GetSize} method or ensure that the {@link
+   *       RestrictionTracker} implements {@link Sizes.HasSize}.
+   *   <li>It <i>should</i> define a {@link SplitRestriction} method.
    *   <li>It <i>may</i> define a {@link NewTracker} method returning a subtype of {@code
    *       RestrictionTracker<R>} where {@code R} is the restriction type returned by {@link
    *       GetInitialRestriction}. This method is optional in case the restriction type returned by
    *       {@link GetInitialRestriction} implements {@link HasDefaultTracker}.
    *   <li>It <i>may</i> define a {@link GetRestrictionCoder} method.
    *   <li>The type of restrictions used by all of these methods must be the same.
-   *   <li>Its {@link ProcessElement} method <i>may</i> return a {@link ProcessContinuation} to
-   *       indicate whether there is more work to be done for the current element.
-   *   <li>Its {@link ProcessElement} method <i>must not</i> use any extra context parameters, such
-   *       as {@link BoundedWindow}.
    *   <li>The {@link DoFn} itself <i>may</i> be annotated with {@link BoundedPerElement} or {@link
    *       UnboundedPerElement}, but not both at the same time. If it's not annotated with either of
    *       these, it's assumed to be {@link BoundedPerElement} if its {@link ProcessElement} method
    *       returns {@code void} and {@link UnboundedPerElement} if it returns a {@link
    *       ProcessContinuation}.
+   *   <li>Timers and state must not be used.
    * </ul>
    *
    * <p>A non-splittable {@link DoFn} <i>must not</i> define any of these methods.
+   *
+   * <p>This method must satisfy the following constraints:
+   *
+   * <ul>
+   *   <li>One of its arguments must be a {@link RestrictionTracker}. The argument must be of the
+   *       exact type {@code RestrictionTracker<RestrictionT, PositionT>}.
+   *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
+   *       passed the current element being processed; the argument type must match the input type
+   *       of this DoFn.
+   *   <li>If one of its arguments is tagged with the {@link Restriction} annotation, then it will
+   *       be passed the current restriction being processed; the argument must be of type {@code
+   *       RestrictionT}.
+   *   <li>If one of its arguments is tagged with the {@link Timestamp} annotation, then it will be
+   *       passed the timestamp of the current element being processed; the argument must be of type
+   *       {@link Instant}.
+   *   <li>If one of its arguments is a subtype of {@link BoundedWindow}, then it will be passed the
+   *       window of the current element. When applied by {@link ParDo} the subtype of {@link
+   *       BoundedWindow} must match the type of windows on the input {@link PCollection}. If the
+   *       window is not accessed a runner may perform additional optimizations.
+   *   <li>If one of its arguments is of type {@link PaneInfo}, then it will be passed information
+   *       about the current triggering pane.
+   *   <li>If one of the parameters is of type {@link PipelineOptions}, then it will be passed the
+   *       options for the current pipeline.
+   *   <li>If one of the parameters is of type {@link OutputReceiver}, then it will be passed an
+   *       output receiver for outputting elements to the default output.
+   *   <li>If one of the parameters is of type {@link MultiOutputReceiver}, then it will be passed
+   *       an output receiver for outputting to multiple tagged outputs.
+   *   <li>If one of the parameters is of type {@link BundleFinalizer}, then it will be passed a
+   *       mechanism to register a callback that will be invoked after the runner successfully
+   *       commits the output of this bundle. See <a
+   *       href="https://s.apache.org/beam-finalizing-bundles">Apache Beam Portability API: How to
+   *       Finalize Bundles</a> for further details.
+   *   <li>May return a {@link ProcessContinuation} to indicate whether there is more work to be
+   *       done for the current element, otherwise must return {@code void}.
+   * </ul>
    */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   public @interface ProcessElement {}
 
-  /** Parameter annotation for the input element for a {@link ProcessElement} method. */
+  /**
+   * Parameter annotation for the input element for {@link ProcessElement}, {@link
+   * GetInitialRestriction}, {@link GetSize}, {@link SplitRestriction}, and {@link NewTracker}
+   * methods.
+   */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.PARAMETER)
   public @interface Element {}
 
   /**
+   * Parameter annotation for the restriction for {@link GetSize}, {@link SplitRestriction}, and
+   * {@link NewTracker} methods. Must match the return type used on the method annotated with {@link
+   * GetInitialRestriction}.
+   */
+  @Documented
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.PARAMETER)
+  public @interface Restriction {}
+
+  /**
    * Parameter annotation for the input element timestamp for {@link ProcessElement}, {@link
-   * GetInitialRestriction}, {@link SplitRestriction}, and {@link NewTracker} methods.
+   * GetInitialRestriction}, {@link GetSize}, {@link SplitRestriction}, and {@link NewTracker}
+   * methods.
    */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
@@ -758,11 +804,19 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * Annotation for the method that maps an element to an initial restriction for a <a
    * href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn}.
    *
-   * <p>Signature: {@code RestrictionT getInitialRestriction(InputT element, <optional arguments>);}
+   * <p>Signature: {@code RestrictionT getInitialRestriction(<arguments>);}
    *
-   * <p>The optional arguments are allowed to be:
+   * <p>This method must satisfy the following constraints:
    *
    * <ul>
+   *   <li>The return type {@code RestrictionT} defines the restriction type used within this
+   *       splittable DoFn. All other methods that use a {@link Restriction @Restriction} parameter
+   *       must use the same type that is used here. It is suggested to use as narrow of a return
+   *       type definition as possible (for example prefer to use a square type over a shape type as
+   *       a square is a type of a shape).
+   *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
+   *       passed the current element being processed; the argument must be of type {@code InputT}.
+   *       Note that schema element parameters are currently unsupported.
    *   <li>If one of its arguments is tagged with the {@link Timestamp} annotation, then it will be
    *       passed the timestamp of the current element being processed; the argument must be of type
    *       {@link Instant}.
@@ -776,7 +830,6 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *       options for the current pipeline.
    * </ul>
    */
-  // TODO: Make the InputT parameter optional.
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
@@ -787,9 +840,34 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * Annotation for the method that returns the corresponding size for an element and restriction
    * pair.
    *
-   * <p>Signature: {@code double getSize(InputT element, RestrictionT restriction);}
+   * <p>Signature: {@code double getSize(<arguments>);}
    *
-   * <p>Returns a double representing the size of the element and restriction.
+   * <p>This method must satisfy the following constraints:
+   *
+   * <ul>
+   *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
+   *       passed the current element being processed; the argument must be of type {@code InputT}.
+   *       Note that schema element parameters are currently unsupported.
+   *   <li>If one of its arguments is tagged with the {@link Restriction} annotation, then it will
+   *       be passed the current restriction being processed; the argument must be of type {@code
+   *       RestrictionT}.
+   *   <li>If one of its arguments is tagged with the {@link Timestamp} annotation, then it will be
+   *       passed the timestamp of the current element being processed; the argument must be of type
+   *       {@link Instant}.
+   *   <li>If one of its arguments is a {@link RestrictionTracker}, then it will be passed a tracker
+   *       that is initialized for the current {@link Restriction}. The argument must be of the
+   *       exact type {@code RestrictionTracker<RestrictionT, PositionT>}.
+   *   <li>If one of its arguments is a subtype of {@link BoundedWindow}, then it will be passed the
+   *       window of the current element. When applied by {@link ParDo} the subtype of {@link
+   *       BoundedWindow} must match the type of windows on the input {@link PCollection}. If the
+   *       window is not accessed a runner may perform additional optimizations.
+   *   <li>If one of its arguments is of type {@link PaneInfo}, then it will be passed information
+   *       about the current triggering pane.
+   *   <li>If one of the parameters is of type {@link PipelineOptions}, then it will be passed the
+   *       options for the current pipeline.
+   * </ul>
+   *
+   * <p>Returns a double representing the size of the current element and restriction.
    *
    * <p>Splittable {@link DoFn}s should only provide this method if the default implementation
    * within the {@link RestrictionTracker} is an inaccurate representation of known work.
@@ -838,15 +916,30 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn} into multiple parts to
    * be processed in parallel.
    *
-   * <p>Signature: {@code void splitRestriction(InputT element, RestrictionT restriction,
-   * OutputReceiver<RestrictionT> receiver, <optional arguments>);}
+   * <p>This method is used to perform bulk splitting while a restriction is not actively being
+   * processed while {@link RestrictionTracker#trySplit} is used to perform splitting during
+   * processing.
    *
-   * <p>The optional arguments are allowed to be:
+   * <p>Signature: {@code void splitRestriction(<arguments>);}
+   *
+   * <p>This method must satisfy the following constraints:
    *
    * <ul>
+   *   <li>If one of the arguments is of type {@link OutputReceiver}, then it will be passed an
+   *       output receiver for outputting the splits. All splits must be output through this
+   *       parameter.
+   *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
+   *       passed the current element being processed; the argument must be of type {@code InputT}.
+   *       Note that schema element parameters are currently unsupported.
+   *   <li>If one of its arguments is tagged with the {@link Restriction} annotation, then it will
+   *       be passed the current restriction being processed; the argument must be of type {@code
+   *       RestrictionT}.
    *   <li>If one of its arguments is tagged with the {@link Timestamp} annotation, then it will be
    *       passed the timestamp of the current element being processed; the argument must be of type
    *       {@link Instant}.
+   *   <li>If one of its arguments is a {@link RestrictionTracker}, then it will be passed a tracker
+   *       that is initialized for the current {@link Restriction}. The argument must be of the
+   *       exact type {@code RestrictionTracker<RestrictionT, PositionT>}.
    *   <li>If one of its arguments is a subtype of {@link BoundedWindow}, then it will be passed the
    *       window of the current element. When applied by {@link ParDo} the subtype of {@link
    *       BoundedWindow} must match the type of windows on the input {@link PCollection}. If the
@@ -856,11 +949,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *   <li>If one of the parameters is of type {@link PipelineOptions}, then it will be passed the
    *       options for the current pipeline.
    * </ul>
-   *
-   * <p>Optional: if this method is omitted, the restriction will not be split (equivalent to
-   * defining the method and outputting the {@code restriction} unchanged).
    */
-  // TODO: Make the InputT parameter optional.
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
@@ -871,13 +960,20 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * Annotation for the method that creates a new {@link RestrictionTracker} for the restriction of
    * a <a href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn}.
    *
-   * <p>Signature: {@code MyRestrictionTracker newTracker(RestrictionT restriction, <optional
-   * arguments>);} where {@code MyRestrictionTracker} must be a subtype of {@code
-   * RestrictionTracker<RestrictionT>}.
+   * <p>Signature: {@code MyRestrictionTracker newTracker(<optional arguments>);}
    *
-   * <p>The optional arguments are allowed to be:
+   * <p>This method must satisfy the following constraints:
    *
    * <ul>
+   *   <li>The return type must be a subtype of {@code RestrictionTracker<RestrictionT, PositionT>}.
+   *       It is suggested to use as narrow of a return type definition as possible (for example
+   *       prefer to use a square type over a shape type as a square is a type of a shape).
+   *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
+   *       passed the current element being processed; the argument must be of type {@code InputT}.
+   *       Note that schema element parameters are currently unsupported.
+   *   <li>If one of its arguments is tagged with the {@link Restriction} annotation, then it will
+   *       be passed the current restriction being processed; the argument must be of type {@code
+   *       RestrictionT}.
    *   <li>If one of its arguments is tagged with the {@link Timestamp} annotation, then it will be
    *       passed the timestamp of the current element being processed; the argument must be of type
    *       {@link Instant}.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -300,6 +300,12 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
             }
 
             @Override
+            public Object restriction() {
+              throw new UnsupportedOperationException(
+                  "Not expected to access Restriction from a regular DoFn in DoFnTester");
+            }
+
+            @Override
             public RestrictionTracker<?, ?> restrictionTracker() {
               throw new UnsupportedOperationException(
                   "Not expected to access RestrictionTracker from a regular DoFn in DoFnTester");

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
@@ -759,12 +759,13 @@ public class Watch {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRestriction(KV<InputT, List<TimestampedValue<OutputT>>> element) {
+    public OffsetRange getInitialRestriction(
+        @Element KV<InputT, List<TimestampedValue<OutputT>>> element) {
       return new OffsetRange(0, element.getValue().size());
     }
 
     @NewTracker
-    public OffsetRangeTracker newTracker(OffsetRange restriction) {
+    public OffsetRangeTracker newTracker(@Restriction OffsetRange restriction) {
       return restriction.newTracker();
     }
 
@@ -924,12 +925,13 @@ public class Watch {
     }
 
     @GetInitialRestriction
-    public GrowthState getInitialRestriction(InputT element) {
+    public GrowthState getInitialRestriction(@Element InputT element) {
       return PollingGrowthState.of(getTerminationCondition().forNewInput(Instant.now(), element));
     }
 
     @NewTracker
-    public GrowthTracker<OutputT, TerminationStateT> newTracker(GrowthState restriction) {
+    public GrowthTracker<OutputT, TerminationStateT> newTracker(
+        @Restriction GrowthState restriction) {
       return new GrowthTracker<>(restriction, coderFunnel);
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -44,6 +44,7 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.OnTimerCon
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.OutputReceiverParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.PaneInfoParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.ProcessContextParameter;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionTrackerParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SchemaElementParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SideInputParameter;
@@ -57,6 +58,8 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.TimestampP
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.WindowParameter;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.Sizes;
+import org.apache.beam.sdk.transforms.splittabledofn.Sizes.HasSize;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.ByteBuddy;
@@ -112,6 +115,7 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
   public static final String WINDOW_PARAMETER_METHOD = "window";
   public static final String PANE_INFO_PARAMETER_METHOD = "paneInfo";
   public static final String PIPELINE_OPTIONS_PARAMETER_METHOD = "pipelineOptions";
+  public static final String RESTRICTION_PARAMETER_METHOD = "restriction";
   public static final String RESTRICTION_TRACKER_PARAMETER_METHOD = "restrictionTracker";
   public static final String STATE_PARAMETER_METHOD = "state";
   public static final String TIMER_PARAMETER_METHOD = "timer";
@@ -341,9 +345,8 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
   public static class DefaultSplitRestriction {
     /** Doesn't split the restriction. */
     @SuppressWarnings("unused")
-    public static <InputT, RestrictionT> void invokeSplitRestriction(
-        InputT element, RestrictionT restriction, DoFn.OutputReceiver<RestrictionT> receiver) {
-      receiver.output(restriction);
+    public static void invokeSplitRestriction(DoFnInvoker.ArgumentProvider argumentProvider) {
+      argumentProvider.outputReceiver(null).output(argumentProvider.restriction());
     }
   }
 
@@ -367,8 +370,23 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
   public static class DefaultNewTracker {
     /** Uses {@link HasDefaultTracker} to produce the tracker. */
     @SuppressWarnings("unused")
-    public static RestrictionTracker invokeNewTracker(Object restriction) {
-      return ((HasDefaultTracker) restriction).newTracker();
+    public static <InputT, OutputT, RestrictionT, PositionT>
+        RestrictionTracker<RestrictionT, PositionT> invokeNewTracker(
+            DoFnInvoker.ArgumentProvider<InputT, OutputT> argumentProvider) {
+      return ((HasDefaultTracker) argumentProvider.restriction()).newTracker();
+    }
+  }
+
+  public static class DefaultGetSize {
+    /** Uses {@link Sizes.HasSize} to produce the size. */
+    @SuppressWarnings("unused")
+    public static <InputT, OutputT> double invokeGetSize(
+        DoFnInvoker.ArgumentProvider<InputT, OutputT> argumentProvider) {
+      if (argumentProvider.restrictionTracker() instanceof HasSize) {
+        return ((HasSize) argumentProvider.restrictionTracker()).getSize();
+      } else {
+        return 1.0;
+      }
     }
   }
 
@@ -417,16 +435,18 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
                     clazzDescription, signature.onWindowExpiration()))
             .method(ElementMatchers.named("invokeGetInitialRestriction"))
             .intercept(
-                delegateWithDowncastOrThrow(clazzDescription, signature.getInitialRestriction()))
+                delegateMethodWithExtraParametersOrThrow(
+                    clazzDescription, signature.getInitialRestriction()))
             .method(ElementMatchers.named("invokeSplitRestriction"))
-            .intercept(splitRestrictionDelegation(clazzDescription, signature))
+            .intercept(splitRestrictionDelegation(clazzDescription, signature.splitRestriction()))
             .method(ElementMatchers.named("invokeGetRestrictionCoder"))
             .intercept(getRestrictionCoderDelegation(clazzDescription, signature))
             .method(ElementMatchers.named("invokeNewTracker"))
-            .intercept(newTrackerDelegation(clazzDescription, signature.newTracker()));
+            .intercept(newTrackerDelegation(clazzDescription, signature.newTracker()))
+            .method(ElementMatchers.named("invokeGetSize"))
+            .intercept(getSizeDelegation(clazzDescription, signature.getSize()));
 
     DynamicType.Unloaded<?> unloaded = builder.make();
-
     @SuppressWarnings("unchecked")
     Class<? extends DoFnInvoker<?, ?>> res =
         (Class<? extends DoFnInvoker<?, ?>>)
@@ -454,12 +474,11 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
   }
 
   private static Implementation splitRestrictionDelegation(
-      TypeDescription doFnType, DoFnSignature signature) {
-    if (signature.splitRestriction() == null) {
+      TypeDescription doFnType, DoFnSignature.SplitRestrictionMethod signature) {
+    if (signature == null) {
       return MethodDelegation.to(DefaultSplitRestriction.class);
     } else {
-      return new DowncastingParametersMethodDelegation(
-          doFnType, signature.splitRestriction().targetMethod());
+      return new DoFnMethodWithExtraParametersDelegation(doFnType, signature);
     }
   }
 
@@ -470,7 +489,18 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
       // is a subtype of HasDefaultTracker.
       return MethodDelegation.to(DefaultNewTracker.class);
     } else {
-      return delegateWithDowncastOrThrow(doFnType, signature);
+      return new DoFnMethodWithExtraParametersDelegation(doFnType, signature);
+    }
+  }
+
+  private static Implementation getSizeDelegation(
+      TypeDescription doFnType, @Nullable DoFnSignature.GetSizeMethod signature) {
+    if (signature == null) {
+      // We must have already verified that in this case the restriction type
+      // is a subtype of HasDefaultTracker.
+      return MethodDelegation.to(DefaultGetSize.class);
+    } else {
+      return new DoFnMethodWithExtraParametersDelegation(doFnType, signature);
     }
   }
 
@@ -482,11 +512,26 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
         : new DoFnMethodDelegation(doFnType, method.targetMethod());
   }
 
+  /** Delegates to the given method if available, or does nothing. */
+  private static Implementation delegateOrThrow(
+      TypeDescription doFnType, DoFnSignature.DoFnMethod method) {
+    return (method == null)
+        ? ExceptionMethod.throwing(UnsupportedOperationException.class)
+        : new DoFnMethodDelegation(doFnType, method.targetMethod());
+  }
+
   /** Delegates method with extra parameters to the given method if available, or does nothing. */
   private static Implementation delegateMethodWithExtraParametersOrNoop(
       TypeDescription doFnType, DoFnSignature.MethodWithExtraParameters method) {
     return (method == null)
         ? FixedValue.originType()
+        : new DoFnMethodWithExtraParametersDelegation(doFnType, method);
+  }
+
+  private static Implementation delegateMethodWithExtraParametersOrThrow(
+      TypeDescription doFnType, DoFnSignature.MethodWithExtraParameters method) {
+    return (method == null)
+        ? ExceptionMethod.throwing(UnsupportedOperationException.class)
         : new DoFnMethodWithExtraParametersDelegation(doFnType, method);
   }
 
@@ -546,8 +591,14 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
             MethodDescription instrumentedMethod) {
           // Figure out how many locals we'll need. This corresponds to "this", the parameters
           // of the instrumented method, and an argument to hold the return value if the target
-          // method has a return value.
-          int numLocals = 1 + instrumentedMethod.getParameters().size() + (targetHasReturn ? 1 : 0);
+          // method has a return value. We properly calculate the size of the return type since
+          // some return types like the primitive double and long require space for 2 locals.
+          int numLocals =
+              1
+                  + instrumentedMethod.getParameters().size()
+                  + (targetHasReturn
+                      ? Type.getReturnType(instrumentedMethod.getDescriptor()).getSize()
+                      : 0);
 
           Integer returnVarIndex = null;
           if (targetHasReturn) {
@@ -838,9 +889,19 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
           }
 
           @Override
+          public StackManipulation dispatch(RestrictionParameter p) {
+            // DoFnInvoker.ArgumentProvider.restriction() returns an Object,
+            // but the methods expect a concrete subtype of it.
+            // Insert a downcast.
+            return new StackManipulation.Compound(
+                simpleExtraContextParameter(RESTRICTION_PARAMETER_METHOD),
+                TypeCasting.to(new TypeDescription.ForLoadedType(p.restrictionT().getRawType())));
+          }
+
+          @Override
           public StackManipulation dispatch(RestrictionTrackerParameter p) {
             // DoFnInvoker.ArgumentProvider.restrictionTracker() returns a RestrictionTracker,
-            // but the @ProcessElement method expects a concrete subtype of it.
+            // but the methods expect a concrete subtype of it.
             // Insert a downcast.
             return new StackManipulation.Compound(
                 simpleExtraContextParameter(RESTRICTION_TRACKER_PARAMETER_METHOD),
@@ -1014,7 +1075,7 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
         locals[i + 1] = describeType(localTypes[i]);
       }
       if (hasReturnLocal) {
-        locals[locals.length - 1] = returnType.getInternalName();
+        locals[locals.length - 1] = describeType(Type.getReturnType(targetMethod.getDescriptor()));
       }
 
       Object[] stack = stackTop == null ? new Object[] {} : new Object[] {stackTop};
@@ -1036,7 +1097,8 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
       size = size.aggregate(MethodInvocation.invoke(targetMethod).apply(mv, context));
 
       if (returnVarIndex != null) {
-        mv.visitVarInsn(Opcodes.ASTORE, returnVarIndex);
+        Type returnType = Type.getReturnType(targetMethod.getDescriptor());
+        mv.visitVarInsn(returnType.getOpcode(Opcodes.ISTORE), returnVarIndex);
         size = size.aggregate(new Size(-1, 0)); // Reduces the size of the stack
       }
       mv.visitJumpInsn(Opcodes.GOTO, catchBlockEnd);
@@ -1060,7 +1122,8 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
 
       // After catch block, should have same locals and will have the return on the stack.
       if (returnVarIndex != null) {
-        mv.visitVarInsn(Opcodes.ALOAD, returnVarIndex);
+        Type returnType = Type.getReturnType(targetMethod.getDescriptor());
+        mv.visitVarInsn(returnType.getOpcode(Opcodes.ILOAD), returnVarIndex);
         size = size.aggregate(new Size(1, 0)); // Increases the size of the stack
       }
       mv.visitLabel(wrapEnd);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -116,6 +116,10 @@ public abstract class DoFnSignature {
   @Nullable
   public abstract NewTrackerMethod newTracker();
 
+  /** Details about this {@link DoFn}'s {@link DoFn.GetSize} method. */
+  @Nullable
+  public abstract GetSizeMethod getSize();
+
   /** Details about this {@link DoFn}'s {@link DoFn.OnTimer} methods. */
   @Nullable
   public abstract Map<String, OnTimerMethod> onTimerMethods();
@@ -169,6 +173,8 @@ public abstract class DoFnSignature {
     abstract Builder setGetRestrictionCoder(GetRestrictionCoderMethod getRestrictionCoder);
 
     abstract Builder setNewTracker(NewTrackerMethod newTracker);
+
+    abstract Builder setGetSize(GetSizeMethod getSize);
 
     abstract Builder setStateDeclarations(Map<String, StateDeclaration> stateDeclarations);
 
@@ -235,6 +241,8 @@ public abstract class DoFnSignature {
         return cases.dispatch((WindowParameter) this);
       } else if (this instanceof PaneInfoParameter) {
         return cases.dispatch((PaneInfoParameter) this);
+      } else if (this instanceof RestrictionParameter) {
+        return cases.dispatch((RestrictionParameter) this);
       } else if (this instanceof RestrictionTrackerParameter) {
         return cases.dispatch((RestrictionTrackerParameter) this);
       } else if (this instanceof StateParameter) {
@@ -294,6 +302,8 @@ public abstract class DoFnSignature {
       ResultT dispatch(WindowParameter p);
 
       ResultT dispatch(PaneInfoParameter p);
+
+      ResultT dispatch(RestrictionParameter p);
 
       ResultT dispatch(RestrictionTrackerParameter p);
 
@@ -376,6 +386,11 @@ public abstract class DoFnSignature {
 
         @Override
         public ResultT dispatch(PaneInfoParameter p) {
+          return dispatchDefault(p);
+        }
+
+        @Override
+        public ResultT dispatch(RestrictionParameter p) {
           return dispatchDefault(p);
         }
 
@@ -496,6 +511,11 @@ public abstract class DoFnSignature {
     /** Returns a {@link PipelineOptionsParameter}. */
     public static PipelineOptionsParameter pipelineOptions() {
       return PIPELINE_OPTIONS_PARAMETER;
+    }
+
+    /** Returns a {@link RestrictionParameter}. */
+    public static RestrictionParameter restrictionParameter(TypeDescriptor<?> restrictionT) {
+      return new AutoValue_DoFnSignature_Parameter_RestrictionParameter(restrictionT);
     }
 
     /** Returns a {@link RestrictionTrackerParameter}. */
@@ -694,6 +714,19 @@ public abstract class DoFnSignature {
     @AutoValue
     public abstract static class PaneInfoParameter extends Parameter {
       PaneInfoParameter() {}
+    }
+
+    /**
+     * Descriptor for a {@link Parameter} of type {@link DoFn.Restriction}.
+     *
+     * <p>All such descriptors are equal.
+     */
+    @AutoValue
+    public abstract static class RestrictionParameter extends Parameter {
+      // Package visible for AutoValue
+      RestrictionParameter() {}
+
+      public abstract TypeDescriptor<?> restrictionT();
     }
 
     /**
@@ -1090,25 +1123,21 @@ public abstract class DoFnSignature {
     @Override
     public abstract Method targetMethod();
 
-    /** Type of the restriction taken and returned. */
-    public abstract TypeDescriptor<?> restrictionT();
-
     /** The window type used by this method, if any. */
     @Nullable
     @Override
     public abstract TypeDescriptor<? extends BoundedWindow> windowT();
 
-    /** Types of optional parameters of the annotated method, in the order they appear. */
+    /** Types of parameters of the annotated method, in the order they appear. */
     @Override
     public abstract List<Parameter> extraParameters();
 
     static SplitRestrictionMethod create(
         Method targetMethod,
-        TypeDescriptor<?> restrictionT,
         TypeDescriptor<? extends BoundedWindow> windowT,
         List<Parameter> extraParameters) {
       return new AutoValue_DoFnSignature_SplitRestrictionMethod(
-          targetMethod, restrictionT, windowT, extraParameters);
+          targetMethod, windowT, extraParameters);
     }
   }
 
@@ -1118,9 +1147,6 @@ public abstract class DoFnSignature {
     /** The annotated method itself. */
     @Override
     public abstract Method targetMethod();
-
-    /** Type of the input restriction. */
-    public abstract TypeDescriptor<?> restrictionT();
 
     /** Type of the returned {@link RestrictionTracker}. */
     public abstract TypeDescriptor<?> trackerT();
@@ -1136,12 +1162,35 @@ public abstract class DoFnSignature {
 
     static NewTrackerMethod create(
         Method targetMethod,
-        TypeDescriptor<?> restrictionT,
         TypeDescriptor<?> trackerT,
         TypeDescriptor<? extends BoundedWindow> windowT,
         List<Parameter> extraParameters) {
       return new AutoValue_DoFnSignature_NewTrackerMethod(
-          targetMethod, restrictionT, trackerT, windowT, extraParameters);
+          targetMethod, trackerT, windowT, extraParameters);
+    }
+  }
+
+  /** Describes a {@link DoFn.NewTracker} method. */
+  @AutoValue
+  public abstract static class GetSizeMethod implements MethodWithExtraParameters {
+    /** The annotated method itself. */
+    @Override
+    public abstract Method targetMethod();
+
+    /** The window type used by this method, if any. */
+    @Nullable
+    @Override
+    public abstract TypeDescriptor<? extends BoundedWindow> windowT();
+
+    /** Types of optional parameters of the annotated method, in the order they appear. */
+    @Override
+    public abstract List<Parameter> extraParameters();
+
+    static GetSizeMethod create(
+        Method targetMethod,
+        TypeDescriptor<? extends BoundedWindow> windowT,
+        List<Parameter> extraParameters) {
+      return new AutoValue_DoFnSignature_GetSizeMethod(targetMethod, windowT, extraParameters);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -54,7 +54,9 @@ import org.apache.beam.sdk.transforms.DoFn.SideInput;
 import org.apache.beam.sdk.transforms.DoFn.StateId;
 import org.apache.beam.sdk.transforms.DoFn.TimerId;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.FieldAccessDeclaration;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature.GetInitialRestrictionMethod;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionTrackerParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SchemaElementParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.StateParameter;
@@ -159,6 +161,7 @@ public class DoFnSignatures {
   private static final Collection<Class<? extends Parameter>>
       ALLOWED_GET_INITIAL_RESTRICTION_PARAMETERS =
           ImmutableList.of(
+              Parameter.ElementParameter.class,
               Parameter.WindowParameter.class,
               Parameter.TimestampParameter.class,
               Parameter.PaneInfoParameter.class,
@@ -166,6 +169,10 @@ public class DoFnSignatures {
 
   private static final Collection<Class<? extends Parameter>> ALLOWED_SPLIT_RESTRICTION_PARAMETERS =
       ImmutableList.of(
+          Parameter.ElementParameter.class,
+          Parameter.RestrictionParameter.class,
+          Parameter.RestrictionTrackerParameter.class,
+          Parameter.OutputReceiverParameter.class,
           Parameter.WindowParameter.class,
           Parameter.TimestampParameter.class,
           Parameter.PaneInfoParameter.class,
@@ -173,6 +180,18 @@ public class DoFnSignatures {
 
   private static final Collection<Class<? extends Parameter>> ALLOWED_NEW_TRACKER_PARAMETERS =
       ImmutableList.of(
+          Parameter.ElementParameter.class,
+          Parameter.RestrictionParameter.class,
+          Parameter.WindowParameter.class,
+          Parameter.TimestampParameter.class,
+          Parameter.PaneInfoParameter.class,
+          Parameter.PipelineOptionsParameter.class);
+
+  private static final Collection<Class<? extends Parameter>> ALLOWED_GET_SIZE_PARAMETERS =
+      ImmutableList.of(
+          Parameter.ElementParameter.class,
+          Parameter.RestrictionParameter.class,
+          Parameter.RestrictionTrackerParameter.class,
           Parameter.WindowParameter.class,
           Parameter.TimestampParameter.class,
           Parameter.PaneInfoParameter.class,
@@ -435,6 +454,7 @@ public class DoFnSignatures {
     Method getRestrictionCoderMethod =
         findAnnotatedMethod(errors, DoFn.GetRestrictionCoder.class, fnClass, false);
     Method newTrackerMethod = findAnnotatedMethod(errors, DoFn.NewTracker.class, fnClass, false);
+    Method getSizeMethod = findAnnotatedMethod(errors, DoFn.GetSize.class, fnClass, false);
 
     Collection<Method> onTimerMethods =
         declaredMethodsWithAnnotation(DoFn.OnTimer.class, fnClass, DoFn.class);
@@ -498,7 +518,7 @@ public class DoFnSignatures {
       errors.checkArgument(
           onTimerMethodMap.containsKey(decl.id()),
           "No callback registered via %s for timer %s",
-          DoFn.OnTimer.class.getSimpleName(),
+          format(DoFn.OnTimer.class),
           decl.id());
     }
 
@@ -508,7 +528,7 @@ public class DoFnSignatures {
       errors.checkArgument(
           onTimerFamilyMethodMap.containsKey(decl.id()),
           "No callback registered via %s for timerFamily %s",
-          DoFn.OnTimerFamily.class.getSimpleName(),
+          format(DoFn.OnTimerFamily.class),
           decl.id());
     }
 
@@ -549,41 +569,98 @@ public class DoFnSignatures {
               errors, fnT, onWindowExpirationMethod, inputT, outputT, fnContext));
     }
 
-    ErrorReporter getInitialRestrictionErrors;
-    if (getInitialRestrictionMethod != null) {
-      getInitialRestrictionErrors =
+    if (processElement.isSplittable()) {
+      ErrorReporter getInitialRestrictionErrors =
           errors.forMethod(DoFn.GetInitialRestriction.class, getInitialRestrictionMethod);
-      signatureBuilder.setGetInitialRestriction(
+      getInitialRestrictionErrors.checkNotNull(
+          getInitialRestrictionMethod,
+          "Splittable, but does not define the required @%s method.",
+          DoFnSignatures.format(DoFn.GetInitialRestriction.class));
+
+      GetInitialRestrictionMethod method =
           analyzeGetInitialRestrictionMethod(
-              getInitialRestrictionErrors,
+              errors.forMethod(DoFn.GetInitialRestriction.class, getInitialRestrictionMethod),
               fnT,
               getInitialRestrictionMethod,
               inputT,
               outputT,
-              fnContext));
-    }
+              fnContext);
 
-    if (splitRestrictionMethod != null) {
-      ErrorReporter splitRestrictionErrors =
-          errors.forMethod(DoFn.SplitRestriction.class, splitRestrictionMethod);
-      signatureBuilder.setSplitRestriction(
-          analyzeSplitRestrictionMethod(
-              splitRestrictionErrors, fnT, splitRestrictionMethod, inputT, outputT, fnContext));
-    }
+      signatureBuilder.setGetInitialRestriction(method);
+      TypeDescriptor<?> restrictionT = method.restrictionT();
 
-    if (getRestrictionCoderMethod != null) {
-      ErrorReporter getRestrictionCoderErrors =
-          errors.forMethod(DoFn.GetRestrictionCoder.class, getRestrictionCoderMethod);
-      signatureBuilder.setGetRestrictionCoder(
-          analyzeGetRestrictionCoderMethod(
-              getRestrictionCoderErrors, fnT, getRestrictionCoderMethod));
-    }
+      if (newTrackerMethod != null) {
+        signatureBuilder.setNewTracker(
+            analyzeNewTrackerMethod(
+                errors.forMethod(DoFn.NewTracker.class, newTrackerMethod),
+                fnT,
+                newTrackerMethod,
+                inputT,
+                outputT,
+                restrictionT,
+                fnContext));
+      } else {
+        errors
+            .forMethod(DoFn.NewTracker.class, null)
+            .checkArgument(
+                restrictionT.isSubtypeOf(TypeDescriptor.of(HasDefaultTracker.class)),
+                "Splittable, either @%s method must be defined or %s must implement %s.",
+                format(DoFn.NewTracker.class),
+                format(restrictionT),
+                format(HasDefaultTracker.class));
+      }
 
-    if (newTrackerMethod != null) {
-      ErrorReporter newTrackerErrors = errors.forMethod(DoFn.NewTracker.class, newTrackerMethod);
-      signatureBuilder.setNewTracker(
-          analyzeNewTrackerMethod(
-              newTrackerErrors, fnT, newTrackerMethod, inputT, outputT, fnContext));
+      if (splitRestrictionMethod != null) {
+        signatureBuilder.setSplitRestriction(
+            analyzeSplitRestrictionMethod(
+                errors.forMethod(DoFn.SplitRestriction.class, splitRestrictionMethod),
+                fnT,
+                splitRestrictionMethod,
+                inputT,
+                outputT,
+                restrictionT,
+                fnContext));
+      }
+
+      if (getSizeMethod != null) {
+        signatureBuilder.setGetSize(
+            analyzeGetSizeMethod(
+                errors.forMethod(DoFn.GetSize.class, getSizeMethod),
+                fnT,
+                getSizeMethod,
+                inputT,
+                outputT,
+                restrictionT,
+                fnContext));
+      }
+
+      if (getRestrictionCoderMethod != null) {
+        signatureBuilder.setGetRestrictionCoder(
+            analyzeGetRestrictionCoderMethod(
+                errors.forMethod(DoFn.GetRestrictionCoder.class, getRestrictionCoderMethod),
+                fnT,
+                getRestrictionCoderMethod));
+      }
+    } else {
+      // Validate that none of the splittable DoFn only methods have been declared.
+      List<String> forbiddenMethods = new ArrayList<>();
+      if (getInitialRestrictionMethod != null) {
+        forbiddenMethods.add("@" + format(DoFn.GetInitialRestriction.class));
+      }
+      if (splitRestrictionMethod != null) {
+        forbiddenMethods.add("@" + format(DoFn.SplitRestriction.class));
+      }
+      if (newTrackerMethod != null) {
+        forbiddenMethods.add("@" + format(DoFn.NewTracker.class));
+      }
+      if (getRestrictionCoderMethod != null) {
+        forbiddenMethods.add("@" + format(DoFn.GetRestrictionCoder.class));
+      }
+      if (getSizeMethod != null) {
+        forbiddenMethods.add("@" + format(DoFn.GetSize.class));
+      }
+      errors.checkArgument(
+          forbiddenMethods.isEmpty(), "Non-splittable, but defines methods: %s", forbiddenMethods);
     }
 
     signatureBuilder.setIsBoundedPerElement(inferBoundedness(fnT, processElement, errors));
@@ -598,8 +675,6 @@ public class DoFnSignatures {
     // Additional validation for splittable DoFn's.
     if (processElement.isSplittable()) {
       verifySplittableMethods(signature, errors);
-    } else {
-      verifyUnsplittableMethods(errors, signature);
     }
 
     return signature;
@@ -641,8 +716,8 @@ public class DoFnSignatures {
         errors.checkArgument(
             isBounded == null,
             "Both @%s and @%s specified",
-            DoFn.BoundedPerElement.class.getSimpleName(),
-            DoFn.UnboundedPerElement.class.getSimpleName());
+            format(DoFn.BoundedPerElement.class),
+            format(DoFn.UnboundedPerElement.class));
         isBounded =
             supertype.getRawType().isAnnotationPresent(DoFn.BoundedPerElement.class)
                 ? PCollection.IsBounded.BOUNDED
@@ -661,8 +736,8 @@ public class DoFnSignatures {
           isBounded == null,
           "Non-splittable, but annotated as @"
               + ((isBounded == PCollection.IsBounded.BOUNDED)
-                  ? DoFn.BoundedPerElement.class.getSimpleName()
-                  : DoFn.UnboundedPerElement.class.getSimpleName()));
+                  ? format(DoFn.BoundedPerElement.class)
+                  : format(DoFn.UnboundedPerElement.class)));
       checkState(!processElement.hasReturnValue(), "Should have been inferred splittable");
       isBounded = PCollection.IsBounded.BOUNDED;
     }
@@ -686,95 +761,40 @@ public class DoFnSignatures {
         signature.getInitialRestriction();
     DoFnSignature.NewTrackerMethod newTracker = signature.newTracker();
     DoFnSignature.GetRestrictionCoderMethod getRestrictionCoder = signature.getRestrictionCoder();
-    DoFnSignature.SplitRestrictionMethod splitRestriction = signature.splitRestriction();
 
     ErrorReporter processElementErrors =
         errors.forMethod(DoFn.ProcessElement.class, processElement.targetMethod());
 
-    List<String> missingRequiredMethods = new ArrayList<>();
-    if (getInitialRestriction == null) {
-      missingRequiredMethods.add("@" + DoFn.GetInitialRestriction.class.getSimpleName());
-    }
-    if (newTracker == null) {
-      if (getInitialRestriction != null
-          && getInitialRestriction
-              .restrictionT()
-              .isSubtypeOf(TypeDescriptor.of(HasDefaultTracker.class))) {
-        // no-op we are using the annotation @HasDefaultTracker
-      } else {
-        missingRequiredMethods.add("@" + DoFn.NewTracker.class.getSimpleName());
-      }
-    } else {
-      ErrorReporter getInitialRestrictionErrors =
-          errors.forMethod(DoFn.GetInitialRestriction.class, getInitialRestriction.targetMethod());
-      TypeDescriptor<?> restrictionT = getInitialRestriction.restrictionT();
-      getInitialRestrictionErrors.checkArgument(
-          restrictionT.equals(newTracker.restrictionT()),
-          "Uses restriction type %s, but @%s method %s uses restriction type %s",
-          formatType(restrictionT),
-          DoFn.NewTracker.class.getSimpleName(),
-          format(newTracker.targetMethod()),
-          formatType(newTracker.restrictionT()));
-    }
-
-    if (!missingRequiredMethods.isEmpty()) {
-      processElementErrors.throwIllegalArgument(
-          "Splittable, but does not define the following required methods: %s",
-          missingRequiredMethods);
-    }
-
-    ErrorReporter getInitialRestrictionErrors =
-        errors.forMethod(DoFn.GetInitialRestriction.class, getInitialRestriction.targetMethod());
     TypeDescriptor<?> restrictionT = getInitialRestriction.restrictionT();
+
+    if (newTracker == null) {
+      ErrorReporter newTrackerErrors = errors.forMethod(DoFn.NewTracker.class, null);
+      newTrackerErrors.checkArgument(
+          restrictionT.isSubtypeOf(TypeDescriptor.of(HasDefaultTracker.class)),
+          "Splittable, but does not define @%s method or %s does not implement %s.",
+          format(DoFn.NewTracker.class),
+          format(restrictionT),
+          format(HasDefaultTracker.class));
+    }
+
     processElementErrors.checkArgument(
         processElement.trackerT().getRawType().equals(RestrictionTracker.class),
         "Has tracker type %s, but the DoFn's tracker type must be of type RestrictionTracker.",
-        formatType(processElement.trackerT()));
+        format(processElement.trackerT()));
 
     if (getRestrictionCoder != null) {
+      ErrorReporter getInitialRestrictionErrors =
+          errors.forMethod(DoFn.GetInitialRestriction.class, getInitialRestriction.targetMethod());
       getInitialRestrictionErrors.checkArgument(
           getRestrictionCoder.coderT().isSubtypeOf(coderTypeOf(restrictionT)),
           "Uses restriction type %s, but @%s method %s returns %s "
               + "which is not a subtype of %s",
-          formatType(restrictionT),
-          DoFn.GetRestrictionCoder.class.getSimpleName(),
+          format(restrictionT),
+          format(DoFn.GetRestrictionCoder.class),
           format(getRestrictionCoder.targetMethod()),
-          formatType(getRestrictionCoder.coderT()),
-          formatType(coderTypeOf(restrictionT)));
+          format(getRestrictionCoder.coderT()),
+          format(coderTypeOf(restrictionT)));
     }
-
-    if (splitRestriction != null) {
-      getInitialRestrictionErrors.checkArgument(
-          splitRestriction.restrictionT().equals(restrictionT),
-          "Uses restriction type %s, but @%s method %s uses restriction type %s",
-          formatType(restrictionT),
-          DoFn.SplitRestriction.class.getSimpleName(),
-          format(splitRestriction.targetMethod()),
-          formatType(splitRestriction.restrictionT()));
-    }
-  }
-
-  /**
-   * Verifies that a non-splittable {@link DoFn} does not declare any methods that only make sense
-   * for splittable {@link DoFn}: {@link DoFn.GetInitialRestriction}, {@link DoFn.SplitRestriction},
-   * {@link DoFn.NewTracker}, {@link DoFn.GetRestrictionCoder}.
-   */
-  private static void verifyUnsplittableMethods(ErrorReporter errors, DoFnSignature signature) {
-    List<String> forbiddenMethods = new ArrayList<>();
-    if (signature.getInitialRestriction() != null) {
-      forbiddenMethods.add("@" + DoFn.GetInitialRestriction.class.getSimpleName());
-    }
-    if (signature.splitRestriction() != null) {
-      forbiddenMethods.add("@" + DoFn.SplitRestriction.class.getSimpleName());
-    }
-    if (signature.newTracker() != null) {
-      forbiddenMethods.add("@" + DoFn.NewTracker.class.getSimpleName());
-    }
-    if (signature.getRestrictionCoder() != null) {
-      forbiddenMethods.add("@" + DoFn.GetRestrictionCoder.class.getSimpleName());
-    }
-    errors.checkArgument(
-        forbiddenMethods.isEmpty(), "Non-splittable, but defines methods: %s", forbiddenMethods);
   }
 
   /**
@@ -844,7 +864,7 @@ public class DoFnSignatures {
 
     @Nullable TypeDescriptor<? extends BoundedWindow> windowT = getWindowType(fnClass, m);
 
-    List<DoFnSignature.Parameter> extraParameters = new ArrayList<>();
+    List<Parameter> extraParameters = new ArrayList<>();
     ErrorReporter onTimerErrors = errors.forMethod(DoFn.OnTimer.class, m);
     for (int i = 0; i < params.length; ++i) {
       Parameter parameter =
@@ -933,7 +953,7 @@ public class DoFnSignatures {
 
     @Nullable TypeDescriptor<? extends BoundedWindow> windowT = getWindowType(fnClass, m);
 
-    List<DoFnSignature.Parameter> extraParameters = new ArrayList<>();
+    List<Parameter> extraParameters = new ArrayList<>();
     ErrorReporter onWindowExpirationErrors = errors.forMethod(DoFn.OnWindowExpiration.class, m);
     for (int i = 0; i < params.length; ++i) {
       Parameter parameter =
@@ -971,7 +991,7 @@ public class DoFnSignatures {
         void.class.equals(m.getReturnType())
             || DoFn.ProcessContinuation.class.equals(m.getReturnType()),
         "Must return void or %s",
-        DoFn.ProcessContinuation.class.getSimpleName());
+        format(DoFn.ProcessContinuation.class));
 
     MethodAnalysisContext methodContext = MethodAnalysisContext.create();
 
@@ -1069,6 +1089,8 @@ public class DoFnSignatures {
       return (paramT.equals(inputT))
           ? Parameter.elementParameter(paramT)
           : Parameter.schemaElementParameter(paramT, null, param.getIndex());
+    } else if (hasRestrictionAnnotation(param.getAnnotations())) {
+      return Parameter.restrictionParameter(paramT);
     } else if (hasTimestampAnnotation(param.getAnnotations())) {
       methodErrors.checkArgument(
           rawType.equals(Instant.class),
@@ -1079,7 +1101,7 @@ public class DoFnSignatures {
     } else if (hasSideInputAnnotation(param.getAnnotations())) {
       String sideInputId = getSideInputId(param.getAnnotations());
       paramErrors.checkArgument(
-          sideInputId != null, "%s missing %s annotation", SideInput.class.getSimpleName());
+          sideInputId != null, "%s missing %s annotation", format(SideInput.class));
       return Parameter.sideInputParameter(paramT, sideInputId);
     } else if (rawType.equals(PaneInfo.class)) {
       return Parameter.paneInfoParameter();
@@ -1087,19 +1109,19 @@ public class DoFnSignatures {
       paramErrors.checkArgument(
           paramT.equals(expectedProcessContextT),
           "ProcessContext argument must have type %s",
-          formatType(expectedProcessContextT));
+          format(expectedProcessContextT));
       return Parameter.processContext();
     } else if (rawType.equals(DoFn.OnTimerContext.class)) {
       paramErrors.checkArgument(
           paramT.equals(expectedOnTimerContextT),
           "OnTimerContext argument must have type %s",
-          formatType(expectedOnTimerContextT));
+          format(expectedOnTimerContextT));
       return Parameter.onTimerContext();
     } else if (BoundedWindow.class.isAssignableFrom(rawType)) {
       methodErrors.checkArgument(
           !methodContext.hasWindowParameter(),
           "Multiple %s parameters",
-          BoundedWindow.class.getSimpleName());
+          format(BoundedWindow.class));
       return Parameter.boundedWindow((TypeDescriptor<? extends BoundedWindow>) paramT);
     } else if (rawType.equals(OutputReceiver.class)) {
       // It's a schema row receiver if it's an OutputReceiver<Row> _and_ the output type is not
@@ -1121,13 +1143,13 @@ public class DoFnSignatures {
       methodErrors.checkArgument(
           !methodContext.hasPipelineOptionsParamter(),
           "Multiple %s parameters",
-          PipelineOptions.class.getSimpleName());
+          format(PipelineOptions.class));
       return Parameter.pipelineOptions();
     } else if (RestrictionTracker.class.isAssignableFrom(rawType)) {
       methodErrors.checkArgument(
           !methodContext.hasRestrictionTrackerParameter(),
           "Multiple %s parameters",
-          RestrictionTracker.class.getSimpleName());
+          format(RestrictionTracker.class));
       return Parameter.restrictionTracker(paramT);
 
     } else if (rawType.equals(Timer.class)) {
@@ -1135,29 +1157,23 @@ public class DoFnSignatures {
       String id = getTimerId(param.getAnnotations());
 
       paramErrors.checkArgument(
-          id != null,
-          "%s missing %s annotation",
-          Timer.class.getSimpleName(),
-          TimerId.class.getSimpleName());
+          id != null, "%s missing %s annotation", format(Timer.class), format(TimerId.class));
 
       paramErrors.checkArgument(
           !methodContext.getTimerParameters().containsKey(id),
           "duplicate %s: \"%s\"",
-          TimerId.class.getSimpleName(),
+          format(TimerId.class),
           id);
 
       TimerDeclaration timerDecl = fnContext.getTimerDeclarations().get(id);
       paramErrors.checkArgument(
-          timerDecl != null,
-          "reference to undeclared %s: \"%s\"",
-          TimerId.class.getSimpleName(),
-          id);
+          timerDecl != null, "reference to undeclared %s: \"%s\"", format(TimerId.class), id);
 
       paramErrors.checkArgument(
           timerDecl.field().getDeclaringClass().equals(getDeclaringClass(param.getMethod())),
           "%s %s declared in a different class %s."
               + " Timers may be referenced only in the lexical scope where they are declared.",
-          TimerId.class.getSimpleName(),
+          format(TimerId.class),
           id,
           timerDecl.field().getDeclaringClass().getName());
 
@@ -1167,7 +1183,7 @@ public class DoFnSignatures {
       boolean isValidTimerIdForTimerFamily =
           fnContext.getTimerFamilyDeclarations().size() > 0 && rawType.equals(String.class);
       paramErrors.checkArgument(
-          isValidTimerIdForTimerFamily, "%s not allowed here", DoFn.TimerId.class.getSimpleName());
+          isValidTimerIdForTimerFamily, "%s not allowed here", format(DoFn.TimerId.class));
       return Parameter.timerIdParameter();
     } else if (rawType.equals(TimerMap.class)) {
       String id = getTimerFamilyId(param.getAnnotations());
@@ -1175,27 +1191,27 @@ public class DoFnSignatures {
       paramErrors.checkArgument(
           id != null,
           "%s missing %s annotation",
-          TimerMap.class.getSimpleName(),
-          DoFn.TimerFamily.class.getSimpleName());
+          format(TimerMap.class),
+          format(DoFn.TimerFamily.class));
 
       paramErrors.checkArgument(
           !methodContext.getTimerFamilyParameters().containsKey(id),
           "duplicate %s: \"%s\"",
-          DoFn.TimerFamily.class.getSimpleName(),
+          format(DoFn.TimerFamily.class),
           id);
 
       TimerFamilyDeclaration timerDecl = fnContext.getTimerFamilyDeclarations().get(id);
       paramErrors.checkArgument(
           timerDecl != null,
           "reference to undeclared %s: \"%s\"",
-          DoFn.TimerFamily.class.getSimpleName(),
+          format(DoFn.TimerFamily.class),
           id);
 
       paramErrors.checkArgument(
           timerDecl.field().getDeclaringClass().equals(getDeclaringClass(param.getMethod())),
           "%s %s declared in a different class %s."
               + " Timers may be referenced only in the lexical scope where they are declared.",
-          DoFn.TimerFamily.class.getSimpleName(),
+          format(DoFn.TimerFamily.class),
           id,
           timerDecl.field().getDeclaringClass().getName());
 
@@ -1203,13 +1219,12 @@ public class DoFnSignatures {
     } else if (State.class.isAssignableFrom(rawType)) {
       // m.getParameters() is not available until Java 8
       String id = getStateId(param.getAnnotations());
-      paramErrors.checkArgument(
-          id != null, "missing %s annotation", DoFn.StateId.class.getSimpleName());
+      paramErrors.checkArgument(id != null, "missing %s annotation", format(DoFn.StateId.class));
 
       paramErrors.checkArgument(
           !methodContext.getStateParameters().containsKey(id),
           "duplicate %s: \"%s\"",
-          DoFn.StateId.class.getSimpleName(),
+          format(DoFn.StateId.class),
           id);
 
       // By static typing this is already a well-formed State subclass
@@ -1217,29 +1232,26 @@ public class DoFnSignatures {
 
       StateDeclaration stateDecl = fnContext.getStateDeclarations().get(id);
       paramErrors.checkArgument(
-          stateDecl != null,
-          "reference to undeclared %s: \"%s\"",
-          DoFn.StateId.class.getSimpleName(),
-          id);
+          stateDecl != null, "reference to undeclared %s: \"%s\"", format(DoFn.StateId.class), id);
 
       paramErrors.checkArgument(
           stateDecl.stateType().isSubtypeOf(stateType),
           "data type of reference to %s %s must be a supertype of %s",
-          StateId.class.getSimpleName(),
+          format(StateId.class),
           id,
-          formatType(stateDecl.stateType()));
+          format(stateDecl.stateType()));
 
       paramErrors.checkArgument(
           stateDecl.field().getDeclaringClass().equals(getDeclaringClass(param.getMethod())),
           "%s %s declared in a different class %s."
               + " State may be referenced only in the class where it is declared.",
-          StateId.class.getSimpleName(),
+          format(StateId.class),
           id,
           stateDecl.field().getDeclaringClass().getName());
 
       return Parameter.stateParameter(stateDecl);
     } else {
-      paramErrors.throwIllegalArgument("%s is not a valid context parameter.", formatType(paramT));
+      paramErrors.throwIllegalArgument("%s is not a valid context parameter.", format(paramT));
       // Unreachable
       return null;
     }
@@ -1284,6 +1296,10 @@ public class DoFnSignatures {
 
   private static boolean hasElementAnnotation(List<Annotation> annotations) {
     return annotations.stream().anyMatch(a -> a.annotationType().equals(DoFn.Element.class));
+  }
+
+  private static boolean hasRestrictionAnnotation(List<Annotation> annotations) {
+    return annotations.stream().anyMatch(a -> a.annotationType().equals(DoFn.Restriction.class));
   }
 
   private static boolean hasTimestampAnnotation(List<Annotation> annotations) {
@@ -1337,7 +1353,7 @@ public class DoFnSignatures {
         params.length == 0
             || (params.length == 1 && fnT.resolveType(params[0]).equals(expectedContextT)),
         "Must take a single argument of type %s",
-        formatType(expectedContextT));
+        format(expectedContextT));
     return DoFnSignature.BundleMethod.create(m);
   }
 
@@ -1355,7 +1371,7 @@ public class DoFnSignatures {
         params.length == 0
             || (params.length == 1 && fnT.resolveType(params[0]).equals(expectedContextT)),
         "Must take a single argument of type %s",
-        formatType(expectedContextT));
+        format(expectedContextT));
     return DoFnSignature.BundleMethod.create(m);
   }
 
@@ -1376,17 +1392,12 @@ public class DoFnSignatures {
       FnAnalysisContext fnContext) {
     // Method is of the form:
     // @GetInitialRestriction
-    // RestrictionT getInitialRestriction(InputT element, ... additional optional parameters ...);
+    // RestrictionT getInitialRestriction(... parameters ...);
 
     Type[] params = m.getGenericParameterTypes();
-    errors.checkArgument(
-        params.length >= 1 && fnT.resolveType(params[0]).equals(inputT),
-        "First argument must be of type %s",
-        formatType(inputT));
-
     MethodAnalysisContext methodContext = MethodAnalysisContext.create();
     TypeDescriptor<? extends BoundedWindow> windowT = getWindowType(fnT, m);
-    for (int i = 1; i < params.length; ++i) {
+    for (int i = 0; i < params.length; ++i) {
       Parameter extraParam =
           analyzeExtraParameter(
               errors,
@@ -1397,7 +1408,14 @@ public class DoFnSignatures {
                   m, i, fnT.resolveType(params[i]), Arrays.asList(m.getParameterAnnotations()[i])),
               inputT,
               outputT);
-
+      if (extraParam instanceof SchemaElementParameter) {
+        errors.throwIllegalArgument(
+            "Schema @%s are not supported for @%s method. Found %s, did you mean to use %s?",
+            format(DoFn.Element.class),
+            format(DoFn.GetInitialRestriction.class),
+            format(((SchemaElementParameter) extraParam).elementT()),
+            format(inputT));
+      }
       methodContext.addParameter(extraParam);
     }
 
@@ -1426,32 +1444,17 @@ public class DoFnSignatures {
       Method m,
       TypeDescriptor<?> inputT,
       TypeDescriptor<?> outputT,
+      TypeDescriptor<?> restrictionT,
       FnAnalysisContext fnContext) {
     // Method is of the form:
     // @SplitRestriction
-    // void splitRestriction(InputT element, RestrictionT restriction, ... additional optional
-    // parameters ...);
+    // void splitRestriction(... parameters ...);
     errors.checkArgument(void.class.equals(m.getReturnType()), "Must return void");
 
     Type[] params = m.getGenericParameterTypes();
-    errors.checkArgument(params.length >= 3, "Must have at least 3 arguments");
-    errors.checkArgument(
-        fnT.resolveType(params[0]).equals(inputT),
-        "First argument must be the element type %s",
-        formatType(inputT));
-
-    TypeDescriptor<?> restrictionT = fnT.resolveType(params[1]);
-    TypeDescriptor<?> receiverT = fnT.resolveType(params[2]);
-    TypeDescriptor<?> expectedReceiverT = outputReceiverTypeOf(restrictionT);
-    errors.checkArgument(
-        receiverT.equals(expectedReceiverT),
-        "Third argument must be %s, but is %s",
-        formatType(expectedReceiverT),
-        formatType(receiverT));
-
     MethodAnalysisContext methodContext = MethodAnalysisContext.create();
     TypeDescriptor<? extends BoundedWindow> windowT = getWindowType(fnT, m);
-    for (int i = 3; i < params.length; ++i) {
+    for (int i = 0; i < params.length; ++i) {
       Parameter extraParam =
           analyzeExtraParameter(
               errors,
@@ -1461,8 +1464,22 @@ public class DoFnSignatures {
               ParameterDescription.of(
                   m, i, fnT.resolveType(params[i]), Arrays.asList(m.getParameterAnnotations()[i])),
               inputT,
-              outputT);
-
+              restrictionT);
+      if (extraParam instanceof SchemaElementParameter) {
+        errors.throwIllegalArgument(
+            "Schema @%s are not supported for @%s method. Found %s, did you mean to use %s?",
+            format(DoFn.Element.class),
+            format(DoFn.SplitRestriction.class),
+            format(((SchemaElementParameter) extraParam).elementT()),
+            format(inputT));
+      } else if (extraParam instanceof RestrictionParameter) {
+        errors.checkArgument(
+            restrictionT.equals(((RestrictionParameter) extraParam).restrictionT()),
+            "Uses restriction type %s, but @%s method uses restriction type %s",
+            format(((RestrictionParameter) extraParam).restrictionT()),
+            format(DoFn.GetInitialRestriction.class),
+            format(restrictionT));
+      }
       methodContext.addParameter(extraParam);
     }
 
@@ -1471,7 +1488,7 @@ public class DoFnSignatures {
     }
 
     return DoFnSignature.SplitRestrictionMethod.create(
-        m, restrictionT, windowT, methodContext.getExtraParameters());
+        m, windowT, methodContext.getExtraParameters());
   }
 
   private static ImmutableMap<String, TimerFamilyDeclaration> analyzeTimerFamilyDeclarations(
@@ -1511,7 +1528,7 @@ public class DoFnSignatures {
     if (declarations.containsKey(id)) {
       errors.throwIllegalArgument(
           "Duplicate %s \"%s\", used on both of [%s] and [%s]",
-          DoFn.TimerId.class.getSimpleName(),
+          format(DoFn.TimerId.class),
           id,
           field.toString(),
           declarations.get(id).field().toString());
@@ -1521,13 +1538,13 @@ public class DoFnSignatures {
     if (!(timerSpecRawType.equals(TimerSpec.class))) {
       errors.throwIllegalArgument(
           "%s annotation on non-%s field [%s]",
-          DoFn.TimerId.class.getSimpleName(), TimerSpec.class.getSimpleName(), field.toString());
+          format(DoFn.TimerId.class), format(TimerSpec.class), field.toString());
     }
 
     if (!Modifier.isFinal(field.getModifiers())) {
       errors.throwIllegalArgument(
           "Non-final field %s annotated with %s. Timer declarations must be final.",
-          field.toString(), DoFn.TimerId.class.getSimpleName());
+          field.toString(), format(DoFn.TimerId.class));
     }
   }
 
@@ -1544,7 +1561,7 @@ public class DoFnSignatures {
     if (declarations.containsKey(id)) {
       errors.throwIllegalArgument(
           "Duplicate %s \"%s\", used on both of [%s] and [%s]",
-          DoFn.TimerFamily.class.getSimpleName(),
+          format(DoFn.TimerFamily.class),
           id,
           field.toString(),
           declarations.get(id).field().toString());
@@ -1554,15 +1571,13 @@ public class DoFnSignatures {
     if (!(timerSpecRawType.equals(TimerSpec.class))) {
       errors.throwIllegalArgument(
           "%s annotation on non-%s field [%s]",
-          DoFn.TimerFamily.class.getSimpleName(),
-          TimerSpec.class.getSimpleName(),
-          field.toString());
+          format(DoFn.TimerFamily.class), format(TimerSpec.class), field.toString());
     }
 
     if (!Modifier.isFinal(field.getModifiers())) {
       errors.throwIllegalArgument(
           "Non-final field %s annotated with %s. TimerMap declarations must be final.",
-          field.toString(), DoFn.TimerFamily.class.getSimpleName());
+          field.toString(), format(DoFn.TimerFamily.class));
     }
   }
 
@@ -1579,7 +1594,7 @@ public class DoFnSignatures {
     errors.checkArgument(
         resT.isSubtypeOf(TypeDescriptor.of(Coder.class)),
         "Must return a Coder, but returns %s",
-        formatType(resT));
+        format(resT));
     return DoFnSignature.GetRestrictionCoderMethod.create(m, resT);
   }
 
@@ -1601,25 +1616,23 @@ public class DoFnSignatures {
       Method m,
       TypeDescriptor<?> inputT,
       TypeDescriptor<?> outputT,
+      TypeDescriptor<?> restrictionT,
       FnAnalysisContext fnContext) {
     // Method is of the form:
     // @NewTracker
-    // TrackerT newTracker(RestrictionT restriction, ... additional optional parameters ...);
+    // TrackerT newTracker(... parameters ...);
     Type[] params = m.getGenericParameterTypes();
-    errors.checkArgument(params.length >= 1, "Must have at least one argument");
-
-    TypeDescriptor<?> restrictionT = fnT.resolveType(params[0]);
     TypeDescriptor<?> trackerT = fnT.resolveType(m.getGenericReturnType());
     TypeDescriptor<?> expectedTrackerT = restrictionTrackerTypeOf(restrictionT);
     errors.checkArgument(
         trackerT.isSubtypeOf(expectedTrackerT),
         "Returns %s, but must return a subtype of %s",
-        formatType(trackerT),
-        formatType(expectedTrackerT));
+        format(trackerT),
+        format(expectedTrackerT));
 
     MethodAnalysisContext methodContext = MethodAnalysisContext.create();
     TypeDescriptor<? extends BoundedWindow> windowT = getWindowType(fnT, m);
-    for (int i = 1; i < params.length; ++i) {
+    for (int i = 0; i < params.length; ++i) {
       Parameter extraParam =
           analyzeExtraParameter(
               errors,
@@ -1630,7 +1643,21 @@ public class DoFnSignatures {
                   m, i, fnT.resolveType(params[i]), Arrays.asList(m.getParameterAnnotations()[i])),
               inputT,
               outputT);
-
+      if (extraParam instanceof SchemaElementParameter) {
+        errors.throwIllegalArgument(
+            "Schema @%s are not supported for @%s method. Found %s, did you mean to use %s?",
+            format(DoFn.Element.class),
+            format(DoFn.NewTracker.class),
+            format(((SchemaElementParameter) extraParam).elementT()),
+            format(inputT));
+      } else if (extraParam instanceof RestrictionParameter) {
+        errors.checkArgument(
+            restrictionT.equals(((RestrictionParameter) extraParam).restrictionT()),
+            "Uses restriction type %s, but @%s method uses restriction type %s",
+            format(((RestrictionParameter) extraParam).restrictionT()),
+            format(DoFn.GetInitialRestriction.class),
+            format(restrictionT));
+      }
       methodContext.addParameter(extraParam);
     }
 
@@ -1639,7 +1666,65 @@ public class DoFnSignatures {
     }
 
     return DoFnSignature.NewTrackerMethod.create(
-        m, restrictionT, trackerT, windowT, methodContext.getExtraParameters());
+        m, fnT.resolveType(m.getGenericReturnType()), windowT, methodContext.getExtraParameters());
+  }
+
+  @VisibleForTesting
+  static DoFnSignature.GetSizeMethod analyzeGetSizeMethod(
+      ErrorReporter errors,
+      TypeDescriptor<? extends DoFn<?, ?>> fnT,
+      Method m,
+      TypeDescriptor<?> inputT,
+      TypeDescriptor<?> outputT,
+      TypeDescriptor<?> restrictionT,
+      FnAnalysisContext fnContext) {
+    // Method is of the form:
+    // @GetSize
+    // double getSize(... parameters ...);
+    Type[] params = m.getGenericParameterTypes();
+
+    errors.checkArgument(
+        m.getGenericReturnType().equals(Double.TYPE),
+        "Returns %s, but must return a double",
+        format(TypeDescriptor.of(m.getGenericReturnType())));
+
+    MethodAnalysisContext methodContext = MethodAnalysisContext.create();
+    TypeDescriptor<? extends BoundedWindow> windowT = getWindowType(fnT, m);
+    for (int i = 0; i < params.length; ++i) {
+      Parameter extraParam =
+          analyzeExtraParameter(
+              errors,
+              fnContext,
+              methodContext,
+              fnT,
+              ParameterDescription.of(
+                  m, i, fnT.resolveType(params[i]), Arrays.asList(m.getParameterAnnotations()[i])),
+              inputT,
+              outputT);
+      if (extraParam instanceof SchemaElementParameter) {
+        errors.throwIllegalArgument(
+            "Schema @%s are not supported for @%s method. Found %s, did you mean to use %s?",
+            format(DoFn.Element.class),
+            format(DoFn.GetSize.class),
+            format(((SchemaElementParameter) extraParam).elementT()),
+            format(inputT));
+      } else if (extraParam instanceof RestrictionParameter) {
+        errors.checkArgument(
+            restrictionT.equals(((RestrictionParameter) extraParam).restrictionT()),
+            "Uses restriction type %s, but @%s method uses restriction type %s",
+            format(((RestrictionParameter) extraParam).restrictionT()),
+            format(DoFn.GetInitialRestriction.class),
+            format(restrictionT));
+      }
+
+      methodContext.addParameter(extraParam);
+    }
+
+    for (Parameter parameter : methodContext.getExtraParameters()) {
+      checkParameterOneOf(errors, parameter, ALLOWED_GET_SIZE_PARAMETERS);
+    }
+
+    return DoFnSignature.GetSizeMethod.create(m, windowT, methodContext.getExtraParameters());
   }
 
   private static Collection<Method> declaredMethodsWithAnnotation(
@@ -1707,16 +1792,14 @@ public class DoFnSignatures {
       if (!Modifier.isFinal(field.getModifiers())) {
         errors.throwIllegalArgument(
             "Non-final field %s annotated with %s. Field access declarations must be final.",
-            field.toString(), DoFn.FieldAccess.class.getSimpleName());
+            field.toString(), format(DoFn.FieldAccess.class));
         continue;
       }
       Class<?> fieldAccessRawType = field.getType();
       if (!fieldAccessRawType.equals(FieldAccessDescriptor.class)) {
         errors.throwIllegalArgument(
             "Field %s annotated with %s, but the value was not of type %s",
-            field.toString(),
-            DoFn.FieldAccess.class.getSimpleName(),
-            FieldAccessDescriptor.class.getSimpleName());
+            field.toString(), format(DoFn.FieldAccess.class), format(FieldAccessDescriptor.class));
       }
       fieldAccessDeclarations.put(
           fieldAccessAnnotation.value(),
@@ -1738,7 +1821,7 @@ public class DoFnSignatures {
       if (declarations.containsKey(id)) {
         errors.throwIllegalArgument(
             "Duplicate %s \"%s\", used on both of [%s] and [%s]",
-            DoFn.StateId.class.getSimpleName(),
+            format(DoFn.StateId.class),
             id,
             field.toString(),
             declarations.get(id).field().toString());
@@ -1749,8 +1832,8 @@ public class DoFnSignatures {
       if (!(TypeDescriptor.of(stateSpecRawType).isSubtypeOf(TypeDescriptor.of(StateSpec.class)))) {
         errors.throwIllegalArgument(
             "%s annotation on non-%s field [%s] that has class %s",
-            DoFn.StateId.class.getSimpleName(),
-            StateSpec.class.getSimpleName(),
+            format(DoFn.StateId.class),
+            format(StateSpec.class),
             field.toString(),
             stateSpecRawType.getName());
         continue;
@@ -1759,7 +1842,7 @@ public class DoFnSignatures {
       if (!Modifier.isFinal(field.getModifiers())) {
         errors.throwIllegalArgument(
             "Non-final field %s annotated with %s. State declarations must be final.",
-            field.toString(), DoFn.StateId.class.getSimpleName());
+            field.toString(), format(DoFn.StateId.class));
         continue;
       }
 
@@ -1797,7 +1880,7 @@ public class DoFnSignatures {
     Collection<Method> matches = declaredMethodsWithAnnotation(anno, fnClazz, DoFn.class);
 
     if (matches.isEmpty()) {
-      errors.checkArgument(!required, "No method annotated with @%s found", anno.getSimpleName());
+      errors.checkArgument(!required, "No method annotated with @%s found", format(anno));
       return null;
     }
 
@@ -1810,7 +1893,7 @@ public class DoFnSignatures {
           first.getName().equals(other.getName())
               && Arrays.equals(first.getParameterTypes(), other.getParameterTypes()),
           "Found multiple methods annotated with @%s. [%s] and [%s]",
-          anno.getSimpleName(),
+          format(anno),
           format(first),
           format(other));
     }
@@ -1828,8 +1911,12 @@ public class DoFnSignatures {
     return ReflectHelpers.METHOD_FORMATTER.apply(method);
   }
 
-  private static String formatType(TypeDescriptor<?> t) {
+  private static String format(TypeDescriptor<?> t) {
     return ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(t.getType());
+  }
+
+  private static String format(Class<?> kls) {
+    return ReflectHelpers.CLASS_SIMPLE_NAME.apply(kls);
   }
 
   static class ErrorReporter {
@@ -1843,15 +1930,14 @@ public class DoFnSignatures {
       return new ErrorReporter(
           this,
           String.format(
-              "@%s %s",
-              annotation.getSimpleName(), (method == null) ? "(absent)" : format(method)));
+              "@%s %s", format(annotation), (method == null) ? "(absent)" : format(method)));
     }
 
     ErrorReporter forParameter(ParameterDescription param) {
       return new ErrorReporter(
           this,
           String.format(
-              "parameter of type %s at index %s", formatType(param.getType()), param.getIndex()));
+              "parameter of type %s at index %s", format(param.getType()), param.getIndex()));
     }
 
     void throwIllegalArgument(String message, Object... args) {
@@ -1878,7 +1964,7 @@ public class DoFnSignatures {
       checkState(
           fieldValue instanceof StateSpec,
           "Malformed %s class %s: state declaration field %s does not have type %s.",
-          DoFn.class.getSimpleName(),
+          format(DoFn.class),
           target.getClass().getName(),
           stateDeclaration.field().getName(),
           StateSpec.class);
@@ -1888,9 +1974,7 @@ public class DoFnSignatures {
       throw new RuntimeException(
           String.format(
               "Malformed %s class %s: state declaration field %s is not accessible.",
-              DoFn.class.getSimpleName(),
-              target.getClass().getName(),
-              stateDeclaration.field().getName()));
+              format(DoFn.class), target.getClass().getName(), stateDeclaration.field().getName()));
     }
   }
 
@@ -1901,7 +1985,7 @@ public class DoFnSignatures {
       checkState(
           fieldValue instanceof TimerSpec,
           "Malformed %s class %s: timer declaration field %s does not have type %s.",
-          DoFn.class.getSimpleName(),
+          format(DoFn.class),
           target.getClass().getName(),
           timerDeclaration.field().getName(),
           TimerSpec.class);
@@ -1911,9 +1995,7 @@ public class DoFnSignatures {
       throw new RuntimeException(
           String.format(
               "Malformed %s class %s: timer declaration field %s is not accessible.",
-              DoFn.class.getSimpleName(),
-              target.getClass().getName(),
-              timerDeclaration.field().getName()));
+              format(DoFn.class), target.getClass().getName(), timerDeclaration.field().getName()));
     }
   }
 
@@ -1924,7 +2006,7 @@ public class DoFnSignatures {
       checkState(
           fieldValue instanceof TimerSpec,
           "Malformed %s class %s: timer declaration field %s does not have type %s.",
-          DoFn.class.getSimpleName(),
+          format(DoFn.class),
           target.getClass().getName(),
           timerFamilyDeclaration.field().getName(),
           TimerSpec.class);
@@ -1934,7 +2016,7 @@ public class DoFnSignatures {
       throw new RuntimeException(
           String.format(
               "Malformed %s class %s: timer declaration field %s is not accessible.",
-              DoFn.class.getSimpleName(),
+              format(DoFn.class),
               target.getClass().getName(),
               timerFamilyDeclaration.field().getName()));
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -68,8 +68,8 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
    *
    * <p>{@code fractionOfRemainder = 0} means a checkpoint is required.
    *
-   * <p>The API is recommended to be implemented for batch pipeline given that it is very important
-   * for pipeline scaling and end to end pipeline execution.
+   * <p>The API is recommended to be implemented for a batch pipeline to improve parallel processing
+   * performance.
    *
    * <p>The API is required to be implemented for a streaming pipeline.
    *

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SplittableDoFnTest.java
@@ -94,13 +94,12 @@ public class SplittableDoFnTest implements Serializable {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRange(String element) {
+    public OffsetRange getInitialRange(@Element String element) {
       return new OffsetRange(0, element.length());
     }
 
     @SplitRestriction
-    public void splitRange(
-        String element, OffsetRange range, OutputReceiver<OffsetRange> receiver) {
+    public void splitRange(@Restriction OffsetRange range, OutputReceiver<OffsetRange> receiver) {
       receiver.output(new OffsetRange(range.getFrom(), (range.getFrom() + range.getTo()) / 2));
       receiver.output(new OffsetRange((range.getFrom() + range.getTo()) / 2, range.getTo()));
     }
@@ -257,7 +256,7 @@ public class SplittableDoFnTest implements Serializable {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRange(String element) {
+    public OffsetRange getInitialRange() {
       return new OffsetRange(0, MAX_INDEX);
     }
   }
@@ -326,7 +325,7 @@ public class SplittableDoFnTest implements Serializable {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRestriction(Integer value) {
+    public OffsetRange getInitialRestriction() {
       return new OffsetRange(0, 1);
     }
   }
@@ -469,7 +468,7 @@ public class SplittableDoFnTest implements Serializable {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRange(Integer element) {
+    public OffsetRange getInitialRange() {
       return new OffsetRange(0, MAX_INDEX);
     }
   }
@@ -581,7 +580,7 @@ public class SplittableDoFnTest implements Serializable {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRestriction(Integer value) {
+    public OffsetRange getInitialRestriction() {
       return new OffsetRange(0, 1);
     }
   }
@@ -690,14 +689,14 @@ public class SplittableDoFnTest implements Serializable {
     private transient State state;
 
     @GetInitialRestriction
-    public OffsetRange getInitialRestriction(String value) {
+    public OffsetRange getInitialRestriction() {
       assertEquals(State.OUTSIDE_BUNDLE, state);
       return new OffsetRange(0, 1);
     }
 
     @SplitRestriction
     public void splitRestriction(
-        String value, OffsetRange range, OutputReceiver<OffsetRange> receiver) {
+        @Restriction OffsetRange range, OutputReceiver<OffsetRange> receiver) {
       assertEquals(State.OUTSIDE_BUNDLE, state);
       receiver.output(range);
     }
@@ -777,13 +776,12 @@ public class SplittableDoFnTest implements Serializable {
               ParDo.of(
                   new DoFn<String, String>() {
                     @ProcessElement
-                    public void process(
-                        @Element String element, RestrictionTracker<OffsetRange, Long> tracker) {
+                    public void process(RestrictionTracker<OffsetRange, Long> tracker) {
                       // Doesn't matter
                     }
 
                     @GetInitialRestriction
-                    public OffsetRange getInitialRestriction(String element) {
+                    public OffsetRange getInitialRestriction() {
                       return new OffsetRange(0, 1);
                     }
                   }));
@@ -796,12 +794,12 @@ public class SplittableDoFnTest implements Serializable {
                   new DoFn<String, String>() {
                     @ProcessElement
                     public ProcessContinuation process(
-                        @Element String element, RestrictionTracker<OffsetRange, Long> tracker) {
+                        RestrictionTracker<OffsetRange, Long> tracker) {
                       return stop();
                     }
 
                     @GetInitialRestriction
-                    public OffsetRange getInitialRestriction(String element) {
+                    public OffsetRange getInitialRestriction() {
                       return new OffsetRange(0, 1);
                     }
                   }));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
@@ -90,7 +91,7 @@ public class DoFnInvokersTest {
 
   @Before
   public void setUp() {
-    mockElement = new String("element");
+    mockElement = "element";
     mockTimestamp = new Instant(0);
     MockitoAnnotations.initMocks(this);
     when(mockArgumentProvider.window()).thenReturn(mockWindow);
@@ -324,12 +325,12 @@ public class DoFnInvokersTest {
       }
 
       @GetInitialRestriction
-      public SomeRestriction getInitialRestriction(String element) {
+      public SomeRestriction getInitialRestriction(@Element String element) {
         return null;
       }
 
       @NewTracker
-      public SomeRestrictionTracker newTracker(SomeRestriction restriction) {
+      public SomeRestrictionTracker newTracker(@Restriction SomeRestriction restriction) {
         return null;
       }
     }
@@ -401,16 +402,18 @@ public class DoFnInvokersTest {
     }
 
     @GetInitialRestriction
-    public SomeRestriction getInitialRestriction(String element) {
+    public SomeRestriction getInitialRestriction(@Element String element) {
       return null;
     }
 
     @SplitRestriction
     public void splitRestriction(
-        String element, SomeRestriction restriction, OutputReceiver<SomeRestriction> receiver) {}
+        @Element String element,
+        @Restriction SomeRestriction restriction,
+        OutputReceiver<SomeRestriction> receiver) {}
 
     @NewTracker
-    public SomeRestrictionTracker newTracker(SomeRestriction restriction) {
+    public SomeRestrictionTracker newTracker(@Restriction SomeRestriction restriction) {
       return null;
     }
 
@@ -431,15 +434,15 @@ public class DoFnInvokersTest {
     final SomeRestriction part2 = new SomeRestriction();
     final SomeRestriction part3 = new SomeRestriction();
     when(fn.getRestrictionCoder()).thenReturn(coder);
-    when(fn.getInitialRestriction("blah")).thenReturn(restriction);
+    when(fn.getInitialRestriction(mockElement)).thenReturn(restriction);
     doAnswer(
             AdditionalAnswers.delegatesTo(
                 new MockFn() {
                   @DoFn.SplitRestriction
                   @Override
                   public void splitRestriction(
-                      String element,
-                      SomeRestriction restriction,
+                      @Element String element,
+                      @Restriction SomeRestriction restriction,
                       DoFn.OutputReceiver<SomeRestriction> receiver) {
                     receiver.output(part1);
                     receiver.output(part2);
@@ -447,29 +450,65 @@ public class DoFnInvokersTest {
                   }
                 }))
         .when(fn)
-        .splitRestriction(eq("blah"), same(restriction), Mockito.any());
+        .splitRestriction(eq(mockElement), same(restriction), Mockito.any());
     when(fn.newTracker(restriction)).thenReturn(tracker);
     when(fn.processElement(mockProcessContext, tracker)).thenReturn(resume());
 
     assertEquals(coder, invoker.invokeGetRestrictionCoder(CoderRegistry.createDefault()));
-    assertEquals(restriction, invoker.invokeGetInitialRestriction("blah"));
-    final List<SomeRestriction> outputs = new ArrayList<>();
-    invoker.invokeSplitRestriction(
-        "blah",
+
+    assertEquals(
         restriction,
-        new OutputReceiver<SomeRestriction>() {
+        invoker.invokeGetInitialRestriction(
+            new FakeArgumentProvider<String, String>() {
+              @Override
+              public String element(DoFn<String, String> doFn) {
+                return mockElement;
+              }
+            }));
+    List<SomeRestriction> outputs = new ArrayList<>();
+    invoker.invokeSplitRestriction(
+        new FakeArgumentProvider<String, String>() {
           @Override
-          public void output(SomeRestriction output) {
-            outputs.add(output);
+          public String element(DoFn<String, String> doFn) {
+            return mockElement;
           }
 
           @Override
-          public void outputWithTimestamp(SomeRestriction output, Instant timestamp) {
-            outputs.add(output);
+          public Object restriction() {
+            return restriction;
+          }
+
+          @Override
+          public OutputReceiver outputReceiver(DoFn doFn) {
+            return new OutputReceiver<SomeRestriction>() {
+              @Override
+              public void output(SomeRestriction output) {
+                outputs.add(output);
+              }
+
+              @Override
+              public void outputWithTimestamp(SomeRestriction output, Instant timestamp) {
+                fail("Unexpected output with timestamp");
+              }
+            };
           }
         });
+
     assertEquals(Arrays.asList(part1, part2, part3), outputs);
-    assertEquals(tracker, invoker.invokeNewTracker(restriction));
+    assertEquals(
+        tracker,
+        invoker.invokeNewTracker(
+            new FakeArgumentProvider<String, String>() {
+              @Override
+              public String element(DoFn<String, String> doFn) {
+                return mockElement;
+              }
+
+              @Override
+              public Object restriction() {
+                return restriction;
+              }
+            }));
     assertEquals(
         resume(),
         invoker.invokeProcessElement(
@@ -537,7 +576,7 @@ public class DoFnInvokersTest {
           ProcessContext c, RestrictionTracker<RestrictionWithDefaultTracker, Void> tracker) {}
 
       @GetInitialRestriction
-      public RestrictionWithDefaultTracker getInitialRestriction(String element) {
+      public RestrictionWithDefaultTracker getInitialRestriction(@Element String element) {
         return null;
       }
     }
@@ -553,28 +592,47 @@ public class DoFnInvokersTest {
         invoker.<RestrictionWithDefaultTracker>invokeGetRestrictionCoder(coderRegistry),
         instanceOf(CoderForDefaultTracker.class));
     invoker.invokeSplitRestriction(
-        "blah",
-        "foo",
-        new DoFn.OutputReceiver<String>() {
-          private boolean invoked;
-
+        new FakeArgumentProvider<String, String>() {
           @Override
-          public void output(String output) {
-            assertFalse(invoked);
-            invoked = true;
-            assertEquals("foo", output);
+          public String element(DoFn<String, String> doFn) {
+            return "blah";
           }
 
           @Override
-          public void outputWithTimestamp(String output, Instant instant) {
-            assertFalse(invoked);
-            invoked = true;
-            assertEquals("foo", output);
+          public Object restriction() {
+            return "foo";
+          }
+
+          @Override
+          public OutputReceiver<String> outputReceiver(DoFn<String, String> doFn) {
+            return new DoFn.OutputReceiver<String>() {
+              private boolean invoked;
+
+              @Override
+              public void output(String output) {
+                assertFalse(invoked);
+                invoked = true;
+                assertEquals("foo", output);
+              }
+
+              @Override
+              public void outputWithTimestamp(String output, Instant instant) {
+                assertFalse(invoked);
+                invoked = true;
+                assertEquals("foo", output);
+              }
+            };
           }
         });
     assertEquals(stop(), invoker.invokeProcessElement(mockArgumentProvider));
     assertThat(
-        invoker.invokeNewTracker(new RestrictionWithDefaultTracker()),
+        invoker.invokeNewTracker(
+            new FakeArgumentProvider<String, String>() {
+              @Override
+              public Object restriction() {
+                return new RestrictionWithDefaultTracker();
+              }
+            }),
         instanceOf(DefaultTracker.class));
   }
 
@@ -749,12 +807,12 @@ public class DoFnInvokersTest {
               }
 
               @GetInitialRestriction
-              public SomeRestriction getInitialRestriction(Integer element) {
+              public SomeRestriction getInitialRestriction(@Element Integer element) {
                 return null;
               }
 
               @NewTracker
-              public SomeRestrictionTracker newTracker(SomeRestriction restriction) {
+              public SomeRestrictionTracker newTracker(@Restriction SomeRestriction restriction) {
                 return null;
               }
             })

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -1054,18 +1054,17 @@ public class FnApiDoFnRunnerTest implements Serializable {
     }
 
     @GetInitialRestriction
-    public OffsetRange restriction(String element) {
+    public OffsetRange restriction(@Element String element) {
       return new OffsetRange(0, Integer.parseInt(element));
     }
 
     @NewTracker
-    public RestrictionTracker<OffsetRange, Long> newTracker(OffsetRange restriction) {
+    public RestrictionTracker<OffsetRange, Long> newTracker(@Restriction OffsetRange restriction) {
       return new OffsetRangeTracker(restriction);
     }
 
     @SplitRestriction
-    public void splitRange(
-        String element, OffsetRange range, OutputReceiver<OffsetRange> receiver) {
+    public void splitRange(@Restriction OffsetRange range, OutputReceiver<OffsetRange> receiver) {
       receiver.output(new OffsetRange(range.getFrom(), (range.getFrom() + range.getTo()) / 2));
       receiver.output(new OffsetRange((range.getFrom() + range.getTo()) / 2, range.getTo()));
     }

--- a/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseReadSplittableDoFn.java
+++ b/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseReadSplittableDoFn.java
@@ -77,13 +77,15 @@ class HBaseReadSplittableDoFn extends DoFn<HBaseQuery, Result> {
   }
 
   @GetInitialRestriction
-  public ByteKeyRange getInitialRestriction(HBaseQuery query) {
+  public ByteKeyRange getInitialRestriction(@Element HBaseQuery query) {
     return HBaseUtils.getByteKeyRange(query.getScan());
   }
 
   @SplitRestriction
   public void splitRestriction(
-      HBaseQuery query, ByteKeyRange range, OutputReceiver<ByteKeyRange> receiver)
+      @Element HBaseQuery query,
+      @Restriction ByteKeyRange range,
+      OutputReceiver<ByteKeyRange> receiver)
       throws Exception {
     List<HRegionLocation> regionLocations =
         HBaseUtils.getRegionLocations(connection, query.getTableId(), range);
@@ -95,7 +97,7 @@ class HBaseReadSplittableDoFn extends DoFn<HBaseQuery, Result> {
   }
 
   @NewTracker
-  public ByteKeyRangeTracker newTracker(ByteKeyRange range) {
+  public ByteKeyRangeTracker newTracker(@Restriction ByteKeyRange range) {
     return ByteKeyRangeTracker.of(range);
   }
 


### PR DESCRIPTION
Defined a new @Restriction parameter type to pass in the restriction.
Updated GetSize/GetInitialRestriction/SplitRestriction/NewTracker to take these new DoFn style parameters.
Updated lots of documentation and existing implementations to use the new DoFn argument passing.
Fixed ByteBuddyDoFnInvokerFactory to support return values that aren't references.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
