### PR TITLE
[BEAM-2535] Fix timer map

### DIFF
--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
@@ -120,7 +120,7 @@ public class SimpleDoFnRunnerTest {
 
     runner.onTimer(
         ThrowingDoFn.TIMER_ID,
-        ThrowingDoFn.TIMER_ID,
+        "",
         GlobalWindow.INSTANCE,
         new Instant(0),
         new Instant(0),

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -137,7 +137,6 @@ def commonExcludeCategories = [
   'org.apache.beam.sdk.testing.UsesGaugeMetrics',
   'org.apache.beam.sdk.testing.UsesSetState',
   'org.apache.beam.sdk.testing.UsesMapState',
-  'org.apache.beam.sdk.testing.UsesTimerMap',
   'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs',
   'org.apache.beam.sdk.testing.UsesUnboundedPCollections',
   'org.apache.beam.sdk.testing.UsesTestStream',

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/SimpleParDoFn.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/SimpleParDoFn.java
@@ -355,7 +355,8 @@ public class SimpleParDoFn<InputT, OutputT> implements ParDoFn {
   }
 
   private void processUserTimer(TimerData timer) throws Exception {
-    if (fnSignature.timerDeclarations().containsKey(timer.getTimerId())) {
+    if (fnSignature.timerDeclarations().containsKey(timer.getTimerId())
+        || fnSignature.timerFamilyDeclarations().containsKey(timer.getTimerFamilyId())) {
       BoundedWindow window = ((WindowNamespace) timer.getNamespace()).getWindow();
       fnRunner.onTimer(
           timer.getTimerId(),

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
@@ -79,7 +79,9 @@ class ParDoTranslatorBatch<InputT, OutputT>
     // TODO: add support of states and timers
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
     boolean stateful =
-        signature.stateDeclarations().size() > 0 || signature.timerDeclarations().size() > 0;
+        signature.stateDeclarations().size() > 0
+                || signature.timerDeclarations().size() > 0
+                || signature.timerFamilyDeclarations().size() > 0;
     checkState(!stateful, "States and timers are not supported for the moment.");
 
     DoFnSchemaInformation doFnSchemaInformation =

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
@@ -80,8 +80,8 @@ class ParDoTranslatorBatch<InputT, OutputT>
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
     boolean stateful =
         signature.stateDeclarations().size() > 0
-                || signature.timerDeclarations().size() > 0
-                || signature.timerFamilyDeclarations().size() > 0;
+            || signature.timerDeclarations().size() > 0
+            || signature.timerFamilyDeclarations().size() > 0;
     checkState(!stateful, "States and timers are not supported for the moment.");
 
     DoFnSchemaInformation doFnSchemaInformation =

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
@@ -273,7 +273,7 @@ public final class TranslationUtils {
               SparkRunner.class.getSimpleName()));
     }
 
-    if (signature.timerDeclarations().size() > 0) {
+    if (signature.timerDeclarations().size() > 0 || signature.timerFamilyDeclarations().size() > 0) {
       throw new UnsupportedOperationException(
           String.format(
               "Found %s annotations on %s, but %s cannot yet be used with timers in the %s.",

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
@@ -273,7 +273,8 @@ public final class TranslationUtils {
               SparkRunner.class.getSimpleName()));
     }
 
-    if (signature.timerDeclarations().size() > 0 || signature.timerFamilyDeclarations().size() > 0) {
+    if (signature.timerDeclarations().size() > 0
+        || signature.timerFamilyDeclarations().size() > 0) {
       throw new UnsupportedOperationException(
           String.format(
               "Found %s annotations on %s, but %s cannot yet be used with timers in the %s.",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -583,7 +583,8 @@ public class ParDo {
     }
 
     // Timers are semantically incompatible with splitting
-    if (!signature.timerDeclarations().isEmpty() && signature.processElement().isSplittable()) {
+    if ((!signature.timerDeclarations().isEmpty() || !signature.timerFamilyDeclarations().isEmpty())
+        && signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
           String.format(
               "%s is splittable and uses timers, but these are not compatible",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,6 +95,7 @@ import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.jar.asm.MethodVisit
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.jar.asm.Opcodes;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.jar.asm.Type;
 import org.apache.beam.vendor.bytebuddy.v1_9_3.net.bytebuddy.matcher.ElementMatchers;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Primitives;
 
 /** Dynamically generates a {@link DoFnInvoker} instances for invoking a {@link DoFn}. */
@@ -172,7 +172,8 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
       implements DoFnInvoker<InputT, OutputT> {
     protected DoFnT delegate;
 
-    private Map<String, OnTimerInvoker> onTimerInvokers = new HashMap<>();
+    private Map<String, OnTimerInvoker> onTimerInvokers = Maps.newHashMap();
+    private Map<String, OnTimerInvoker> onTimerFamilyInvokers = Maps.newHashMap();
 
     public DoFnInvokerBase(DoFnT delegate) {
       this.delegate = delegate;
@@ -191,12 +192,26 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
       this.onTimerInvokers.put(timerId, onTimerInvoker);
     }
 
+    /**
+     * Associates the given timerFamily ID with the given {@link OnTimerInvoker}.
+     *
+     * <p>ByteBuddy does not like to generate conditional code, so we use a map + lookup of the
+     * timer ID rather than a generated conditional branch to choose which OnTimerInvoker to invoke.
+     */
+    void addOnTimerFamilyInvoker(String timerFamilyId, OnTimerInvoker onTimerInvoker) {
+      this.onTimerFamilyInvokers.put(timerFamilyId, onTimerInvoker);
+    }
+
     @Override
     public void invokeOnTimer(
         String timerId,
         String timerFamilyId,
         DoFnInvoker.ArgumentProvider<InputT, OutputT> arguments) {
-      @Nullable OnTimerInvoker onTimerInvoker = onTimerInvokers.get(timerId);
+      @Nullable
+      OnTimerInvoker onTimerInvoker =
+          (timerFamilyId.isEmpty())
+              ? onTimerInvokers.get(timerId)
+              : onTimerFamilyInvokers.get(timerFamilyId);
 
       if (onTimerInvoker != null) {
         onTimerInvoker.invokeOnTimer(arguments);
@@ -216,59 +231,6 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
     }
   }
 
-  /**
-   * Internal base class for generated {@link DoFnInvoker} instances.
-   *
-   * <p>This class should <i>not</i> be extended directly, or by Beam users. It must be public for
-   * generated instances to have adequate access, as they are generated "inside" the invoked {@link
-   * DoFn} class.
-   */
-  public abstract static class DoFnInvokerTimerFamily<
-          InputT, OutputT, DoFnT extends DoFn<InputT, OutputT>>
-      implements DoFnInvoker<InputT, OutputT> {
-    protected DoFnT delegate;
-
-    private Map<String, OnTimerInvoker> onTimerInvokers = new HashMap<>();
-
-    public DoFnInvokerTimerFamily(DoFnT delegate) {
-      this.delegate = delegate;
-    }
-
-    /**
-     * Associates the given timerFamily ID with the given {@link OnTimerInvoker}.
-     *
-     * <p>ByteBuddy does not like to generate conditional code, so we use a map + lookup of the
-     * timer ID rather than a generated conditional branch to choose which OnTimerInvoker to invoke.
-     */
-    void addOnTimerFamilyInvoker(String timerFamilyId, OnTimerInvoker onTimerInvoker) {
-      this.onTimerInvokers.put(timerFamilyId, onTimerInvoker);
-    }
-
-    @Override
-    public void invokeOnTimer(
-        String timerId,
-        String timerFamilyId,
-        DoFnInvoker.ArgumentProvider<InputT, OutputT> arguments) {
-      @Nullable OnTimerInvoker onTimerInvoker = onTimerInvokers.get(timerFamilyId);
-
-      if (onTimerInvoker != null) {
-        onTimerInvoker.invokeOnTimer(arguments);
-      } else {
-        throw new IllegalArgumentException(
-            String.format(
-                "Attempted to invoke timerFamily %s on %s, but that timerFamily is not registered."
-                    + " This is the responsibility of the runner, which must only deliver"
-                    + " registered timers.",
-                timerFamilyId, delegate.getClass().getName()));
-      }
-    }
-
-    @Override
-    public DoFn<InputT, OutputT> getFn() {
-      return delegate;
-    }
-  }
-
   /** @return the {@link DoFnInvoker} for the given {@link DoFn}. */
   public <InputT, OutputT> DoFnInvoker<InputT, OutputT> newByteBuddyInvoker(
       DoFnSignature signature, DoFn<InputT, OutputT> fn) {
@@ -279,33 +241,21 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
         fn.getClass());
 
     try {
-      if (signature.timerFamilyDeclarations().size() > 0) {
-        @SuppressWarnings("unchecked")
-        DoFnInvokerTimerFamily<InputT, OutputT, DoFn<InputT, OutputT>> invoker =
-            (DoFnInvokerTimerFamily<InputT, OutputT, DoFn<InputT, OutputT>>)
-                getByteBuddyInvokerConstructor(signature).newInstance(fn);
+      @SuppressWarnings("unchecked")
+      DoFnInvokerBase<InputT, OutputT, DoFn<InputT, OutputT>> invoker =
+          (DoFnInvokerBase<InputT, OutputT, DoFn<InputT, OutputT>>)
+              getByteBuddyInvokerConstructor(signature).newInstance(fn);
 
-        for (DoFnSignature.OnTimerFamilyMethod onTimerFamilyMethod :
-            signature.onTimerFamilyMethods().values()) {
-          invoker.addOnTimerFamilyInvoker(
-              onTimerFamilyMethod.id(),
-              OnTimerInvokers.forTimerFamily(fn, onTimerFamilyMethod.id()));
-        }
-        return invoker;
-      } else {
-
-        @SuppressWarnings("unchecked")
-        DoFnInvokerBase<InputT, OutputT, DoFn<InputT, OutputT>> invoker =
-            (DoFnInvokerBase<InputT, OutputT, DoFn<InputT, OutputT>>)
-                getByteBuddyInvokerConstructor(signature).newInstance(fn);
-
-        for (OnTimerMethod onTimerMethod : signature.onTimerMethods().values()) {
-          invoker.addOnTimerInvoker(
-              onTimerMethod.id(), OnTimerInvokers.forTimer(fn, onTimerMethod.id()));
-        }
-        return invoker;
+      for (OnTimerMethod onTimerMethod : signature.onTimerMethods().values()) {
+        invoker.addOnTimerInvoker(
+            onTimerMethod.id(), OnTimerInvokers.forTimer(fn, onTimerMethod.id()));
       }
-
+      for (DoFnSignature.OnTimerFamilyMethod onTimerFamilyMethod :
+          signature.onTimerFamilyMethods().values()) {
+        invoker.addOnTimerFamilyInvoker(
+            onTimerFamilyMethod.id(), OnTimerInvokers.forTimerFamily(fn, onTimerFamilyMethod.id()));
+      }
+      return invoker;
     } catch (InstantiationException
         | IllegalAccessException
         | IllegalArgumentException
@@ -325,12 +275,7 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
     Class<? extends DoFn<?, ?>> fnClass = signature.fnClass();
     Constructor<?> constructor = byteBuddyInvokerConstructorCache.get(fnClass);
     if (constructor == null) {
-      Class<? extends DoFnInvoker<?, ?>> invokerClass =
-          generateInvokerClass(
-              signature,
-              signature.timerFamilyDeclarations().size() > 0
-                  ? DoFnInvokerTimerFamily.class
-                  : DoFnInvokerBase.class);
+      Class<? extends DoFnInvoker<?, ?>> invokerClass = generateInvokerClass(signature);
       try {
         constructor = invokerClass.getConstructor(fnClass);
       } catch (IllegalArgumentException | NoSuchMethodException | SecurityException e) {
@@ -391,8 +336,7 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
   }
 
   /** Generates a {@link DoFnInvoker} class for the given {@link DoFnSignature}. */
-  private static Class<? extends DoFnInvoker<?, ?>> generateInvokerClass(
-      DoFnSignature signature, Class<? extends DoFnInvoker> clazz) {
+  private static Class<? extends DoFnInvoker<?, ?>> generateInvokerClass(DoFnSignature signature) {
     Class<? extends DoFn<?, ?>> fnClass = signature.fnClass();
 
     final TypeDescription clazzDescription = new TypeDescription.ForLoadedType(fnClass);
@@ -406,12 +350,12 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
                     .withSuffix(DoFnInvoker.class.getSimpleName()))
 
             // class <invoker class> extends DoFnInvokerBase {
-            .subclass(clazz, ConstructorStrategy.Default.NO_CONSTRUCTORS)
+            .subclass(DoFnInvokerBase.class, ConstructorStrategy.Default.NO_CONSTRUCTORS)
 
             //   public <invoker class>(<fn class> delegate) { this.delegate = delegate; }
             .defineConstructor(Visibility.PUBLIC)
             .withParameter(fnClass)
-            .intercept(new InvokerConstructor(clazz))
+            .intercept(new InvokerConstructor(DoFnInvokerBase.class))
 
             //   public invokeProcessElement(ProcessContext, ExtraContextFactory) {
             //     delegate.<@ProcessElement>(... pass just the right args ...);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -1559,6 +1559,9 @@ public class DoFnSignatures {
       Map<String, TimerFamilyDeclaration> declarations,
       String id,
       Field field) {
+    if (id.isEmpty()) {
+      errors.throwIllegalArgument("TimerFamily id must not be empty");
+    }
 
     if (declarations.containsKey(id)) {
       errors.throwIllegalArgument(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -118,6 +118,7 @@ import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PDone;
@@ -4482,7 +4483,17 @@ public class ParDoTest implements Serializable {
 
     @Test
     @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTimerMap.class})
-    public void testTimerFamilyEventTime() throws Exception {
+    public void testTimerFamilyEventTimeBounded() throws Exception {
+      runTestTimerFamilyEventTime(false);
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTimerMap.class})
+    public void testTimerFamilyEventTimeUnbounded() throws Exception {
+      runTestTimerFamilyEventTime(true);
+    }
+
+    public void runTestTimerFamilyEventTime(boolean useStreaming) {
       final String timerFamilyId = "foo";
 
       DoFn<KV<String, Integer>, String> fn =
@@ -4512,14 +4523,27 @@ public class ParDoTest implements Serializable {
           };
 
       PCollection<String> output =
-          pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
+          pipeline
+              .apply(Create.of(KV.of("hello", 37)))
+              .setIsBoundedInternal(useStreaming ? IsBounded.UNBOUNDED : IsBounded.BOUNDED)
+              .apply(ParDo.of(fn));
       PAssert.that(output).containsInAnyOrder("process", "timer1", "timer2");
       pipeline.run();
     }
 
     @Test
     @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTimerMap.class})
-    public void testTimerWithMultipleTimerFamily() throws Exception {
+    public void testTimerWithMultipleTimerFamilyBounded() throws Exception {
+      runTestTimerWithMultipleTimerFamily(false);
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTimerMap.class})
+    public void testTimerWithMultipleTimerFamilyUnbounded() throws Exception {
+      runTestTimerWithMultipleTimerFamily(true);
+    }
+
+    public void runTestTimerWithMultipleTimerFamily(boolean useStreaming) throws Exception {
       final String timerFamilyId1 = "foo";
       final String timerFamilyId2 = "bar";
 
@@ -4556,14 +4580,27 @@ public class ParDoTest implements Serializable {
           };
 
       PCollection<String> output =
-          pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
+          pipeline
+              .apply(Create.of(KV.of("hello", 37)))
+              .setIsBoundedInternal(useStreaming ? IsBounded.UNBOUNDED : IsBounded.BOUNDED)
+              .apply(ParDo.of(fn));
       PAssert.that(output).containsInAnyOrder("process", "timer", "timer");
       pipeline.run();
     }
 
     @Test
     @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTimerMap.class})
-    public void testTimerFamilyAndTimer() throws Exception {
+    public void testTimerFamilyAndTimerBounded() throws Exception {
+      runTestTimerFamilyAndTimer(false);
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTimerMap.class})
+    public void testTimerFamilyAndTimerUnbounded() throws Exception {
+      runTestTimerFamilyAndTimer(true);
+    }
+
+    public void runTestTimerFamilyAndTimer(boolean useStreaming) throws Exception {
       final String timerFamilyId = "foo";
       final String timerId = "timer";
 
@@ -4599,7 +4636,10 @@ public class ParDoTest implements Serializable {
           };
 
       PCollection<String> output =
-          pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
+          pipeline
+              .apply(Create.of(KV.of("hello", 37)))
+              .setIsBoundedInternal(useStreaming ? IsBounded.UNBOUNDED : IsBounded.BOUNDED)
+              .apply(ParDo.of(fn));
       PAssert.that(output).containsInAnyOrder("process", "family:foo:timer", "timer");
       pipeline.run();
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -114,7 +114,7 @@ public class DoFnInvokersTest {
   }
 
   private void invokeOnTimer(String timerId, DoFn<String, String> fn) {
-    DoFnInvokers.invokerFor(fn).invokeOnTimer(timerId, timerId, mockArgumentProvider);
+    DoFnInvokers.invokerFor(fn).invokeOnTimer(timerId, "", mockArgumentProvider);
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -889,7 +889,7 @@ public class DoFnInvokersTest {
     SimpleTimerDoFn fn = new SimpleTimerDoFn();
 
     DoFnInvoker<String, String> invoker = DoFnInvokers.invokerFor(fn);
-    invoker.invokeOnTimer(timerId, timerId, mockArgumentProvider);
+    invoker.invokeOnTimer(timerId, "", mockArgumentProvider);
     assertThat(fn.status, equalTo("OK now"));
   }
 
@@ -918,7 +918,7 @@ public class DoFnInvokersTest {
     SimpleTimerDoFn fn = new SimpleTimerDoFn();
 
     DoFnInvoker<String, String> invoker = DoFnInvokers.invokerFor(fn);
-    invoker.invokeOnTimer(timerId, timerId, mockArgumentProvider);
+    invoker.invokeOnTimer(timerId, "", mockArgumentProvider);
     assertThat(fn.window, equalTo(testWindow));
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -773,7 +773,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
           (Iterator<BoundedWindow>) timer.getWindows().iterator();
       while (windowIterator.hasNext()) {
         currentWindow = windowIterator.next();
-        doFnInvoker.invokeOnTimer(timerId, timerId, onTimerContext);
+        doFnInvoker.invokeOnTimer(timerId, "", onTimerContext);
       }
     } finally {
       currentTimer = null;


### PR DESCRIPTION
Fixes TimerMap bug that caused it to not work on DataflowRunner.

Fixes TimerMap bug that caused it to fail if .a single ParDo had both a TimerFamily and a Timer declaration.

The TimerMap tests were only running on batch runners because the input was a Create producing a bounded PCollection. Make sure that all the tests are run on both batch and streaming runners.