### PR TITLE
[BEAM-9545] Dataframe transforms

### DIFF
--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -74,6 +74,9 @@ class Expression(object):
   def __ne__(self, other):
     return not self == other
 
+  def __repr__(self):
+    return '%s[%s]' % (self.__class__.__name__, self._id)
+
   def evaluate_at(self, session):  # type: (Session) -> T
     """Returns the result of self with the bindings given in session."""
     raise NotImplementedError(type(self))
@@ -195,7 +198,7 @@ class ComputedExpression(Expression):
     return self._args
 
   def evaluate_at(self, session):
-    return self._func(*(arg.evaluate_at(session) for arg in self._args))
+    return self._func(*(session.evaluate(arg) for arg in self._args))
 
   def requires_partition_by_index(self):
     return self._requires_partition_by_index

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -64,7 +64,7 @@ class DeferredDataFrame(frame_base.DeferredFrame):
     if name in self._expr.proxy().columns:
       return self[name]
     else:
-      return super(DeferredDataFrame, self).__getattr__(name)
+      return object.__getattribute__(self, name)
 
   def __getitem__(self, key):
     if key in self._expr.proxy().columns:
@@ -99,6 +99,10 @@ class DeferredDataFrame(frame_base.DeferredFrame):
   @property
   def loc(self):
     return _DeferredLoc(self)
+
+
+for meth in ('filter', ):
+  setattr(DeferredDataFrame, meth, frame_base._elementwise_method(meth))
 
 
 class DeferredGroupBy(frame_base.DeferredFrame):

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -1,0 +1,244 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import pandas as pd
+
+import apache_beam as beam
+from apache_beam import transforms
+from apache_beam.dataframe import expressions
+from apache_beam.dataframe import frame_base
+
+
+class DataframeTransform(transforms.PTransform):
+  """A PTransform for applying function that takes and returns dataframes
+  to one or more PCollections.
+
+  For example, if pcoll is a PCollection of dataframes, one could write::
+
+      pcoll | DataframeTransform(lambda df: df.group_by('key').sum())
+
+  To pass multiple PCollections, pass a tuple of PCollections wich will be
+  passed to the callable as positional arguments, or a dictionary of
+  PCollections, in which case they will be passed as keyword arguments.
+  """
+  def __init__(self, func, proxy):
+    self._func = func
+    self._proxy = proxy
+
+  def expand(self, input_pcolls):
+    def wrap_as_dict(values):
+      if isinstance(values, dict):
+        return dict
+      elif isinstance(values, tuple):
+        return dict(enumerate(values))
+      else:
+        return {None: values}
+
+    # TODO: Infer the proxy from the input schema.
+    def proxy(key):
+      if key is None:
+        return self._proxy
+      else:
+        return self._proxy[key]
+
+    # The input can be a dictionary, tuple, or plain PCollection.
+    # Wrap as a dict for homogeneity.
+    # TODO: Possibly inject batching here.
+    input_dict = wrap_as_dict(input_pcolls)
+    placeholders = {
+        key: frame_base.DeferredFrame.wrap(
+            expressions.PlaceholderExpression(proxy(key)))
+        for key in input_dict.keys()
+    }
+
+    # The calling convention of the user-supplied func varies according to the
+    # type of the input.
+    if isinstance(input_pcolls, dict):
+      result_frames = self._func(**placeholders)
+    elif isinstance(input_pcolls, tuple):
+      self._func(*(value for _, value in sorted(placeholders.items())))
+    else:
+      result_frames = self._func(placeholders[None])
+
+    # Likewise the output may be a dict, tuple, or raw (deferred) Dataframe.
+    result_dict = wrap_as_dict(result_frames)
+
+    result_pcolls = self._apply_deferred_ops(
+        {placeholders[key]._expr: pcoll
+         for key, pcoll in input_dict.items()},
+        {key: df._expr
+         for key, df in result_dict.items()})
+
+    # Convert the result back into a set of PCollections.
+    if isinstance(result_frames, dict):
+      return result_pcolls
+    elif isinstance(result_frames, tuple):
+      return tuple(*(value for _, value in sorted(result_pcolls.items())))
+    else:
+      return result_pcolls[None]
+
+  def _apply_deferred_ops(
+      self,
+      inputs,  # type: Dict[PlaceholderExpr, PCollection]
+      outputs,  # type: Dict[Any, Expression]
+      ):  # -> Dict[Any, PCollection]
+    """Construct a Beam graph that evaluates a set of expressions on a set of
+    input PCollections.
+
+    :param inputs: A mapping of placeholder expressions to PCollections.
+    :param outputs: A mapping of keys to expressions defined in terms of the
+        placeholders of inputs.
+
+    Returns a dictionary whose keys are those of outputs, and whose values are
+    PCollections corresponding to the values of outputs evaluated at the
+    values of inputs.
+
+    Logically, `_apply_deferred_ops({x: a, y: b}, {f: F(x, y), g: G(x, y)})`
+    returns `{f: F(a, b), g: G(a, b)}`.
+    """
+    class ComputeStage(beam.PTransform):
+      """A helper transform that computes a single stage of operations.
+      """
+      def __init__(self, stage):
+        self.stage = stage
+
+      def default_label(self):
+        return '%s:%s' % (self.stage.ops, id(self))
+
+      def expand(self, pcolls):
+        if self.stage.is_grouping:
+          # Arrange such that partitioned_pcoll is properly partitioned.
+          input_pcolls = {
+              k: pcoll | 'Flat%s' % k >> beam.FlatMap(_partition_by_index)
+              for k,
+              pcoll in pcolls.items()
+          }
+          partitioned_pcoll = input_pcolls | beam.CoGroupByKey(
+          ) | beam.MapTuple(
+              lambda _, inputs: {k: pd.concat(vs)
+                                 for k, vs in inputs.items()})
+        else:
+          # Already partitioned, or no partitioning needed.
+          (k, pcoll), = pcolls.items()
+          partitioned_pcoll = pcoll | beam.Map(lambda df: {k: df})
+
+        # Actually evaluate the expressions.
+        def evaluate(partition, stage=self.stage):
+          session = expressions.Session(
+              {expr: partition[expr._id]
+               for expr in stage.inputs})
+          for expr in stage.outputs:
+            yield beam.pvalue.TaggedOutput(expr._id, expr.evaluate_at(session))
+
+        return partitioned_pcoll | beam.FlatMap(evaluate).with_outputs()
+
+    class Stage(object):
+      """Used to build up a set of operations that can be fused together.
+      """
+      def __init__(self, inputs, is_grouping):
+        self.inputs = set(inputs)
+        self.is_grouping = is_grouping or len(self.inputs) > 1
+        self.ops = []
+        self.outputs = set()
+
+    # First define some helper functions.
+    def output_is_partitioned_by_index(expr, stage):
+      if expr in stage.inputs:
+        return stage.is_grouping
+      elif expr.preserves_partition_by_index():
+        if expr.requires_partition_by_index():
+          return True
+        else:
+          return all(
+              output_is_partitioned_by_index(arg, stage) for arg in expr.args())
+      else:
+        return False
+
+    def _partition_by_index(df, levels=None, parts=10):
+      if levels is None:
+        levels = list(range(df.index.nlevels))
+      elif isinstance(levels, (int, str)):
+        levels = [levels]
+      hashes = sum(
+          pd.util.hash_array(df.index.get_level_values(level))
+          for level in levels)
+      for k in range(parts):
+        yield k, df[hashes % parts == k]
+
+    def common_stages(stage_lists):
+      if stage_lists:
+        for stage in stage_lists[0]:
+          if all(stage in other for other in stage_lists[1:]):
+            yield stage
+
+    @memoize
+    def expr_to_stages(expr):
+      assert expr not in inputs
+      # First attempt to compute this expression as part of an existing stage,
+      # if possible.
+      for stage in common_stages([expr_to_stages(arg) for arg in expr.args()
+                                  if arg not in inputs]):
+        if (not expr.requires_partition_by_index() or
+            all(output_is_partitioned_by_index(arg, stage)
+                for arg in expr.args())):
+          break
+      else:
+        # Otherwise, compute this expression as part of a new stage.
+        stage = Stage(expr.args(), expr.requires_partition_by_index())
+        for arg in expr.args():
+          if arg not in inputs:
+            expr_to_stages(arg).append(stage)
+            expr_to_stage(arg).outputs.add(arg)
+      stage.ops.append(expr)
+      # This is a list as given expression may be available in many stages.
+      return [stage]
+
+    def expr_to_stage(expr):
+      # Any will do; the first requires the fewest intermediate stages.
+      return expr_to_stages(expr)[0]
+
+    # Ensure each output is computed.
+    for expr in outputs.values():
+      if expr not in inputs:
+        expr_to_stage(expr).outputs.add(expr)
+
+    @memoize
+    def stage_to_result(stage):
+      return {expr._id: expr_to_pcoll(expr)
+              for expr in stage.inputs} | ComputeStage(stage)
+
+    @memoize
+    def expr_to_pcoll(expr):
+      if expr in inputs:
+        return inputs[expr]
+      else:
+        return stage_to_result(expr_to_stage(expr))[expr._id]
+
+    # Now we can compute and return the result.
+    return {k: expr_to_pcoll(expr) for k, expr in outputs.items()}
+
+
+def memoize(f):
+  cache = {}
+
+  def wrapper(*args):
+    if args not in cache:
+      cache[args] = f(*args)
+    return cache[args]
+
+  return wrapper

--- a/sdks/python/apache_beam/dataframe/transforms_test.py
+++ b/sdks/python/apache_beam/dataframe/transforms_test.py
@@ -1,0 +1,87 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import unittest
+
+import pandas as pd
+
+import apache_beam as beam
+from apache_beam.dataframe import expressions
+from apache_beam.dataframe import frame_base
+from apache_beam.dataframe import transforms
+from apache_beam.testing.util import assert_that
+
+
+class TransformTest(unittest.TestCase):
+  def run_test(self, input, func):
+    expected = func(input)
+
+    empty = input[0:0]
+    input_placeholder = expressions.PlaceholderExpression(empty)
+    input_deferred = frame_base.DeferredFrame.wrap(input_placeholder)
+    actual_deferred = func(input_deferred)._expr.evaluate_at(
+        expressions.Session({input_placeholder: input}))
+
+    def check_correct(actual):
+      if actual is None:
+        raise AssertionError('Empty frame but expected: \n\n%s' % (expected))
+      sorted_actual = actual.sort_index()
+      sorted_expected = expected.sort_index()
+      if not sorted_actual.equals(sorted_expected):
+        raise AssertionError(
+            'Dataframes not equal: \n\n%s\n\n%s' %
+            (sorted_actual, sorted_expected))
+
+    check_correct(actual_deferred)
+
+    with beam.Pipeline() as p:
+      input_pcoll = p | beam.Create([input[::2], input[1::2]])
+      output_pcoll = input_pcoll | transforms.DataframeTransform(
+          func, proxy=empty)
+      assert_that(
+          output_pcoll,
+          lambda actual: check_correct(pd.concat(actual) if actual else None))
+
+  def test_identity(self):
+    df = pd.DataFrame({
+        'Animal': ['Falcon', 'Falcon', 'Parrot', 'Parrot'],
+        'Speed': [380., 370., 24., 26.]
+    })
+    self.run_test(df, lambda x: x)
+
+  def test_sum_mean(self):
+    df = pd.DataFrame({
+        'Animal': ['Falcon', 'Falcon', 'Parrot', 'Parrot'],
+        'Speed': [380., 370., 24., 26.]
+    })
+    self.run_test(df, lambda df: df.groupby('Animal').sum())
+    self.run_test(df, lambda df: df.groupby('Animal').mean())
+
+  def test_filter(self):
+    df = pd.DataFrame({
+        'Animal': ['Aardvark', 'Ant', 'Elephant', 'Zebra'],
+        'Speed': [5, 2, 35, 40]
+    })
+    self.run_test(df, lambda df: df.filter(items=['Animal']))
+    self.run_test(df, lambda df: df.filter(regex='A.*'))
+    self.run_test(
+        df, lambda df: df.set_index('Animal').filter(regex='F.*', axis='index'))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Still a bit rough, but it works.

CC: @TheNeuralBit Follow-up to https://github.com/apache/beam/pull/10757

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
