### PR TITLE
[BEAM-9231] Annotate as Experimental/Internal missing classes in beam-sdks-java-core

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CoderTranslator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CoderTranslator.java
@@ -18,8 +18,6 @@
 package org.apache.beam.runners.core.construction;
 
 import java.util.List;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 
 /**
@@ -29,7 +27,6 @@ import org.apache.beam.sdk.coders.Coder;
  * the capability to encode an additional payload, which is not currently supported. This exists as
  * a temporary measure.
  */
-@Experimental(Kind.CORE_RUNNERS_ONLY)
 public interface CoderTranslator<T extends Coder<?>> {
   /** Extract all component {@link Coder coders} within a coder. */
   List<? extends Coder<?>> getComponents(T from);

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CoderTranslators.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CoderTranslators.java
@@ -22,8 +22,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.model.pipeline.v1.SchemaApi;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -147,7 +145,6 @@ class CoderTranslators {
     };
   }
 
-  @Experimental(Kind.SCHEMAS)
   static CoderTranslator<RowCoder> row() {
     return new CoderTranslator<RowCoder>() {
       @Override

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
@@ -28,6 +28,8 @@ import org.apache.beam.model.expansion.v1.ExpansionApi;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.Impulse;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -53,6 +55,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterable
  * service. Note that this is a low-level API and mainly for internal use. A user may want to use
  * high-level wrapper classes rather than this one.
  */
+@Experimental(Kind.PORTABILITY)
 public class External {
   private static final String EXPANDED_TRANSFORM_BASE_NAME = "external";
   private static final String IMPULSE_PREFIX = "IMPULSE";

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.runners.PTransformMatcher;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -48,7 +46,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects
  * <p>Once {@link PTransform PTransforms} have URNs, this will be removed and replaced with a
  * UrnPTransformMatcher.
  */
-@Experimental(Kind.CORE_RUNNERS_ONLY)
 public class PTransformMatchers {
   private PTransformMatchers() {}
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SdkComponents.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SdkComponents.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
-import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
@@ -296,7 +295,6 @@ public class SdkComponents {
    * contained {@link Coder coders}, {@link WindowingStrategy windowing strategies}, {@link
    * PCollection PCollections}, and {@link PTransform PTransforms}.
    */
-  @Experimental
   public RunnerApi.Components toComponents() {
     return componentsBuilder.build();
   }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
@@ -39,6 +39,7 @@ import org.apache.beam.runners.core.construction.ParDoTranslation.ParDoLike;
 import org.apache.beam.runners.core.construction.ReadTranslation.BoundedReadPayloadTranslator;
 import org.apache.beam.runners.core.construction.ReadTranslation.UnboundedReadPayloadTranslator;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.runners.AppliedPTransform;
@@ -87,7 +88,7 @@ import org.joda.time.Instant;
  * <p>This transform is intended as a helper for internal use by runners when implementing {@code
  * ParDo.of(splittable DoFn)}, but not for direct use by pipeline writers.
  */
-@Experimental(Experimental.Kind.SPLITTABLE_DO_FN)
+@Experimental(Kind.SPLITTABLE_DO_FN)
 public class SplittableParDo<InputT, OutputT, RestrictionT>
     extends PTransform<PCollection<InputT>, PCollectionTuple> {
   /**

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
@@ -38,8 +38,6 @@ import org.apache.beam.runners.core.construction.PTransformTranslation.Transform
 import org.apache.beam.runners.core.construction.ParDoTranslation.ParDoLike;
 import org.apache.beam.runners.core.construction.ReadTranslation.BoundedReadPayloadTranslator;
 import org.apache.beam.runners.core.construction.ReadTranslation.UnboundedReadPayloadTranslator;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.runners.AppliedPTransform;
@@ -88,7 +86,6 @@ import org.joda.time.Instant;
  * <p>This transform is intended as a helper for internal use by runners when implementing {@code
  * ParDo.of(splittable DoFn)}, but not for direct use by pipeline writers.
  */
-@Experimental(Kind.SPLITTABLE_DO_FN)
 public class SplittableParDo<InputT, OutputT, RestrictionT>
     extends PTransform<PCollection<InputT>, PCollectionTuple> {
   /**

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/TriggerTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/TriggerTranslation.java
@@ -22,8 +22,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.windowing.AfterAll;
 import org.apache.beam.sdk.transforms.windowing.AfterEach;
@@ -49,7 +47,6 @@ import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 /** Utilities for working with {@link TriggerTranslation Triggers}. */
-@Experimental(Kind.TRIGGER)
 public class TriggerTranslation implements Serializable {
 
   @VisibleForTesting static final ProtoConverter CONVERTER = new ProtoConverter();

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/TriggerTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/TriggerTranslation.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.windowing.AfterAll;
 import org.apache.beam.sdk.transforms.windowing.AfterEach;
@@ -48,7 +49,7 @@ import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 /** Utilities for working with {@link TriggerTranslation Triggers}. */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class TriggerTranslation implements Serializable {
 
   @VisibleForTesting static final ProtoConverter CONVERTER = new ProtoConverter();

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/ProtoOverrides.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/ProtoOverrides.java
@@ -27,7 +27,6 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.ComponentsOrBuilder;
 import org.apache.beam.model.pipeline.v1.RunnerApi.MessageWithComponents;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Pipeline;
-import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.runners.PTransformOverride;
 
 /**
@@ -37,7 +36,6 @@ import org.apache.beam.sdk.runners.PTransformOverride;
  * code should rely on the more powerful and native {@link
  * org.apache.beam.sdk.Pipeline#replaceAll(List)}.
  */
-@Experimental
 public class ProtoOverrides {
   /**
    * Update all composites present in the {@code originalPipeline} with an URN equal to the provided

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryStateInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryStateInternals.java
@@ -28,8 +28,6 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.StateTag.StateBinder;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.state.BagState;
@@ -57,7 +55,6 @@ import org.joda.time.Instant;
  * In-memory implementation of {@link StateInternals}. Used in {@code BatchModeExecutionContext} and
  * for running tests that need state.
  */
-@Experimental(Kind.STATE)
 public class InMemoryStateInternals<K> implements StateInternals {
 
   public static <K> InMemoryStateInternals<K> forKey(@Nullable K key) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/MergingStateAccessor.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/MergingStateAccessor.java
@@ -18,8 +18,6 @@
 package org.apache.beam.runners.core;
 
 import java.util.Map;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.State;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 
@@ -28,7 +26,6 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
  *
  * <p>For internal use only.
  */
-@Experimental(Kind.STATE)
 public interface MergingStateAccessor<K, W extends BoundedWindow> extends StateAccessor<K> {
   /**
    * Analogous to {@link #access}, but returned as a map from each window which is about to be

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StateAccessor.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StateAccessor.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.core;
 
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.State;
 
 /**
@@ -26,7 +24,6 @@ import org.apache.beam.sdk.state.State;
  *
  * <p>For internal use only.
  */
-@Experimental(Kind.STATE)
 public interface StateAccessor<K> {
   /**
    * Access the storage for the given {@code address} in the current window.

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StateInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StateInternals.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.core;
 
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.State;
 import org.apache.beam.sdk.state.StateContext;
 import org.apache.beam.sdk.state.StateContexts;
@@ -39,7 +37,6 @@ import org.apache.beam.sdk.transforms.GroupByKey;
  * <p>This is a low-level API intended for use by the Beam SDK. It should not be used directly, and
  * is highly likely to change.
  */
-@Experimental(Kind.STATE)
 public interface StateInternals {
 
   /** The key for this {@link StateInternals}. */

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StateInternalsFactory.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StateInternalsFactory.java
@@ -18,8 +18,6 @@
 package org.apache.beam.runners.core;
 
 import java.io.Serializable;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /**
  * A factory for providing {@link StateInternals} for a particular key.
@@ -27,7 +25,6 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
  * <p>Because it will generally be embedded in a {@link org.apache.beam.sdk.transforms.DoFn DoFn},
  * albeit at execution time, it is marked {@link Serializable}.
  */
-@Experimental(Kind.STATE)
 public interface StateInternalsFactory<K> {
 
   /** Returns {@link StateInternals} for the provided key. */

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StateTag.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StateTag.java
@@ -19,8 +19,6 @@ package org.apache.beam.runners.core;
 
 import java.io.IOException;
 import java.io.Serializable;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
@@ -47,7 +45,6 @@ import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
  *
  * @param <StateT> The type of state being tagged.
  */
-@Experimental(Kind.STATE)
 public interface StateTag<StateT extends State> extends Serializable {
 
   /** Append the UTF-8 encoding of this tag to the given {@link Appendable}. */

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StateTags.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StateTags.java
@@ -20,8 +20,6 @@ package org.apache.beam.runners.core;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.state.BagState;
@@ -42,7 +40,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Equivalence
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 
 /** Static utility methods for creating {@link StateTag} instances. */
-@Experimental(Kind.STATE)
 public class StateTags {
 
   private static final CoderRegistry STANDARD_REGISTRY = CoderRegistry.createDefault();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternalsFactory.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternalsFactory.java
@@ -18,8 +18,6 @@
 package org.apache.beam.runners.core;
 
 import java.io.Serializable;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /**
  * A factory for providing {@link TimerInternals} for a particular key.
@@ -27,7 +25,6 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
  * <p>Because it will generally be embedded in a {@link org.apache.beam.sdk.transforms.DoFn DoFn},
  * albeit at execution time, it is marked {@link Serializable}.
  */
-@Experimental(Kind.STATE)
 public interface TimerInternalsFactory<K> {
 
   /** Returns {@link TimerInternals} for the provided key. */

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/CounterCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/CounterCell.java
@@ -19,9 +19,6 @@ package org.apache.beam.runners.core.metrics;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricsContainer;
@@ -34,7 +31,6 @@ import org.apache.beam.sdk.metrics.MetricsContainer;
  * In that case retrieving the underlying cell and reporting directly to it avoids a step of
  * indirection.
  */
-@Experimental(Kind.METRICS)
 public class CounterCell implements Counter, MetricCell<Long> {
 
   private final DirtyState dirty = new DirtyState();
@@ -46,7 +42,6 @@ public class CounterCell implements Counter, MetricCell<Long> {
    * MetricsContainerImpl}, unless they need to define their own version of {@link
    * MetricsContainer}. These constructors are *only* public so runners can instantiate.
    */
-  @Internal
   public CounterCell(MetricName name) {
     this.name = name;
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DirtyState.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DirtyState.java
@@ -20,9 +20,6 @@ package org.apache.beam.runners.core.metrics;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
-import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * Atomically tracks the dirty-state of a metric.
@@ -40,8 +37,6 @@ import org.apache.beam.sdk.annotations.Internal;
  * the next round of metric updating will see the changes. If this was for the final commit, then
  * the metric updates shouldn't be extracted until all possible user modifications have completed.
  */
-@Experimental(Kind.METRICS)
-@Internal
 public class DirtyState implements Serializable {
   private enum State {
     /** Indicates that there have been changes to the MetricCell since last commit. */

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionCell.java
@@ -19,9 +19,6 @@ package org.apache.beam.runners.core.metrics;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricsContainer;
@@ -34,7 +31,6 @@ import org.apache.beam.sdk.metrics.MetricsContainer;
  * context). In that case retrieving the underlying cell and reporting directly to it avoids a step
  * of indirection.
  */
-@Experimental(Kind.METRICS)
 public class DistributionCell implements Distribution, MetricCell<DistributionData> {
 
   private final DirtyState dirty = new DirtyState();
@@ -47,7 +43,6 @@ public class DistributionCell implements Distribution, MetricCell<DistributionDa
    * MetricsContainerImpl}, unless they need to define their own version of {@link
    * MetricsContainer}. These constructors are *only* public so runners can instantiate.
    */
-  @Internal
   public DistributionCell(MetricName name) {
     this.name = name;
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/GaugeCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/GaugeCell.java
@@ -19,9 +19,6 @@ package org.apache.beam.runners.core.metrics;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.metrics.Gauge;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricsContainer;
@@ -34,7 +31,6 @@ import org.apache.beam.sdk.metrics.MetricsContainer;
  * that case retrieving the underlying cell and reporting directly to it avoids a step of
  * indirection.
  */
-@Experimental(Kind.METRICS)
 public class GaugeCell implements Gauge, MetricCell<GaugeData> {
 
   private final DirtyState dirty = new DirtyState();
@@ -46,7 +42,6 @@ public class GaugeCell implements Gauge, MetricCell<GaugeData> {
    * MetricsContainerImpl}, unless they need to define their own version of {@link
    * MetricsContainer}. These constructors are *only* public so runners can instantiate.
    */
-  @Internal
   public GaugeCell(MetricName name) {
     this.name = name;
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/GaugeCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/GaugeCell.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.core.metrics;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.metrics.Gauge;
 import org.apache.beam.sdk.metrics.MetricName;
@@ -33,7 +34,7 @@ import org.apache.beam.sdk.metrics.MetricsContainer;
  * that case retrieving the underlying cell and reporting directly to it avoids a step of
  * indirection.
  */
-@Experimental(Experimental.Kind.METRICS)
+@Experimental(Kind.METRICS)
 public class GaugeCell implements Gauge, MetricCell<GaugeData> {
 
   private final DirtyState dirty = new DirtyState();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricCell.java
@@ -18,8 +18,6 @@
 package org.apache.beam.runners.core.metrics;
 
 import java.io.Serializable;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /**
  * A {@link MetricCell} is used for accumulating in-memory changes to a metric. It represents a
@@ -27,7 +25,6 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
  *
  * @param <DataT> The type of metric data stored (and extracted) from this cell.
  */
-@Experimental(Kind.METRICS)
 public interface MetricCell<DataT> extends Serializable {
   /**
    * Return the {@link DirtyState} tracking whether this metric cell contains uncommitted changes.

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricUpdates.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricUpdates.java
@@ -20,13 +20,10 @@ package org.apache.beam.runners.core.metrics;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.Collections;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 
 /** Representation of multiple metric updates. */
-@Experimental(Kind.METRICS)
 @AutoValue
 public abstract class MetricUpdates {
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
@@ -32,8 +32,6 @@ import org.apache.beam.model.pipeline.v1.MetricsApi.IntDistributionData;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.runners.core.construction.BeamUrns;
 import org.apache.beam.runners.core.metrics.MetricUpdates.MetricUpdate;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metric;
@@ -57,7 +55,6 @@ import org.slf4j.LoggerFactory;
  * <p>For consistency, all threads that update metrics should finish before getting the final
  * cumulative values/updates.
  */
-@Experimental(Kind.METRICS)
 public class MetricsContainerImpl implements Serializable, MetricsContainer {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsContainerImpl.class);

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsMap.java
@@ -23,8 +23,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 
@@ -32,7 +30,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterable
  * A map from {@code K} to {@code T} that supports getting or creating values associated with a key
  * in a thread-safe manner.
  */
-@Experimental(Kind.METRICS)
 public class MetricsMap<K, T> implements Serializable {
 
   /** Interface for creating instances to populate the {@link MetricsMap}. */

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsPusher.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsPusher.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsOptions;
@@ -36,7 +37,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterable
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /** Component that regularly merges metrics and pushes them to a metrics sink. */
-@Experimental(Experimental.Kind.METRICS)
+@Experimental(Kind.METRICS)
 public class MetricsPusher implements Serializable {
 
   private MetricsSink metricsSink;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsPusher.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsPusher.java
@@ -26,8 +26,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsOptions;
@@ -37,7 +35,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterable
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /** Component that regularly merges metrics and pushes them to a metrics sink. */
-@Experimental(Kind.METRICS)
 public class MetricsPusher implements Serializable {
 
   private MetricsSink metricsSink;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsTranslation.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsTranslation.java
@@ -22,8 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.cache.CacheBuilder;
@@ -31,7 +29,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.cache.CacheLoade
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.cache.LoadingCache;
 
 /** Translation utilities for metrics classes to/from Fn API. */
-@Experimental(Kind.METRICS)
 public abstract class MetricsTranslation {
 
   private MetricsTranslation() {}

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterAllStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterAllStateMachine.java
@@ -21,8 +21,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.util.Arrays;
 import java.util.List;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
@@ -30,7 +28,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  * A {@link TriggerStateMachine} that fires and finishes once after all of its sub-triggers have
  * fired.
  */
-@Experimental(Kind.TRIGGER)
 public class AfterAllStateMachine extends TriggerStateMachine {
 
   private AfterAllStateMachine(List<TriggerStateMachine> subTriggers) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterAllStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterAllStateMachine.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
@@ -29,7 +30,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  * A {@link TriggerStateMachine} that fires and finishes once after all of its sub-triggers have
  * fired.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterAllStateMachine extends TriggerStateMachine {
 
   private AfterAllStateMachine(List<TriggerStateMachine> subTriggers) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
@@ -26,8 +26,6 @@ import org.apache.beam.runners.core.StateAccessor;
 import org.apache.beam.runners.core.StateMerging;
 import org.apache.beam.runners.core.StateTag;
 import org.apache.beam.runners.core.StateTags;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.InstantCoder;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.GroupingState;
@@ -49,7 +47,6 @@ import org.joda.time.format.PeriodFormatter;
  */
 // This class should be inlined to subclasses and deleted, simplifying them too
 // https://issues.apache.org/jira/browse/BEAM-1486
-@Experimental(Kind.TRIGGER)
 public abstract class AfterDelayFromFirstElementStateMachine extends TriggerStateMachine {
 
   protected static final List<SerializableFunction<Instant, Instant>> IDENTITY = ImmutableList.of();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
@@ -27,6 +27,7 @@ import org.apache.beam.runners.core.StateMerging;
 import org.apache.beam.runners.core.StateTag;
 import org.apache.beam.runners.core.StateTags;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.InstantCoder;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.GroupingState;
@@ -48,7 +49,7 @@ import org.joda.time.format.PeriodFormatter;
  */
 // This class should be inlined to subclasses and deleted, simplifying them too
 // https://issues.apache.org/jira/browse/BEAM-1486
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public abstract class AfterDelayFromFirstElementStateMachine extends TriggerStateMachine {
 
   protected static final List<SerializableFunction<Instant, Instant>> IDENTITY = ImmutableList.of();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterFirstStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterFirstStateMachine.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
@@ -29,7 +30,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  * Create a composite {@link TriggerStateMachine} that fires once after at least one of its
  * sub-triggers have fired.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterFirstStateMachine extends TriggerStateMachine {
 
   AfterFirstStateMachine(List<TriggerStateMachine> subTriggers) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterFirstStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterFirstStateMachine.java
@@ -21,8 +21,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.util.Arrays;
 import java.util.List;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
@@ -30,7 +28,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  * Create a composite {@link TriggerStateMachine} that fires once after at least one of its
  * sub-triggers have fired.
  */
-@Experimental(Kind.TRIGGER)
 public class AfterFirstStateMachine extends TriggerStateMachine {
 
   AfterFirstStateMachine(List<TriggerStateMachine> subTriggers) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterPaneStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterPaneStateMachine.java
@@ -23,8 +23,6 @@ import org.apache.beam.runners.core.StateAccessor;
 import org.apache.beam.runners.core.StateMerging;
 import org.apache.beam.runners.core.StateTag;
 import org.apache.beam.runners.core.StateTags;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.transforms.Sum;
@@ -32,7 +30,6 @@ import org.apache.beam.sdk.transforms.Sum;
 /**
  * {@link TriggerStateMachine}s that fire based on properties of the elements in the current pane.
  */
-@Experimental(Kind.TRIGGER)
 public class AfterPaneStateMachine extends TriggerStateMachine {
 
   private static final StateTag<CombiningState<Long, long[], Long>> ELEMENTS_IN_PANE_TAG =

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterPaneStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterPaneStateMachine.java
@@ -24,6 +24,7 @@ import org.apache.beam.runners.core.StateMerging;
 import org.apache.beam.runners.core.StateTag;
 import org.apache.beam.runners.core.StateTags;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.transforms.Sum;
@@ -31,7 +32,7 @@ import org.apache.beam.sdk.transforms.Sum;
 /**
  * {@link TriggerStateMachine}s that fire based on properties of the elements in the current pane.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterPaneStateMachine extends TriggerStateMachine {
 
   private static final StateTag<CombiningState<Long, long[], Long>> ELEMENTS_IN_PANE_TAG =

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterProcessingTimeStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterProcessingTimeStateMachine.java
@@ -20,8 +20,6 @@ package org.apache.beam.runners.core.triggers;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.joda.time.Instant;
@@ -37,7 +35,6 @@ import org.joda.time.Instant;
  */
 // The superclass should be inlined here, its only real use
 // https://issues.apache.org/jira/browse/BEAM-1486
-@Experimental(Kind.TRIGGER)
 public class AfterProcessingTimeStateMachine extends AfterDelayFromFirstElementStateMachine {
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterProcessingTimeStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterProcessingTimeStateMachine.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.joda.time.Instant;
@@ -36,7 +37,7 @@ import org.joda.time.Instant;
  */
 // The superclass should be inlined here, its only real use
 // https://issues.apache.org/jira/browse/BEAM-1486
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterProcessingTimeStateMachine extends AfterDelayFromFirstElementStateMachine {
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
@@ -21,8 +21,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.util.Objects;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
@@ -53,7 +51,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  * AfterWatermark.pastEndOfWindow.withEarlyFirings(OnceTrigger)} or {@code
  * AfterWatermark.pastEndOfWindow.withEarlyFirings(OnceTrigger)}.
  */
-@Experimental(Kind.TRIGGER)
 public class AfterWatermarkStateMachine {
 
   private static final String TO_STRING = "AfterWatermark.pastEndOfWindow()";

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
@@ -52,7 +53,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  * AfterWatermark.pastEndOfWindow.withEarlyFirings(OnceTrigger)} or {@code
  * AfterWatermark.pastEndOfWindow.withEarlyFirings(OnceTrigger)}.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterWatermarkStateMachine {
 
   private static final String TO_STRING = "AfterWatermark.pastEndOfWindow()";

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/DefaultTriggerStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/DefaultTriggerStateMachine.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.core.triggers;
 
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 
 /**
@@ -26,7 +24,6 @@ import org.apache.beam.sdk.state.TimeDomain;
  * {@link RepeatedlyStateMachine#forever} and {@link AfterWatermarkStateMachine#pastEndOfWindow} for
  * more details.
  */
-@Experimental(Kind.TRIGGER)
 public class DefaultTriggerStateMachine extends TriggerStateMachine {
 
   private DefaultTriggerStateMachine() {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/DefaultTriggerStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/DefaultTriggerStateMachine.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.core.triggers;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 
 /**
@@ -25,7 +26,7 @@ import org.apache.beam.sdk.state.TimeDomain;
  * {@link RepeatedlyStateMachine#forever} and {@link AfterWatermarkStateMachine#pastEndOfWindow} for
  * more details.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class DefaultTriggerStateMachine extends TriggerStateMachine {
 
   private DefaultTriggerStateMachine() {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/Clock.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/Clock.java
@@ -17,11 +17,9 @@
  */
 package org.apache.beam.runners.direct;
 
-import org.apache.beam.sdk.annotations.Internal;
 import org.joda.time.Instant;
 
 /** Access to the current time. */
-@Internal
 @FunctionalInterface
 public interface Clock {
   /** Returns the current time as an {@link Instant}. */

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectTestOptions.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectTestOptions.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.runners.direct;
 
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
@@ -31,7 +30,6 @@ import org.apache.beam.sdk.options.PipelineOptions;
  * <p>Currently, the only use is to disable user-friendly overrides that prevent fully testing
  * certain composite transforms.
  */
-@Internal
 @Hidden
 public interface DirectTestOptions extends PipelineOptions, ApplicationNameOptions {
   @Default.Boolean(true)

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
@@ -56,7 +56,6 @@ import org.apache.beam.runners.core.TimerInternals.TimerData;
 import org.apache.beam.runners.local.Bundle;
 import org.apache.beam.runners.local.StructuralKey;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -137,7 +136,6 @@ import org.joda.time.Instant;
  * Watermark_PCollection = Watermark_Out_ProducingPTransform
  * </pre>
  */
-@Internal
 public class WatermarkManager<ExecutableT, CollectionT> {
   // The number of updates to apply in #tryApplyPendingUpdates
   private static final int MAX_INCREMENTAL_UPDATES = 10;

--- a/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSink.java
+++ b/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSink.java
@@ -26,6 +26,7 @@ import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.GaugeResult;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -55,7 +56,7 @@ public class MetricsGraphiteSink implements MetricsSink {
     this.charset = UTF_8;
   }
 
-  @Experimental(Experimental.Kind.METRICS)
+  @Experimental(Kind.METRICS)
   @Override
   public void writeMetrics(MetricQueryResults metricQueryResults) throws Exception {
     final long metricTimestamp = System.currentTimeMillis() / 1000L;

--- a/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSink.java
+++ b/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSink.java
@@ -25,8 +25,6 @@ import java.net.Socket;
 import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.regex.Pattern;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.GaugeResult;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -56,7 +54,6 @@ public class MetricsGraphiteSink implements MetricsSink {
     this.charset = UTF_8;
   }
 
-  @Experimental(Kind.METRICS)
   @Override
   public void writeMetrics(MetricQueryResults metricQueryResults) throws Exception {
     final long metricTimestamp = System.currentTimeMillis() / 1000L;

--- a/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSink.java
+++ b/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSink.java
@@ -34,8 +34,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import javax.xml.ws.http.HTTPException;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -52,7 +50,6 @@ public class MetricsHttpSink implements MetricsSink {
     this.urlString = pipelineOptions.getMetricsHttpSinkUrl();
   }
 
-  @Experimental(Kind.METRICS)
   @Override
   public void writeMetrics(MetricQueryResults metricQueryResults) throws Exception {
     URL url = new URL(urlString);

--- a/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSink.java
+++ b/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSink.java
@@ -35,6 +35,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import javax.xml.ws.http.HTTPException;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -51,7 +52,7 @@ public class MetricsHttpSink implements MetricsSink {
     this.urlString = pipelineOptions.getMetricsHttpSinkUrl();
   }
 
-  @Experimental(Experimental.Kind.METRICS)
+  @Experimental(Kind.METRICS)
   @Override
   public void writeMetrics(MetricQueryResults metricQueryResults) throws Exception {
     URL url = new URL(urlString);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -85,7 +85,6 @@ import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -1721,7 +1720,6 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
    * A marker {@link DoFn} for writing the contents of a {@link PCollection} to a streaming {@link
    * PCollectionView} backend implementation.
    */
-  @Internal
   public static class StreamingPCollectionViewWriterFn<T> extends DoFn<Iterable<T>, T> {
     private final PCollectionView<?> view;
     private final Coder<T> dataCoder;

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
@@ -23,7 +23,6 @@ import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.util.OutputReference;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.runners.AppliedPTransform;
@@ -39,7 +38,6 @@ import org.apache.beam.sdk.values.TupleTag;
  * A {@link TransformTranslator} knows how to translate a particular subclass of {@link PTransform}
  * for the Cloud Dataflow service. It does so by mutating the {@link TranslationContext}.
  */
-@Internal
 public interface TransformTranslator<TransformT extends PTransform> {
   void translate(TransformT transform, TranslationContext context);
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineWorkerPoolOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineWorkerPoolOptions.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.dataflow.DataflowRunnerInfo;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.DefaultValueFactory;
@@ -47,7 +48,7 @@ public interface DataflowPipelineWorkerPoolOptions extends GcpOptions {
   void setNumWorkers(int value);
 
   /** Type of autoscaling algorithm to use. */
-  @Experimental(Experimental.Kind.AUTOSCALING)
+  @Experimental(Kind.AUTOSCALING)
   enum AutoscalingAlgorithmType {
     /** Use numWorkers machines. Do not autoscale the worker pool. */
     NONE("AUTOSCALING_ALGORITHM_NONE"),
@@ -86,7 +87,7 @@ public interface DataflowPipelineWorkerPoolOptions extends GcpOptions {
           + "BASIC (deprecated): autoscale the worker pool size up to maxNumWorkers until the job "
           + "completes. "
           + "THROUGHPUT_BASED: autoscale the workerpool based on throughput (up to maxNumWorkers).")
-  @Experimental(Experimental.Kind.AUTOSCALING)
+  @Experimental(Kind.AUTOSCALING)
   AutoscalingAlgorithmType getAutoscalingAlgorithm();
 
   void setAutoscalingAlgorithm(AutoscalingAlgorithmType value);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
@@ -46,7 +46,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.gcp.storage.GcsCreateOptions;
 import org.apache.beam.sdk.extensions.gcp.util.BackOffAdapter;
 import org.apache.beam.sdk.io.FileSystems;
@@ -70,7 +69,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Helper routines for packages. */
-@Internal
 class PackageUtil implements Closeable {
 
   private static final Logger LOG = LoggerFactory.getLogger(PackageUtil.class);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/PortablePipelineResult.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/PortablePipelineResult.java
@@ -21,8 +21,6 @@ import org.apache.beam.model.jobmanagement.v1.JobApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /** Result of a portable {@link PortablePipelineRunner#run(RunnerApi.Pipeline, JobInfo)}. */
 public interface PortablePipelineResult extends PipelineResult {
@@ -32,6 +30,5 @@ public interface PortablePipelineResult extends PipelineResult {
    *
    * @throws UnsupportedOperationException if the runner doesn't support retrieving metrics.
    */
-  @Experimental(Kind.METRICS)
   JobApi.MetricResults portableMetrics() throws UnsupportedOperationException;
 }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/PortablePipelineResult.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/PortablePipelineResult.java
@@ -22,6 +22,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /** Result of a portable {@link PortablePipelineRunner#run(RunnerApi.Pipeline, JobInfo)}. */
 public interface PortablePipelineResult extends PipelineResult {
@@ -31,6 +32,6 @@ public interface PortablePipelineResult extends PipelineResult {
    *
    * @throws UnsupportedOperationException if the runner doesn't support retrieving metrics.
    */
-  @Experimental(Experimental.Kind.METRICS)
+  @Experimental(Kind.METRICS)
   JobApi.MetricResults portableMetrics() throws UnsupportedOperationException;
 }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/state/SamzaMapState.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/state/SamzaMapState.java
@@ -20,11 +20,12 @@ package org.apache.beam.runners.samza.state;
 import java.util.Iterator;
 import java.util.Map;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.MapState;
 import org.apache.beam.sdk.state.ReadableState;
 
 /** Samza's extended MapState, allowing extra access methods to the state. */
-@Experimental(Experimental.Kind.STATE)
+@Experimental(Kind.STATE)
 public interface SamzaMapState<KeyT, ValueT> extends MapState<KeyT, ValueT> {
 
   /**

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/state/SamzaMapState.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/state/SamzaMapState.java
@@ -19,13 +19,10 @@ package org.apache.beam.runners.samza.state;
 
 import java.util.Iterator;
 import java.util.Map;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.MapState;
 import org.apache.beam.sdk.state.ReadableState;
 
 /** Samza's extended MapState, allowing extra access methods to the state. */
-@Experimental(Kind.STATE)
 public interface SamzaMapState<KeyT, ValueT> extends MapState<KeyT, ValueT> {
 
   /**

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/state/SamzaSetState.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/state/SamzaSetState.java
@@ -19,11 +19,12 @@ package org.apache.beam.runners.samza.state;
 
 import java.util.Iterator;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.SetState;
 
 /** Samza's extended SetState, allowing extra access methods to the state. */
-@Experimental(Experimental.Kind.STATE)
+@Experimental(Kind.STATE)
 public interface SamzaSetState<T> extends SetState<T> {
 
   /**

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/state/SamzaSetState.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/state/SamzaSetState.java
@@ -18,13 +18,10 @@
 package org.apache.beam.runners.samza.state;
 
 import java.util.Iterator;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.SetState;
 
 /** Samza's extended SetState, allowing extra access methods to the state. */
-@Experimental(Kind.STATE)
 public interface SamzaSetState<T> extends SetState<T> {
 
   /**

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunner.java
@@ -34,7 +34,6 @@ import org.apache.beam.runners.spark.structuredstreaming.translation.batch.Pipel
 import org.apache.beam.runners.spark.structuredstreaming.translation.streaming.PipelineTranslatorStreaming;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineRunner;
-import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -66,7 +65,6 @@ import org.slf4j.LoggerFactory;
  * SparkStructuredStreamingPipelineResult result = (SparkStructuredStreamingPipelineResult) p.run();
  * }
  */
-@Experimental(value = Experimental.Kind.WITH_EXCEPTIONS)
 public final class SparkStructuredStreamingRunner
     extends PipelineRunner<SparkStructuredStreamingPipelineResult> {
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkCombineFn.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkCombineFn.java
@@ -41,7 +41,6 @@ import org.apache.beam.runners.core.SideInputReader;
 import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.spark.util.SideInputBroadcast;
 import org.apache.beam.runners.spark.util.SparkSideInputReader;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.IterableCoder;
@@ -770,7 +769,6 @@ public class SparkCombineFn<InputT, ValueT, AccumT, OutputT> implements Serializ
   }
 
   /** Extracts the stream of accumulated values. */
-  @Internal
   public Stream<WindowedValue<OutputT>> extractOutputStream(
       WindowedAccumulator<?, ?, AccumT, ?> accumulator) {
     return accumulator.extractOutput().stream()

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SparkCompat.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SparkCompat.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.beam.runners.spark.translation.SparkCombineFn;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -32,7 +31,6 @@ import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
 
 /** A set of functions to provide API compatibility between Spark 2 and Spark 3. */
-@Internal
 public class SparkCompat {
   /**
    * Union of dStreams in the given StreamingContext.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/Experimental.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/Experimental.java
@@ -36,6 +36,7 @@ import java.lang.annotation.Target;
   ElementType.CONSTRUCTOR,
   ElementType.FIELD,
   ElementType.METHOD,
+  ElementType.PACKAGE,
   ElementType.TYPE
 })
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/Experimental.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/Experimental.java
@@ -109,5 +109,8 @@ public @interface Experimental {
 
     /** Experimental APIs related to exception handling in PTransforms. */
     WITH_EXCEPTIONS,
+
+    /** Portability related APIs. */
+    PORTABILITY,
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/Internal.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/Internal.java
@@ -35,6 +35,7 @@ import java.lang.annotation.Target;
   ElementType.CONSTRUCTOR,
   ElementType.FIELD,
   ElementType.METHOD,
+  ElementType.PACKAGE,
   ElementType.TYPE
 })
 @Documented

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/package-info.java
@@ -17,6 +17,7 @@
  */
 /** Defines annotations used across the SDK. */
 @DefaultAnnotation(NonNull.class)
+@Internal
 package org.apache.beam.sdk.annotations;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/expansion/ExternalTransformRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/expansion/ExternalTransformRegistrar.java
@@ -19,13 +19,14 @@ package org.apache.beam.sdk.expansion;
 
 import java.util.Map;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.ExternalTransformBuilder;
 
 /**
  * A registrar which contains a mapping from URNs to available {@link ExternalTransformBuilder}s.
  * Should be used with {@link com.google.auto.service.AutoService}.
  */
-@Experimental
+@Experimental(Kind.PORTABILITY)
 public interface ExternalTransformRegistrar {
 
   /** A mapping from URN to an {@link ExternalTransformBuilder} class. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/expansion/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/expansion/package-info.java
@@ -17,7 +17,10 @@
  */
 /** Contains classes needed to expose transforms to other SDKs. */
 @DefaultAnnotation(NonNull.class)
+@Experimental(Kind.PORTABILITY)
 package org.apache.beam.sdk.expansion;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/harness/JvmInitializer.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/harness/JvmInitializer.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.harness;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.PipelineOptions;
 
 /**
@@ -33,6 +34,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
  * automate this.
  */
 @Experimental
+@Internal
 public interface JvmInitializer {
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/harness/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/harness/package-info.java
@@ -18,7 +18,9 @@
 
 /** Utilities for configuring worker environment. */
 @DefaultAnnotation(NonNull.class)
+@Internal
 package org.apache.beam.sdk.harness;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.beam.sdk.annotations.Internal;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -1769,7 +1769,7 @@ public class AvroIO {
    * A {@link Sink} for use with {@link FileIO#write} and {@link FileIO#writeDynamic}, writing
    * elements with a given (common) schema, like {@link #writeGenericRecords(Schema)}.
    */
-  @Experimental
+  @Experimental(Kind.SOURCE_SINK)
   public static <ElementT extends IndexedRecord> Sink<ElementT> sink(Schema schema) {
     return sink(schema.toString());
   }
@@ -1778,7 +1778,7 @@ public class AvroIO {
    * A {@link Sink} for use with {@link FileIO#write} and {@link FileIO#writeDynamic}, writing
    * elements with a given (common) schema, like {@link #writeGenericRecords(String)}.
    */
-  @Experimental
+  @Experimental(Kind.SOURCE_SINK)
   public static <ElementT extends IndexedRecord> Sink<ElementT> sink(String jsonSchema) {
     return new AutoValue_AvroIO_Sink.Builder<ElementT>()
         .setJsonSchema(jsonSchema)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
@@ -55,6 +55,7 @@ import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
@@ -129,7 +130,7 @@ import org.apache.commons.compress.utils.IOUtils;
  * @param <T> The type of records to be read from the source.
  */
 // CHECKSTYLE.ON: JavadocStyle
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class AvroSource<T> extends BlockBasedSource<T> {
   // Default minimum bundle size (chosen as two default-size Avro blocks to attempt to
   // ensure that every source has at least one block of records).
@@ -512,7 +513,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
    *
    * @param <T> The type of records stored in the block.
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   static class AvroBlock<T> extends Block<T> {
     private final Mode<T> mode;
 
@@ -615,7 +616,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
    *
    * @param <T> The type of records contained in the block.
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   public static class AvroReader<T> extends BlockBasedReader<T> {
     // Initialized in startReading.
     @Nullable private AvroMetadata metadata;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -59,7 +60,7 @@ import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
  *
  * @param <T> The type of records to be read from the source.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
   /**
    * Creates a {@code BlockBasedSource} based on a file name or pattern. Subclasses must call this
@@ -111,7 +112,7 @@ public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
   protected abstract BlockBasedReader<T> createSingleFileReader(PipelineOptions options);
 
   /** A {@code Block} represents a block of records that can be read. */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   protected abstract static class Block<T> {
     /** Returns the current record. */
     public abstract T getCurrentRecord();
@@ -135,7 +136,7 @@ public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
    * subrange of a file, the blocks that will be read by this reader are those such that the first
    * byte of the block is within the range {@code [start, end)}.
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   protected abstract static class BlockBasedReader<T> extends FileBasedReader<T> {
     private boolean atSplitPoint;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.range.OffsetRangeTracker;
 import org.apache.beam.sdk.io.range.RangeTracker;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -103,7 +104,7 @@ public abstract class BoundedSource<T> extends Source<T> {
    * org.apache.beam.sdk.io.range.RangeTracker} to manage the (source-specific) range of positions
    * that is being split.
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   public abstract static class BoundedReader<T> extends Source.Reader<T> {
     /**
      * Returns a value in [0, 1] representing approximately what fraction of the {@link

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -28,6 +28,7 @@ import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -60,7 +61,7 @@ import org.joda.time.Instant;
  *
  * @param <T> The type to read from the compressed file.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class CompressedSource<T> extends FileBasedSource<T> {
   /**
    * Factory interface for creating channels that decompress the content of an underlying channel.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -562,7 +563,7 @@ public class FileIO {
      *
      * <p>This works only in runners supporting {@link Experimental.Kind#SPLITTABLE_DO_FN}.
      */
-    @Experimental(Experimental.Kind.SPLITTABLE_DO_FN)
+    @Experimental(Kind.SPLITTABLE_DO_FN)
     public Match continuously(
         Duration pollInterval, TerminationCondition<String, ?> terminationCondition) {
       return withConfiguration(getConfiguration().continuously(pollInterval, terminationCondition));
@@ -611,7 +612,7 @@ public class FileIO {
     }
 
     /** Like {@link Match#continuously}. */
-    @Experimental(Experimental.Kind.SPLITTABLE_DO_FN)
+    @Experimental(Kind.SPLITTABLE_DO_FN)
     public MatchAll continuously(
         Duration pollInterval, TerminationCondition<String, ?> terminationCondition) {
       return withConfiguration(getConfiguration().continuously(pollInterval, terminationCondition));
@@ -825,7 +826,7 @@ public class FileIO {
 
   /** Implementation of {@link #write} and {@link #writeDynamic}. */
   @AutoValue
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   public abstract static class Write<DestinationT, UserT>
       extends PTransform<PCollection<UserT>, WriteFilesResult<DestinationT>> {
     /** A policy for generating names for shard files. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ReadAllViaFileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ReadAllViaFileBasedSource.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io;
 
 import java.io.IOException;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.FileIO.ReadableFile;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
@@ -40,7 +41,7 @@ import org.apache.beam.sdk.values.PCollection;
  * <p>To obtain the collection of {@link ReadableFile} from a filepattern, use {@link
  * FileIO#readMatches()}.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class ReadAllViaFileBasedSource<T>
     extends PTransform<PCollection<ReadableFile>, PCollection<T>> {
   private final long desiredBundleSizeBytes;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Source.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Source.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.NoSuchElementException;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
@@ -50,7 +51,7 @@ import org.joda.time.Instant;
  *
  * @param <T> Type of elements read by the source.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public abstract class Source<T> implements Serializable, HasDisplayData {
   /**
    * Checks that this source is valid, before it can be used in a pipeline.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/UnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/UnboundedSource.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.joda.time.Instant;
@@ -144,7 +145,7 @@ public abstract class UnboundedSource<
    *
    * <p>A given {@code UnboundedReader} object will only be accessed by a single thread at once.
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   public abstract static class UnboundedReader<OutputT> extends Source.Reader<OutputT> {
     private static final byte[] EMPTY = new byte[0];
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -106,7 +107,7 @@ import org.slf4j.LoggerFactory;
  *
  * <pre>{@code p.apply(WriteFiles.to(new MySink(...)).withNumShards(3));}</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 @AutoValue
 public abstract class WriteFiles<UserT, DestinationT, OutputT>
     extends PTransform<PCollection<UserT>, WriteFilesResult<DestinationT>> {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MatchResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MatchResult.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.FileSystems;
 
 /** The result of {@link org.apache.beam.sdk.io.FileSystem#match}. */
@@ -107,7 +108,7 @@ public abstract class MatchResult {
      *     .apply(WithTimestamps.of(metadata -> new Instant(metadata.lastModifiedMillis())));
      * }</pre>
      */
-    @Experimental
+    @Experimental(Kind.FILESYSTEM)
     public abstract long lastModifiedMillis();
 
     public static Builder builder() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MetadataCoderV2.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MetadataCoderV2.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.VarLongCoder;
@@ -28,7 +29,7 @@ import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata.Builder;
 
 /** A {@link Coder} for {@link Metadata} that includes {@link Metadata#lastModifiedMillis()}. */
-@Experimental
+@Experimental(Kind.FILESYSTEM)
 public class MetadataCoderV2 extends AtomicCoder<Metadata> {
   private static final MetadataCoderV2 INSTANCE = new MetadataCoderV2();
   private static final MetadataCoder V1_CODER = MetadataCoder.of();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/DelegatingCounter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/DelegatingCounter.java
@@ -17,12 +17,11 @@
  */
 package org.apache.beam.sdk.metrics;
 
-// Intentionally package private, this is meant to be used with Metrics.java and
-// LabeledMetrics.java
-
 import java.io.Serializable;
+import org.apache.beam.sdk.annotations.Internal;
 
 /** Implementation of {@link Counter} that delegates to the instance for the current context. */
+@Internal
 public class DelegatingCounter implements Metric, Counter, Serializable {
   private final MetricName name;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Gauge.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Gauge.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.metrics;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /**
  * A metric that reports the latest value out of reported values.
@@ -25,7 +26,7 @@ import org.apache.beam.sdk.annotations.Experimental;
  * <p>Since metrics are collected from many workers the value may not be the absolute last, but one
  * of the latest values.
  */
-@Experimental(Experimental.Kind.METRICS)
+@Experimental(Kind.METRICS)
 public interface Gauge extends Metric {
   /** Set current value for this gauge. */
   void set(long value);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricsOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricsOptions.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.metrics;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
@@ -25,7 +26,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 
 /** Extension of {@link PipelineOptions} that defines {@link MetricsSink} specific options. */
-@Experimental(Experimental.Kind.METRICS)
+@Experimental(Kind.METRICS)
 public interface MetricsOptions extends PipelineOptions {
   @Description("The beam sink class to which the metrics will be pushed")
   @Default.InstanceFactory(NoOpMetricsSink.class)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricsSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricsSink.java
@@ -19,9 +19,10 @@ package org.apache.beam.sdk.metrics;
 
 import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /** Interface for all metric sinks. */
-@Experimental(Experimental.Kind.METRICS)
+@Experimental(Kind.METRICS)
 public interface MetricsSink extends Serializable {
   void writeMetrics(MetricQueryResults metricQueryResults) throws Exception;
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/package-info.java
@@ -25,7 +25,10 @@
  * to support metrics.
  */
 @DefaultAnnotation(NonNull.class)
+@Experimental(Kind.METRICS)
 package org.apache.beam.sdk.metrics;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ManualDockerEnvironmentOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ManualDockerEnvironmentOptions.java
@@ -19,10 +19,11 @@ package org.apache.beam.sdk.options;
 
 import com.google.auto.service.AutoService;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
 /** Pipeline options to tune DockerEnvironment. */
-@Experimental
+@Experimental(Kind.PORTABILITY)
 @Hidden
 public interface ManualDockerEnvironmentOptions extends PipelineOptions {
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -537,7 +537,7 @@ public class PipelineOptionsFactory {
    * @see PipelineOptionsFactory#register(Class)
    * @see Cache#Cache()
    */
-  @Experimental(Experimental.Kind.UNSPECIFIED)
+  @Experimental
   public static synchronized void resetCache() {
     CACHE.set(new Cache());
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
@@ -19,9 +19,12 @@ package org.apache.beam.sdk.options;
 
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.options.Validation.Required;
 
 /** Pipeline options common to all portable runners. */
+@Experimental(Kind.PORTABILITY)
 public interface PortablePipelineOptions extends PipelineOptions {
 
   // TODO: https://issues.apache.org/jira/browse/BEAM-4106: Consider pulling this out into a new

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/RemoteEnvironmentOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/RemoteEnvironmentOptions.java
@@ -19,10 +19,11 @@ package org.apache.beam.sdk.options;
 
 import com.google.auto.service.AutoService;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
 /** Options that are used to control configuration of the remote environment. */
-@Experimental
+@Experimental(Kind.PORTABILITY)
 @Hidden
 public interface RemoteEnvironmentOptions extends PipelineOptions {
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
@@ -24,9 +24,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /** Options that are used to control configuration of the SDK harness. */
-@Experimental
+@Experimental(Kind.PORTABILITY)
 @Description("Options that are used to control configuration of the SDK harness.")
 public interface SdkHarnessOptions extends PipelineOptions {
   /** The set of log levels that can be used in the SDK harness. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/package-info.java
@@ -21,7 +21,9 @@
  * <p>Internals for use by runners.
  */
 @DefaultAnnotation(NonNull.class)
+@Internal
 package org.apache.beam.sdk.runners;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.beam.sdk.annotations.Internal;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/package-info.java
@@ -22,7 +22,10 @@
  * <p>For further details, see the documentation for each class in this package.
  */
 @DefaultAnnotation(NonNull.class)
+@Experimental(Kind.SCHEMAS)
 package org.apache.beam.sdk.schemas;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/TimeDomain.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/TimeDomain.java
@@ -18,13 +18,14 @@
 package org.apache.beam.sdk.state;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * {@link TimeDomain} specifies whether an operation is based on timestamps of elements or current
  * "real-world" time as reported while processing.
  */
-@Experimental(Experimental.Kind.TIMERS)
+@Experimental(Kind.TIMERS)
 public enum TimeDomain {
   /**
    * The {@link #EVENT_TIME} domain corresponds to the timestamps on the elements. Time advances on

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/Timer.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/Timer.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.state;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -40,7 +41,7 @@ import org.joda.time.Instant;
  * <p>Timer callbacks are not guaranteed to be called immediately according to the local view of the
  * {@link TimeDomain}, but will be called at some time after the requested time, in timestamp order.
  */
-@Experimental(Experimental.Kind.TIMERS)
+@Experimental(Kind.TIMERS)
 public interface Timer {
   /**
    * Sets or resets the time in the timer's {@link TimeDomain} at which it should fire. If the timer

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/TimerMap.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/TimerMap.java
@@ -18,9 +18,10 @@
 package org.apache.beam.sdk.state;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.joda.time.Instant;
 
-@Experimental(Experimental.Kind.TIMERS)
+@Experimental(Kind.TIMERS)
 public interface TimerMap {
 
   void set(String timerId, Instant absoluteTime);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/Timers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/Timers.java
@@ -19,10 +19,11 @@ package org.apache.beam.sdk.state;
 
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.joda.time.Instant;
 
 /** Interface for interacting with time. */
-@Experimental(Experimental.Kind.TIMERS)
+@Experimental(Kind.TIMERS)
 public interface Timers {
   /**
    * Sets a timer to fire when the event time watermark, the current processing time, or the

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/package-info.java
@@ -18,7 +18,10 @@
 
 /** Classes and interfaces for interacting with state. */
 @DefaultAnnotation(NonNull.class)
+@Experimental(Kind.STATE)
 package org.apache.beam.sdk.state;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/DataflowPortabilityApiUnsupported.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/DataflowPortabilityApiUnsupported.java
@@ -17,5 +17,8 @@
  */
 package org.apache.beam.sdk.testing;
 
+import org.apache.beam.sdk.annotations.Internal;
+
 /** Category tag for the dataflow fn-api worker unsupported tests. */
+@Internal
 public interface DataflowPortabilityApiUnsupported {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/FlattenWithHeterogeneousCoders.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/FlattenWithHeterogeneousCoders.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.testing;
 
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.values.PCollection;
@@ -26,4 +27,5 @@ import org.apache.beam.sdk.values.PCollectionList;
  * Category tag for tests that use a {@link Flatten} where the input {@link PCollectionList}
  * contains {@link PCollection PCollections} heterogeneous {@link Coder coders}.
  */
+@Internal
 public interface FlattenWithHeterogeneousCoders {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -276,6 +276,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
   }
 
   /** Information accessible when running a {@link DoFn.OnTimer} method. */
+  @Experimental(Kind.TIMERS)
   public abstract class OnTimerContext extends WindowedContext {
 
     /** Returns the timestamp of the current timer. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnOutputReceivers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnOutputReceivers.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.transforms.DoFn.MultiOutputReceiver;
@@ -31,6 +32,7 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.joda.time.Instant;
 
 /** Common {@link OutputReceiver} and {@link MultiOutputReceiver} classes. */
+@Internal
 public class DoFnOutputReceivers {
   private static class RowOutputReceiver<T> implements OutputReceiver<Row> {
     WindowedContextOutputReceiver<T> outputReceiver;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnSchemaInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnSchemaInformation.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -37,6 +38,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
 /** Represents information about how a DoFn extracts schemas. */
 @Experimental(Kind.SCHEMAS)
 @AutoValue
+@Internal
 public abstract class DoFnSchemaInformation implements Serializable {
   /**
    * The schema of the @Element parameter. If the Java type does not match the input PCollection but

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ExternalTransformBuilder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ExternalTransformBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.transforms;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.expansion.ExternalTransformRegistrar;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.POutput;
@@ -38,7 +39,7 @@ import org.apache.beam.sdk.values.POutput;
  * @param <InputT> The input type of the externally configured PTransform.
  * @param <OutputT> The output type of the externally configured PTransform.
  */
-@Experimental
+@Experimental(Kind.PORTABILITY)
 public interface ExternalTransformBuilder<ConfigT, InputT extends PInput, OutputT extends POutput> {
 
   /** Builds the transform after it has been configured. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FlatMapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FlatMapElements.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.Contextful.Fn;
 import org.apache.beam.sdk.transforms.WithFailures.ExceptionElement;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -130,7 +131,7 @@ public class FlatMapElements<InputT, OutputT>
   }
 
   /** Like {@link #via(ProcessFunction)}, but allows access to additional context. */
-  @Experimental(Experimental.Kind.CONTEXTFUL)
+  @Experimental(Kind.CONTEXTFUL)
   public <NewInputT> FlatMapElements<NewInputT, OutputT> via(
       Contextful<Fn<NewInputT, Iterable<OutputT>>> fn) {
     return new FlatMapElements<>(
@@ -196,7 +197,7 @@ public class FlatMapElements<InputT, OutputT>
    * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
    * WithFailures.Result}.
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public <NewFailureT> FlatMapWithFailures<InputT, OutputT, NewFailureT> exceptionsInto(
       TypeDescriptor<NewFailureT> failureTypeDescriptor) {
     return new FlatMapWithFailures<>(
@@ -227,7 +228,7 @@ public class FlatMapElements<InputT, OutputT>
    * PCollection<String> failures = result.failures();
    * }</pre>
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public <FailureT> FlatMapWithFailures<InputT, OutputT, FailureT> exceptionsVia(
       InferableFunction<ExceptionElement<InputT>, FailureT> exceptionHandler) {
     return new FlatMapWithFailures<>(
@@ -240,7 +241,7 @@ public class FlatMapElements<InputT, OutputT>
   }
 
   /** A {@code PTransform} that adds exception handling to {@link FlatMapElements}. */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public static class FlatMapWithFailures<InputT, OutputT, FailureT>
       extends PTransform<PCollection<InputT>, WithFailures.Result<PCollection<OutputT>, FailureT>> {
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
@@ -182,7 +182,7 @@ public class MapElements<InputT, OutputT>
    * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
    * WithFailures.Result}.
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public <NewFailureT> MapWithFailures<InputT, OutputT, NewFailureT> exceptionsInto(
       TypeDescriptor<NewFailureT> failureTypeDescriptor) {
     return new MapWithFailures<>(
@@ -212,7 +212,7 @@ public class MapElements<InputT, OutputT>
    * PCollection<String> failures = result.failures();
    * }</pre>
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public <FailureT> MapWithFailures<InputT, OutputT, FailureT> exceptionsVia(
       InferableFunction<ExceptionElement<InputT>, FailureT> exceptionHandler) {
     return new MapWithFailures<>(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -122,7 +123,7 @@ import org.slf4j.LoggerFactory;
  * <p>Note: This transform works only in runners supporting Splittable DoFn: see <a
  * href="https://beam.apache.org/documentation/runners/capability-matrix/">capability matrix</a>.
  */
-@Experimental(Experimental.Kind.SPLITTABLE_DO_FN)
+@Experimental(Kind.SPLITTABLE_DO_FN)
 public class Watch {
   private static final Logger LOG = LoggerFactory.getLogger(Watch.class);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithFailures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithFailures.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
@@ -67,7 +68,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  *      .apply("FlattenFailureCollections", Flatten.pCollections());
  * }</pre>
  */
-@Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+@Experimental(Kind.WITH_EXCEPTIONS)
 public class WithFailures {
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -99,7 +99,7 @@ import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.matcher.ElementMatc
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Primitives;
 
 /** Dynamically generates a {@link DoFnInvoker} instances for invoking a {@link DoFn}. */
-public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
+class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
 
   public static final String START_BUNDLE_CONTEXT_PARAMETER_METHOD = "startBundleContext";
   public static final String FINISH_BUNDLE_CONTEXT_PARAMETER_METHOD = "finishBundleContext";

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
@@ -17,9 +17,11 @@
  */
 package org.apache.beam.sdk.transforms.reflect;
 
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.DoFn;
 
 /** Static utilities for working with {@link DoFnInvoker}. */
+@Internal
 public class DoFnInvokers {
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.state.State;
@@ -57,6 +58,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Predicates;
  * <p>See <a href="https://s.apache.org/a-new-dofn">A new DoFn</a>.
  */
 @AutoValue
+@Internal
 public abstract class DoFnSignature {
   /** Class of the original {@link DoFn} from which this signature was produced. */
   public abstract Class<? extends DoFn<?, ?>> fnClass();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
@@ -83,6 +84,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.joda.time.Instant;
 
 /** Utilities for working with {@link DoFnSignature}. See {@link #getSignature}. */
+@Internal
 public class DoFnSignatures {
 
   private DoFnSignatures() {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/OnTimerInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/OnTimerInvoker.java
@@ -17,9 +17,11 @@
  */
 package org.apache.beam.sdk.transforms.reflect;
 
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.DoFn.OnTimer;
 
 /** Interface for invoking the {@link OnTimer} method for a particular timer. */
+@Internal
 public interface OnTimerInvoker<InputT, OutputT> {
 
   /** Invoke the {@link OnTimer} method in the provided context. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/package-info.java
@@ -23,7 +23,9 @@
  * org.apache.beam.sdk.transforms.reflect.DoFnInvoker}'s from them.
  */
 @DefaultAnnotation(NonNull.class)
+@Internal
 package org.apache.beam.sdk.transforms.reflect;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.beam.sdk.annotations.Internal;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTracker.java
@@ -22,6 +22,8 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.range.ByteKey;
 import org.apache.beam.sdk.io.range.ByteKeyRange;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
@@ -36,6 +38,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Bytes
  * <p>Note, one can complete a range by claiming the {@link ByteKey#EMPTY} once one runs out of keys
  * to process.
  */
+@Experimental(Kind.SPLITTABLE_DO_FN)
 public class ByteKeyRangeTracker extends RestrictionTracker<ByteKeyRange, ByteKey>
     implements Sizes.HasSize {
   /* An empty range which contains no keys. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/HasDefaultTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/HasDefaultTracker.java
@@ -17,11 +17,15 @@
  */
 package org.apache.beam.sdk.transforms.splittabledofn;
 
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+
 /**
  * Interface for restrictions for which a default implementation of {@link
  * org.apache.beam.sdk.transforms.DoFn.NewTracker} is available, depending only on the restriction
  * itself.
  */
+@Experimental(Kind.SPLITTABLE_DO_FN)
 public interface HasDefaultTracker<
     RestrictionT extends HasDefaultTracker<RestrictionT, TrackerT>,
     TrackerT extends RestrictionTracker<RestrictionT, ?>> {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
@@ -22,6 +22,8 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.range.OffsetRange;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 
@@ -29,6 +31,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects
  * A {@link RestrictionTracker} for claiming offsets in an {@link OffsetRange} in a monotonically
  * increasing fashion.
  */
+@Experimental(Kind.SPLITTABLE_DO_FN)
 public class OffsetRangeTracker extends RestrictionTracker<OffsetRange, Long>
     implements Sizes.HasSize {
   private OffsetRange range;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -17,12 +17,15 @@
  */
 package org.apache.beam.sdk.transforms.splittabledofn;
 
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
 
 /**
  * Manages access to the restriction and keeps track of its claimed part for a <a
  * href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn}.
  */
+@Experimental(Kind.SPLITTABLE_DO_FN)
 public abstract class RestrictionTracker<RestrictionT, PositionT> {
   /**
    * Attempts to claim the block of work in the current restriction identified by the given

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/Sizes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/Sizes.java
@@ -17,7 +17,11 @@
  */
 package org.apache.beam.sdk.transforms.splittabledofn;
 
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+
 /** Definitions and convenience methods for reporting sizes for SplittableDoFns. */
+@Experimental(Kind.SPLITTABLE_DO_FN)
 public final class Sizes {
   /**
    * {@link RestrictionTracker}s which can provide a size should implement this interface.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/SplitResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/SplitResult.java
@@ -19,8 +19,11 @@ package org.apache.beam.sdk.transforms.splittabledofn;
 
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /** A representation of a split result. */
+@Experimental(Kind.SPLITTABLE_DO_FN)
 @AutoValue
 public abstract class SplitResult<RestrictionT> {
   /** Returns a {@link SplitResult} for the specified primary and residual restrictions. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/package-info.java
@@ -20,7 +20,10 @@
  * {@link org.apache.beam.sdk.transforms.DoFn}.
  */
 @DefaultAnnotation(NonNull.class)
+@Experimental(Kind.SPLITTABLE_DO_FN)
 package org.apache.beam.sdk.transforms.splittabledofn;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterAll.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterAll.java
@@ -22,13 +22,14 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.joda.time.Instant;
 
 /** A composite {@link Trigger} that fires when all of its sub-triggers are ready. */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterAll extends OnceTrigger {
 
   private AfterAll(List<Trigger> subTriggers) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterEach.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterEach.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.joda.time.Instant;
 
@@ -41,7 +42,7 @@ import org.joda.time.Instant;
  *       Repeatedly.forever(a)}, since the repeated trigger never finishes.
  * </ul>
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterEach extends Trigger {
 
   private AfterEach(List<Trigger> subTriggers) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterFirst.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterFirst.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.joda.time.Instant;
@@ -29,7 +30,7 @@ import org.joda.time.Instant;
 /**
  * A composite {@link Trigger} that fires once after at least one of its sub-triggers have fired.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterFirst extends OnceTrigger {
 
   AfterFirst(List<Trigger> subTriggers) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterPane.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterPane.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.transforms.windowing;
 import java.util.List;
 import java.util.Objects;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
 import org.joda.time.Instant;
 
@@ -27,7 +28,7 @@ import org.joda.time.Instant;
  * A {@link Trigger} that fires at some point after a specified number of input elements have
  * arrived.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterPane extends OnceTrigger {
 
   private final int countElems;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterProcessingTime.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterProcessingTime.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.joda.time.Duration;
@@ -33,7 +34,7 @@ import org.joda.time.format.PeriodFormatter;
  * A {@link Trigger} trigger that fires at a specified point in processing time, relative to when
  * input first arrives.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterProcessingTime extends OnceTrigger {
 
   private static final PeriodFormatter DURATION_FORMATTER = PeriodFormat.wordBased(Locale.ENGLISH);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -55,7 +56,7 @@ import org.joda.time.Instant;
  * AfterWatermark.pastEndOfWindow.withEarlyFirings(OnceTrigger)} or {@code
  * AfterWatermark.pastEndOfWindow.withLateFirings(OnceTrigger)}.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class AfterWatermark {
 
   private static final String TO_STRING = "AfterWatermark.pastEndOfWindow()";

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/DefaultTrigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/DefaultTrigger.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.transforms.windowing;
 
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.joda.time.Instant;
 
 /**
@@ -27,7 +28,7 @@ import org.joda.time.Instant;
  *
  * <p>This is a distinguished class to make it easy for runners to optimize for this common case.
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public class DefaultTrigger extends Trigger {
 
   private DefaultTrigger() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/TimestampCombiner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/TimestampCombiner.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Arrays;
 import java.util.Collections;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
@@ -34,7 +35,7 @@ import org.joda.time.Instant;
  * <p>In particular, these govern the timestamp on the output of a grouping transform such as {@link
  * GroupByKey} or {@link Combine}.
  */
-@Experimental(Experimental.Kind.OUTPUT_TIME)
+@Experimental(Kind.OUTPUT_TIME)
 public enum TimestampCombiner {
   /**
    * The policy of taking at the earliest of a set of timestamps.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Trigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Trigger.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
@@ -69,7 +70,7 @@ import org.joda.time.Instant;
  *       have fired at least once. An {@link AfterAll} trigger finishes after it fires once.
  * </ul>
  */
-@Experimental(Experimental.Kind.TRIGGER)
+@Experimental(Kind.TRIGGER)
 public abstract class Trigger implements Serializable {
 
   @Nullable protected final List<Trigger> subTriggers;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ApiSurface.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ApiSurface.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Function;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Predicate;
@@ -84,6 +85,7 @@ import org.slf4j.LoggerFactory;
  * not interesting.
  */
 @SuppressWarnings("rawtypes")
+@Internal
 public class ApiSurface {
   private static final Logger LOG = LoggerFactory.getLogger(ApiSurface.class);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/AppliedCombineFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/AppliedCombineFn.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.util;
 
 import java.io.Serializable;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
@@ -39,6 +40,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.Visi
  * @param <AccumT> type of mutable accumulator values
  * @param <OutputT> type of output values
  */
+@Internal
 public class AppliedCombineFn<K, InputT, AccumT, OutputT> implements Serializable {
 
   private final GlobalCombineFn<InputT, AccumT, OutputT> fn;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/BufferedElementCountingOutputStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/BufferedElementCountingOutputStream.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ArrayBlockingQueue;
 import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder.Context;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 
@@ -67,6 +68,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.Visi
  * <p>The counts are encoded as variable length longs. See {@link VarInt#encode(long, OutputStream)}
  * for more details. The end of the iterable is detected by reading a count of 0.
  */
+@Internal
 @NotThreadSafe
 public class BufferedElementCountingOutputStream extends OutputStream {
   private static final int MAX_POOLED = 12;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/CombineContextFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/CombineContextFactory.java
@@ -17,12 +17,14 @@
  */
 package org.apache.beam.sdk.util;
 
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.state.StateContext;
 import org.apache.beam.sdk.transforms.CombineWithContext.Context;
 import org.apache.beam.sdk.values.PCollectionView;
 
 /** Factory that produces {@code Combine.Context} based on different inputs. */
+@Internal
 public class CombineContextFactory {
 
   private static final Context NULL_CONTEXT =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/CombineFnUtil.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/CombineFnUtil.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.util;
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
@@ -31,6 +32,7 @@ import org.apache.beam.sdk.transforms.CombineWithContext.Context;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 
 /** Static utility methods that create combine function instances. */
+@Internal
 public class CombineFnUtil {
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/DoFnInfo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/DoFnInfo.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.util;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
@@ -33,6 +34,7 @@ import org.apache.beam.sdk.values.WindowingStrategy;
  * @param <InputT> the type of the (main) input elements of the {@link DoFn}
  * @param <OutputT> the type of the (main) output elements of the {@link DoFn}
  */
+@Internal
 public class DoFnInfo<InputT, OutputT> implements Serializable {
   private final DoFn<InputT, OutputT> doFn;
   private final WindowingStrategy<?, ?> windowingStrategy;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/DoFnWithExecutionInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/DoFnWithExecutionInformation.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.util;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.Map;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
 import org.apache.beam.sdk.values.PCollectionView;
@@ -27,6 +28,7 @@ import org.apache.beam.sdk.values.TupleTag;
 
 /** The data that the Java SDK harness needs to execute a DoFn. */
 @AutoValue
+@Internal
 public abstract class DoFnWithExecutionInformation implements Serializable {
   public static DoFnWithExecutionInformation of(
       DoFn<?, ?> fn,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExplicitShardedFile.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExplicitShardedFile.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
@@ -36,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A sharded file where the file names are simply provided. */
+@Internal
 public class ExplicitShardedFile implements ShardedFile {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExplicitShardedFile.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExposedByteArrayInputStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExposedByteArrayInputStream.java
@@ -19,10 +19,12 @@ package org.apache.beam.sdk.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * {@link ByteArrayInputStream} that allows accessing the entire internal buffer without copying.
  */
+@Internal
 public class ExposedByteArrayInputStream extends ByteArrayInputStream {
 
   public ExposedByteArrayInputStream(byte[] buf) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExposedByteArrayOutputStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExposedByteArrayOutputStream.java
@@ -19,12 +19,14 @@ package org.apache.beam.sdk.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * {@link ByteArrayOutputStream} special cased to treat writes of a single byte-array specially.
  * When calling {@link #toByteArray()} after writing only one {@code byte[]} using {@link
  * #writeAndOwn(byte[])}, it will return that array directly.
  */
+@Internal
 public class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
 
   private byte[] swappedBuffer;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/FilePatternMatchingShardedFile.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/FilePatternMatchingShardedFile.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -44,6 +45,7 @@ import org.slf4j.LoggerFactory;
  * <p>Note that file matching should only occur once the file system is in a stable state and
  * guaranteed to provide a consistent result during file pattern matching.
  */
+@Internal
 public class FilePatternMatchingShardedFile implements ShardedFile {
 
   private static final Logger LOG = LoggerFactory.getLogger(FilePatternMatchingShardedFile.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IdentityWindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IdentityWindowFn.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.util;
 import java.util.Collection;
 import java.util.Collections;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -48,6 +49,7 @@ import org.joda.time.Instant;
  * <p>This {@link WindowFn} is an internal implementation detail of sdk-provided utilities, and
  * should not be used by {@link Pipeline} writers.
  */
+@Internal
 public class IdentityWindowFn<T> extends NonMergingWindowFn<T, BoundedWindow> {
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetector.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetector.java
@@ -17,12 +17,15 @@
  */
 package org.apache.beam.sdk.util;
 
+import org.apache.beam.sdk.annotations.Internal;
+
 /**
  * An object for detecting illegal mutations.
  *
  * <p>The {@link AutoCloseable} aspect of this interface allows use in a try-with-resources style,
  * where the implementing class may choose to perform a final mutation check upon {@link #close()}.
  */
+@Internal
 public interface MutationDetector extends AutoCloseable {
   /** @throws IllegalMutationException if illegal mutations are detected. */
   void verifyUnmodified() throws IllegalMutationException;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetectors.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetectors.java
@@ -18,12 +18,14 @@
 package org.apache.beam.sdk.util;
 
 import java.util.Objects;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Static methods for creating and working with {@link MutationDetector}. */
+@Internal
 public class MutationDetectors {
   private static final Logger LOG = LoggerFactory.getLogger(MutationDetectors.class);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NameUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NameUtils.java
@@ -21,6 +21,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -28,6 +29,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.Visi
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 
 /** Helpers for extracting the name of objects and classes. */
+@Internal
 public class NameUtils {
 
   /** Classes may implement this interface to change how names are generated for their instances. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NumberedShardedFile.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NumberedShardedFile.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
@@ -44,6 +45,7 @@ import org.slf4j.LoggerFactory;
  * Utility methods for working with sharded files. For internal use only; many parameters are just
  * hardcoded to allow existing uses to work OK.
  */
+@Internal
 public class NumberedShardedFile implements ShardedFile {
 
   private static final Logger LOG = LoggerFactory.getLogger(NumberedShardedFile.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ReleaseInfo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ReleaseInfo.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * <p>Properties will always include a name and version.
  */
 @AutoValue
+@Internal
 public abstract class ReleaseInfo implements Serializable {
   private static final String PROPERTIES_PATH = "/org/apache/beam/sdk/sdk.properties";
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ShardedFile.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ShardedFile.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.util;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * Bare-bones class for using sharded files.
@@ -27,6 +28,7 @@ import java.util.List;
  * <p>For internal use only; used only in SDK tests. Must be {@link Serializable} so it can be
  * shipped as a {@link org.apache.beam.sdk.testing.SerializableMatcher}.
  */
+@Internal
 public interface ShardedFile extends Serializable {
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ShardingWritableByteChannel.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ShardingWritableByteChannel.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * Implements a WritableByteChannel that may contain multiple output shards.
@@ -31,6 +32,7 @@ import java.util.ArrayList;
  * <p>The channel is considered open if all downstream channels are open, and closes all downstream
  * channels when closed.
  */
+@Internal
 public class ShardingWritableByteChannel implements WritableByteChannel {
 
   /** Special shard number that causes a write to all shards. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/StreamUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/StreamUtils.java
@@ -22,8 +22,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.SoftReference;
+import org.apache.beam.sdk.annotations.Internal;
 
 /** Utility functions for stream operations. */
+@Internal
 public class StreamUtils {
 
   private StreamUtils() {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/StringUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/StringUtils.java
@@ -21,8 +21,10 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.beam.sdk.annotations.Internal;
 
 /** Utilities for working with JSON and other human-readable string formats. */
+@Internal
 public class StringUtils {
   /**
    * Converts the given array of bytes into a legal JSON string.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/SystemDoFnInternal.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/SystemDoFnInternal.java
@@ -22,6 +22,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * Annotation to mark {@code DoFns} as an internal component of the Beam SDK.
@@ -29,6 +30,7 @@ import java.lang.annotation.Target;
  * <p>This is internal to the Beam SDK.
  */
 @Documented
+@Internal
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface SystemDoFnInternal {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/UnownedInputStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/UnownedInputStream.java
@@ -21,12 +21,14 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 
 /**
  * A {@link OutputStream} wrapper which protects against the user attempting to modify the
  * underlying stream by closing it or using mark.
  */
+@Internal
 public class UnownedInputStream extends FilterInputStream {
   public UnownedInputStream(InputStream delegate) {
     super(delegate);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/UnownedOutputStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/UnownedOutputStream.java
@@ -20,12 +20,14 @@ package org.apache.beam.sdk.util;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 
 /**
  * A {@link OutputStream} wrapper which protects against the user attempting to modify the
  * underlying stream by closing it.
  */
+@Internal
 public class UnownedOutputStream extends FilterOutputStream {
   public UnownedOutputStream(OutputStream delegate) {
     super(delegate);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/UserCodeException.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/UserCodeException.java
@@ -19,11 +19,13 @@ package org.apache.beam.sdk.util;
 
 import java.util.Arrays;
 import java.util.Objects;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * An exception that was thrown in user-code. Sets the stack trace from the first time execution
  * enters user code down through the rest of the user's stack frames until the exception is reached.
  */
+@Internal
 public class UserCodeException extends RuntimeException {
 
   public static UserCodeException wrap(Throwable t) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Weighted.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Weighted.java
@@ -17,7 +17,10 @@
  */
 package org.apache.beam.sdk.util;
 
+import org.apache.beam.sdk.annotations.Internal;
+
 /** Interface representing an object that has a weight, in unspecified units. */
+@Internal
 public interface Weighted {
   /** Returns the weight of the object. */
   long getWeight();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WeightedValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WeightedValue.java
@@ -17,11 +17,14 @@
  */
 package org.apache.beam.sdk.util;
 
+import org.apache.beam.sdk.annotations.Internal;
+
 /**
  * A {@code T} with an accompanying weight. Units are unspecified.
  *
  * @param <T> the underlying type of object
  */
+@Internal
 public final class WeightedValue<T> implements Weighted {
 
   private final T value;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowTracing.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowTracing.java
@@ -17,10 +17,12 @@
  */
 package org.apache.beam.sdk.util;
 
+import org.apache.beam.sdk.annotations.Internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Logging for window operations. Generally only feasible to enable on hand-picked pipelines. */
+@Internal
 public final class WindowTracing {
   private static final Logger LOG = LoggerFactory.getLogger(WindowTracing.class);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
@@ -54,6 +55,7 @@ import org.joda.time.Instant;
  *
  * @param <T> the type of the value
  */
+@Internal
 public abstract class WindowedValue<T> {
 
   /** Returns a {@code WindowedValue} with the given value, timestamp, and windows. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ZipFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ZipFiles.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.FluentIterable;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterators;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.ByteSource;
@@ -43,6 +44,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.Files;
  * Functions for zipping a directory (including a subdirectory) into a ZIP-file or unzipping it
  * again.
  */
+@Internal
 public final class ZipFiles {
   private ZipFiles() {}
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ElementByteSizeObservableIterable.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ElementByteSizeObservableIterable.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.util.common;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Observer;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * An abstract class used for iterables that notify observers about size in bytes of their elements,
@@ -28,6 +29,7 @@ import java.util.Observer;
  * @param <V> the type of elements returned by this iterable
  * @param <InputT> type type of iterator returned by this iterable
  */
+@Internal
 public abstract class ElementByteSizeObservableIterable<
         V, InputT extends ElementByteSizeObservableIterator<V>>
     implements Iterable<V> {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ElementByteSizeObservableIterator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ElementByteSizeObservableIterator.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.util.common;
 
 import java.util.Iterator;
 import java.util.Observable;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * An abstract class used for iterators that notify observers about size in bytes of their elements,
@@ -27,6 +28,7 @@ import java.util.Observable;
  *
  * @param <V> value type
  */
+@Internal
 public abstract class ElementByteSizeObservableIterator<V> extends Observable
     implements Iterator<V> {
   protected final void notifyValueReturned(long byteSize) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ElementByteSizeObserver.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ElementByteSizeObserver.java
@@ -19,8 +19,10 @@ package org.apache.beam.sdk.util.common;
 
 import java.util.Observable;
 import java.util.Observer;
+import org.apache.beam.sdk.annotations.Internal;
 
 /** An observer that gets notified when additional bytes are read and/or used. */
+@Internal
 public abstract class ElementByteSizeObserver implements Observer {
   private boolean isLazy = false;
   private long totalSize = 0;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/Reiterable.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/Reiterable.java
@@ -17,11 +17,14 @@
  */
 package org.apache.beam.sdk.util.common;
 
+import org.apache.beam.sdk.annotations.Internal;
+
 /**
  * An {@link Iterable} that returns {@link Reiterator} iterators.
  *
  * @param <T> the type of elements returned by the iterator
  */
+@Internal
 public interface Reiterable<T> extends Iterable<T> {
   @Override
   Reiterator<T> iterator();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/Reiterator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/Reiterator.java
@@ -18,12 +18,14 @@
 package org.apache.beam.sdk.util.common;
 
 import java.util.Iterator;
+import org.apache.beam.sdk.annotations.Internal;
 
 /**
  * An {@link Iterator} with the ability to copy its iteration state.
  *
  * @param <T> the type of elements returned by this iterator
  */
+@Internal
 public interface Reiterator<T> extends Iterator<T> {
   /**
    * Returns a copy of the current {@link Reiterator}. The copy's iteration state is logically

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/package-info.java
@@ -21,4 +21,7 @@
  *
  * <p>Defines utilities that can be used by Beam runners.
  */
+@Internal
 package org.apache.beam.sdk.util;
+
+import org.apache.beam.sdk.annotations.Internal;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/ValueInSingleWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/ValueInSingleWindow.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.InstantCoder;
 import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -36,6 +37,7 @@ import org.joda.time.Instant;
  * @param <T> the type of the value
  */
 @AutoValue
+@Internal
 public abstract class ValueInSingleWindow<T> {
   /** Returns the value of this {@code ValueInSingleWindow}. */
   @Nullable

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowingStrategy.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowingStrategy.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.values;
 import java.io.Serializable;
 import java.util.Objects;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -271,7 +272,7 @@ public class WindowingStrategy<T, W extends BoundedWindow> implements Serializab
         onTimeBehavior);
   }
 
-  @Experimental(Experimental.Kind.OUTPUT_TIME)
+  @Experimental(Kind.OUTPUT_TIME)
   public WindowingStrategy<T, W> withTimestampCombiner(TimestampCombiner timestampCombiner) {
 
     return new WindowingStrategy<>(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowingStrategy.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowingStrategy.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.util.Objects;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -43,6 +44,7 @@ import org.joda.time.Duration;
  * @param <W> {@link BoundedWindow} subclass used to represent the windows used by this {@code
  *     WindowingStrategy}
  */
+@Internal
 public class WindowingStrategy<T, W extends BoundedWindow> implements Serializable {
 
   /**

--- a/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/operator/OutputValues.java
+++ b/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/operator/OutputValues.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.extensions.euphoria.core.client.operator;
 
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.euphoria.core.client.operator.base.Operator;
 import org.apache.beam.sdk.extensions.euphoria.core.translate.OperatorTransform;
 import org.apache.beam.sdk.values.KV;
@@ -33,7 +32,6 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  * @param <KeyT> key type
  * @param <OutputT> output type
  */
-@Internal
 class OutputValues<InputT, KeyT, OutputT> extends Operator<OutputT>
     implements CompositeOperator<InputT, OutputT> {
 

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/storage/package-info.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/storage/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Defines IO connectors for Google Cloud Storage. */
+@Experimental(Kind.FILESYSTEM)
 package org.apache.beam.sdk.extensions.gcp.storage;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/AsJsons.java
+++ b/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/AsJsons.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.Contextful;
 import org.apache.beam.sdk.transforms.InferableFunction;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -79,7 +80,7 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
    * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
    * WithFailures.Result}.
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public <NewFailureT> AsJsonsWithFailures<NewFailureT> exceptionsInto(
       TypeDescriptor<NewFailureT> failureTypeDescriptor) {
     return new AsJsonsWithFailures<>(null, failureTypeDescriptor);
@@ -106,7 +107,7 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
    * PCollection<KV<MyPojo, Map<String, String>>> failures = result.failures();
    * }</pre>
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public <FailureT> AsJsonsWithFailures<FailureT> exceptionsVia(
       InferableFunction<WithFailures.ExceptionElement<InputT>, FailureT> exceptionHandler) {
     return new AsJsonsWithFailures<>(exceptionHandler, exceptionHandler.getOutputTypeDescriptor());
@@ -135,7 +136,7 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
    * PCollection<KV<MyPojo, Map<String, String>>> failures = result.failures();
    * }</pre>
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public AsJsonsWithFailures<KV<InputT, Map<String, String>>> exceptionsVia() {
     DefaultExceptionAsMapHandler<InputT> exceptionHandler =
         new DefaultExceptionAsMapHandler<InputT>() {};

--- a/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/ParseJsons.java
+++ b/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/ParseJsons.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.Contextful;
 import org.apache.beam.sdk.transforms.InferableFunction;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -76,7 +77,7 @@ public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollec
    * <p>See {@link WithFailures} documentation for usage patterns of the returned {@link
    * WithFailures.Result}.
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public <NewFailureT> ParseJsonsWithFailures<NewFailureT> exceptionsInto(
       TypeDescriptor<NewFailureT> failureTypeDescriptor) {
     return new ParseJsonsWithFailures<>(null, failureTypeDescriptor);
@@ -102,7 +103,7 @@ public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollec
    * PCollection<KV<String, Map<String, String>>> failures = result.failures();
    * }</pre>
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public <FailureT> ParseJsonsWithFailures<FailureT> exceptionsVia(
       InferableFunction<WithFailures.ExceptionElement<String>, FailureT> exceptionHandler) {
     return new ParseJsonsWithFailures<>(
@@ -132,7 +133,7 @@ public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollec
    * PCollection<KV<String, Map<String, String>>> failures = result.failures();
    * }</pre>
    */
-  @Experimental(Experimental.Kind.WITH_EXCEPTIONS)
+  @Experimental(Kind.WITH_EXCEPTIONS)
   public ParseJsonsWithFailures<KV<String, Map<String, String>>> exceptionsVia() {
     DefaultExceptionAsMapHandler<String> exceptionHandler =
         new DefaultExceptionAsMapHandler<String>() {};

--- a/sdks/java/extensions/kryo/src/main/java/org/apache/beam/sdk/extensions/kryo/package-info.java
+++ b/sdks/java/extensions/kryo/src/main/java/org/apache/beam/sdk/extensions/kryo/package-info.java
@@ -17,4 +17,7 @@
  */
 
 /** Euphoria API focused on Beam coders. */
+@Internal
 package org.apache.beam.sdk.extensions.kryo;
+
+import org.apache.beam.sdk.annotations.Internal;

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
-import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.DurationNanos;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed64;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SFixed32;

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.DurationNanos;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed64;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.SFixed32;
@@ -107,7 +109,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
  *   <li>google.protobuf.BytesValue maps to a nullable FieldType.BYTES
  * </ul>
  */
-@Experimental(Experimental.Kind.SCHEMAS)
+@Experimental(Kind.SCHEMAS)
 public class ProtoSchemaTranslator {
   /** This METADATA tag is used to store the field number of a proto tag. */
   public static final String PROTO_NUMBER_METADATA_TAG = "PROTO_NUMBER";

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/package-info.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/package-info.java
@@ -17,4 +17,7 @@
  */
 
 /** Utilities for computing statistical indicators using probabilistic sketches. */
+@Experimental
 package org.apache.beam.sdk.extensions.sketching;
+
+import org.apache.beam.sdk.annotations.Experimental;

--- a/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/example/package-info.java
+++ b/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/example/package-info.java
@@ -17,4 +17,7 @@
  */
 
 /** Example how to use Data Catalog table provider. */
+@Experimental
 package org.apache.beam.sdk.extensions.sql.example;
+
+import org.apache.beam.sdk.annotations.Experimental;

--- a/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/package-info.java
+++ b/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/package-info.java
@@ -17,4 +17,7 @@
  */
 
 /** Table schema for Google Cloud Data Catalog. */
+@Experimental
 package org.apache.beam.sdk.extensions.sql.meta.provider.datacatalog;
+
+import org.apache.beam.sdk.annotations.Experimental;

--- a/sdks/java/extensions/sql/hcatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/hcatalog/package-info.java
+++ b/sdks/java/extensions/sql/hcatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/hcatalog/package-info.java
@@ -17,4 +17,7 @@
  */
 
 /** Table schema for HCatalog. */
+@Experimental
 package org.apache.beam.sdk.extensions.sql.meta.provider.hcatalog;
+
+import org.apache.beam.sdk.annotations.Experimental;

--- a/sdks/java/extensions/sql/jdbc/src/main/java/org/apache/beam/sdk/extensions/sql/jdbc/package-info.java
+++ b/sdks/java/extensions/sql/jdbc/src/main/java/org/apache/beam/sdk/extensions/sql/jdbc/package-info.java
@@ -17,4 +17,7 @@
  */
 
 /** Provides default commandline for sqlline. */
+@Experimental
 package org.apache.beam.sdk.extensions.sql.jdbc;
+
+import org.apache.beam.sdk.annotations.Experimental;

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/package-info.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/package-info.java
@@ -17,4 +17,7 @@
  */
 
 /** ZetaSQL Dialect package. */
+@Experimental
 package org.apache.beam.sdk.extensions.sql.zetasql;
+
+import org.apache.beam.sdk.annotations.Experimental;

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/translation/package-info.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/translation/package-info.java
@@ -17,4 +17,7 @@
  */
 
 /** Conversion logic between ZetaSQL resolved query nodes and Calcite rel nodes. */
+@Experimental
 package org.apache.beam.sdk.extensions.sql.zetasql.translation;
+
+import org.apache.beam.sdk.annotations.Experimental;

--- a/sdks/java/extensions/zetasketch/src/main/java/org/apache/beam/sdk/extensions/zetasketch/package-info.java
+++ b/sdks/java/extensions/zetasketch/src/main/java/org/apache/beam/sdk/extensions/zetasketch/package-info.java
@@ -20,4 +20,7 @@
  * {@code PTransform}s to compute statistical sketches on data streams based on the <a
  * href="https://github.com/google/zetasketch">ZetaSketch</a> implementation.
  */
+@Experimental
 package org.apache.beam.sdk.extensions.zetasketch;
+
+import org.apache.beam.sdk.annotations.Experimental;

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/dynamodb/DynamoDBIO.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/dynamodb/DynamoDBIO.java
@@ -38,6 +38,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.MapCoder;
@@ -119,7 +120,7 @@ import org.slf4j.LoggerFactory;
  *       number of segment. Note This number should base on the number of your workers
  * </ul>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public final class DynamoDBIO {
   public static <T> Read<T> read() {
     return new AutoValue_DynamoDBIO_Read.Builder().build();

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/dynamodb/package-info.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/dynamodb/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Defines IO connectors for Amazon Web Services DynamoDB. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.aws.dynamodb;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/package-info.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/package-info.java
@@ -19,4 +19,8 @@
  * Defines {@link org.apache.beam.sdk.options.PipelineOptions} for configuring pipeline execution
  * for Amazon Web Services components.
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.aws.options;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystemRegistrar.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystemRegistrar.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import com.google.auto.service.AutoService;
 import javax.annotation.Nonnull;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.FileSystemRegistrar;
 import org.apache.beam.sdk.io.aws.options.S3Options;
@@ -30,7 +31,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
 
 /** {@link AutoService} registrar for the {@link S3FileSystem}. */
 @AutoService(FileSystemRegistrar.class)
-@Experimental(Experimental.Kind.FILESYSTEM)
+@Experimental(Kind.FILESYSTEM)
 public class S3FileSystemRegistrar implements FileSystemRegistrar {
 
   @Override

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/package-info.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Defines IO connectors for Amazon Web Services S3. */
+@Experimental(Kind.FILESYSTEM)
 package org.apache.beam.sdk.io.aws.s3;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/sns/SnsIO.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/sns/SnsIO.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -79,7 +80,7 @@ import org.slf4j.LoggerFactory;
  *   <li>an output tag where you can get results. Example in SnsIOTest
  * </ul>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public final class SnsIO {
 
   // Write data tp SNS

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/sns/package-info.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/sns/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Defines IO connectors for Amazon Web Services SNS. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.aws.sns;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/sqs/SqsIO.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/sqs/SqsIO.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.aws.options.AwsOptions;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -76,7 +77,7 @@ import org.joda.time.Duration;
  *
  * <p>For more information on the available options see {@link AwsOptions}.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class SqsIO {
 
   public static Read read() {

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/sqs/package-info.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/sqs/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Defines IO connectors for Amazon Web Services SQS. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.aws.sqs;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/dynamodb/DynamoDBIO.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/dynamodb/DynamoDBIO.java
@@ -31,6 +31,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.MapCoder;
@@ -123,7 +124,7 @@ import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
  *       writeRequest>
  * </ul>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public final class DynamoDBIO {
   public static <T> Read<T> read() {
     return new AutoValue_DynamoDBIO_Read.Builder().build();

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/dynamodb/package-info.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/dynamodb/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Defines IO connectors for Amazon Web Services DynamoDB. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.aws2.dynamodb;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/AwsModule.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/AwsModule.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -53,7 +54,7 @@ import software.amazon.awssdk.http.apache.ProxyConfiguration;
  * A Jackson {@link Module} that registers a {@link JsonSerializer} and {@link JsonDeserializer} for
  * {@link AwsCredentialsProvider} and some subclasses. The serialized form is a JSON map.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 @AutoService(Module.class)
 public class AwsModule extends SimpleModule {
   private static final String ACCESS_KEY_ID = "accessKeyId";

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/AwsOptions.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/AwsOptions.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.aws2.options;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
@@ -30,7 +31,7 @@ import software.amazon.awssdk.http.apache.ProxyConfiguration;
 /**
  * Options used to configure Amazon Web Services specific options such as credentials and region.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public interface AwsOptions extends PipelineOptions {
 
   /** AWS region used by the AWS client. */

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/package-info.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/package-info.java
@@ -19,4 +19,8 @@
  * Defines {@link org.apache.beam.sdk.options.PipelineOptions} for configuring pipeline execution
  * for Amazon Web Services components.
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.aws2.options;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sns/SnsIO.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sns/SnsIO.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -79,7 +80,7 @@ import software.amazon.awssdk.services.sns.model.PublishResponse;
  *   <li>publishRequestFn, a function to convert your message into PublishRequest
  * </ul>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public final class SnsIO {
 
   // Write data tp SNS

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sns/package-info.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sns/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Defines IO connectors for Amazon Web Services SNS. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.aws2.sns;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sqs/SqsIO.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sqs/SqsIO.java
@@ -23,6 +23,7 @@ import com.google.auto.value.AutoValue;
 import java.net.URI;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.aws2.options.AwsOptions;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -76,7 +77,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
  *
  * <p>For more information on the available options see {@link AwsOptions}.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class SqsIO {
 
   public static Read read() {

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sqs/package-info.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sqs/package-info.java
@@ -15,5 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /** Defines IO connectors for Amazon Web Services SQS. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.aws2.sqs;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/amqp/src/main/java/org/apache/beam/sdk/io/amqp/AmqpIO.java
+++ b/sdks/java/io/amqp/src/main/java/org/apache/beam/sdk/io/amqp/AmqpIO.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.UnboundedSource;
@@ -89,7 +90,7 @@ import org.joda.time.Instant;
  *
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class AmqpIO {
 
   public static Read read() {

--- a/sdks/java/io/amqp/src/main/java/org/apache/beam/sdk/io/amqp/package-info.java
+++ b/sdks/java/io/amqp/src/main/java/org/apache/beam/sdk/io/amqp/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing using AMQP 1.0 protocol. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.amqp;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
@@ -45,6 +45,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -103,7 +104,7 @@ import org.slf4j.LoggerFactory;
  *        .withEntity(Person.class));
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class CassandraIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(CassandraIO.class);

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/Mapper.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/Mapper.java
@@ -21,6 +21,7 @@ import com.datastax.driver.core.ResultSet;
 import java.util.Iterator;
 import java.util.concurrent.Future;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 
 /**
@@ -41,7 +42,7 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
  *        .withMapperFactoryFn(factory));
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public interface Mapper<T> {
 
   /**

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/package-info.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/package-info.java
@@ -21,4 +21,8 @@
  *
  * @see org.apache.beam.sdk.io.cassandra.CassandraIO
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.cassandra;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseIO.java
+++ b/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseIO.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.clickhouse.TableSchema.ColumnType;
 import org.apache.beam.sdk.io.clickhouse.TableSchema.DefaultType;
 import org.apache.beam.sdk.metrics.Counter;
@@ -116,7 +117,7 @@ import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
  * Type casting should be done using {@link org.apache.beam.sdk.schemas.transforms.Cast} before
  * {@link ClickHouseIO}.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class ClickHouseIO {
 
   public static final long DEFAULT_MAX_INSERT_BLOCK_SIZE = 1000000;

--- a/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseWriter.java
+++ b/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseWriter.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.clickhouse;
 import java.io.IOException;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.clickhouse.TableSchema.ColumnType;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Charsets;
@@ -30,7 +31,7 @@ import org.joda.time.ReadableInstant;
 import ru.yandex.clickhouse.util.ClickHouseRowBinaryStream;
 
 /** Writes Rows and field values using {@link ClickHouseRowBinaryStream}. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class ClickHouseWriter {
   private static final Instant EPOCH_INSTANT = new Instant(0L);
 

--- a/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/TableSchema.java
+++ b/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/TableSchema.java
@@ -26,11 +26,12 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
 
 /** A descriptor for ClickHouse table schema. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 @AutoValue
 public abstract class TableSchema implements Serializable {
 

--- a/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/package-info.java
+++ b/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/package-info.java
@@ -20,4 +20,8 @@
  *
  * @see org.apache.beam.sdk.io.clickhouse.ClickHouseIO
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.clickhouse;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -49,6 +49,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -151,7 +152,7 @@ import org.slf4j.LoggerFactory;
  * socket timeout of 30000ms. {@code withConnectTimeout()} can be used to override the default
  * connect timeout of 1000ms.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class ElasticsearchIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchIO.class);

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/package-info.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Transforms for reading and writing from Elasticsearch. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.elasticsearch;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -688,7 +688,7 @@ public class BigQueryIO {
      * <p>Use new template-compatible source implementation. This implementation is compatible with
      * repeated template invocations. It does not support dynamic work rebalancing.
      */
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public Read withTemplateCompatibility() {
       return new Read(this.inner.withTemplateCompatibility());
     }
@@ -700,7 +700,7 @@ public class BigQueryIO {
   @AutoValue
   public abstract static class TypedRead<T> extends PTransform<PBegin, PCollection<T>> {
     /** Determines the method used to read data from BigQuery. */
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public enum Method {
       /** The default behavior if no method is explicitly set. Currently {@link #EXPORT}. */
       DEFAULT,
@@ -742,7 +742,7 @@ public class BigQueryIO {
 
       abstract Builder<T> setQueryLocation(String location);
 
-      @Experimental(Experimental.Kind.SOURCE_SINK)
+      @Experimental(Kind.SOURCE_SINK)
       abstract Builder<T> setMethod(Method method);
 
       /**
@@ -750,13 +750,13 @@ public class BigQueryIO {
        *     #setRowRestriction(ValueProvider)} instead.
        */
       @Deprecated
-      @Experimental(Experimental.Kind.SOURCE_SINK)
+      @Experimental(Kind.SOURCE_SINK)
       abstract Builder<T> setReadOptions(TableReadOptions readOptions);
 
-      @Experimental(Experimental.Kind.SOURCE_SINK)
+      @Experimental(Kind.SOURCE_SINK)
       abstract Builder<T> setSelectedFields(ValueProvider<List<String>> selectedFields);
 
-      @Experimental(Experimental.Kind.SOURCE_SINK)
+      @Experimental(Kind.SOURCE_SINK)
       abstract Builder<T> setRowRestriction(ValueProvider<String> rowRestriction);
 
       abstract TypedRead<T> build();
@@ -767,13 +767,13 @@ public class BigQueryIO {
 
       abstract Builder<T> setKmsKey(String kmsKey);
 
-      @Experimental(Experimental.Kind.SCHEMAS)
+      @Experimental(Kind.SCHEMAS)
       abstract Builder<T> setTypeDescriptor(TypeDescriptor<T> typeDescriptor);
 
-      @Experimental(Experimental.Kind.SCHEMAS)
+      @Experimental(Kind.SCHEMAS)
       abstract Builder<T> setToBeamRowFn(ToBeamRowFunction<T> toRowFn);
 
-      @Experimental(Experimental.Kind.SCHEMAS)
+      @Experimental(Kind.SCHEMAS)
       abstract Builder<T> setFromBeamRowFn(FromBeamRowFunction<T> fromRowFn);
     }
 
@@ -803,20 +803,20 @@ public class BigQueryIO {
     @Nullable
     abstract String getQueryLocation();
 
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     abstract Method getMethod();
 
     /** @deprecated Use {@link #getSelectedFields()} and {@link #getRowRestriction()} instead. */
     @Deprecated
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     @Nullable
     abstract TableReadOptions getReadOptions();
 
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     @Nullable
     abstract ValueProvider<List<String>> getSelectedFields();
 
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     @Nullable
     abstract ValueProvider<String> getRowRestriction();
 
@@ -827,15 +827,15 @@ public class BigQueryIO {
     abstract String getKmsKey();
 
     @Nullable
-    @Experimental(Experimental.Kind.SCHEMAS)
+    @Experimental(Kind.SCHEMAS)
     abstract TypeDescriptor<T> getTypeDescriptor();
 
     @Nullable
-    @Experimental(Experimental.Kind.SCHEMAS)
+    @Experimental(Kind.SCHEMAS)
     abstract ToBeamRowFunction<T> getToBeamRowFn();
 
     @Nullable
-    @Experimental(Experimental.Kind.SCHEMAS)
+    @Experimental(Kind.SCHEMAS)
     abstract FromBeamRowFunction<T> getFromBeamRowFn();
 
     /**
@@ -1425,7 +1425,7 @@ public class BigQueryIO {
      *
      * <p>Setting these conversion functions is necessary to enable {@link Schema} support.
      */
-    @Experimental(Experimental.Kind.SCHEMAS)
+    @Experimental(Kind.SCHEMAS)
     public TypedRead<T> withBeamRowConverters(
         TypeDescriptor<T> typeDescriptor,
         ToBeamRowFunction<T> toRowFn,
@@ -1503,7 +1503,7 @@ public class BigQueryIO {
     }
 
     /** See {@link Method}. */
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public TypedRead<T> withMethod(Method method) {
       return toBuilder().setMethod(method).build();
     }
@@ -1513,14 +1513,14 @@ public class BigQueryIO {
      *     instead.
      */
     @Deprecated
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public TypedRead<T> withReadOptions(TableReadOptions readOptions) {
       ensureReadOptionsFieldsNotSet();
       return toBuilder().setReadOptions(readOptions).build();
     }
 
     /** See {@link #withSelectedFields(ValueProvider)}. */
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public TypedRead<T> withSelectedFields(List<String> selectedFields) {
       return withSelectedFields(StaticValueProvider.of(selectedFields));
     }
@@ -1531,14 +1531,14 @@ public class BigQueryIO {
      *
      * <p>Requires {@link Method#DIRECT_READ}. Not compatible with {@link #fromQuery(String)}.
      */
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public TypedRead<T> withSelectedFields(ValueProvider<List<String>> selectedFields) {
       ensureReadOptionsNotSet();
       return toBuilder().setSelectedFields(selectedFields).build();
     }
 
     /** See {@link #withRowRestriction(ValueProvider)}. */
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public TypedRead<T> withRowRestriction(String rowRestriction) {
       return withRowRestriction(StaticValueProvider.of(rowRestriction));
     }
@@ -1550,13 +1550,13 @@ public class BigQueryIO {
      *
      * <p>Requires {@link Method#DIRECT_READ}. Not compatible with {@link #fromQuery(String)}.
      */
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public TypedRead<T> withRowRestriction(ValueProvider<String> rowRestriction) {
       ensureReadOptionsNotSet();
       return toBuilder().setRowRestriction(rowRestriction).build();
     }
 
-    @Experimental(Experimental.Kind.SOURCE_SINK)
+    @Experimental(Kind.SOURCE_SINK)
     public TypedRead<T> withTemplateCompatibility() {
       return toBuilder().setWithTemplateCompatibility(true).build();
     }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
@@ -39,6 +39,7 @@ import java.io.Serializable;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
 
 /** An interface for real, mock, or fake implementations of Cloud BigQuery services. */
@@ -51,7 +52,7 @@ public interface BigQueryServices extends Serializable {
   DatasetService getDatasetService(BigQueryOptions bqOptions);
 
   /** Returns a real, mock, or fake {@link StorageClient}. */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   StorageClient getStorageClient(BigQueryOptions bqOptions) throws IOException;
 
   /** An interface for the Cloud BigQuery load service. */
@@ -181,7 +182,7 @@ public interface BigQueryServices extends Serializable {
   }
 
   /** An interface representing a client object for making calls to the BigQuery Storage API. */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   interface StorageClient extends AutoCloseable {
     /** Create a new read session against an existing table. */
     ReadSession createReadSession(CreateReadSessionRequest request);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -76,6 +76,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.extensions.gcp.auth.NullCredentialInitializer;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.extensions.gcp.util.BackOffAdapter;
@@ -1018,7 +1019,7 @@ class BigQueryServicesImpl implements BigQueryServices {
     }
   }
 
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   static class StorageClientImpl implements StorageClient {
 
     private static final HeaderProvider USER_AGENT_HEADER_PROVIDER =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceDef.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceDef.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 
 import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.transforms.SerializableFunction;
@@ -47,6 +48,6 @@ interface BigQuerySourceDef extends Serializable {
    * @return Beam schema of the source
    * @throws BigQuerySchemaRetrievalException if schema retrieval fails
    */
-  @Experimental(Experimental.Kind.SCHEMAS)
+  @Experimental(Kind.SCHEMAS)
   Schema getBeamSchema(BigQueryOptions bqOptions);
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageQuerySource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageQuerySource.java
@@ -27,6 +27,7 @@ import java.io.ObjectInputStream;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.TypedRead.QueryPriority;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -35,7 +36,7 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 
 /** A {@link org.apache.beam.sdk.io.Source} representing reading the results of a query. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class BigQueryStorageQuerySource<T> extends BigQueryStorageSourceBase<T> {
 
   public static <T> BigQueryStorageQuerySource<T> create(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.StorageClient;
@@ -45,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * A base class for {@link BoundedSource} implementations which read from BigQuery using the
  * BigQuery storage API.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 abstract class BigQueryStorageSourceBase<T> extends BoundedSource<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryStorageSourceBase.class);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -41,6 +41,7 @@ import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.BigQueryServerStream;
@@ -55,7 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A {@link org.apache.beam.sdk.io.Source} representing a single stream in a read session. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryStorageStreamSource.class);
@@ -149,7 +150,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
   }
 
   /** A {@link org.apache.beam.sdk.io.Source.Reader} which reads records from a stream. */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
+  @Experimental(Kind.SOURCE_SINK)
   public static class BigQueryStorageStreamReader<T> extends BoundedSource.BoundedReader<T> {
 
     private final DatumReader<GenericRecord> datumReader;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageTableSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageTableSource.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -39,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A {@link org.apache.beam.sdk.io.Source} representing reading from a table. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class BigQueryStorageTableSource<T> extends BigQueryStorageSourceBase<T> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryStorageTableSource.class);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -173,7 +174,7 @@ import org.slf4j.LoggerFactory;
  * pipeline. Please refer to the documentation of corresponding {@link PipelineRunner
  * PipelineRunners} for more details.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class BigtableIO {
   private static final Logger LOG = LoggerFactory.getLogger(BigtableIO.class);
 
@@ -206,7 +207,6 @@ public class BigtableIO {
    *
    * @see BigtableIO
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   @AutoValue
   public abstract static class Read extends PTransform<PBegin, PCollection<Row>> {
 
@@ -493,7 +493,6 @@ public class BigtableIO {
    *
    * @see BigtableIO
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   @AutoValue
   public abstract static class Write
       extends PTransform<PCollection<KV<ByteString, Iterable<Mutation>>>, PDone> {
@@ -728,7 +727,6 @@ public class BigtableIO {
    *
    * @see BigtableIO
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   public static class WriteWithResults
       extends PTransform<
           PCollection<KV<ByteString, Iterable<Mutation>>>, PCollection<BigtableWriteResult>> {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/package-info.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/package-info.java
@@ -20,4 +20,8 @@
  *
  * @see org.apache.beam.sdk.io.gcp.bigtable.BigtableIO
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.gcp.bigtable;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/common/GcpIoPipelineOptionsRegistrar.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/common/GcpIoPipelineOptionsRegistrar.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.gcp.common;
 
 import com.google.auto.service.AutoService;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryOptions;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -26,6 +27,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
 
 /** A registrar containing the default GCP options. */
 @AutoService(PipelineOptionsRegistrar.class)
+@Internal
 public class GcpIoPipelineOptionsRegistrar implements PipelineOptionsRegistrar {
   @Override
   public Iterable<Class<? extends PipelineOptions>> getPipelineOptions() {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreIO.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.gcp.datastore;
 
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /**
  * {@link DatastoreIO} provides an API for reading from and writing to <a
@@ -26,7 +27,7 @@ import org.apache.beam.sdk.annotations.Experimental;
  *
  * <p>To use the v1 version see {@link DatastoreV1}.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class DatastoreIO {
 
   private DatastoreIO() {}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/package-info.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/package-info.java
@@ -21,4 +21,8 @@
  * href="https://developers.google.com/datastore/">Google Cloud Datastore</a> over different
  * versions of the Cloud Datastore Client libraries.
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.gcp.datastore;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -786,7 +786,7 @@ public class PubsubIO {
     }
 
     /** Exposes {@link PubSubIO.Read} as an external transform for cross-language usage. */
-    @Experimental
+    @Experimental(Kind.PORTABILITY)
     @AutoService(ExternalTransformRegistrar.class)
     public static class External implements ExternalTransformRegistrar {
 
@@ -1089,7 +1089,7 @@ public class PubsubIO {
     }
 
     /** Exposes {@link PubSubIO.Write} as an external transform for cross-language usage. */
-    @Experimental
+    @Experimental(Kind.PORTABILITY)
     @AutoService(ExternalTransformRegistrar.class)
     public static class External implements ExternalTransformRegistrar {
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -46,6 +46,7 @@ import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
@@ -239,7 +240,7 @@ import org.slf4j.LoggerFactory;
  * <p>{@link SpannerIO.Write} can be used as a streaming sink, however as with batch mode note that
  * the write order of individual {@link Mutation}/{@link MutationGroup} objects is not guaranteed.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class SpannerIO {
   private static final Logger LOG = LoggerFactory.getLogger(SpannerIO.class);
 
@@ -256,7 +257,6 @@ public class SpannerIO {
    * configured with a {@link Read#withInstanceId} and {@link Read#withDatabaseId} that identify the
    * Cloud Spanner database.
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   public static Read read() {
     return new AutoValue_SpannerIO_Read.Builder()
         .setSpannerConfig(SpannerConfig.create())
@@ -270,7 +270,6 @@ public class SpannerIO {
    * A {@link PTransform} that works like {@link #read}, but executes read operations coming from a
    * {@link PCollection}.
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   public static ReadAll readAll() {
     return new AutoValue_SpannerIO_ReadAll.Builder()
         .setSpannerConfig(SpannerConfig.create())
@@ -310,7 +309,6 @@ public class SpannerIO {
   }
 
   /** Implementation of {@link #readAll}. */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   @AutoValue
   public abstract static class ReadAll
       extends PTransform<PCollection<ReadOperation>, PCollection<Struct>> {
@@ -431,7 +429,6 @@ public class SpannerIO {
   }
 
   /** Implementation of {@link #read}. */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   @AutoValue
   public abstract static class Read extends PTransform<PBegin, PCollection<Struct>> {
 
@@ -617,7 +614,6 @@ public class SpannerIO {
    *
    * @see SpannerIO
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   @AutoValue
   public abstract static class CreateTransaction
       extends PTransform<PBegin, PCollectionView<Transaction>> {
@@ -722,7 +718,6 @@ public class SpannerIO {
    *
    * @see SpannerIO
    */
-  @Experimental(Experimental.Kind.SOURCE_SINK)
   @AutoValue
   public abstract static class Write extends PTransform<PCollection<Mutation>, SpannerWriteResult> {
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/package-info.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/package-info.java
@@ -20,4 +20,8 @@
  * Provides an API for reading from and writing to <a
  * href="https://developers.google.com/spanner/">Google Cloud Spanner</a>.
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.gcp.spanner;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/BigqueryClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/BigqueryClient.java
@@ -60,6 +60,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.gcp.util.BackOffAdapter;
 import org.apache.beam.sdk.extensions.gcp.util.Transport;
 import org.apache.beam.sdk.util.FluentBackoff;
@@ -110,6 +111,7 @@ import org.slf4j.LoggerFactory;
  *    client.insertDataToTable(projectId, datasetId, tableName, rows)
  * ]}</pre>
  */
+@Internal
 public class BigqueryClient {
   private static final Logger LOG = LoggerFactory.getLogger(BigqueryClient.class);
   // The maximum number of retries to execute a BigQuery RPC

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeBigQueryServices.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeBigQueryServices.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -37,7 +38,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
 /** A fake implementation of BigQuery's query service.. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class FakeBigQueryServices implements BigQueryServices {
   private JobService jobService;
   private DatasetService datasetService;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeBigQueryServices.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeBigQueryServices.java
@@ -25,8 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -38,7 +37,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
 /** A fake implementation of BigQuery's query service.. */
-@Experimental(Kind.SOURCE_SINK)
+@Internal
 public class FakeBigQueryServices implements BigQueryServices {
   private JobService jobService;
   private DatasetService datasetService;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeDatasetService.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeDatasetService.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.io.gcp.bigquery.ErrorContainer;
@@ -47,6 +48,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 
 /** A fake dataset service that can be serialized, for use in testReadFromTable. */
+@Internal
 public class FakeDatasetService implements DatasetService, Serializable {
   // Table information must be static, as each ParDo will get a separate instance of
   // FakeDatasetServices, and they must all modify the same storage.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeJobService.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeJobService.java
@@ -65,8 +65,7 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.Coder.Context;
 import org.apache.beam.sdk.extensions.gcp.util.BackOffAdapter;
@@ -88,7 +87,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.joda.time.Duration;
 
 /** A fake implementation of BigQuery's job service. */
-@Experimental(Kind.SOURCE_SINK)
+@Internal
 public class FakeJobService implements JobService, Serializable {
   private static final JsonFactory JSON_FACTORY = Transport.getJsonFactory();
   // Whenever a job is started, the first 2 calls to GetJob will report the job as pending,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeJobService.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeJobService.java
@@ -66,6 +66,7 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.Coder.Context;
 import org.apache.beam.sdk.extensions.gcp.util.BackOffAdapter;
@@ -87,7 +88,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.joda.time.Duration;
 
 /** A fake implementation of BigQuery's job service. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class FakeJobService implements JobService, Serializable {
   private static final JsonFactory JSON_FACTORY = Transport.getJsonFactory();
   // Whenever a job is started, the first 2 calls to GetJob will report the job as pending,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/package-info.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/package-info.java
@@ -16,4 +16,7 @@
  * limitations under the License.
  */
 /** Defines utilities for unit testing Google Cloud Platform components of Apache Beam pipelines. */
+@Internal
 package org.apache.beam.sdk.io.gcp.testing;
+
+import org.apache.beam.sdk.annotations.Internal;

--- a/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/package-info.java
+++ b/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Classes shared by Hadoop based IOs. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.hadoop;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/package-info.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/package-info.java
@@ -20,4 +20,8 @@
  * {@link org.apache.beam.sdk.io.FileSystem} implementation for any Hadoop {@link
  * org.apache.hadoop.fs.FileSystem}.
  */
+@Experimental(Kind.FILESYSTEM)
 package org.apache.beam.sdk.io.hdfs;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIO.java
+++ b/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIO.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -294,7 +295,7 @@ import org.slf4j.LoggerFactory;
  * }
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class HadoopFormatIO {
   private static final Logger LOG = LoggerFactory.getLogger(HadoopFormatIO.class);
 

--- a/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/package-info.java
+++ b/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/package-info.java
@@ -21,4 +21,8 @@
  *
  * @see org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.hadoop.format;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
+++ b/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
@@ -273,6 +273,7 @@ public class HBaseIO {
    * A {@link PTransform} that works like {@link #read}, but executes read operations coming from a
    * {@link PCollection} of {@link HBaseQuery}.
    */
+  @Experimental(Kind.SPLITTABLE_DO_FN)
   public static ReadAll readAll() {
     return new ReadAll(null);
   }

--- a/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
+++ b/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.hadoop.SerializableConfiguration;
@@ -146,7 +147,7 @@ import org.slf4j.LoggerFactory;
  * be different in some aspects, but the idea is that users can easily migrate from one to the other
  * .
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class HBaseIO {
   private static final Logger LOG = LoggerFactory.getLogger(HBaseIO.class);
 

--- a/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/package-info.java
+++ b/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/package-info.java
@@ -21,4 +21,8 @@
  *
  * @see org.apache.beam.sdk.io.hbase.HBaseIO
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.hbase;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/HCatalogIO.java
+++ b/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/HCatalogIO.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.hadoop.WritableCoder;
@@ -121,7 +122,7 @@ import org.slf4j.LoggerFactory;
  *       .withBatchSize(1024L)) //optional, assumes a default batch size of 1024 if none specified
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class HCatalogIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(HCatalogIO.class);

--- a/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/package-info.java
+++ b/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing using HCatalog. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.hcatalog;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/test/EmbeddedMetastoreService.java
+++ b/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/test/EmbeddedMetastoreService.java
@@ -23,6 +23,7 @@ import static org.apache.hive.hcatalog.common.HCatUtil.makePathASafeFileName;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.CommandNeedRetryException;
@@ -37,6 +38,7 @@ import org.apache.hadoop.hive.ql.session.SessionState;
  *
  * <p>Used only for testing.
  */
+@Internal
 public final class EmbeddedMetastoreService implements AutoCloseable {
   private final Driver driver;
   private final HiveConf hiveConf;

--- a/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/test/HCatalogIOTestUtils.java
+++ b/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/test/HCatalogIOTestUtils.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.values.KV;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.hcatalog.common.HCatException;
@@ -36,6 +37,7 @@ import org.apache.hive.hcatalog.data.transfer.WriteEntity;
 import org.apache.hive.hcatalog.data.transfer.WriterContext;
 
 /** Utility class for HCatalogIOTest and HCatalogIOIT. */
+@Internal
 public class HCatalogIOTestUtils {
   public static final String TEST_DATABASE = "default";
   public static final String TEST_TABLE = "mytable";

--- a/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/test/package-info.java
+++ b/sdks/java/io/hcatalog/src/main/java/org/apache/beam/sdk/io/hcatalog/test/package-info.java
@@ -21,4 +21,7 @@
  *
  * <p>In 'main' because other projects may depend on it.
  */
+@Internal
 package org.apache.beam.sdk.io.hcatalog.test;
+
+import org.apache.beam.sdk.annotations.Internal;

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -39,6 +39,7 @@ import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -184,7 +185,7 @@ import org.slf4j.LoggerFactory;
  * Consider using <a href="https://en.wikipedia.org/wiki/Merge_(SQL)">MERGE ("upsert")
  * statements</a> supported by your database instead.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class JdbcIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcIO.class);
@@ -202,7 +203,7 @@ public class JdbcIO {
   }
 
   /** Read Beam {@link Row}s from a JDBC data source. */
-  @Experimental(Experimental.Kind.SCHEMAS)
+  @Experimental(Kind.SCHEMAS)
   public static ReadRows readRows() {
     return new AutoValue_JdbcIO_ReadRows.Builder()
         .setFetchSize(DEFAULT_FETCH_SIZE)
@@ -446,7 +447,7 @@ public class JdbcIO {
 
   /** Implementation of {@link #readRows()}. */
   @AutoValue
-  @Experimental(Experimental.Kind.SCHEMAS)
+  @Experimental(Kind.SCHEMAS)
   public abstract static class ReadRows extends PTransform<PBegin, PCollection<Row>> {
     @Nullable
     abstract SerializableFunction<Void, DataSource> getDataSourceProviderFn();

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/package-info.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from JDBC. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.jdbc;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -38,6 +38,7 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.Read.Unbounded;
@@ -109,7 +110,7 @@ import org.joda.time.Instant;
  *
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class JmsIO {
 
   public static Read<JmsRecord> read() {

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/package-info.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from JMS (Java Messaging Service). */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.jms;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.avro.Schema;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
@@ -281,7 +282,7 @@ import org.slf4j.LoggerFactory;
  * Kafka cluster. Kafka client usually fails to initialize with a clear error message in case of
  * incompatibility.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class KafkaIO {
 
   /**

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -396,7 +396,7 @@ public class KafkaIO {
 
     abstract Builder<K, V> toBuilder();
 
-    @Experimental
+    @Experimental(Kind.PORTABILITY)
     @AutoValue.Builder
     abstract static class Builder<K, V>
         implements ExternalTransformBuilder<External.Configuration, PBegin, PCollection<KV<K, V>>> {
@@ -500,7 +500,7 @@ public class KafkaIO {
      * Exposes {@link KafkaIO.TypedWithoutMetadata} as an external transform for cross-language
      * usage.
      */
-    @Experimental
+    @Experimental(Kind.PORTABILITY)
     @AutoService(ExternalTransformRegistrar.class)
     public static class External implements ExternalTransformRegistrar {
 
@@ -1469,7 +1469,7 @@ public class KafkaIO {
 
     abstract Builder<K, V> toBuilder();
 
-    @Experimental
+    @Experimental(Kind.PORTABILITY)
     @AutoValue.Builder
     abstract static class Builder<K, V>
         implements ExternalTransformBuilder<External.Configuration, PCollection<KV<K, V>>, PDone> {
@@ -1504,7 +1504,7 @@ public class KafkaIO {
     }
 
     /** Exposes {@link KafkaIO.Write} as an external transform for cross-language usage. */
-    @Experimental
+    @Experimental(Kind.PORTABILITY)
     @AutoService(ExternalTransformRegistrar.class)
     public static class External implements ExternalTransformRegistrar {
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/package-info.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from Apache Kafka. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.kafka;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/InstantDeserializer.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/InstantDeserializer.java
@@ -18,6 +18,8 @@
 package org.apache.beam.sdk.io.kafka.serialization;
 
 import java.util.Map;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.joda.time.Instant;
@@ -27,6 +29,7 @@ import org.joda.time.Instant;
  *
  * <p>This decodes the number of milliseconds since epoch using {@link LongDeserializer}.
  */
+@Experimental(Kind.SOURCE_SINK)
 public class InstantDeserializer implements Deserializer<Instant> {
   private static final LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/InstantSerializer.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/InstantSerializer.java
@@ -18,6 +18,8 @@
 package org.apache.beam.sdk.io.kafka.serialization;
 
 import java.util.Map;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.joda.time.Instant;
@@ -27,6 +29,7 @@ import org.joda.time.Instant;
  *
  * <p>This encodes the number of milliseconds since epoch using {@link LongSerializer}.
  */
+@Experimental(Kind.SOURCE_SINK)
 public class InstantSerializer implements Serializer<Instant> {
   private static final LongSerializer LONG_SERIALIZER = new LongSerializer();
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/package-info.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Kafka serializers and deserializers. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.kafka.serialization;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisIO.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisIO.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.Read.Unbounded;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -226,7 +227,7 @@ import org.slf4j.LoggerFactory;
  * href="https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer-sample/default_config.properties">sample
  * of configuration file</a>.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public final class KinesisIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(KinesisIO.class);

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/package-info.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from Amazon Kinesis. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.kinesis;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/kudu/src/main/java/org/apache/beam/sdk/io/kudu/KuduIO.java
+++ b/sdks/java/io/kudu/src/main/java/org/apache/beam/sdk/io/kudu/KuduIO.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
@@ -119,7 +120,7 @@ import org.slf4j.LoggerFactory;
  *
  * {@code KuduIO} does not support authentication in this release.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class KuduIO {
   private static final Logger LOG = LoggerFactory.getLogger(KuduIO.class);
 

--- a/sdks/java/io/kudu/src/main/java/org/apache/beam/sdk/io/kudu/package-info.java
+++ b/sdks/java/io/kudu/src/main/java/org/apache/beam/sdk/io/kudu/package-info.java
@@ -21,4 +21,8 @@
  *
  * @see org.apache.beam.sdk.io.kudu.KuduIO
  */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.kudu;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/AggregationQuery.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/AggregationQuery.java
@@ -24,12 +24,13 @@ import com.mongodb.lang.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.bson.BsonDocument;
 import org.bson.Document;
 
 /** Builds a MongoDB AggregateIterable object. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 @AutoValue
 public abstract class AggregationQuery
     implements SerializableFunction<MongoCollection<Document>, MongoCursor<Document>> {

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/FindQuery.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/FindQuery.java
@@ -29,13 +29,14 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
 /** Builds a MongoDB FindQuery object. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 @AutoValue
 public abstract class FindQuery
     implements SerializableFunction<MongoCollection<Document>, MongoCursor<Document>> {

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -112,7 +113,7 @@ import org.joda.time.Instant;
  * used to write the data to the OutputStream. By default, it writes UTF-8 strings to the file
  * separated with line feeds.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class MongoDbGridFSIO {
 
   /** Callback for the parser to use to submit data. */

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -107,7 +108,7 @@ import org.slf4j.LoggerFactory;
  *
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class MongoDbIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbIO.class);

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/package-info.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from MongoDB. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.mongodb;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
+++ b/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
@@ -99,7 +100,7 @@ import org.slf4j.LoggerFactory;
  *
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class MqttIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(MqttIO.class);

--- a/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/package-info.java
+++ b/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from MQTT. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.mqtt;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java
+++ b/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java
@@ -31,6 +31,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.FileIO;
@@ -121,7 +122,7 @@ import org.apache.parquet.io.SeekableInputStream;
  * @see <a href="https://beam.apache.org/documentation/io/built-in/parquet/">Beam ParquetIO
  *     documentation</a>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class ParquetIO {
 
   /**

--- a/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/package-info.java
+++ b/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from Parquet. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.parquet;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -38,6 +38,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.UnboundedSource;
@@ -117,7 +118,7 @@ import org.joda.time.Instant;
  *   .apply(RabbitMqIO.write().withUri("amqp://user:password@localhost:5672").withQueue("QUEUE"));
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class RabbitMqIO {
   public static Read read() {
     return new AutoValue_RabbitMqIO_Read.Builder()

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/package-info.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from RabbitMQ. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.rabbitmq;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.transforms.Create;
@@ -105,7 +106,7 @@ import redis.clients.jedis.ScanResult;
  *
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class RedisIO {
 
   /** Read data from a Redis server. */

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/package-info.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from Redis. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.redis;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/solr/src/main/java/org/apache/beam/sdk/io/solr/SolrIO.java
+++ b/sdks/java/io/solr/src/main/java/org/apache/beam/sdk/io/solr/SolrIO.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -111,7 +112,7 @@ import org.slf4j.LoggerFactory;
  * <p>When writing it is possible to customize the retry behavior if an error is encountered. By
  * default this is disabled and only one attempt will be made.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class SolrIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(SolrIO.class);

--- a/sdks/java/io/solr/src/main/java/org/apache/beam/sdk/io/solr/package-info.java
+++ b/sdks/java/io/solr/src/main/java/org/apache/beam/sdk/io/solr/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing from/to Solr. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.solr;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/synthetic/src/main/java/org/apache/beam/sdk/io/synthetic/SyntheticBoundedSource.java
+++ b/sdks/java/io/synthetic/src/main/java/org/apache/beam/sdk/io/synthetic/SyntheticBoundedSource.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -50,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * enables repeatable execution for debugging. The SyntheticBoundedInput configurable parameters are
  * defined in {@link SyntheticSourceOptions}.*
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class SyntheticBoundedSource extends OffsetBasedSource<KV<byte[], byte[]>> {
 
   private static final long serialVersionUID = 0;

--- a/sdks/java/io/synthetic/src/main/java/org/apache/beam/sdk/io/synthetic/SyntheticUnboundedSource.java
+++ b/sdks/java/io/synthetic/src/main/java/org/apache/beam/sdk/io/synthetic/SyntheticUnboundedSource.java
@@ -22,6 +22,7 @@ import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -34,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A {@link SyntheticUnboundedSource} that reads {@code KV<byte[], byte[]>}. */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class SyntheticUnboundedSource
     extends UnboundedSource<KV<byte[], byte[]>, SyntheticRecordsCheckpoint> {
 

--- a/sdks/java/io/synthetic/src/main/java/org/apache/beam/sdk/io/synthetic/delay/package-info.java
+++ b/sdks/java/io/synthetic/src/main/java/org/apache/beam/sdk/io/synthetic/delay/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Delay related classes. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.synthetic.delay;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/synthetic/src/main/java/org/apache/beam/sdk/io/synthetic/package-info.java
+++ b/sdks/java/io/synthetic/src/main/java/org/apache/beam/sdk/io/synthetic/package-info.java
@@ -16,4 +16,8 @@
  * limitations under the License.
  */
 /** Transforms for performing Synthetic Operations in Apache Beam pipelines. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.synthetic;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/tika/src/main/java/org/apache/beam/sdk/io/tika/TikaIO.java
+++ b/sdks/java/io/tika/src/main/java/org/apache/beam/sdk/io/tika/TikaIO.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.nio.channels.Channels;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.io.FileIO.ReadableFile;
@@ -88,7 +89,7 @@ import org.xml.sax.ContentHandler;
  *    .apply(TikaIO.parseFiles());
  * }</pre>
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
+@Experimental(Kind.SOURCE_SINK)
 public class TikaIO {
   /** Parses files matching a given filepattern. */
   public static Parse parse() {

--- a/sdks/java/io/tika/src/main/java/org/apache/beam/sdk/io/tika/package-info.java
+++ b/sdks/java/io/tika/src/main/java/org/apache/beam/sdk/io/tika/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transform for reading and parsing files with Apache Tika. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.tika;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/package-info.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/package-info.java
@@ -17,4 +17,8 @@
  */
 
 /** Transforms for reading and writing Xml files. */
+@Experimental(Kind.SOURCE_SINK)
 package org.apache.beam.sdk.io.xml;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;


### PR DESCRIPTION
Also make `SplittableDoFn` classes in `beam-sdks-java-core` Experimental and make Experimental annotations homogeneous.
For easier review take a look better at the separate commits.
R: @lukecwik 
