### PR TITLE
[BEAM-9269] Add commit deadline for Spanner writes.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
@@ -28,12 +28,20 @@ import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.spi.v1.SpannerInterceptorProvider;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
 import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.ReleaseInfo;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.joda.time.Duration;
 
 /** Configuration for a Cloud Spanner client. */
 @AutoValue
@@ -42,6 +50,10 @@ public abstract class SpannerConfig implements Serializable {
   private static final String USER_AGENT_PREFIX = "Apache_Beam_Java";
   // A default host name for batch traffic.
   private static final String DEFAULT_HOST = "https://batch-spanner.googleapis.com/";
+  // Deadline for Commit API call.
+  private static final Duration DEFAULT_COMMIT_DEADLINE = Duration.standardSeconds(15);
+  // Total allowable backoff time.
+  private static final Duration DEFAULT_MAX_CUMULATIVE_BACKOFF = Duration.standardMinutes(15);
 
   @Nullable
   public abstract ValueProvider<String> getProjectId();
@@ -56,13 +68,24 @@ public abstract class SpannerConfig implements Serializable {
   public abstract ValueProvider<String> getHost();
 
   @Nullable
+  public abstract ValueProvider<Duration> getCommitDeadline();
+
+  @Nullable
+  public abstract ValueProvider<Duration> getMaxCumulativeBackoff();
+
+  @Nullable
   @VisibleForTesting
   abstract ServiceFactory<Spanner, SpannerOptions> getServiceFactory();
 
   abstract Builder toBuilder();
 
   public static SpannerConfig create() {
-    return builder().setHost(ValueProvider.StaticValueProvider.of(DEFAULT_HOST)).build();
+    return builder()
+        .setHost(ValueProvider.StaticValueProvider.of(DEFAULT_HOST))
+        .setCommitDeadline(ValueProvider.StaticValueProvider.of(DEFAULT_COMMIT_DEADLINE))
+        .setMaxCumulativeBackoff(
+            ValueProvider.StaticValueProvider.of(DEFAULT_MAX_CUMULATIVE_BACKOFF))
+        .build();
   }
 
   static Builder builder() {
@@ -103,6 +126,10 @@ public abstract class SpannerConfig implements Serializable {
 
     abstract Builder setHost(ValueProvider<String> host);
 
+    abstract Builder setCommitDeadline(ValueProvider<Duration> commitDeadline);
+
+    abstract Builder setMaxCumulativeBackoff(ValueProvider<Duration> maxCumulativeBackoff);
+
     abstract Builder setServiceFactory(ServiceFactory<Spanner, SpannerOptions> serviceFactory);
 
     public abstract SpannerConfig build();
@@ -136,6 +163,22 @@ public abstract class SpannerConfig implements Serializable {
     return toBuilder().setHost(host).build();
   }
 
+  public SpannerConfig withCommitDeadline(Duration commitDeadline) {
+    return withCommitDeadline(ValueProvider.StaticValueProvider.of(commitDeadline));
+  }
+
+  public SpannerConfig withCommitDeadline(ValueProvider<Duration> commitDeadline) {
+    return toBuilder().setCommitDeadline(commitDeadline).build();
+  }
+
+  public SpannerConfig withMaxCumulativeBackoff(Duration maxCumulativeBackoff) {
+    return withMaxCumulativeBackoff(ValueProvider.StaticValueProvider.of(maxCumulativeBackoff));
+  }
+
+  public SpannerConfig withMaxCumulativeBackoff(ValueProvider<Duration> maxCumulativeBackoff) {
+    return toBuilder().setMaxCumulativeBackoff(maxCumulativeBackoff).build();
+  }
+
   @VisibleForTesting
   SpannerConfig withServiceFactory(ServiceFactory<Spanner, SpannerOptions> serviceFactory) {
     return toBuilder().setServiceFactory(serviceFactory).build();
@@ -143,6 +186,28 @@ public abstract class SpannerConfig implements Serializable {
 
   public SpannerAccessor connectToSpanner() {
     SpannerOptions.Builder builder = SpannerOptions.newBuilder();
+
+    if (getCommitDeadline() != null && getCommitDeadline().get().getMillis() > 0) {
+
+      // In Spanner API version 1.21 or above, we can set the deadline / total Timeout on an API
+      // call using the following code:
+      //
+      // UnaryCallSettings.Builder commitSettings =
+      // builder.getSpannerStubSettingsBuilder().commitSettings();
+      // RetrySettings.Builder commitRetrySettings = commitSettings.getRetrySettings().toBuilder()
+      // commitSettings.setRetrySettings(
+      //     commitRetrySettings.setTotalTimeout(
+      //         Duration.ofMillis(getCommitDeadlineMillis().get()))
+      //     .build());
+      //
+      // However, at time of this commit, the Spanner API is at only at v1.6.0, where the only
+      // method to set a deadline is with GRPC Interceptors, so we have to use that...
+      SpannerInterceptorProvider interceptorProvider =
+          SpannerInterceptorProvider.createDefault()
+              .with(new CommitDeadlineSettingInterceptor(getCommitDeadline().get()));
+      builder.setInterceptorProvider(interceptorProvider);
+    }
+
     if (getProjectId() != null) {
       builder.setProjectId(getProjectId().get());
     }
@@ -164,5 +229,23 @@ public abstract class SpannerConfig implements Serializable {
             DatabaseId.of(options.getProjectId(), getInstanceId().get(), getDatabaseId().get()));
     DatabaseAdminClient databaseAdminClient = spanner.getDatabaseAdminClient();
     return new SpannerAccessor(spanner, databaseClient, databaseAdminClient, batchClient);
+  }
+
+  private static class CommitDeadlineSettingInterceptor implements ClientInterceptor {
+    private final long commitDeadlineMilliseconds;
+
+    private CommitDeadlineSettingInterceptor(Duration commitDeadline) {
+      this.commitDeadlineMilliseconds = commitDeadline.getMillis();
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      if (method.getFullMethodName().equals("google.spanner.v1.Spanner/Commit")) {
+        callOptions =
+            callOptions.withDeadlineAfter(commitDeadlineMilliseconds, TimeUnit.MILLISECONDS);
+      }
+      return next.newCall(method, callOptions);
+    }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1370,7 +1370,7 @@ public class SpannerIO {
     @ProcessElement
     public void processElement(ProcessContext c) throws Exception {
       Iterable<MutationGroup> mutations = c.element();
-      boolean tryIndividual = false;
+
       // Batch upsert rows.
       try {
         mutationGroupBatchesReceived.inc();
@@ -1427,7 +1427,8 @@ public class SpannerIO {
             if (sleepTimeMsecs == BackOff.STOP) {
               LOG.error(
                   "DEADLINE_EXCEEDED writing batch of {} mutations to Cloud Spanner. "
-                      + "Aborting after too many retries.");
+                      + "Aborting after too many retries.",
+                  mutationsSize);
               spannerWriteFail.inc();
               throw exception;
             }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -26,6 +26,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import com.google.auto.value.AutoValue;
 import com.google.cloud.ServiceFactory;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.Op;
@@ -44,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.SerializableCoder;
@@ -62,6 +64,9 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.util.BackOff;
+import org.apache.beam.sdk.util.FluentBackoff;
+import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -71,9 +76,11 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Stopwatch;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.UnsignedBytes;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,8 +135,7 @@ import org.slf4j.LoggerFactory;
  * <pre>{@code
  * SpannerConfig spannerConfig = ...
  *
- * PCollectionView<Transaction> tx =
- * p.apply(
+ * PCollectionView<Transaction> tx = p.apply(
  *    SpannerIO.createTransaction()
  *        .withSpannerConfig(spannerConfig)
  *        .withTimestampBound(TimestampBound.strong()));
@@ -199,6 +205,37 @@ import org.slf4j.LoggerFactory;
  * Note that each worker will need enough memory to hold {@code GroupingFactor x MaxBatchSizeBytes}
  * Mutations, so if you have a large {@code MaxBatchSize} you may need to reduce {@code
  * GroupingFactor}
+ *
+ * <h3>Monitoring</h3>
+ *
+ * <p>Several counters are provided for monitoring purpooses:
+ *
+ * <ul>
+ *   <li><tt>batchable_mutation_groups</tt><br>
+ *       Counts the mutations that are batched for writing to Spanner.
+ *   <li><tt>unbatchable_mutation_groups</tt><br>
+ *       Counts the mutations that can not be batched and are applied individually - either because
+ *       they are too large to fit into a batch, or they are ranged deletes.
+ *   <li><tt>mutation_group_batches_received, mutation_group_batches_write_success,
+ *       mutation_group_batches_write_failed</tt><br>
+ *       Count the number of batches that are processed. If Failure Mode is set to {@link
+ *       FailureMode#REPORT_FAILURES REPORT_FAILURES}, then failed batches will be split up and the
+ *       individual mutation groups retried separately.
+ *   <li><tt>mutation_groups_received, mutation_groups_write_success,
+ *       mutation_groups_write_fail</tt><br>
+ *       Count the number of individual MutationGroups that are processed.
+ *   <li><tt>spanner_write_success, spanner_write_fail</tt><br>
+ *       The number of writes to Spanner that have occurred.
+ *   <li><tt>spanner_write_retries</tt><br>
+ *       The number of times a write is retried after a failure - either due to a timeout, or when
+ *       batches fail and {@link FailureMode#REPORT_FAILURES REPORT_FAILURES} is set so that
+ *       individual Mutation Groups are retried.
+ *   <li><tt>spanner_write_timeouts</tt><br>
+ *       The number of timeouts that occur when writing to Spanner. Writes that timed out are
+ *       retried after a backoff. Large numbers of timeouts suggest an overloaded Spanner instance.
+ *   <li><tt>spanner_write_total_latency_ms</tt><br>
+ *       The total amount of time spent writing to Spanner, in milliseconds.
+ * </ul>
  *
  * <h3>Database Schema Preparation</h3>
  *
@@ -812,6 +849,28 @@ public class SpannerIO {
       return withHost(ValueProvider.StaticValueProvider.of(host));
     }
 
+    /**
+     * Specifies the deadline for the Commit API call. Default is 15 secs. DEADLINE_EXCEEDED errors
+     * will prompt a backoff/retry until the value of {@link #withMaxCumulativeBackoff(Duration)} is
+     * reached. DEADLINE_EXCEEDED errors are are reported with logging and counters.
+     */
+    public Write withCommitDeadline(Duration commitDeadline) {
+      SpannerConfig config = getSpannerConfig();
+      return withSpannerConfig(config.withCommitDeadline(commitDeadline));
+    }
+
+    /**
+     * Specifies the maximum cumulative backoff time when retrying after DEADLINE_EXCEEDED errors.
+     * Default is 15 mins.
+     *
+     * <p>If the mutations still have not been written after this time, they are treated as a
+     * failure, and handled according to the setting of {@link #withFailureMode(FailureMode)}.
+     */
+    public Write withMaxCumulativeBackoff(Duration maxCumulativeBackoff) {
+      SpannerConfig config = getSpannerConfig();
+      return withSpannerConfig(config.withMaxCumulativeBackoff(maxCumulativeBackoff));
+    }
+
     @VisibleForTesting
     Write withServiceFactory(ServiceFactory<Spanner, SpannerOptions> serviceFactory) {
       SpannerConfig config = getSpannerConfig();
@@ -1248,19 +1307,43 @@ public class SpannerIO {
     }
   }
 
-  private static class WriteToSpannerFn extends DoFn<Iterable<MutationGroup>, Void> {
+  @VisibleForTesting
+  static class WriteToSpannerFn extends DoFn<Iterable<MutationGroup>, Void> {
 
     private transient SpannerAccessor spannerAccessor;
     private final SpannerConfig spannerConfig;
     private final FailureMode failureMode;
-    private final Counter mutationGroupBatchesCounter =
-        Metrics.counter(WriteGrouped.class, "mutation_group_batches");
-    private final Counter mutationGroupWriteSuccessCounter =
+
+    @VisibleForTesting static Sleeper sleeper = Sleeper.DEFAULT;
+
+    private final Counter mutationGroupBatchesReceived =
+        Metrics.counter(WriteGrouped.class, "mutation_group_batches_received");
+    private final Counter mutationGroupBatchesWriteSuccess =
+        Metrics.counter(WriteGrouped.class, "mutation_group_batches_write_success");
+    private final Counter mutationGroupBatchesWriteFail =
+        Metrics.counter(WriteGrouped.class, "mutation_group_batches_write_fail");
+
+    private final Counter mutationGroupsReceived =
+        Metrics.counter(WriteGrouped.class, "mutation_groups_received");
+    private final Counter mutationGroupsWriteSuccess =
         Metrics.counter(WriteGrouped.class, "mutation_groups_write_success");
-    private final Counter mutationGroupWriteFailCounter =
+    private final Counter mutationGroupsWriteFail =
         Metrics.counter(WriteGrouped.class, "mutation_groups_write_fail");
 
+    private final Counter spannerWriteSuccess =
+        Metrics.counter(WriteGrouped.class, "spanner_write_success");
+    private final Counter spannerWriteFail =
+        Metrics.counter(WriteGrouped.class, "spanner_write_fail");
+    private final Counter spannerWriteTotalLatency =
+        Metrics.counter(WriteGrouped.class, "spanner_write_total_latency_ms");
+    private final Counter spannerWriteTimeouts =
+        Metrics.counter(WriteGrouped.class, "spanner_write_timeouts");
+    private final Counter spannerWriteRetries =
+        Metrics.counter(WriteGrouped.class, "spanner_write_retries");
+
     private final TupleTag<MutationGroup> failedTag;
+
+    private FluentBackoff bundleWriteBackoff;
 
     WriteToSpannerFn(
         SpannerConfig spannerConfig, FailureMode failureMode, TupleTag<MutationGroup> failedTag) {
@@ -1271,7 +1354,12 @@ public class SpannerIO {
 
     @Setup
     public void setup() throws Exception {
+      // set up non-serializable values here.
       spannerAccessor = spannerConfig.connectToSpanner();
+      bundleWriteBackoff =
+          FluentBackoff.DEFAULT
+              .withMaxCumulativeBackoff(spannerConfig.getMaxCumulativeBackoff().get())
+              .withInitialBackoff(spannerConfig.getMaxCumulativeBackoff().get().dividedBy(60));
     }
 
     @Teardown
@@ -1285,30 +1373,84 @@ public class SpannerIO {
       boolean tryIndividual = false;
       // Batch upsert rows.
       try {
-        mutationGroupBatchesCounter.inc();
+        mutationGroupBatchesReceived.inc();
+        mutationGroupsReceived.inc(Iterables.size(mutations));
         Iterable<Mutation> batch = Iterables.concat(mutations);
-        spannerAccessor.getDatabaseClient().writeAtLeastOnce(batch);
-        mutationGroupWriteSuccessCounter.inc(Iterables.size(mutations));
+        writeMutations(batch);
+        mutationGroupBatchesWriteSuccess.inc();
+        mutationGroupsWriteSuccess.inc(Iterables.size(mutations));
         return;
       } catch (SpannerException e) {
+        mutationGroupBatchesWriteFail.inc();
         if (failureMode == FailureMode.REPORT_FAILURES) {
-          tryIndividual = true;
+          // fall through and retry individual mutationGroups.
         } else if (failureMode == FailureMode.FAIL_FAST) {
+          mutationGroupsWriteFail.inc(Iterables.size(mutations));
           throw e;
         } else {
           throw new IllegalArgumentException("Unknown failure mode " + failureMode);
         }
       }
-      if (tryIndividual) {
-        for (MutationGroup mg : mutations) {
-          try {
-            spannerAccessor.getDatabaseClient().writeAtLeastOnce(mg);
-            mutationGroupWriteSuccessCounter.inc();
-          } catch (SpannerException e) {
-            mutationGroupWriteFailCounter.inc();
-            LOG.warn("Failed to write the mutation group: " + mg, e);
-            c.output(failedTag, mg);
+
+      // If we are here, writing a batch has failed, retry individual mutations.
+      for (MutationGroup mg : mutations) {
+        try {
+          spannerWriteRetries.inc();
+          writeMutations(mg);
+          mutationGroupsWriteSuccess.inc();
+        } catch (SpannerException e) {
+          mutationGroupsWriteFail.inc();
+          LOG.warn("Failed to write the mutation group: " + mg, e);
+          c.output(failedTag, mg);
+        }
+      }
+    }
+
+    /** Write the Mutations to Spanner, handling DEADLINE_EXCEEDED with backoff/retries. */
+    private void writeMutations(Iterable<Mutation> mutations) throws SpannerException, IOException {
+      BackOff backoff = bundleWriteBackoff.backoff();
+      long mutationsSize = Iterables.size(mutations);
+
+      while (true) {
+        Stopwatch timer = Stopwatch.createStarted();
+        // loop is broken on success, timeout backoff/retry attempts exceeded, or other failure.
+        try {
+          spannerAccessor.getDatabaseClient().writeAtLeastOnce(mutations);
+          spannerWriteSuccess.inc();
+          return;
+        } catch (SpannerException exception) {
+          if (exception.getErrorCode() == ErrorCode.DEADLINE_EXCEEDED) {
+            spannerWriteTimeouts.inc();
+
+            // Potentially backoff/retry after DEADLINE_EXCEEDED.
+            long sleepTimeMsecs = backoff.nextBackOffMillis();
+            if (sleepTimeMsecs == BackOff.STOP) {
+              LOG.error(
+                  "DEADLINE_EXCEEDED writing batch of {} mutations to Cloud Spanner. "
+                      + "Aborting after too many retries.");
+              spannerWriteFail.inc();
+              throw exception;
+            }
+            LOG.info(
+                "DEADLINE_EXCEEDED writing batch of {} mutations to Cloud Spanner, "
+                    + "retrying after backoff of {}ms\n"
+                    + "({})",
+                mutationsSize,
+                sleepTimeMsecs,
+                exception.getMessage());
+            spannerWriteRetries.inc();
+            try {
+              sleeper.sleep(sleepTimeMsecs);
+            } catch (InterruptedException e) {
+              // ignore.
+            }
+          } else {
+            // Some other failure: pass up the stack.
+            spannerWriteFail.inc();
+            throw exception;
           }
+        } finally {
+          spannerWriteTotalLatency.inc(timer.elapsed(TimeUnit.MILLISECONDS));
         }
       }
     }


### PR DESCRIPTION
Spanner's default commit deadline of 60mins does not give enough feedback to the pipeline when the spanner database is overloaded.

Using a shorter (configurable) commit deadline of 15secs, along with backoff/retry logic allows the Dataflow pipeline to take some of the load off Spanner when it gets overloaded, leading to greater overall throughput.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
