### PR TITLE
[BEAM-2645] Define the display data model type

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -97,7 +97,7 @@ message Pipeline {
 
   // (Optional) Static display data for the pipeline. If there is none,
   // it may be omitted.
-  DisplayData display_data = 3;
+  repeated DisplayData display_data = 3;
 }
 
 // An applied PTransform! This does not contain the graph data, but only the
@@ -167,9 +167,8 @@ message PTransform {
   map<string, string> outputs = 4;
 
   // (Optional) Static display data for this PTransform application. If
-  // there is none, or it is not relevant (such as use by the Fn API)
-  // then it may be omitted.
-  DisplayData display_data = 6;
+  // there is none, it may be omitted.
+  repeated DisplayData display_data = 6;
 
   // (Optional) Environment where the current PTransform should be executed in.
   // Runner that executes the pipeline may choose to override this if needed. If
@@ -366,10 +365,9 @@ message PCollection {
   // (Required) The id of the windowing strategy for this PCollection.
   string windowing_strategy_id = 4;
 
-  // (Optional) Static display data for this PTransform application. If
-  // there is none, or it is not relevant (such as use by the Fn API)
-  // then it may be omitted.
-  DisplayData display_data = 5;
+  // (Optional) Static display data for the PCollection. If there is none,
+  // it may be omitted.
+  repeated DisplayData display_data = 5;
 }
 
 // The payload for the primitive ParDo transform.
@@ -1103,6 +1101,10 @@ message Environment {
   // the URN does not require any arguments, this may be omitted.
   bytes payload = 3;
 
+  // (Optional) Static display data for the environment. If there is none,
+  // it may be omitted.
+  repeated DisplayData display_data = 4;
+
   reserved 1;
 }
 
@@ -1205,58 +1207,58 @@ message FunctionSpec {
   bytes payload = 3;
 }
 
-// TODO: transfer javadoc here
+// A set of well known URNs describing display data.
+//
+// All descriptions must contain how the value should be classified and how it
+// is encoded. Note that some types are logical types which convey contextual
+// information about the pipeline in addition to an encoding while others only
+// specify the encoding itself.
+message StandardDisplayData {
+  enum DisplayData {
+    // A string label and value. Has a payload containing an encoded
+    // LabelledStringPayload.
+    LABELLED_STRING = 0 [(beam_urn) = "beam:display_data:labelled_string:v1"];
+
+    // Some samples that are being considered to become standard display data
+    // types follow:
+
+    // A path/location of a resource that this transform accesses. Encoded as
+    // the well known google.protobuf.StringValue type.
+    // INPUT_PATH = 1 [(beam_urn) = "beam:display_data:input_path:v1"];
+
+    // A timestamp encoded as the well known protobuf type
+    // google.protobuf.timestamp. Note that the value may be outside of the
+    // RFC3339 limit imposed.
+    // TIMESTAMP = 2 [(beam_urn) = "beam:display_data:timestamp:v1"];
+
+    // A duration encoded as the well known protobuf type
+    // google.protobuf.duration. Note that the value may be outside of the
+    // RFC3339 limit imposed.
+    // DURATION = 3 [(beam_urn) = "beam:display_data:duration:v1"];
+  }
+}
+
+message LabelledStringPayload {
+  // (Required) A human readable label for the value.
+  string label = 1;
+
+  // (Required) A value which will be displayed to the user. The urn describes
+  // how the value can be interpreted and/or categorized.
+  string value = 2;
+}
+
+// Static display data associated with a pipeline component. Display data is
+// useful for pipeline runners IOs and diagnostic dashboards to display details
+// about annotated components.
 message DisplayData {
+  // A key used to describe the type of display data. See StandardDisplayData
+  // for the set of well known urns describing how the payload is meant to be
+  // interpreted.
+  string urn = 1;
 
-  // (Required) The list of display data.
-  repeated Item items = 1;
-
-  // A complete identifier for a DisplayData.Item
-  message Identifier {
-
-    // (Required) The transform originating this display data.
-    string transform_id = 1;
-
-    // (Optional) The URN indicating the type of the originating transform,
-    // if there is one.
-    string transform_urn = 2;
-
-    string key = 3;
-  }
-
-  // A single item of display data.
-  message Item {
-    // (Required)
-    Identifier id = 1;
-
-    // (Required)
-    Type.Enum type = 2;
-
-    // (Required)
-    google.protobuf.Any value = 3;
-
-    // (Optional)
-    google.protobuf.Any short_value = 4;
-
-    // (Optional)
-    string label = 5;
-
-    // (Optional)
-    string link_url = 6;
-  }
-
-  message Type {
-    enum Enum {
-      UNSPECIFIED = 0;
-      STRING = 1;
-      INTEGER = 2;
-      FLOAT = 3;
-      BOOLEAN = 4;
-      TIMESTAMP = 5;
-      DURATION = 6;
-      JAVA_CLASS = 7;
-    }
-  }
+  // (Optional) The data specifying any parameters to the URN. If
+  // the URN does not require any arguments, this may be omitted.
+  bytes payload = 2;
 }
 
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/DisplayDataTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/DisplayDataTranslation.java
@@ -17,22 +17,59 @@
  */
 package org.apache.beam.runners.core.construction;
 
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.StandardDisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData;
-import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.Any;
-import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.BoolValue;
+import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 
 /** Utilities for going to/from DisplayData protos. */
 public class DisplayDataTranslation {
-  public static RunnerApi.DisplayData toProto(DisplayData displayData) {
-    // TODO https://issues.apache.org/jira/browse/BEAM-2645
-    return RunnerApi.DisplayData.newBuilder()
-        .addItems(
-            RunnerApi.DisplayData.Item.newBuilder()
-                .setId(RunnerApi.DisplayData.Identifier.newBuilder().setKey("stubImplementation"))
-                .setLabel("Stub implementation")
-                .setType(RunnerApi.DisplayData.Type.Enum.BOOLEAN)
-                .setValue(Any.pack(BoolValue.newBuilder().setValue(true).build())))
-        .build();
+  public static final String LABELLED_STRING = "beam:display_data:labelled_string:v1";
+
+  static {
+    checkState(
+        LABELLED_STRING.equals(BeamUrns.getUrn(StandardDisplayData.DisplayData.LABELLED_STRING)));
+  }
+
+  private static final Map<String, Function<DisplayData.Item, ByteString>>
+      WELL_KNOWN_URN_TRANSLATORS =
+          ImmutableMap.of(LABELLED_STRING, DisplayDataTranslation::translateStringUtf8);
+
+  public static List<RunnerApi.DisplayData> toProto(DisplayData displayData) {
+    ImmutableList.Builder<RunnerApi.DisplayData> builder = ImmutableList.builder();
+    for (DisplayData.Item item : displayData.items()) {
+      Function<DisplayData.Item, ByteString> translator =
+          WELL_KNOWN_URN_TRANSLATORS.get(item.getKey());
+      String urn;
+      if (translator != null) {
+        urn = item.getKey();
+      } else {
+        urn = LABELLED_STRING;
+        translator = DisplayDataTranslation::translateStringUtf8;
+      }
+      builder.add(
+          RunnerApi.DisplayData.newBuilder()
+              .setUrn(urn)
+              .setPayload(translator.apply(item))
+              .build());
+    }
+    return builder.build();
+  }
+
+  private static ByteString translateStringUtf8(DisplayData.Item item) {
+    String value = String.valueOf(item.getValue() == null ? item.getShortValue() : item.getValue());
+    String label = item.getLabel() == null ? item.getKey() : item.getLabel();
+    return RunnerApi.LabelledStringPayload.newBuilder()
+        .setLabel(label)
+        .setValue(value)
+        .build()
+        .toByteString();
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PCollectionTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PCollectionTranslation.java
@@ -35,7 +35,6 @@ public class PCollectionTranslation {
     String coderId = components.registerCoder(pCollection.getCoder());
     String windowingStrategyId =
         components.registerWindowingStrategy(pCollection.getWindowingStrategy());
-    // TODO: Display Data
 
     return RunnerApi.PCollection.newBuilder()
         .setUniqueName(pCollection.getName())

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -476,7 +476,7 @@ public class PTransformTranslation {
     }
 
     transformBuilder.setUniqueName(appliedPTransform.getFullName());
-    transformBuilder.setDisplayData(
+    transformBuilder.addAllDisplayData(
         DisplayDataTranslation.toProto(DisplayData.from(appliedPTransform.getTransform())));
     return transformBuilder;
   }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/DisplayDataTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/DisplayDataTranslationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.construction;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.display.HasDisplayData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link org.apache.beam.runners.core.construction.DisplayDataTranslation}. */
+@RunWith(JUnit4.class)
+public class DisplayDataTranslationTest {
+
+  @Test
+  public void testTranslation() {
+    assertThat(
+        DisplayDataTranslation.toProto(
+            DisplayData.from(
+                new HasDisplayData() {
+
+                  @Override
+                  public void populateDisplayData(DisplayData.Builder builder) {
+                    builder.add(DisplayData.item("foo", "value"));
+                    builder.add(DisplayData.item("foo2", "value2").withLabel("label"));
+                  }
+                })),
+        containsInAnyOrder(
+            RunnerApi.DisplayData.newBuilder()
+                .setUrn(DisplayDataTranslation.LABELLED_STRING)
+                .setPayload(
+                    RunnerApi.LabelledStringPayload.newBuilder()
+                        .setLabel("foo")
+                        .setValue("value")
+                        .build()
+                        .toByteString())
+                .build(),
+            RunnerApi.DisplayData.newBuilder()
+                .setUrn(DisplayDataTranslation.LABELLED_STRING)
+                .setPayload(
+                    RunnerApi.LabelledStringPayload.newBuilder()
+                        .setLabel("label")
+                        .setValue("value2")
+                        .build()
+                        .toByteString())
+                .build()));
+  }
+}


### PR DESCRIPTION
Use a URN + value system with an optional label allowing for 'dynamic' types to be specified and labelled with a set of well known types.
Fix-up existing Java usage.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
