### PR TITLE
[BEAM-3545] Return metrics as MonitoringInfos

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -72,9 +72,12 @@ func UnmarshalPlan(desc *fnpb.ProcessBundleDescriptor) (*Plan, error) {
 			return nil, errors.Errorf("unwindowed coder %v on DataSource %v: %v", cid, id, u.Coder)
 		}
 
+		// There's only a single pair in this map, but a for loop range statement
+		// is the easiest way to extract it, so this loop will iterate only once.
 		for key, pid := range transform.GetOutputs() {
 			u.SID = StreamID{PtransformID: id, Port: port}
 			u.Name = key
+			u.outputPID = pid
 
 			u.Out, err = b.makePCollection(pid)
 			if err != nil {

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -204,7 +204,7 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 		data.Close()
 		state.Close()
 
-		m := plan.Metrics()
+		mets, mons := monitoring(plan)
 		// Move the plan back to the candidate state
 		c.mu.Lock()
 		// Mark the instruction as failed.
@@ -223,7 +223,9 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 			InstructionId: string(instID),
 			Response: &fnpb.InstructionResponse_ProcessBundle{
 				ProcessBundle: &fnpb.ProcessBundleResponse{
-					Metrics: m,
+					// TODO(lostluck): Delete legacy monitoring Metrics once they can be safely dropped.
+					Metrics:         mets,
+					MonitoringInfos: mons,
 				},
 			},
 		}
@@ -243,13 +245,15 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 			return fail(ctx, instID, "failed to return progress: instruction %v not active", ref)
 		}
 
-		m := plan.Metrics()
+		mets, mons := monitoring(plan)
 
 		return &fnpb.InstructionResponse{
 			InstructionId: string(instID),
 			Response: &fnpb.InstructionResponse_ProcessBundleProgress{
 				ProcessBundleProgress: &fnpb.ProcessBundleProgressResponse{
-					Metrics: m,
+					// TODO(lostluck): Delete legacy monitoring Metrics once they can be safely dropped.
+					Metrics:         mets,
+					MonitoringInfos: mons,
 				},
 			},
 		}

--- a/sdks/go/pkg/beam/core/runtime/harness/monitoring.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/monitoring.go
@@ -1,0 +1,195 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harness
+
+import (
+	"time"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/metrics"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	ppb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	"github.com/golang/protobuf/ptypes"
+)
+
+func monitoring(p *exec.Plan) (*fnpb.Metrics, []*ppb.MonitoringInfo) {
+	// Get the legacy style metrics.
+	transforms := make(map[string]*fnpb.Metrics_PTransform)
+	metrics.Extractor{
+		SumInt64: func(l metrics.Labels, v int64) {
+			pb := getTransform(transforms, l)
+			pb.User = append(pb.User, &fnpb.Metrics_User{
+				MetricName: toName(l),
+				Data: &fnpb.Metrics_User_CounterData_{
+					CounterData: &fnpb.Metrics_User_CounterData{
+						Value: v,
+					},
+				},
+			})
+		},
+		DistributionInt64: func(l metrics.Labels, count, sum, min, max int64) {
+			pb := getTransform(transforms, l)
+			pb.User = append(pb.User, &fnpb.Metrics_User{
+				MetricName: toName(l),
+				Data: &fnpb.Metrics_User_DistributionData_{
+					DistributionData: &fnpb.Metrics_User_DistributionData{
+						Count: count,
+						Sum:   sum,
+						Min:   min,
+						Max:   max,
+					},
+				},
+			})
+		},
+		GaugeInt64: func(l metrics.Labels, v int64, t time.Time) {
+			ts, err := ptypes.TimestampProto(t)
+			if err != nil {
+				panic(err)
+			}
+			pb := getTransform(transforms, l)
+			pb.User = append(pb.User, &fnpb.Metrics_User{
+				MetricName: toName(l),
+				Data: &fnpb.Metrics_User_GaugeData_{
+					GaugeData: &fnpb.Metrics_User_GaugeData{
+						Value:     v,
+						Timestamp: ts,
+					},
+				},
+			})
+		},
+	}.ExtractFrom(p.Store)
+
+	// Get the MonitoringInfo versions.
+	var monitoringInfo []*ppb.MonitoringInfo
+	metrics.Extractor{
+		SumInt64: func(l metrics.Labels, v int64) {
+			monitoringInfo = append(monitoringInfo,
+				&ppb.MonitoringInfo{
+					Urn:    "beam:metric:user",
+					Type:   "beam:metrics:sum_int_64",
+					Labels: userLabels(l),
+					Data:   int64Counter(v),
+				})
+		},
+		DistributionInt64: func(l metrics.Labels, count, sum, min, max int64) {
+			monitoringInfo = append(monitoringInfo,
+				&ppb.MonitoringInfo{
+					Urn:    "beam:metric:user",
+					Type:   "beam:metrics:sum_int_64",
+					Labels: userLabels(l),
+					Data:   int64Distribution(count, sum, min, max),
+				})
+		},
+		GaugeInt64: func(l metrics.Labels, v int64, t time.Time) {
+			ts, err := ptypes.TimestampProto(t)
+			if err != nil {
+				panic(err)
+			}
+			monitoringInfo = append(monitoringInfo,
+				&ppb.MonitoringInfo{
+					Type:      "beam:metrics:latest_int_64",
+					Labels:    userLabels(l),
+					Data:      int64Counter(v),
+					Timestamp: ts,
+				})
+		},
+	}.ExtractFrom(p.Store)
+
+	// Get the execution monitoring information from the bundle plan.
+	if snapshot, ok := p.Progress(); ok {
+		// Legacy version.
+		transforms[snapshot.ID] = &fnpb.Metrics_PTransform{
+			ProcessedElements: &fnpb.Metrics_PTransform_ProcessedElements{
+				Measured: &fnpb.Metrics_PTransform_Measured{
+					OutputElementCounts: map[string]int64{
+						snapshot.Name: snapshot.Count,
+					},
+				},
+			},
+		}
+		// Monitoring info version.
+		monitoringInfo = append(monitoringInfo,
+			&ppb.MonitoringInfo{
+				Urn:  "beam:metric:element_count:v1",
+				Type: "beam:metrics:sum_int_64",
+				Labels: map[string]string{
+					"PCOLLECTION": snapshot.Name,
+				},
+				Data: int64Counter(snapshot.Count),
+			})
+	}
+
+	return &fnpb.Metrics{
+		Ptransforms: transforms,
+	}, monitoringInfo
+}
+
+func userLabels(l metrics.Labels) map[string]string {
+	return map[string]string{
+		"PTRANSFORM": l.Transform(),
+		"NAMESPACE":  l.Namespace(),
+		"NAME":       l.Name(),
+	}
+}
+
+func int64Counter(v int64) *ppb.MonitoringInfo_Metric {
+	return &ppb.MonitoringInfo_Metric{
+		Metric: &ppb.Metric{
+			Data: &ppb.Metric_CounterData{
+				CounterData: &ppb.CounterData{
+					Value: &ppb.CounterData_Int64Value{
+						Int64Value: v,
+					},
+				},
+			},
+		},
+	}
+}
+
+func int64Distribution(count, sum, min, max int64) *ppb.MonitoringInfo_Metric {
+	return &ppb.MonitoringInfo_Metric{
+		Metric: &ppb.Metric{
+			Data: &ppb.Metric_DistributionData{
+				DistributionData: &ppb.DistributionData{
+					Distribution: &ppb.DistributionData_IntDistributionData{
+						IntDistributionData: &ppb.IntDistributionData{
+							Count: count,
+							Sum:   sum,
+							Min:   min,
+							Max:   max,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getTransform(transforms map[string]*fnpb.Metrics_PTransform, l metrics.Labels) *fnpb.Metrics_PTransform {
+	if pb, ok := transforms[l.Transform()]; ok {
+		return pb
+	}
+	pb := &fnpb.Metrics_PTransform{}
+	transforms[l.Transform()] = pb
+	return pb
+}
+
+func toName(l metrics.Labels) *fnpb.Metrics_User_MetricName {
+	return &fnpb.Metrics_User_MetricName{
+		Name:      l.Name(),
+		Namespace: l.Namespace(),
+	}
+}

--- a/sdks/go/pkg/beam/core/runtime/harness/monitoring.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/monitoring.go
@@ -87,8 +87,8 @@ func monitoring(p *exec.Plan) (*fnpb.Metrics, []*ppb.MonitoringInfo) {
 		DistributionInt64: func(l metrics.Labels, count, sum, min, max int64) {
 			monitoringInfo = append(monitoringInfo,
 				&ppb.MonitoringInfo{
-					Urn:    "beam:metric:user",
-					Type:   "beam:metrics:sum_int_64",
+					Urn:    "beam:metric:user_distribution",
+					Type:   "beam:metrics:distribution_int_64",
 					Labels: userLabels(l),
 					Data:   int64Distribution(count, sum, min, max),
 				})
@@ -100,6 +100,7 @@ func monitoring(p *exec.Plan) (*fnpb.Metrics, []*ppb.MonitoringInfo) {
 			}
 			monitoringInfo = append(monitoringInfo,
 				&ppb.MonitoringInfo{
+					Urn:       "beam:metric:user",
 					Type:      "beam:metrics:latest_int_64",
 					Labels:    userLabels(l),
 					Data:      int64Counter(v),

--- a/sdks/go/pkg/beam/core/runtime/harness/monitoring.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/monitoring.go
@@ -127,7 +127,7 @@ func monitoring(p *exec.Plan) (*fnpb.Metrics, []*ppb.MonitoringInfo) {
 				Urn:  "beam:metric:element_count:v1",
 				Type: "beam:metrics:sum_int_64",
 				Labels: map[string]string{
-					"PCOLLECTION": snapshot.Name,
+					"PCOLLECTION": snapshot.PID,
 				},
 				Data: int64Counter(snapshot.Count),
 			})


### PR DESCRIPTION
Have the Go SDK return metrics as MonitoringInfos rather than the deprecated metrics proto.

For now, both are being returned, but a later change will remove the legacy metrics.

This moves FnAPI awareness further into the harness to avoid tight coupling of the SDK to the portability protos, even though the base structures are largely inspired by the same.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
