### PR TITLE
[BEAM-9167] Metrics extraction refactoring.

### DIFF
--- a/sdks/go/pkg/beam/core/metrics/dumper.go
+++ b/sdks/go/pkg/beam/core/metrics/dumper.go
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/log"
+)
+
+// DumpToLog is a debugging function that outputs all metrics available locally
+// to beam.Log.
+func DumpToLog(ctx context.Context) {
+	store := GetStore(ctx)
+	if store == nil {
+		log.Errorf(ctx, "Unable to dump metrics: provided context doesn't contain metrics Store.")
+		return
+	}
+	DumpToLogFromStore(ctx, store)
+}
+
+// DumpToLogFromStore dumps the metrics in the provided Store to beam.Log.
+func DumpToLogFromStore(ctx context.Context, store *Store) {
+	dumperExtractor(store, func(format string, args ...interface{}) {
+		log.Errorf(ctx, format, args...)
+	})
+}
+
+// DumpToOutFromContext is a debugging function that outputs all metrics
+// available locally to std out,
+// extracting the metric store from the context.
+func DumpToOutFromContext(ctx context.Context) {
+	store := GetStore(ctx)
+	if store == nil {
+		fmt.Printf("Unable to dump metrics: provided context doesn't contain metrics Store.")
+		return
+	}
+	DumpToOutFromStore(store)
+}
+
+// DumpToOutFromStore is a debugging function that outputs all metrics
+// available locally to std out directly from the store.
+func DumpToOutFromStore(store *Store) {
+	dumperExtractor(store, func(format string, args ...interface{}) {
+		fmt.Printf(format+"\n", args...)
+	})
+}
+
+func dumperExtractor(store *Store, p func(format string, args ...interface{})) {
+	m := make(map[Labels]interface{})
+	e := &Extractor{
+		SumInt64: func(l Labels, v int64) {
+			m[l] = &counter{value: v}
+		},
+		DistributionInt64: func(l Labels, count, sum, min, max int64) {
+			m[l] = &distribution{count: count, sum: sum, min: min, max: max}
+		},
+		GaugeInt64: func(l Labels, v int64, t time.Time) {
+			m[l] = &gauge{v: v, t: t}
+		},
+	}
+	e.ExtractFrom(store)
+	dumpTo(m, p)
+}
+
+type metricDumper struct {
+	store map[Labels]interface{}
+}
+
+func newDumper() *metricDumper {
+	return &metricDumper{store: make(map[Labels]interface{})}
+}
+
+func (dmp *metricDumper) SumCounter(l Labels, v int64) {
+	dmp.store[l] = &counter{value: v}
+}
+
+func (dmp *metricDumper) Distribution(l Labels, count, sum, min, max int64) {
+	dmp.store[l] = &distribution{count: count, sum: sum, min: min, max: max}
+}
+
+func (dmp *metricDumper) Gauge(l Labels, v int64, t time.Time) {
+	dmp.store[l] = &gauge{v: v, t: t}
+}
+
+func dumpTo(store map[Labels]interface{}, p func(format string, args ...interface{})) {
+	var ls []Labels
+	for l := range store {
+		ls = append(ls, l)
+	}
+	sort.Slice(ls, func(i, j int) bool {
+		if ls[i].transform < ls[j].transform {
+			return true
+		}
+		tEq := ls[i].transform == ls[j].transform
+		if tEq && ls[i].namespace < ls[j].namespace {
+			return true
+		}
+		nsEq := ls[i].namespace == ls[j].namespace
+		if tEq && nsEq && ls[i].name < ls[j].name {
+			return true
+		}
+		return false
+	})
+	curT := "probably-definitely-unset"
+	for _, l := range ls {
+		if l.transform != curT {
+			curT = l.transform
+			p("PTransformID: %q", curT)
+		}
+		m := store[l]
+		p("\t%s - %s", name{namespace: l.namespace, name: l.name}, m)
+	}
+}

--- a/sdks/go/pkg/beam/core/metrics/dumper.go
+++ b/sdks/go/pkg/beam/core/metrics/dumper.go
@@ -79,26 +79,6 @@ func dumperExtractor(store *Store, p func(format string, args ...interface{})) {
 	dumpTo(m, p)
 }
 
-type metricDumper struct {
-	store map[Labels]interface{}
-}
-
-func newDumper() *metricDumper {
-	return &metricDumper{store: make(map[Labels]interface{})}
-}
-
-func (dmp *metricDumper) SumCounter(l Labels, v int64) {
-	dmp.store[l] = &counter{value: v}
-}
-
-func (dmp *metricDumper) Distribution(l Labels, count, sum, min, max int64) {
-	dmp.store[l] = &distribution{count: count, sum: sum, min: min, max: max}
-}
-
-func (dmp *metricDumper) Gauge(l Labels, v int64, t time.Time) {
-	dmp.store[l] = &gauge{v: v, t: t}
-}
-
 func dumpTo(store map[Labels]interface{}, p func(format string, args ...interface{})) {
 	var ls []Labels
 	for l := range store {

--- a/sdks/go/pkg/beam/core/metrics/metrics.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics.go
@@ -50,15 +50,11 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/ioutilx"
-	"github.com/apache/beam/sdks/go/pkg/beam/log"
-	"github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
-	"github.com/golang/protobuf/ptypes"
 )
 
 // Metric cells are named and scoped by ptransform, and bundle,
@@ -67,32 +63,11 @@ import (
 // using metrics requires the PTransform have a context.Context
 // argument.
 
-// perBundle is a struct that retains per transform countersets.
-// TODO(lostluck): Migrate the exec package to use these to extract
-// metric data for export to runner, rather than the global store.
-type perBundle struct {
-	mu  sync.Mutex
-	css []*ptCounterSet
-}
-
-type nameHash uint64
-
-// ptCounterSet is the internal tracking struct for a single ptransform
-// in a single bundle for all counter types.
-type ptCounterSet struct {
-	// We store the user path access to the cells in metric type segregated
-	// maps. At present, caching the name hash,
-	counters      map[nameHash]*counter
-	distributions map[nameHash]*distribution
-	gauges        map[nameHash]*gauge
-}
-
 type ctxKey string
 
 const (
-	bundleKey     ctxKey = "beam:bundle"
-	ptransformKey ctxKey = "beam:ptransform"
 	counterSetKey ctxKey = "beam:counterset"
+	storeKey      ctxKey = "beam:bundlestore"
 )
 
 // beamCtx is a caching context for IDs necessary to place metric updates.
@@ -101,12 +76,13 @@ const (
 type beamCtx struct {
 	context.Context
 	bundleID, ptransformID string
-	bs                     *perBundle
+	store                  *Store
 	cs                     *ptCounterSet
 }
 
-// Value implements context.Value for beamCtx, and lifts the
-// values for metrics keys for value for faster lookups.
+// Value implements the Context interface Value method for beamCtx.
+// The implementation lifts the stored values for metrics keys to the
+// top level beamCtx for faster lookups.
 func (ctx *beamCtx) Value(key interface{}) interface{} {
 	switch key {
 	case counterSetKey:
@@ -114,28 +90,27 @@ func (ctx *beamCtx) Value(key interface{}) interface{} {
 			if cs := ctx.Context.Value(key); cs != nil {
 				ctx.cs = cs.(*ptCounterSet)
 			} else {
-				return nil
+				// It's not created previously
+				ctx.store.mu.Lock()
+				cs := &ptCounterSet{
+					pid:           ctx.ptransformID,
+					counters:      make(map[nameHash]*counter),
+					distributions: make(map[nameHash]*distribution),
+					gauges:        make(map[nameHash]*gauge),
+				}
+				ctx.store.css = append(ctx.store.css, cs)
+				ctx.cs = cs
+				ctx.store.mu.Unlock()
 			}
 		}
 		return ctx.cs
-	case bundleKey:
-		if ctx.bundleID == "" {
-			if id := ctx.Context.Value(key); id != nil {
-				ctx.bundleID = id.(string)
-			} else {
-				return nil
+	case storeKey:
+		if ctx.store == nil {
+			if store := ctx.Context.Value(key); store != nil {
+				ctx.store = store.(*Store)
 			}
 		}
-		return ctx.bundleID
-	case ptransformKey:
-		if ctx.ptransformID == "" {
-			if id := ctx.Context.Value(key); id != nil {
-				ctx.ptransformID = id.(string)
-			} else {
-				return nil
-			}
-		}
-		return ctx.ptransformID
+		return ctx.store
 	}
 	return ctx.Context.Value(key)
 }
@@ -144,26 +119,39 @@ func (ctx *beamCtx) String() string {
 	return fmt.Sprintf("beamCtx[%s;%s]", ctx.bundleID, ctx.ptransformID)
 }
 
-// SetBundleID sets the id of the current Bundle.
+// SetBundleID sets the id of the current Bundle, and populates the store.
 func SetBundleID(ctx context.Context, id string) context.Context {
 	// Checking for *beamCtx is an optimization, so we don't dig deeply
 	// for ids if not necessary.
 	if bctx, ok := ctx.(*beamCtx); ok {
-		return &beamCtx{Context: bctx.Context, bundleID: id, bs: &perBundle{}, ptransformID: bctx.ptransformID}
+		return &beamCtx{Context: bctx.Context, bundleID: id, store: newStore(), ptransformID: bctx.ptransformID}
 	}
-	return &beamCtx{Context: ctx, bundleID: id, bs: &perBundle{}}
+	return &beamCtx{Context: ctx, bundleID: id, store: newStore()}
 }
 
 // SetPTransformID sets the id of the current PTransform.
-// Must only be called on a context returened by SetBundleID.
+// Must only be called on a context returned by SetBundleID.
 func SetPTransformID(ctx context.Context, id string) context.Context {
 	// Checking for *beamCtx is an optimization, so we don't dig deeply
 	// for ids if not necessary.
 	if bctx, ok := ctx.(*beamCtx); ok {
-		return &beamCtx{Context: bctx.Context, bundleID: bctx.bundleID, bs: bctx.bs, ptransformID: id}
+		return &beamCtx{Context: bctx.Context, bundleID: bctx.bundleID, store: bctx.store, ptransformID: id}
 	}
-	panic(fmt.Sprintf("SetPTransformID called before SetBundleID for %v", id))
-	return nil // never runs.
+	// Avoid breaking if the bundle is unset in testing.
+	return &beamCtx{Context: ctx, bundleID: bundleIDUnset, store: newStore(), ptransformID: id}
+}
+
+// GetStore extracts the metrics Store for the given context for a bundle.
+//
+// Returns nil if the context doesn't contain a metric Store.
+func GetStore(ctx context.Context) *Store {
+	if bctx, ok := ctx.(*beamCtx); ok {
+		return bctx.store
+	}
+	if v := ctx.Value(storeKey); v != nil {
+		return v.(*Store)
+	}
+	return nil
 }
 
 const (
@@ -171,36 +159,15 @@ const (
 	ptransformIDUnset = "(ptransform id unset)"
 )
 
-func getContextKey(ctx context.Context, n name) key {
-	key := key{name: n, bundle: bundleIDUnset, ptransform: ptransformIDUnset}
-	if id := ctx.Value(bundleKey); id != nil {
-		key.bundle = id.(string)
-	}
-	if id := ctx.Value(ptransformKey); id != nil {
-		key.ptransform = id.(string)
-	}
-	return key
-}
-
 func getCounterSet(ctx context.Context) *ptCounterSet {
-	if id := ctx.Value(counterSetKey); id != nil {
-		return id.(*ptCounterSet)
+	if bctx, ok := ctx.(*beamCtx); ok && bctx.cs != nil {
+		return bctx.cs
 	}
-	// It's not set anywhere and wasn't hoisted, so create it.
-	if bctx, ok := ctx.(*beamCtx); ok {
-		bctx.bs.mu.Lock()
-		cs := &ptCounterSet{
-			counters:      make(map[nameHash]*counter),
-			distributions: make(map[nameHash]*distribution),
-			gauges:        make(map[nameHash]*gauge),
-		}
-		bctx.bs.css = append(bctx.bs.css, cs)
-		bctx.cs = cs
-		bctx.bs.mu.Unlock()
-		return cs
+	if set := ctx.Value(counterSetKey); set != nil {
+		return set.(*ptCounterSet)
 	}
-	panic("counterSet missing, beam isn't set up properly.")
-	return nil // never runs.
+	// This isn't a beam context, so we can't store the metric.
+	return nil
 }
 
 type kind uint8
@@ -223,14 +190,6 @@ func (t kind) String() string {
 	default:
 		panic(fmt.Sprintf("Unknown metric type value: %v", uint8(t)))
 	}
-}
-
-// userMetric knows how to convert it's value to a Metrics_User proto.
-// TODO(lostluck): Move proto translation to the harness package to
-// avoid the proto dependency outside of the harness.
-type userMetric interface {
-	toProto() *fnexecution_v1.Metrics_User
-	kind() kind
 }
 
 // name is a pair of strings identifying a specific metric.
@@ -287,45 +246,6 @@ func hashString(s string, b []byte) {
 	ioutilx.WriteUnsafe(hasher, b[:n])
 }
 
-type key struct {
-	name               name
-	bundle, ptransform string
-}
-
-var (
-	// mu protects access to the global store
-	mu sync.RWMutex
-	// store is a map of BundleIDs to PtransformIDs to userMetrics.
-	// it permits us to extract metric protos for runners per data Bundle, and
-	// per PTransform.
-	// TODO(lostluck): Migrate exec/plan.go to manage it's own perBundle counter stores.
-	// Note: This is safe to use to read the metrics concurrently with user modification
-	// in bundles, as only initial use modifies this map, and only contains the resulting
-	// metrics.
-	store = make(map[string]map[string]map[name]userMetric)
-)
-
-// storeMetric stores a metric away on its first use so it may be retrieved later on.
-// In the event of a name collision, storeMetric can panic, so it's prudent to release
-// locks if they are no longer required.
-func storeMetric(key key, m userMetric) {
-	mu.Lock()
-	defer mu.Unlock()
-	if _, ok := store[key.bundle]; !ok {
-		store[key.bundle] = make(map[string]map[name]userMetric)
-	}
-	if _, ok := store[key.bundle][key.ptransform]; !ok {
-		store[key.bundle][key.ptransform] = make(map[name]userMetric)
-	}
-	if ms, ok := store[key.bundle][key.ptransform][key.name]; ok {
-		if ms.kind() != m.kind() {
-			panic(fmt.Sprintf("metric name %s being reused for a second metric in a single PTransform", key.name))
-		}
-		return
-	}
-	store[key.bundle][key.ptransform][key.name] = m
-}
-
 // Counter is a simple counter for incrementing and decrementing a value.
 type Counter struct {
 	name name
@@ -347,6 +267,9 @@ func NewCounter(ns, n string) *Counter {
 // Inc increments the counter within the given PTransform context by v.
 func (m *Counter) Inc(ctx context.Context, v int64) {
 	cs := getCounterSet(ctx)
+	if cs == nil {
+		return
+	}
 	if c, ok := cs.counters[m.hash]; ok {
 		c.inc(v)
 		return
@@ -356,8 +279,7 @@ func (m *Counter) Inc(ctx context.Context, v int64) {
 		value: v,
 	}
 	cs.counters[m.hash] = c
-	key := getContextKey(ctx, m.name)
-	storeMetric(key, c)
+	GetStore(ctx).storeMetric(cs.pid, m.name, c)
 }
 
 // Dec decrements the counter within the given PTransform context by v.
@@ -378,20 +300,12 @@ func (m *counter) String() string {
 	return fmt.Sprintf("value: %d", m.value)
 }
 
-// toProto returns a Metrics_User populated with the Data messages, but not the name. The
-// caller needs to populate with the metric's name.
-func (m *counter) toProto() *fnexecution_v1.Metrics_User {
-	return &fnexecution_v1.Metrics_User{
-		Data: &fnexecution_v1.Metrics_User_CounterData_{
-			CounterData: &fnexecution_v1.Metrics_User_CounterData{
-				Value: atomic.LoadInt64(&m.value),
-			},
-		},
-	}
-}
-
 func (m *counter) kind() kind {
 	return kindSumCounter
+}
+
+func (m *counter) get() int64 {
+	return atomic.LoadInt64(&m.value)
 }
 
 // Distribution is a simple distribution of values.
@@ -415,6 +329,9 @@ func NewDistribution(ns, n string) *Distribution {
 // Update updates the distribution within the given PTransform context with v.
 func (m *Distribution) Update(ctx context.Context, v int64) {
 	cs := getCounterSet(ctx)
+	if cs == nil {
+		return
+	}
 	if d, ok := cs.distributions[m.hash]; ok {
 		d.update(v)
 		return
@@ -427,8 +344,7 @@ func (m *Distribution) Update(ctx context.Context, v int64) {
 		max:   v,
 	}
 	cs.distributions[m.hash] = d
-	key := getContextKey(ctx, m.name)
-	storeMetric(key, d)
+	GetStore(ctx).storeMetric(cs.pid, m.name, d)
 }
 
 // distribution is a metric cell for distribution values.
@@ -454,25 +370,14 @@ func (m *distribution) String() string {
 	return fmt.Sprintf("count: %d sum: %d min: %d max: %d", m.count, m.sum, m.min, m.max)
 }
 
-// toProto returns a Metrics_User populated with the Data messages, but not the name. The
-// caller needs to populate with the metric's name.
-func (m *distribution) toProto() *fnexecution_v1.Metrics_User {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return &fnexecution_v1.Metrics_User{
-		Data: &fnexecution_v1.Metrics_User_DistributionData_{
-			DistributionData: &fnexecution_v1.Metrics_User_DistributionData{
-				Count: m.count,
-				Sum:   m.sum,
-				Min:   m.min,
-				Max:   m.max,
-			},
-		},
-	}
-}
-
 func (m *distribution) kind() kind {
 	return kindDistribution
+}
+
+func (m *distribution) get() (count, sum, min, max int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.count, m.sum, m.min, m.max
 }
 
 // Gauge is a time, value pair metric.
@@ -499,6 +404,9 @@ var now = time.Now
 // Set sets the gauge to the given value, and associates it with the current time on the clock.
 func (m *Gauge) Set(ctx context.Context, v int64) {
 	cs := getCounterSet(ctx)
+	if cs == nil {
+		return
+	}
 	if g, ok := cs.gauges[m.hash]; ok {
 		g.set(v)
 		return
@@ -509,8 +417,7 @@ func (m *Gauge) Set(ctx context.Context, v int64) {
 		v: v,
 	}
 	cs.gauges[m.hash] = g
-	key := getContextKey(ctx, m.name)
-	storeMetric(key, g)
+	GetStore(ctx).storeMetric(cs.pid, m.name, g)
 }
 
 // gauge is a metric cell for gauge values.
@@ -527,23 +434,6 @@ func (m *gauge) set(v int64) {
 	m.mu.Unlock()
 }
 
-func (m *gauge) toProto() *fnexecution_v1.Metrics_User {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	ts, err := ptypes.TimestampProto(m.t)
-	if err != nil {
-		panic(err)
-	}
-	return &fnexecution_v1.Metrics_User{
-		Data: &fnexecution_v1.Metrics_User_GaugeData_{
-			GaugeData: &fnexecution_v1.Metrics_User_GaugeData{
-				Value:     m.v,
-				Timestamp: ts,
-			},
-		},
-	}
-}
-
 func (m *gauge) kind() kind {
 	return kindGauge
 }
@@ -552,92 +442,8 @@ func (m *gauge) String() string {
 	return fmt.Sprintf("%v time: %s value: %d", m.kind(), m.t, m.v)
 }
 
-// ToProto exports all collected metrics for the given BundleID and PTransform ID pair.
-func ToProto(b, pt string) []*fnexecution_v1.Metrics_User {
-	mu.RLock()
-	defer mu.RUnlock()
-	ps := store[b]
-	s := ps[pt]
-	var ret []*fnexecution_v1.Metrics_User
-	for n, m := range s {
-		p := m.toProto()
-		p.MetricName = &fnexecution_v1.Metrics_User_MetricName{
-			Name:      n.name,
-			Namespace: n.namespace,
-		}
-		ret = append(ret, p)
-	}
-	return ret
-}
-
-// DumpToLog is a debugging function that outputs all metrics available locally to beam.Log.
-func DumpToLog(ctx context.Context) {
-	dumpTo(func(format string, args ...interface{}) {
-		log.Errorf(ctx, format, args...)
-	})
-}
-
-// DumpToOut is a debugging function that outputs all metrics available locally to std out.
-func DumpToOut() {
-	dumpTo(func(format string, args ...interface{}) {
-		fmt.Printf(format+"\n", args...)
-	})
-}
-
-func dumpTo(p func(format string, args ...interface{})) {
-	mu.RLock()
-	defer mu.RUnlock()
-	var bs []string
-	for b := range store {
-		bs = append(bs, b)
-	}
-	sort.Strings(bs)
-
-	for _, b := range bs {
-		var pts []string
-		for pt := range store[b] {
-			pts = append(pts, pt)
-		}
-		sort.Strings(pts)
-
-		for _, pt := range pts {
-			var ns []name
-			for n := range store[b][pt] {
-				ns = append(ns, n)
-			}
-			sort.Slice(ns, func(i, j int) bool {
-				if ns[i].namespace < ns[j].namespace {
-					return true
-				}
-				if ns[i].namespace == ns[j].namespace && ns[i].name < ns[j].name {
-					return true
-				}
-				return false
-			})
-			p("Bundle: %q - PTransformID: %q", b, pt)
-
-			for _, n := range ns {
-				m := store[b][pt][n]
-				p("\t%s - %s", n, m)
-			}
-		}
-	}
-}
-
-// Clear resets all storage associated with metrics for tests.
-// Calling this in pipeline code leads to inaccurate metrics.
-func Clear() {
-	mu.Lock()
-	store = make(map[string]map[string]map[name]userMetric)
-	mu.Unlock()
-}
-
-// ClearBundleData removes stored references associated with a given bundle,
-// so it can be garbage collected.
-func ClearBundleData(b string) {
-	// No concurrency races since mu guards all access to store,
-	// and the metric cell sync.Maps are goroutine safe.
-	mu.Lock()
-	delete(store, b)
-	mu.Unlock()
+func (m *gauge) get() (int64, time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.v, m.t
 }

--- a/sdks/go/pkg/beam/core/metrics/metrics.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics.go
@@ -166,7 +166,8 @@ func getCounterSet(ctx context.Context) *ptCounterSet {
 	if set := ctx.Value(counterSetKey); set != nil {
 		return set.(*ptCounterSet)
 	}
-	// This isn't a beam context, so we can't store the metric.
+	// This isn't a beam context, so we don't have a
+	// useful counterset to return.
 	return nil
 }
 

--- a/sdks/go/pkg/beam/core/metrics/store.go
+++ b/sdks/go/pkg/beam/core/metrics/store.go
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Implementation note: We avoid depending on the FnAPI protos here
+// so we can provide a clean abstraction break for users, and avoid
+// problems if the FnAPI metrics protos need to change.
+
+// Labels provide the context for the given metric.
+type Labels struct {
+	transform, namespace, name string
+}
+
+// Transform returns the transform context for this metric, if available.
+func (l Labels) Transform() string { return l.transform }
+
+// Namespace returns the namespace context for this metric.
+func (l Labels) Namespace() string { return l.namespace }
+
+// Name returns the name for this metric.
+func (l Labels) Name() string { return l.name }
+
+// Extractor allows users to access metrics programatically after
+// pipeline completion. Users assign functions to fields that
+// interest them, and that function is called for each metric
+// of the associated kind.
+type Extractor struct {
+	// SumInt64 extracts data from Sum Int64 counters.
+	SumInt64 func(labels Labels, v int64)
+	// DistributionInt64 extracts data from Distribution Int64 counters.
+	DistributionInt64 func(labels Labels, count, sum, min, max int64)
+	// GaugeInt64 extracts data from Gauge Int64 counters.
+	GaugeInt64 func(labels Labels, v int64, t time.Time)
+}
+
+// ExtractFrom the given metrics Store all the metrics for
+// populated function fields.
+// Returns an error if no fields were set.
+func (e Extractor) ExtractFrom(store *Store) error {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	if e.SumInt64 == nil && e.DistributionInt64 == nil && e.GaugeInt64 == nil {
+		return fmt.Errorf("no Extractor fields were set")
+	}
+
+	for l, um := range store.store {
+		switch um.kind() {
+		case kindSumCounter:
+			if e.SumInt64 != nil {
+				data := um.(*counter).get()
+				e.SumInt64(l, data)
+			}
+		case kindDistribution:
+			if e.DistributionInt64 != nil {
+				count, sum, min, max := um.(*distribution).get()
+				e.DistributionInt64(l, count, sum, min, max)
+			}
+		case kindGauge:
+			if e.GaugeInt64 != nil {
+				v, t := um.(*gauge).get()
+				e.GaugeInt64(l, v, t)
+			}
+		}
+	}
+	return nil
+}
+
+// userMetric knows what kind it is.
+type userMetric interface {
+	kind() kind
+}
+
+type nameHash uint64
+
+// ptCounterSet is the internal tracking struct for a single ptransform
+// in a single bundle for all counter types.
+type ptCounterSet struct {
+	pid string
+	// We store the user path access to the cells in metric type segregated
+	// maps. At present, caching the name hash, with the name in each proxy
+	// avoids the expense of re-hashing on every use.
+	counters      map[nameHash]*counter
+	distributions map[nameHash]*distribution
+	gauges        map[nameHash]*gauge
+}
+
+// Store retains per transform countersets, intended for per bundle use.
+type Store struct {
+	mu  sync.RWMutex
+	css []*ptCounterSet
+
+	store map[Labels]userMetric
+}
+
+func newStore() *Store {
+	return &Store{store: make(map[Labels]userMetric)}
+}
+
+// storeMetric stores a metric away on its first use so it may be retrieved later on.
+// In the event of a name collision, storeMetric can panic, so it's prudent to release
+// locks if they are no longer required.
+func (b *Store) storeMetric(pid string, n name, m userMetric) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	l := Labels{transform: pid, namespace: n.namespace, name: n.name}
+	if ms, ok := b.store[l]; ok {
+		if ms.kind() != m.kind() {
+			panic(fmt.Sprintf("metric name %s being reused for a different metric type in a single PTransform", n))
+		}
+		return
+	}
+	b.store[l] = m
+}

--- a/sdks/go/pkg/beam/metrics_test.go
+++ b/sdks/go/pkg/beam/metrics_test.go
@@ -34,11 +34,6 @@ func ctxWithPtransformID(id string) context.Context {
 	return ctx
 }
 
-func dumpAndClearMetrics() {
-	metrics.DumpToOut()
-	metrics.Clear()
-}
-
 var (
 	wordRE = regexp.MustCompile(`[a-zA-Z]+('[a-z])?`)
 )
@@ -61,8 +56,8 @@ func Example_metricsDeclaredAnywhere() {
 	extractWordsDofn(ctx, "this has six words in it", func(string) {})
 	extractWordsDofn(ctx, "this has seven words in it, see?", func(string) {})
 
-	dumpAndClearMetrics()
-	// Output: Bundle: "exampleBundle" - PTransformID: "example"
+	metrics.DumpToOutFromContext(ctx)
+	// Output: PTransformID: "example"
 	//	example.namespace.characters - count: 13 sum: 43 min: 2 max: 5
 	//	example.namespace.count - value: 13
 }
@@ -85,14 +80,15 @@ func Example_metricsReusable() {
 			c.Inc(ctx, 1)
 		}
 	}
-	extractWordsDofn(ctxWithPtransformID("extract1"), "this has six words in it", func(string) {})
+	ctx = metrics.SetBundleID(ctx, "exampleBundle")
+	extractWordsDofn(metrics.SetPTransformID(ctx, "extract1"), "this has six words in it", func(string) {})
 
-	extractRunesDofn(ctxWithPtransformID("extract2"), "seven thousand", func(rune) {})
+	extractRunesDofn(metrics.SetPTransformID(ctx, "extract2"), "seven thousand", func(rune) {})
 
-	dumpAndClearMetrics()
-	// Output: Bundle: "exampleBundle" - PTransformID: "extract1"
+	metrics.DumpToOutFromContext(ctx)
+	// Output: PTransformID: "extract1"
 	//	example.reusable.count - value: 6
-	// Bundle: "exampleBundle" - PTransformID: "extract2"
+	// PTransformID: "extract2"
 	//	example.reusable.count - value: 14
 }
 

--- a/sdks/go/pkg/beam/runners/direct/direct.go
+++ b/sdks/go/pkg/beam/runners/direct/direct.go
@@ -72,7 +72,9 @@ func Execute(ctx context.Context, p *beam.Pipeline) error {
 	if err = plan.Down(ctx); err != nil {
 		return err
 	}
-	metrics.DumpToLog(ctx)
+	// TODO(lostluck) 2020/01/24: What's the right way to expose the
+	// metrics store for the direct runner?
+	metrics.DumpToLogFromStore(ctx, plan.Store)
 	return nil
 }
 


### PR DESCRIPTION
Changes up how metrics are accessed. Instead of having them globally available, they're exclusively available on a per-bundle metrics store, which reduces the overhead of creating metrics proxies and updating. 

In particular, this change moves the extraction of metrics to the FnAPI protos to the exec package, so the metrics package becomes proto agnostic. It's also forward looking, in that the metric extractors are typed with int64 to distinguish them for eventual inclusion of the float64 variants.

Adds additional benchmarking around specific parts of the work of modifying metrics. Benchmark values, as always, are relative to machine, OS, and Go version.

Two areas for subsequent work:
Left as an open question are parts are how users can get access to the store (or provide an extractor) for metrics after a job. Missing for this is an equivalent "ingestor" for accepting metrics from an outside source for use by runners.

For a more near term CL, is actually using the v2 metrics MonitoringInfo protos instead of the legacy style. This refactoring makes it easier to support both, without the metrics package needing to be tightly coupled to the protos.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
