### PR TITLE
[BEAM-9241] Fix inconsistent proto nullability

### DIFF
--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchemaTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchemaTest.java
@@ -33,6 +33,9 @@ import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.ONEOF_ROW
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.ONEOF_ROW_PRIMITIVE;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.ONEOF_ROW_STRING;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.ONEOF_SCHEMA;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.OPTIONAL_PRIMITIVE_PROTO;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.OPTIONAL_PRIMITIVE_ROW;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.OPTIONAL_PRIMITIVE_SCHEMA;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.OUTER_ONEOF_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.OUTER_ONEOF_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.OUTER_ONEOF_SCHEMA;
@@ -42,11 +45,16 @@ import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.PRIMITIVE
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REPEATED_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REPEATED_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REPEATED_SCHEMA;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REQUIRED_PRIMITIVE_PROTO;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REQUIRED_PRIMITIVE_ROW;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REQUIRED_PRIMITIVE_SCHEMA;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_SCHEMA;
 import static org.junit.Assert.assertEquals;
 
+import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.OptionalPrimitive;
+import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.RequiredPrimitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.EnumMessage;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.EnumMessage.Enum;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.MapPrimitive;
@@ -88,6 +96,46 @@ public class ProtoMessageSchemaTest {
     SerializableFunction<Row, Primitive> fromRow =
         new ProtoMessageSchema().fromRowFunction(TypeDescriptor.of(Primitive.class));
     assertEquals(PRIMITIVE_PROTO, fromRow.apply(PRIMITIVE_ROW));
+  }
+
+  @Test
+  public void testOptionalPrimitiveSchema() {
+    Schema schema = new ProtoMessageSchema().schemaFor(TypeDescriptor.of(OptionalPrimitive.class));
+    assertEquals(OPTIONAL_PRIMITIVE_SCHEMA, schema);
+  }
+
+  @Test
+  public void testOptionalPrimitiveProtoToRow() {
+    SerializableFunction<OptionalPrimitive, Row> toRow =
+        new ProtoMessageSchema().toRowFunction(TypeDescriptor.of(OptionalPrimitive.class));
+    assertEquals(OPTIONAL_PRIMITIVE_ROW, toRow.apply(OPTIONAL_PRIMITIVE_PROTO));
+  }
+
+  @Test
+  public void testOptionalPrimitiveRowToProto() {
+    SerializableFunction<Row, OptionalPrimitive> fromRow =
+        new ProtoMessageSchema().fromRowFunction(TypeDescriptor.of(OptionalPrimitive.class));
+    assertEquals(OPTIONAL_PRIMITIVE_PROTO, fromRow.apply(OPTIONAL_PRIMITIVE_ROW));
+  }
+
+  @Test
+  public void testRequiredPrimitiveSchema() {
+    Schema schema = new ProtoMessageSchema().schemaFor(TypeDescriptor.of(RequiredPrimitive.class));
+    assertEquals(REQUIRED_PRIMITIVE_SCHEMA, schema);
+  }
+
+  @Test
+  public void testRequiredPrimitiveProtoToRow() {
+    SerializableFunction<RequiredPrimitive, Row> toRow =
+        new ProtoMessageSchema().toRowFunction(TypeDescriptor.of(RequiredPrimitive.class));
+    assertEquals(REQUIRED_PRIMITIVE_ROW, toRow.apply(REQUIRED_PRIMITIVE_PROTO));
+  }
+
+  @Test
+  public void testRequiredPrimitiveRowToProto() {
+    SerializableFunction<Row, RequiredPrimitive> fromRow =
+        new ProtoMessageSchema().fromRowFunction(TypeDescriptor.of(RequiredPrimitive.class));
+    assertEquals(REQUIRED_PRIMITIVE_PROTO, fromRow.apply(REQUIRED_PRIMITIVE_ROW));
   }
 
   @Test
@@ -201,7 +249,7 @@ public class ProtoMessageSchemaTest {
       EnumerationType.create(ImmutableMap.of("ZERO", 0, "TWO", 2, "THREE", 3));
   private static final Schema ENUM_SCHEMA =
       Schema.builder()
-          .addField("enum", withFieldNumber(FieldType.logicalType(ENUM_TYPE).withNullable(true), 1))
+          .addField("enum", withFieldNumber(FieldType.logicalType(ENUM_TYPE), 1))
           .build();
   private static final Row ENUM_ROW =
       Row.withSchema(ENUM_SCHEMA).addValues(ENUM_TYPE.valueOf("TWO")).build();

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
@@ -34,6 +34,20 @@ public class ProtoSchemaTranslatorTest {
   }
 
   @Test
+  public void testOptionalPrimitiveSchema() {
+    assertEquals(
+        TestProtoSchemas.OPTIONAL_PRIMITIVE_SCHEMA,
+        ProtoSchemaTranslator.getSchema(Proto2SchemaMessages.OptionalPrimitive.class));
+  }
+
+  @Test
+  public void testRequiredPrimitiveSchema() {
+    assertEquals(
+        TestProtoSchemas.REQUIRED_PRIMITIVE_SCHEMA,
+        ProtoSchemaTranslator.getSchema(Proto2SchemaMessages.RequiredPrimitive.class));
+  }
+
+  @Test
   public void testRepeatedSchema() {
     assertEquals(
         TestProtoSchemas.REPEATED_SCHEMA,
@@ -73,5 +87,19 @@ public class ProtoSchemaTranslatorTest {
     assertEquals(
         TestProtoSchemas.WKT_MESSAGE_SCHEMA,
         ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.WktMessage.class));
+  }
+
+  @Test
+  public void testOptionalNestedSchema() {
+    assertEquals(
+        TestProtoSchemas.OPTIONAL_NESTED_SCHEMA,
+        ProtoSchemaTranslator.getSchema(Proto2SchemaMessages.OptionalNested.class));
+  }
+
+  @Test
+  public void testRequiredNestedSchema() {
+    assertEquals(
+        TestProtoSchemas.REQUIRED_NESTED_SCHEMA,
+        ProtoSchemaTranslator.getSchema(Proto2SchemaMessages.RequiredNested.class));
   }
 }

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -36,6 +36,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.OptionalNested;
+import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.OptionalPrimitive;
+import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.RequiredNested;
+import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.RequiredPrimitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.MapPrimitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Nested;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OneOf;
@@ -65,29 +69,39 @@ class TestProtoSchemas {
   // The schema we expect from the Primitive proto.
   static final Schema PRIMITIVE_SCHEMA =
       Schema.builder()
-          .addNullableField("primitive_double", withFieldNumber(FieldType.DOUBLE, 1))
-          .addNullableField("primitive_float", withFieldNumber(FieldType.FLOAT, 2))
-          .addNullableField("primitive_int32", withFieldNumber(FieldType.INT32, 3))
-          .addNullableField("primitive_int64", withFieldNumber(FieldType.INT64, 4))
-          .addNullableField(
-              "primitive_uint32", withFieldNumber(FieldType.logicalType(new UInt32()), 5))
-          .addNullableField(
-              "primitive_uint64", withFieldNumber(FieldType.logicalType(new UInt64()), 6))
-          .addNullableField(
-              "primitive_sint32", withFieldNumber(FieldType.logicalType(new SInt32()), 7))
-          .addNullableField(
-              "primitive_sint64", withFieldNumber(FieldType.logicalType(new SInt64()), 8))
-          .addNullableField(
-              "primitive_fixed32", withFieldNumber(FieldType.logicalType(new Fixed32()), 9))
-          .addNullableField(
-              "primitive_fixed64", withFieldNumber(FieldType.logicalType(new Fixed64()), 10))
-          .addNullableField(
+          .addField("primitive_double", withFieldNumber(FieldType.DOUBLE, 1))
+          .addField("primitive_float", withFieldNumber(FieldType.FLOAT, 2))
+          .addField("primitive_int32", withFieldNumber(FieldType.INT32, 3))
+          .addField("primitive_int64", withFieldNumber(FieldType.INT64, 4))
+          .addField("primitive_uint32", withFieldNumber(FieldType.logicalType(new UInt32()), 5))
+          .addField("primitive_uint64", withFieldNumber(FieldType.logicalType(new UInt64()), 6))
+          .addField("primitive_sint32", withFieldNumber(FieldType.logicalType(new SInt32()), 7))
+          .addField("primitive_sint64", withFieldNumber(FieldType.logicalType(new SInt64()), 8))
+          .addField("primitive_fixed32", withFieldNumber(FieldType.logicalType(new Fixed32()), 9))
+          .addField("primitive_fixed64", withFieldNumber(FieldType.logicalType(new Fixed64()), 10))
+          .addField(
               "primitive_sfixed32", withFieldNumber(FieldType.logicalType(new SFixed32()), 11))
-          .addNullableField(
+          .addField(
               "primitive_sfixed64", withFieldNumber(FieldType.logicalType(new SFixed64()), 12))
-          .addNullableField("primitive_bool", withFieldNumber(FieldType.BOOLEAN, 13))
-          .addNullableField("primitive_string", withFieldNumber(FieldType.STRING, 14))
-          .addNullableField("primitive_bytes", withFieldNumber(FieldType.BYTES, 15))
+          .addField("primitive_bool", withFieldNumber(FieldType.BOOLEAN, 13))
+          .addField("primitive_string", withFieldNumber(FieldType.STRING, 14))
+          .addField("primitive_bytes", withFieldNumber(FieldType.BYTES, 15))
+          .build();
+
+  static final Schema OPTIONAL_PRIMITIVE_SCHEMA =
+      Schema.builder()
+          .addField("primitive_int32", withFieldNumber(FieldType.INT32, 1))
+          .addField("primitive_bool", withFieldNumber(FieldType.BOOLEAN, 2))
+          .addField("primitive_string", withFieldNumber(FieldType.STRING, 3))
+          .addField("primitive_bytes", withFieldNumber(FieldType.BYTES, 4))
+          .build();
+
+  static final Schema REQUIRED_PRIMITIVE_SCHEMA =
+      Schema.builder()
+          .addField("primitive_int32", withFieldNumber(FieldType.INT32, 1))
+          .addField("primitive_bool", withFieldNumber(FieldType.BOOLEAN, 2))
+          .addField("primitive_string", withFieldNumber(FieldType.STRING, 3))
+          .addField("primitive_bytes", withFieldNumber(FieldType.BYTES, 4))
           .build();
 
   // A sample instance of the  row.
@@ -113,6 +127,32 @@ class TestProtoSchemas {
           .setPrimitiveFixed64(62)
           .setPrimitiveSfixed32(31)
           .setPrimitiveSfixed64(63)
+          .setPrimitiveBool(true)
+          .setPrimitiveString("horsey")
+          .setPrimitiveBytes(ByteString.copyFrom(BYTE_ARRAY))
+          .build();
+
+  // A sample instance of the  row.
+  static final Row OPTIONAL_PRIMITIVE_ROW =
+      Row.withSchema(OPTIONAL_PRIMITIVE_SCHEMA).addValues(32, true, "horsey", BYTE_ARRAY).build();
+
+  // A sample instance of the proto.
+  static final OptionalPrimitive OPTIONAL_PRIMITIVE_PROTO =
+      OptionalPrimitive.newBuilder()
+          .setPrimitiveInt32(32)
+          .setPrimitiveBool(true)
+          .setPrimitiveString("horsey")
+          .setPrimitiveBytes(ByteString.copyFrom(BYTE_ARRAY))
+          .build();
+
+  // A sample instance of the  row.
+  static final Row REQUIRED_PRIMITIVE_ROW =
+      Row.withSchema(REQUIRED_PRIMITIVE_SCHEMA).addValues(32, true, "horsey", BYTE_ARRAY).build();
+
+  // A sample instance of the proto.
+  static final RequiredPrimitive REQUIRED_PRIMITIVE_PROTO =
+      RequiredPrimitive.newBuilder()
+          .setPrimitiveInt32(32)
           .setPrimitiveBool(true)
           .setPrimitiveString("horsey")
           .setPrimitiveBytes(ByteString.copyFrom(BYTE_ARRAY))
@@ -200,28 +240,16 @@ class TestProtoSchemas {
       Schema.builder()
           .addField(
               "string_string_map",
-              withFieldNumber(
-                  FieldType.map(
-                      FieldType.STRING.withNullable(true), FieldType.STRING.withNullable(true)),
-                  1))
+              withFieldNumber(FieldType.map(FieldType.STRING, FieldType.STRING), 1))
           .addField(
               "string_int_map",
-              withFieldNumber(
-                  FieldType.map(
-                      FieldType.STRING.withNullable(true), FieldType.INT32.withNullable(true)),
-                  2))
+              withFieldNumber(FieldType.map(FieldType.STRING, FieldType.INT32), 2))
           .addField(
               "int_string_map",
-              withFieldNumber(
-                  FieldType.map(
-                      FieldType.INT32.withNullable(true), FieldType.STRING.withNullable(true)),
-                  3))
+              withFieldNumber(FieldType.map(FieldType.INT32, FieldType.STRING), 3))
           .addField(
               "string_bytes_map",
-              withFieldNumber(
-                  FieldType.map(
-                      FieldType.STRING.withNullable(true), FieldType.BYTES.withNullable(true)),
-                  4))
+              withFieldNumber(FieldType.map(FieldType.STRING, FieldType.BYTES), 4))
           .build();
 
   // A sample instance of the row.
@@ -253,11 +281,7 @@ class TestProtoSchemas {
               "nested_list", withFieldNumber(FieldType.array(FieldType.row(PRIMITIVE_SCHEMA)), 2))
           .addField(
               "nested_map",
-              withFieldNumber(
-                  FieldType.map(
-                      FieldType.STRING.withNullable(true),
-                      FieldType.row(PRIMITIVE_SCHEMA).withNullable(true)),
-                  3))
+              withFieldNumber(FieldType.map(FieldType.STRING, FieldType.row(PRIMITIVE_SCHEMA)), 3))
           .build();
 
   // A sample instance of the row.
@@ -290,8 +314,8 @@ class TestProtoSchemas {
   static final Schema ONEOF_SCHEMA =
       Schema.builder()
           .addField("special_oneof", FieldType.logicalType(ONE_OF_TYPE))
-          .addField("place1", withFieldNumber(FieldType.STRING.withNullable(true), 1))
-          .addField("place2", withFieldNumber(FieldType.INT32.withNullable(true), 6))
+          .addField("place1", withFieldNumber(FieldType.STRING, 1))
+          .addField("place2", withFieldNumber(FieldType.INT32, 6))
           .build();
 
   // Sample row instances for each OneOf case.
@@ -396,4 +420,28 @@ class TestProtoSchemas {
           .setTimestamp(PROTO_NOW)
           .setDuration(PROTO_DURATION)
           .build();
+
+  // The schema for the OptionalNested proto.
+  static final Schema OPTIONAL_NESTED_SCHEMA =
+      Schema.builder()
+          .addField(
+              "nested",
+              withFieldNumber(FieldType.row(OPTIONAL_PRIMITIVE_SCHEMA), 1).withNullable(true))
+          .build();
+
+  // A sample instance of the proto.
+  static final OptionalNested OPTIONAL_NESTED =
+      OptionalNested.newBuilder().setNested(OPTIONAL_PRIMITIVE_PROTO).build();
+
+  // The schema for the Required Nested proto.
+  static final Schema REQUIRED_NESTED_SCHEMA =
+      Schema.builder()
+          .addField(
+              "nested",
+              withFieldNumber(FieldType.row(REQUIRED_PRIMITIVE_SCHEMA), 1).withNullable(false))
+          .build();
+
+  // A sample instance of the proto.
+  static final RequiredNested REQUIRED_NESTED =
+      RequiredNested.newBuilder().setNested(REQUIRED_PRIMITIVE_PROTO).build();
 }

--- a/sdks/java/extensions/protobuf/src/test/proto/proto2_schema_messages.proto
+++ b/sdks/java/extensions/protobuf/src/test/proto/proto2_schema_messages.proto
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Protocol Buffer messages used for testing Proto2 Schema implementation.
+ */
+
+syntax = "proto2";
+
+package proto2_schema_messages;
+
+option java_package = "org.apache.beam.sdk.extensions.protobuf";
+
+message OptionalPrimitive {
+    optional int32 primitive_int32 = 1;
+    optional bool primitive_bool = 2;
+    optional string primitive_string = 3;
+    optional bytes primitive_bytes = 4;
+}
+
+message RequiredPrimitive {
+    required int32 primitive_int32 = 1;
+    required bool primitive_bool = 2;
+    required string primitive_string = 3;
+    required bytes primitive_bytes = 4;
+}
+
+message RequiredNested {
+    required RequiredPrimitive nested = 1;
+}
+
+message OptionalNested {
+    optional OptionalPrimitive nested = 1;
+}


### PR DESCRIPTION
Fix the nullability issues with protobuf to schema mapping

* Proto3 primitive types should be not nullable.
* Proto2 required types should be not nullable.
* Proto2 optional should also be not nullable as having an optional value
  doesn't mean it has not value. The spec states it has the optional
  value.
* Arrays should be not nullable, as proto arrays always have an empty
  array when no value is set.
* Maps should be not nullable, as proto maps always have an empty map when
  no value is set.
* Elements in an array should be not nullable, as nulls are not allowed in
  an array.
* Names and Values should be not nullable, as nulls are not allowed.
* Rows are nullable, as messages are nullable.


Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
