### PR TITLE
[BEAM-8280][BEAM-8629] Make IOTypeHints immutable

### DIFF
--- a/sdks/python/apache_beam/runners/direct/helper_transforms.py
+++ b/sdks/python/apache_beam/runners/direct/helper_transforms.py
@@ -77,15 +77,15 @@ class PartialGroupByKeyCombiningValues(beam.DoFn):
       yield WindowedValue((k, self._combine_fn.compact(va)), w.end, (w,))
 
   def default_type_hints(self):
-    hints = self._combine_fn.get_type_hints().copy()
+    hints = self._combine_fn.get_type_hints()
     K = typehints.TypeVariable('K')
     if hints.input_types:
       args, kwargs = hints.input_types
       args = (typehints.Tuple[K, args[0]],) + args[1:]
-      hints.set_input_types(*args, **kwargs)
+      hints = hints.with_input_types(*args, **kwargs)
     else:
-      hints.set_input_types(typehints.Tuple[K, typing.Any])
-    hints.set_output_types(typehints.Tuple[K, typing.Any])
+      hints = hints.with_input_types(typehints.Tuple[K, typing.Any])
+    hints = hints.with_output_types(typehints.Tuple[K, typing.Any])
     return hints
 
 
@@ -103,10 +103,10 @@ class FinishCombine(beam.DoFn):
             self._combine_fn.merge_accumulators(vs)))]
 
   def default_type_hints(self):
-    hints = self._combine_fn.get_type_hints().copy()
+    hints = self._combine_fn.get_type_hints()
     K = typehints.TypeVariable('K')
-    hints.set_input_types(typehints.Tuple[K, typing.Any])
+    hints = hints.with_input_types(typehints.Tuple[K, typing.Any])
     if hints.output_types:
       main_output_type = hints.simple_output_type('')
-      hints.set_output_types(typehints.Tuple[K, main_output_type])
+      hints = hints.with_output_types(typehints.Tuple[K, main_output_type])
     return hints

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -757,9 +757,9 @@ def with_input_types(*positional_hints, **keyword_hints):
         validate_composite_type_param(
             t, error_msg_prefix='All type hint arguments')
 
-    th = getattr(f, '_type_hints', IOTypeHints.empty())
-    f._type_hints = th.with_input_types(*converted_positional_hints,
-                                        **converted_keyword_hints)
+    th = getattr(f, '_type_hints', IOTypeHints.empty()).with_input_types(
+        *converted_positional_hints, **converted_keyword_hints)
+    f._type_hints = th  # pylint: disable=protected-access
     return f
   return annotate
 
@@ -843,7 +843,7 @@ def with_output_types(*return_type_hint, **kwargs):
 
   def annotate(f):
     th = getattr(f, '_type_hints', IOTypeHints.empty())
-    f._type_hints = th.with_output_types(return_type_hint)
+    f._type_hints = th.with_output_types(return_type_hint)  # pylint: disable=protected-access
     return f
 
   return annotate

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -242,13 +242,12 @@ class IOTypeHints(NamedTuple('IOTypeHints', [
 
   @classmethod
   def _make_traceback(cls, base):  # type: (Optional[IOTypeHints]) -> List[str]
-    # Don't include this method and the IOTypeHints method that called it.
+    # Omit this method and the IOTypeHints method that called it.
     num_frames_skip = 2
-    tb_lines = 'TH>' + ''.join(traceback.format_stack(
-        limit=cls.traceback_limit + num_frames_skip)[:-num_frames_skip]
-    ).replace('\n', '\nTH>')
+    tb = traceback.format_stack(limit=cls.traceback_limit + num_frames_skip)
+    tb_lines = 'TH>' + ''.join(tb[:-num_frames_skip]).replace('\n', '\nTH>')
 
-    res = [tb_lines +'\nbased on: ' + str(base)]
+    res = [tb_lines + '\nbased on: ' + str(base)]
     if base is not None:
       res += base.origin
     return res

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -241,7 +241,8 @@ class IOTypeHints(NamedTuple('IOTypeHints', [
   traceback_limit = 5
 
   @classmethod
-  def _make_traceback(cls, base):  # type: (Optional[IOTypeHints]) -> List[str]
+  def _make_traceback(cls, base):
+    # type: (Optional[IOTypeHints]) -> List[str]
     # Omit this method and the IOTypeHints method that called it.
     num_frames_skip = 2
     tb = traceback.format_stack(limit=cls.traceback_limit + num_frames_skip)
@@ -254,10 +255,13 @@ class IOTypeHints(NamedTuple('IOTypeHints', [
 
   @classmethod
   def empty(cls):
+    # type: () -> IOTypeHints
+    """Construct a base IOTypeHints object with no hints."""
     return IOTypeHints(None, None, [])
 
   @classmethod
   def from_callable(cls, fn):
+    # type: (Callable) -> Optional[IOTypeHints]
     """Construct an IOTypeHints object from a callable's signature.
 
     Supports Python 3 annotations. For partial annotations, sets unknown types
@@ -348,7 +352,7 @@ class IOTypeHints(NamedTuple('IOTypeHints', [
     Raises:
       ValueError if output type is simple and not iterable.
     """
-    if not self.has_simple_output_type():
+    if self.output_types is None or not self.has_simple_output_type():
       return self
     output_type = self.output_types[0][0]
     if output_type is None or isinstance(output_type, type(None)):

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -90,6 +90,7 @@ from __future__ import absolute_import
 import inspect
 import logging
 import sys
+import traceback
 import types
 from builtins import next
 from builtins import object
@@ -97,6 +98,8 @@ from builtins import zip
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import List
+from typing import NamedTuple
 from typing import Optional
 from typing import Tuple
 from typing import TypeVar
@@ -217,7 +220,10 @@ def get_signature(func):
   return signature
 
 
-class IOTypeHints(object):
+class IOTypeHints(NamedTuple('IOTypeHints', [
+    ('input_types', Optional[Tuple[Tuple[Any, ...], Dict[str, Any]]]),
+    ('output_types', Optional[Tuple[Tuple[Any, ...], Dict[str, Any]]]),
+    ('origin', List[str])])):
   """Encapsulates all type hint information about a Dataflow construct.
 
   This should primarily be used via the WithTypeHints mixin class, though
@@ -228,18 +234,31 @@ class IOTypeHints(object):
       May be None. The list and dict correspond to args and kwargs.
     output_types: (tuple, dict) List of typing types, and an optional dictionary
       (unused). Only the first element of the list is used. May be None.
+    origin: (List[str]) Stack of tracebacks of method calls used to create this
+      instance.
   """
-  __slots__ = ('input_types', 'output_types')
 
-  def __init__(self,
-               input_types=None,  # type: Optional[Tuple[Tuple[Any, ...], Dict[str, Any]]]
-               output_types=None  # type: Optional[Tuple[Tuple[Any, ...], Dict[str, Any]]]
-              ):
-    self.input_types = input_types
-    self.output_types = output_types
+  traceback_limit = 5
 
-  @staticmethod
-  def from_callable(fn):
+  @classmethod
+  def _make_traceback(cls, base):  # type: (Optional[IOTypeHints]) -> List[str]
+    # Don't include this method and the IOTypeHints method that called it.
+    num_frames_skip = 2
+    tb_lines = 'TH>' + ''.join(traceback.format_stack(
+        limit=cls.traceback_limit + num_frames_skip)[:-num_frames_skip]
+    ).replace('\n', '\nTH>')
+
+    res = [tb_lines +'\nbased on: ' + str(base)]
+    if base is not None:
+      res += base.origin
+    return res
+
+  @classmethod
+  def empty(cls):
+    return IOTypeHints(None, None, [])
+
+  @classmethod
+  def from_callable(cls, fn):
     """Construct an IOTypeHints object from a callable's signature.
 
     Supports Python 3 annotations. For partial annotations, sets unknown types
@@ -283,16 +302,19 @@ class IOTypeHints(object):
       output_args.append(typehints.Any)
 
     return IOTypeHints(input_types=(tuple(input_args), input_kwargs),
-                       output_types=(tuple(output_args), {}))
+                       output_types=(tuple(output_args), {}),
+                       origin=cls._make_traceback(None))
 
-  def set_input_types(self, *args, **kwargs):
-    self.input_types = args, kwargs
+  def with_input_types(self, *args, **kwargs):  # type: (...) -> IOTypeHints
+    return self._replace(input_types=(args, kwargs),
+                         origin=self._make_traceback(self))
 
-  def set_output_types(self, *args, **kwargs):
-    self.output_types = args, kwargs
+  def with_output_types(self, *args, **kwargs):  # type: (...) -> IOTypeHints
+    return self._replace(output_types=(args, kwargs),
+                         origin=self._make_traceback(self))
 
   def simple_output_type(self, context):
-    if self.output_types:
+    if self._has_output_types():
       args, kwargs = self.output_types
       if len(args) != 1 or kwargs:
         raise TypeError(
@@ -305,7 +327,7 @@ class IOTypeHints(object):
     return (self.output_types and len(self.output_types[0]) == 1 and
             not self.output_types[1])
 
-  def strip_iterable(self):
+  def strip_iterable(self):  # type: (...) -> IOTypeHints
     """Removes outer Iterable (or equivalent) from output type.
 
     Only affects instances with simple output types, otherwise is a no-op.
@@ -319,7 +341,7 @@ class IOTypeHints(object):
     Example: Generator[Tuple(int, int)] becomes Tuple(int, int)
 
     Returns:
-      A possible copy of this instance with a possibly different output type.
+      A copy of this instance with a possibly different output type.
 
     Raises:
       ValueError if output type is simple and not iterable.
@@ -340,13 +362,9 @@ class IOTypeHints(object):
           pass
 
     yielded_type = typehints.get_yielded_type(output_type)
-    res = self.copy()
-    res.output_types = ((yielded_type,), {})
-    return res
-
-  def copy(self):
-    # type: () -> IOTypeHints
-    return IOTypeHints(self.input_types, self.output_types)
+    return self._replace(
+        output_types=((yielded_type,), {}),
+        origin=self._make_traceback(self))
 
   def with_defaults(self, hints):
     # type: (Optional[IOTypeHints]) -> IOTypeHints
@@ -360,7 +378,11 @@ class IOTypeHints(object):
       output_types = self.output_types
     else:
       output_types = hints.output_types
-    return IOTypeHints(input_types, output_types)
+    res = IOTypeHints(input_types, output_types, self._make_traceback(self))
+    if res == self:
+      return self  # Don't needlessly increase origin traceback length.
+    else:
+      return res
 
   def _has_input_types(self):
     return self.input_types is not None and any(self.input_types)
@@ -374,6 +396,9 @@ class IOTypeHints(object):
   def __repr__(self):
     return 'IOTypeHints[inputs=%s, outputs=%s]' % (
         self.input_types, self.output_types)
+
+  def debug_str(self):
+    return '\n'.join([self.__repr__()] + self.origin)
 
   def __eq__(self, other):
     def same(a, b):
@@ -391,13 +416,17 @@ class IOTypeHints(object):
   def __hash__(self):
     return hash(str(self))
 
+  def __reduce__(self):
+    # Don't include "origin" debug information in pickled form.
+    return (IOTypeHints, (self.input_types, self.output_types, []))
+
 
 class WithTypeHints(object):
   """A mixin class that provides the ability to set and retrieve type hints.
   """
 
   def __init__(self, *unused_args, **unused_kwargs):
-    self._type_hints = IOTypeHints()
+    self._type_hints = IOTypeHints.empty()
 
   def _get_or_create_type_hints(self):
     # type: () -> IOTypeHints
@@ -406,7 +435,7 @@ class WithTypeHints(object):
       # Only return an instance bound to self (see BEAM-8629).
       return self.__dict__['_type_hints']
     except KeyError:
-      self._type_hints = IOTypeHints()
+      self._type_hints = IOTypeHints.empty()
       return self._type_hints
 
   def get_type_hints(self):
@@ -428,14 +457,16 @@ class WithTypeHints(object):
     # type: (WithTypeHintsT, *Any, **Any) -> WithTypeHintsT
     arg_hints = native_type_compatibility.convert_to_beam_types(arg_hints)
     kwarg_hints = native_type_compatibility.convert_to_beam_types(kwarg_hints)
-    self._get_or_create_type_hints().set_input_types(*arg_hints, **kwarg_hints)
+    self._type_hints = self._get_or_create_type_hints().with_input_types(
+        *arg_hints, **kwarg_hints)
     return self
 
   def with_output_types(self, *arg_hints, **kwarg_hints):
     # type: (WithTypeHintsT, *Any, **Any) -> WithTypeHintsT
     arg_hints = native_type_compatibility.convert_to_beam_types(arg_hints)
     kwarg_hints = native_type_compatibility.convert_to_beam_types(kwarg_hints)
-    self._get_or_create_type_hints().set_output_types(*arg_hints, **kwarg_hints)
+    self._type_hints = self._get_or_create_type_hints().with_output_types(
+        *arg_hints, **kwarg_hints)
     return self
 
 
@@ -637,14 +668,14 @@ def get_type_hints(fn):
   # pylint: disable=protected-access
   if not hasattr(fn, '_type_hints'):
     try:
-      fn._type_hints = IOTypeHints()
+      fn._type_hints = IOTypeHints.empty()
     except (AttributeError, TypeError):
       # Can't add arbitrary attributes to this object,
       # but might have some restrictions anyways...
-      hints = IOTypeHints()
+      hints = IOTypeHints.empty()
       # Python 3.7 introduces annotations for _MethodDescriptorTypes.
       if isinstance(fn, _MethodDescriptorType) and sys.version_info < (3, 7):
-        hints.set_input_types(fn.__objclass__)  # type: ignore
+        hints = hints.with_input_types(fn.__objclass__)  # type: ignore
       return hints
   return fn._type_hints
   # pylint: enable=protected-access
@@ -727,8 +758,9 @@ def with_input_types(*positional_hints, **keyword_hints):
         validate_composite_type_param(
             t, error_msg_prefix='All type hint arguments')
 
-    get_type_hints(f).set_input_types(*converted_positional_hints,
-                                      **converted_keyword_hints)
+    th = getattr(f, '_type_hints', IOTypeHints.empty())
+    f._type_hints = th.with_input_types(*converted_positional_hints,
+                                        **converted_keyword_hints)
     return f
   return annotate
 
@@ -811,7 +843,8 @@ def with_output_types(*return_type_hint, **kwargs):
   )
 
   def annotate(f):
-    get_type_hints(f).set_output_types(return_type_hint)
+    th = getattr(f, '_type_hints', IOTypeHints.empty())
+    f._type_hints = th.with_output_types(return_type_hint)
     return f
 
   return annotate

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -304,11 +304,13 @@ class IOTypeHints(NamedTuple('IOTypeHints', [
                        output_types=(tuple(output_args), {}),
                        origin=cls._make_traceback(None))
 
-  def with_input_types(self, *args, **kwargs):  # type: (...) -> IOTypeHints
+  def with_input_types(self, *args, **kwargs):
+    # type: (...) -> IOTypeHints
     return self._replace(input_types=(args, kwargs),
                          origin=self._make_traceback(self))
 
-  def with_output_types(self, *args, **kwargs):  # type: (...) -> IOTypeHints
+  def with_output_types(self, *args, **kwargs):
+    # type: (...) -> IOTypeHints
     return self._replace(output_types=(args, kwargs),
                          origin=self._make_traceback(self))
 
@@ -326,7 +328,8 @@ class IOTypeHints(NamedTuple('IOTypeHints', [
     return (self.output_types and len(self.output_types[0]) == 1 and
             not self.output_types[1])
 
-  def strip_iterable(self):  # type: (...) -> IOTypeHints
+  def strip_iterable(self):
+    # type: () -> IOTypeHints
     """Removes outer Iterable (or equivalent) from output type.
 
     Only affects instances with simple output types, otherwise is a no-op.

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -79,7 +79,10 @@ class IOTypeHintsTest(unittest.TestCase):
     self.assertEqual(th.output_types, ((Any,), {}))
 
   def test_strip_iterable_not_simple_output_noop(self):
-    th = decorators.IOTypeHints(input_types=None, output_types=((int, str), {}), origin=[])
+    th = decorators.IOTypeHints(
+        input_types=None,
+        output_types=((int, str), {}),
+        origin=[])
     th = th.strip_iterable()
     self.assertEqual(((int, str), {}), th.output_types)
 


### PR DESCRIPTION
Also adds an `origin` field that hopefully aids in debugging type check
errors.

This may break uses of `@apache_beam.decorators.with_{input,output}_types(...)` on builtins and Cython functions. For Cython, a possible solution is to use `# cython: binding=True`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
