### PR TITLE
[BEAM-7926] Data-centric Interactive Part3

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -61,7 +61,8 @@ def attempt_to_run_background_caching_job(runner, user_pipeline, options=None):
     runner_pipeline = beam.pipeline.Pipeline.from_runner_api(
         user_pipeline.to_runner_api(use_fake_coders=True), runner, options)
     background_caching_job_result = beam.pipeline.Pipeline.from_runner_api(
-        instr.pin(runner_pipeline).background_caching_pipeline_proto(),
+        instr.build_pipeline_instrument(
+            runner_pipeline).background_caching_pipeline_proto(),
         runner,
         options).run()
     ie.current_env().set_pipeline_result(

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
@@ -183,16 +183,19 @@ class PCollectionVisualization(object):
     self._df_display_id = 'df_{}_{}'.format(self._cache_key, id(self))
 
   def display_plain_text(self):
-    """Displays a random sample of the normalized PCollection data.
+    """Displays a head sample of the normalized PCollection data.
 
     This function is used when the ipython kernel is not connected to a
     notebook frontend such as when running ipython in terminal or in unit tests.
+    It's a visualization in terminal-like UI, not a function to retrieve data
+    for programmatically usages.
     """
     # Double check if the dependency is ready in case someone mistakenly uses
     # the function.
     if _pcoll_visualization_ready:
       data = self._to_dataframe()
-      data_sample = data.sample(n=25 if len(data) > 25 else len(data))
+      # Displays a data-table with at most 25 entries from the head.
+      data_sample = data.head(25)
       display(data_sample)
 
   def display_facets(self, updating_pv=None):

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
@@ -130,12 +130,13 @@ class PCollectionVisualizationTest(unittest.TestCase):
     # When job is done, the dynamic plotting will be stopped.
     self.assertTrue(ie.current_env().is_terminated(self._p))
 
-  @patch('pandas.DataFrame.sample')
-  def test_display_plain_text_when_kernel_has_no_frontend(self, _mocked_sample):
+  @patch('pandas.DataFrame.head')
+  def test_display_plain_text_when_kernel_has_no_frontend(self,
+                                                          _mocked_head):
     # Resets the notebook check to False.
     ie.current_env()._is_in_notebook = False
     self.assertIsNone(pv.visualize(self._pcoll))
-    _mocked_sample.assert_called_once()
+    _mocked_head.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
@@ -131,8 +131,7 @@ class PCollectionVisualizationTest(unittest.TestCase):
     self.assertTrue(ie.current_env().is_terminated(self._p))
 
   @patch('pandas.DataFrame.head')
-  def test_display_plain_text_when_kernel_has_no_frontend(self,
-                                                          _mocked_head):
+  def test_display_plain_text_when_kernel_has_no_frontend(self, _mocked_head):
     # Resets the notebook check to False.
     ie.current_env()._is_in_notebook = False
     self.assertIsNone(pv.visualize(self._pcoll))

--- a/sdks/python/apache_beam/runners/interactive/examples/Interactive Beam Example.ipynb
+++ b/sdks/python/apache_beam/runners/interactive/examples/Interactive Beam Example.ipynb
@@ -33,7 +33,8 @@
    "outputs": [],
    "source": [
     "import apache_beam as beam\n",
-    "from apache_beam.runners.interactive import interactive_runner"
+    "from apache_beam.runners.interactive import interactive_runner\n",
+    "from apache_beam.runners.interactive.interactive_beam import *"
    ]
   },
   {
@@ -42,12 +43,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = beam.Pipeline(interactive_runner.InteractiveRunner())\n",
+    "p = beam.Pipeline(interactive_runner.InteractiveRunner())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "init_pcoll = p |  beam.Create(range(10))\n",
-    "squares = init_pcoll | 'Square' >> beam.Map(lambda x: x*x)\n",
-    "cubes = init_pcoll | 'Cube' >> beam.Map(lambda x: x**3)\n",
-    "result = p.run()\n",
-    "result.wait_until_finish()"
+    "show(init_pcoll)"
    ]
   },
   {
@@ -56,6 +62,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "squares = init_pcoll | 'Square' >> beam.Map(lambda x: x*x)\n",
+    "show(squares)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cubes = init_pcoll | 'Cube' >> beam.Map(lambda x: x**3)\n",
+    "show(cubes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = p.run()\n",
     "init_list = list(range(10))\n",
     "squares_list = list(result.get(squares))\n",
     "cubes_list = list(result.get(cubes))\n",
@@ -114,7 +141,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = p.run()"
+    "show(average_square)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show(average_cube)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.run()"
    ]
   }
  ],
@@ -129,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5rc1"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -161,10 +161,7 @@ def show(*pcolls):
 
   # Build a pipeline fragment for the PCollections and run it.
   result = pf.PipelineFragment(list(pcolls)).run()
-  ie.current_env().set_pipeline_result(
-      user_pipeline,
-      result,
-      is_main_job=True)
+  ie.current_env().set_pipeline_result(user_pipeline, result, is_main_job=True)
 
   # If in notebook, dynamic plotting as computation goes.
   if ie.current_env().is_in_notebook:

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -104,8 +104,7 @@ def show(*pcolls):
   is being executed. If used within an ipython shell, there will be no dynamic
   plotting but a static plotting in the end of pipeline fragment execution.
 
-  The PCollections given must belong to the same pipeline and be watched by
-  Interactive Beam (PCollections defined in __main__ are automatically watched).
+  The PCollections given must belong to the same pipeline.
 
     For example::
 
@@ -149,7 +148,7 @@ def show(*pcolls):
   # arbitrary variables.
   watched_pcollections = set()
   for watching in ie.current_env().watching():
-    for key, val in watching:
+    for _, val in watching:
       if hasattr(val, '__class__') and isinstance(val, beam.pvalue.PCollection):
         watched_pcollections.add(val)
   for pcoll in pcolls:

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -20,14 +20,24 @@
 
 from __future__ import absolute_import
 
+import apache_beam as beam
 import importlib
 import unittest
-
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive import interactive_runner as ir
 
 # The module name is also a variable in module.
 _module_name = 'apache_beam.runners.interactive.interactive_beam_test'
+
+
+def _get_watched_pcollections_with_variable_names():
+  watched_pcollections = {}
+  for watching in ie.current_env().watching():
+    for key, val in watching:
+      if hasattr(val, '__class__') and isinstance(val, beam.pvalue.PCollection):
+        watched_pcollections[val] = key
+  return watched_pcollections
 
 
 class InteractiveBeamTest(unittest.TestCase):
@@ -66,6 +76,31 @@ class InteractiveBeamTest(unittest.TestCase):
     ib.watch(self)
     test_env.watch(self)
     self.assertEqual(ie.current_env().watching(), test_env.watching())
+
+  def test_show_always_watch_given_pcolls(self):
+    p = beam.Pipeline(ir.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    pcoll = p | 'Create' >> beam.Create(range(10))
+    # The pcoll is not watched since watch(locals()) is not explicitly called.
+    self.assertFalse(
+        pcoll in _get_watched_pcollections_with_variable_names())
+    # The call of show watches pcoll.
+    ib.show(pcoll)
+    self.assertTrue(
+        pcoll in _get_watched_pcollections_with_variable_names())
+    # The name of pcoll is made up by show.
+    self.assertEqual(
+        'PCollection_Create/Map_decode_.None_',
+        _get_watched_pcollections_with_variable_names()[pcoll])
+
+  def test_show_mark_pcolls_computed_when_done(self):
+    p = beam.Pipeline(ir.InteractiveRunner())
+    # pylint: disable=range-builtin-not-iterating
+    pcoll = p | 'Create' >> beam.Create(range(10))
+    self.assertFalse(pcoll in ie.current_env().computed_pcollections)
+    # The call of show marks pcoll computed.
+    ib.show(pcoll)
+    self.assertTrue(pcoll in ie.current_env().computed_pcollections)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -20,9 +20,10 @@
 
 from __future__ import absolute_import
 
-import apache_beam as beam
 import importlib
 import unittest
+
+import apache_beam as beam
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner as ir
@@ -82,12 +83,10 @@ class InteractiveBeamTest(unittest.TestCase):
     # pylint: disable=range-builtin-not-iterating
     pcoll = p | 'Create' >> beam.Create(range(10))
     # The pcoll is not watched since watch(locals()) is not explicitly called.
-    self.assertFalse(
-        pcoll in _get_watched_pcollections_with_variable_names())
+    self.assertFalse(pcoll in _get_watched_pcollections_with_variable_names())
     # The call of show watches pcoll.
     ib.show(pcoll)
-    self.assertTrue(
-        pcoll in _get_watched_pcollections_with_variable_names())
+    self.assertTrue(pcoll in _get_watched_pcollections_with_variable_names())
 
   def test_show_mark_pcolls_computed_when_done(self):
     p = beam.Pipeline(ir.InteractiveRunner())

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -88,10 +88,6 @@ class InteractiveBeamTest(unittest.TestCase):
     ib.show(pcoll)
     self.assertTrue(
         pcoll in _get_watched_pcollections_with_variable_names())
-    # The name of pcoll is made up by show.
-    self.assertEqual(
-        'PCollection_Create/Map_decode_.None_',
-        _get_watched_pcollections_with_variable_names()[pcoll])
 
   def test_show_mark_pcolls_computed_when_done(self):
     p = beam.Pipeline(ir.InteractiveRunner())

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -48,15 +48,15 @@ class InteractiveRunner(runners.PipelineRunner):
 
   Allows interactively building and running Beam Python pipelines.
   """
-
-  def __init__(self,
-               underlying_runner=None,
-               cache_dir=None,
-               cache_format='text',
-               render_option=None,
-               skip_display=False,
-               force_compute=True,
-               blocking=True):
+  def __init__(
+      self,
+      underlying_runner=None,
+      cache_dir=None,
+      cache_format='text',
+      render_option=None,
+      skip_display=False,
+      force_compute=True,
+      blocking=True):
     """Constructor of InteractiveRunner.
 
     Args:

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
@@ -100,17 +100,23 @@ class PipelineFragment(object):
         self._runner_pipeline.runner,
         self._options)
 
-  def run(self, display_pipeline_graph=False, use_cache=True):
+  def run(self,
+          display_pipeline_graph=False,
+          use_cache=True,
+          blocking_run=False):
     """Shorthand to run the pipeline fragment."""
     try:
       skip_pipeline_graph = self._runner_pipeline.runner._skip_display
       force_compute = self._runner_pipeline.runner._force_compute
+      blocking = self._runner_pipeline.runner._blocking
       self._runner_pipeline.runner._skip_display = not display_pipeline_graph
       self._runner_pipeline.runner._force_compute = not use_cache
+      self._runner_pipeline.runner._blocking = blocking_run
       return self.deduce_fragment().run()
     finally:
       self._runner_pipeline.runner._skip_display = skip_pipeline_graph
       self._runner_pipeline.runner._force_compute = force_compute
+      self._runner_pipeline.runner._blocking = blocking
 
   def _build_runner_pipeline(self):
     return beam.pipeline.Pipeline.from_runner_api(

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
@@ -103,20 +103,20 @@ class PipelineFragment(object):
   def run(self,
           display_pipeline_graph=False,
           use_cache=True,
-          blocking_run=False):
+          blocking=False):
     """Shorthand to run the pipeline fragment."""
     try:
-      skip_pipeline_graph = self._runner_pipeline.runner._skip_display
-      force_compute = self._runner_pipeline.runner._force_compute
-      blocking = self._runner_pipeline.runner._blocking
+      preserved_skip_display = self._runner_pipeline.runner._skip_display
+      preserved_force_compute = self._runner_pipeline.runner._force_compute
+      preserved_blocking = self._runner_pipeline.runner._blocking
       self._runner_pipeline.runner._skip_display = not display_pipeline_graph
       self._runner_pipeline.runner._force_compute = not use_cache
-      self._runner_pipeline.runner._blocking = blocking_run
+      self._runner_pipeline.runner._blocking = blocking
       return self.deduce_fragment().run()
     finally:
-      self._runner_pipeline.runner._skip_display = skip_pipeline_graph
-      self._runner_pipeline.runner._force_compute = force_compute
-      self._runner_pipeline.runner._blocking = blocking
+      self._runner_pipeline.runner._skip_display = preserved_skip_display
+      self._runner_pipeline.runner._force_compute = preserved_force_compute
+      self._runner_pipeline.runner._blocking = preserved_blocking
 
   def _build_runner_pipeline(self):
     return beam.pipeline.Pipeline.from_runner_api(

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
@@ -100,10 +100,7 @@ class PipelineFragment(object):
         self._runner_pipeline.runner,
         self._options)
 
-  def run(self,
-          display_pipeline_graph=False,
-          use_cache=True,
-          blocking=False):
+  def run(self, display_pipeline_graph=False, use_cache=True, blocking=False):
     """Shorthand to run the pipeline fragment."""
     try:
       preserved_skip_display = self._runner_pipeline.runner._skip_display

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -502,8 +502,13 @@ class PipelineInstrument(object):
     return self._cacheable_var_by_pcoll_id.get(pcoll_id, None)
 
 
-def pin(pipeline, options=None):
+def build_pipeline_instrument(pipeline, options=None):
   """Creates PipelineInstrument for a pipeline and its options with cache.
+
+  Throughout the process, the returned PipelineInstrument snapshots the given
+  pipeline and then mutates the pipeline. It's invoked by interactive components
+  such as the InteractiveRunner and the given pipeline should be implicitly
+  created runner pipelines instead of pipeline instances defined by the user.
 
   This is the shorthand for doing 3 steps: 1) compute once for metadata of the
   given runner pipeline and everything watched from user pipelines; 2) associate

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -100,17 +100,15 @@ class PipelineInstrumentTest(unittest.TestCase):
     # Watch the local variables, i.e., the Beam pipeline defined.
     ib.watch(locals())
 
-    pin = instr.pin(p)
-    self.assertEqual(
-        pin.cache_key(init_pcoll),
-        'init_pcoll_' + str(id(init_pcoll)) + '_' +
-        str(id(init_pcoll.producer)))
-    self.assertEqual(
-        pin.cache_key(squares),
-        'squares_' + str(id(squares)) + '_' + str(id(squares.producer)))
-    self.assertEqual(
-        pin.cache_key(cubes),
-        'cubes_' + str(id(cubes)) + '_' + str(id(cubes.producer)))
+    pipeline_instrument = instr.build_pipeline_instrument(p)
+    self.assertEqual(pipeline_instrument.cache_key(init_pcoll),
+                     'init_pcoll_' + str(
+                         id(init_pcoll)) + '_' + str(id(init_pcoll.producer)))
+    self.assertEqual(pipeline_instrument.cache_key(squares),
+                     'squares_' + str(
+                         id(squares)) + '_' + str(id(squares.producer)))
+    self.assertEqual(pipeline_instrument.cache_key(cubes),
+                     'cubes_' + str(id(cubes)) + '_' + str(id(cubes.producer)))
 
   def test_cacheables(self):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
@@ -120,32 +118,30 @@ class PipelineInstrumentTest(unittest.TestCase):
     cubes = init_pcoll | 'Cube' >> beam.Map(lambda x: x**3)
     ib.watch(locals())
 
-    pin = instr.pin(p)
-    self.assertEqual(
-        pin.cacheables,
-        {
-            pin._cacheable_key(init_pcoll): {
-                'var': 'init_pcoll',
-                'version': str(id(init_pcoll)),
-                'pcoll_id': 'ref_PCollection_PCollection_10',
-                'producer_version': str(id(init_pcoll.producer)),
-                'pcoll': init_pcoll
-            },
-            pin._cacheable_key(squares): {
-                'var': 'squares',
-                'version': str(id(squares)),
-                'pcoll_id': 'ref_PCollection_PCollection_11',
-                'producer_version': str(id(squares.producer)),
-                'pcoll': squares
-            },
-            pin._cacheable_key(cubes): {
-                'var': 'cubes',
-                'version': str(id(cubes)),
-                'pcoll_id': 'ref_PCollection_PCollection_12',
-                'producer_version': str(id(cubes.producer)),
-                'pcoll': cubes
-            }
-        })
+    pipeline_instrument = instr.build_pipeline_instrument(p)
+    self.assertEqual(pipeline_instrument.cacheables, {
+        pipeline_instrument._cacheable_key(init_pcoll): {
+            'var': 'init_pcoll',
+            'version': str(id(init_pcoll)),
+            'pcoll_id': 'ref_PCollection_PCollection_10',
+            'producer_version': str(id(init_pcoll.producer)),
+            'pcoll': init_pcoll
+        },
+        pipeline_instrument._cacheable_key(squares): {
+            'var': 'squares',
+            'version': str(id(squares)),
+            'pcoll_id': 'ref_PCollection_PCollection_11',
+            'producer_version': str(id(squares.producer)),
+            'pcoll': squares
+        },
+        pipeline_instrument._cacheable_key(cubes): {
+            'var': 'cubes',
+            'version': str(id(cubes)),
+            'pcoll_id': 'ref_PCollection_PCollection_12',
+            'producer_version': str(id(cubes.producer)),
+            'pcoll': cubes
+        }
+    })
 
   def test_has_unbounded_source(self):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
@@ -175,7 +171,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     _ = c | beam.Map(lambda x: x)
 
     ib.watch(locals())
-    instrumenter = instr.pin(p)
+    instrumenter = instr.build_pipeline_instrument(p)
     actual_pipeline = instrumenter.background_caching_pipeline_proto()
 
     # Now recreate the expected pipeline, which should only have the unbounded
@@ -232,13 +228,13 @@ class PipelineInstrumentTest(unittest.TestCase):
     # Copied instance when execution has no user defined variables.
     p_copy, _, _ = self._example_pipeline(False)
     # Instrument the copied pipeline.
-    pin = instr.pin(p_copy)
+    pipeline_instrument = instr.build_pipeline_instrument(p_copy)
     # Manually instrument original pipeline with expected pipeline transforms.
-    init_pcoll_cache_key = pin.cache_key(init_pcoll)
+    init_pcoll_cache_key = pipeline_instrument.cache_key(init_pcoll)
     _ = init_pcoll | (
         ('_WriteCache_' + init_pcoll_cache_key) >> cache.WriteCache(
             ie.current_env().cache_manager(), init_pcoll_cache_key))
-    second_pcoll_cache_key = pin.cache_key(second_pcoll)
+    second_pcoll_cache_key = pipeline_instrument.cache_key(second_pcoll)
     _ = second_pcoll | (
         ('_WriteCache_' + second_pcoll_cache_key) >> cache.WriteCache(
             ie.current_env().cache_manager(), second_pcoll_cache_key))
@@ -260,7 +256,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     # Mark the completeness of PCollections from the original(user) pipeline.
     ie.current_env().mark_pcollection_computed(
         (p_origin, init_pcoll, second_pcoll))
-    instr.pin(p_copy)
+    instr.build_pipeline_instrument(p_copy)
 
     cached_init_pcoll = p_origin | (
         '_ReadCache_' + init_pcoll_cache_key) >> cache.ReadCache(
@@ -299,8 +295,8 @@ class PipelineInstrumentTest(unittest.TestCase):
         interactive_runner.InteractiveRunner())
     ib.watch({'irrelevant_user_pipeline': irrelevant_user_pipeline})
     # Build instrument from the runner pipeline.
-    pipeline_instrument = instr.pin(runner_pipeline)
-    self.assertIs(pipeline_instrument.user_pipeline, user_pipeline)
+    pipeline_instrument = instr.build_pipeline_instrument(runner_pipeline)
+    self.assertTrue(pipeline_instrument.user_pipeline is user_pipeline)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -101,14 +101,16 @@ class PipelineInstrumentTest(unittest.TestCase):
     ib.watch(locals())
 
     pipeline_instrument = instr.build_pipeline_instrument(p)
-    self.assertEqual(pipeline_instrument.cache_key(init_pcoll),
-                     'init_pcoll_' + str(
-                         id(init_pcoll)) + '_' + str(id(init_pcoll.producer)))
-    self.assertEqual(pipeline_instrument.cache_key(squares),
-                     'squares_' + str(
-                         id(squares)) + '_' + str(id(squares.producer)))
-    self.assertEqual(pipeline_instrument.cache_key(cubes),
-                     'cubes_' + str(id(cubes)) + '_' + str(id(cubes.producer)))
+    self.assertEqual(
+        pipeline_instrument.cache_key(init_pcoll),
+        'init_pcoll_' + str(id(init_pcoll)) + '_' +
+        str(id(init_pcoll.producer)))
+    self.assertEqual(
+        pipeline_instrument.cache_key(squares),
+        'squares_' + str(id(squares)) + '_' + str(id(squares.producer)))
+    self.assertEqual(
+        pipeline_instrument.cache_key(cubes),
+        'cubes_' + str(id(cubes)) + '_' + str(id(cubes.producer)))
 
   def test_cacheables(self):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
@@ -119,29 +121,31 @@ class PipelineInstrumentTest(unittest.TestCase):
     ib.watch(locals())
 
     pipeline_instrument = instr.build_pipeline_instrument(p)
-    self.assertEqual(pipeline_instrument.cacheables, {
-        pipeline_instrument._cacheable_key(init_pcoll): {
-            'var': 'init_pcoll',
-            'version': str(id(init_pcoll)),
-            'pcoll_id': 'ref_PCollection_PCollection_10',
-            'producer_version': str(id(init_pcoll.producer)),
-            'pcoll': init_pcoll
-        },
-        pipeline_instrument._cacheable_key(squares): {
-            'var': 'squares',
-            'version': str(id(squares)),
-            'pcoll_id': 'ref_PCollection_PCollection_11',
-            'producer_version': str(id(squares.producer)),
-            'pcoll': squares
-        },
-        pipeline_instrument._cacheable_key(cubes): {
-            'var': 'cubes',
-            'version': str(id(cubes)),
-            'pcoll_id': 'ref_PCollection_PCollection_12',
-            'producer_version': str(id(cubes.producer)),
-            'pcoll': cubes
-        }
-    })
+    self.assertEqual(
+        pipeline_instrument.cacheables,
+        {
+            pipeline_instrument._cacheable_key(init_pcoll): {
+                'var': 'init_pcoll',
+                'version': str(id(init_pcoll)),
+                'pcoll_id': 'ref_PCollection_PCollection_10',
+                'producer_version': str(id(init_pcoll.producer)),
+                'pcoll': init_pcoll
+            },
+            pipeline_instrument._cacheable_key(squares): {
+                'var': 'squares',
+                'version': str(id(squares)),
+                'pcoll_id': 'ref_PCollection_PCollection_11',
+                'producer_version': str(id(squares.producer)),
+                'pcoll': squares
+            },
+            pipeline_instrument._cacheable_key(cubes): {
+                'var': 'cubes',
+                'version': str(id(cubes)),
+                'pcoll_id': 'ref_PCollection_PCollection_12',
+                'producer_version': str(id(cubes.producer)),
+                'pcoll': cubes
+            }
+        })
 
   def test_has_unbounded_source(self):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())


### PR DESCRIPTION
1. Implemented `show` API in `interactive_beam` module. Users can
invoke the API to introspect data through dynamic visualization for
given PCollections immediately after they define those PCollections
without running pipelines explicitly. API `show` always implicitly
executes the right pipeline fragment no matter how broken/messy the
in-memory state is for a notebook which makes the user flow
data-centric.
2. Updated the example notebook.
3. Use heading to sample data from PCollectionVisualization for
print-display when there is no frontend.
4. Spell out build_pipeline_instrument to replace the abbrev. pin function.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
