### PR TITLE
[BEAM-9233] Support -buildmode=pie -ldflags=-w with unregistered Go functions

### DIFF
--- a/sdks/go/pkg/beam/core/util/symtab/symtab.go
+++ b/sdks/go/pkg/beam/core/util/symtab/symtab.go
@@ -17,7 +17,6 @@
 package symtab
 
 import (
-	"debug/dwarf"
 	"debug/elf"
 	"debug/macho"
 	"debug/pe"
@@ -31,19 +30,23 @@ import (
 
 // SymbolTable allows for mapping between symbols and their addresses.
 type SymbolTable struct {
-	data   *dwarf.Data
-	offset uintptr // offset between file addresses and runtime addresses
+	addr2Sym map[uintptr]string
+	sym2Addr map[string]uintptr
+	offset   uintptr // offset between file addresses and runtime addresses
 }
 
 // New creates a new symbol table based on the debug info
 // read from the specified file.
 func New(filename string) (*SymbolTable, error) {
-	d, err := dwarfData(filename)
+	addr2Sym, sym2Addr, err := symbolData(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	sym := &SymbolTable{data: d}
+	sym := &SymbolTable{
+		addr2Sym: addr2Sym,
+		sym2Addr: sym2Addr,
+	}
 
 	// Work out the offset between the file addresses and the
 	// runtime addreses, in case this is a position independent
@@ -59,53 +62,92 @@ func New(filename string) (*SymbolTable, error) {
 	return sym, nil
 }
 
-// dwarfData returns the debug info for the specified file.
-func dwarfData(filename string) (*dwarf.Data, error) {
+// symbolData reads the file's symbol table and builds two maps,
+// one from symbol to address and one from address to symbol.
+// The maps only include function symbols.
+func symbolData(filename string) (map[uintptr]string, map[string]uintptr, error) {
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
-	// The interface contract for the xxx.NewFile() methods takes an
-	// io.ReaderAt which suggests the Reader needs to stay alive for the duration
-	// of the symbol table.
+	defer f.Close()
 
 	// First try ELF
 	ef, err := elf.NewFile(f)
 	if err == nil {
-		d, err := ef.DWARF()
-		if err != nil {
-			f.Close()
-			return nil, errors.Wrap(err, "No working DWARF")
-		}
-		return d, nil
+		return elfSymbolData(ef)
 	}
 
 	// then Mach-O
 	mf, err := macho.NewFile(f)
 	if err == nil {
-		d, err := mf.DWARF()
-		if err != nil {
-			f.Close()
-			return nil, errors.Wrap(err, "No working DWARF")
-		}
-		return d, nil
+		return machoSymbolData(mf)
 	}
 
 	// finally try Windows PE format
 	pf, err := pe.NewFile(f)
 	if err == nil {
-		d, err := pf.DWARF()
-		if err != nil {
-			f.Close()
-			return nil, errors.Wrap(err, "No working DWARF")
-		}
-		return d, nil
+		return peSymbolData(pf)
 	}
 
 	// Give up, we don't recognize it
-	f.Close()
-	return nil, errors.New("Unknown file format")
+	return nil, nil, errors.New("Unknown file format")
+}
+
+// elfSymbolData builds function symbol maps from an ELF file.
+func elfSymbolData(ef *elf.File) (map[uintptr]string, map[string]uintptr, error) {
+	syms, err := ef.Symbols()
+	if err != nil {
+		return nil, nil, err
+	}
+	addr2Sym := make(map[uintptr]string)
+	sym2Addr := make(map[string]uintptr)
+	for _, sym := range syms {
+		if elf.ST_TYPE(sym.Info) != elf.STT_FUNC {
+			continue
+		}
+		value := uintptr(sym.Value)
+		addr2Sym[value] = sym.Name
+		sym2Addr[sym.Name] = value
+	}
+	return addr2Sym, sym2Addr, nil
+}
+
+// machoSymbolData builds function symbol maps from a Mach-O file.
+func machoSymbolData(mf *macho.File) (map[uintptr]string, map[string]uintptr, error) {
+	addr2Sym := make(map[uintptr]string)
+	sym2Addr := make(map[string]uintptr)
+	for _, sym := range mf.Symtab.Syms {
+		if int(sym.Sect-1) >= len(mf.Sections) {
+			continue
+		}
+		if mf.Sections[sym.Sect-1].Seg != "__TEXT" {
+			continue
+		}
+		value := uintptr(sym.Value)
+		addr2Sym[value] = sym.Name
+		sym2Addr[sym.Name] = value
+	}
+	return addr2Sym, sym2Addr, nil
+}
+
+// peSymbolData builds function symbol maps from a PE file.
+func peSymbolData(pf *pe.File) (map[uintptr]string, map[string]uintptr, error) {
+	addr2Sym := make(map[uintptr]string)
+	sym2Addr := make(map[string]uintptr)
+	for _, sym := range pf.Symbols {
+		if sym.SectionNumber <= 0 || int(sym.SectionNumber-1) >= len(pf.Sections) {
+			continue
+		}
+		const text = 0x20
+		if pf.Sections[sym.SectionNumber-1].Characteristics&text == 0 {
+			continue
+		}
+		value := uintptr(sym.Value)
+		addr2Sym[value] = sym.Name
+		sym2Addr[sym.Name] = value
+	}
+	return addr2Sym, sym2Addr, nil
 }
 
 // fnname returns the name of the function that called it.
@@ -120,47 +162,18 @@ func fnname() string {
 // Addr2Sym returns the symbol name for the provided address.
 func (s *SymbolTable) Addr2Sym(addr uintptr) (string, error) {
 	addr -= s.offset
-	reader := s.data.Reader()
-	for {
-		e, err := reader.Next()
-		if err != nil {
-			return "", err
-		}
-
-		if e == nil {
-			break
-		}
-
-		if e.Tag == dwarf.TagSubprogram {
-			nf := e.Field[1]
-			if nf.Val.(uint64) == uint64(addr) {
-				return e.Field[0].Val.(string), nil
-			}
-		}
+	sym, ok := s.addr2Sym[addr]
+	if !ok {
+		return "", errors.Errorf("no symbol found at address %x", addr)
 	}
-	return "", errors.Errorf("no symbol found at address %x", addr)
+	return sym, nil
 }
 
 // Sym2Addr returns the address of the provided symbol name.
 func (s *SymbolTable) Sym2Addr(symbol string) (uintptr, error) {
-	reader := s.data.Reader()
-	for {
-		e, err := reader.Next()
-		if err != nil {
-			return 0, err
-		}
-
-		if e == nil {
-			break
-		}
-
-		if e.Tag == dwarf.TagSubprogram && len(e.Field) >= 2 {
-			nf := e.Field[0]
-			if nf.Attr.String() == "Name" && nf.Val.(string) == symbol {
-				addr := e.Field[1].Val.(uint64)
-				return uintptr(addr) + s.offset, nil
-			}
-		}
+	addr, ok := s.sym2Addr[symbol]
+	if !ok {
+		return 0, errors.Errorf("no symbol %q", symbol)
 	}
-	return 0, errors.Errorf("no symbol %q", symbol)
+	return addr + s.offset, nil
 }

--- a/sdks/go/pkg/beam/core/util/symtab/symtab_test.go
+++ b/sdks/go/pkg/beam/core/util/symtab/symtab_test.go
@@ -91,23 +91,28 @@ func TestSym2Addr(t *testing.T) {
 	gotool := filepath.Join(runtime.GOROOT(), "bin", "go")
 
 	for _, arg := range []string{"-buildmode=exe", "-buildmode=pie"} {
-		args := []string{
-			gotool,
-			"build",
-			"-o",
-			bin,
-			arg,
-			fname,
-		}
-		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
-			t.Logf("%s", out)
-			t.Errorf("%v failed: %v", args, err)
-			continue
-		}
+		for _, strip := range []bool{false, true} {
+			args := []string{
+				gotool,
+				"build",
+				"-o",
+				bin,
+				arg,
+			}
+			if strip {
+				args = append(args, "-ldflags=-w")
+			}
+			args = append(args, fname)
+			if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+				t.Logf("%s", out)
+				t.Errorf("%v failed: %v", args, err)
+				continue
+			}
 
-		if out, err := exec.Command(bin).CombinedOutput(); err != nil {
-			t.Logf("%s", out)
-			t.Errorf("test program built with %v failed: %v", args, err)
+			if out, err := exec.Command(bin).CombinedOutput(); err != nil {
+				t.Logf("%s", out)
+				t.Errorf("test program built with %v failed: %v", args, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Use symbol tables, rather than DWARF, to map between symbol names and address.
This will work when the DWARF information is stripped.
It should also be more efficient, as it does not require parsing the DWARF information.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
