### PR TITLE
[BEAM-8932] Modify PubsubUnboundedSource and PubsubReader to use the PubsubMessage proto.

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -1254,15 +1254,10 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         stepContext.addInput(
             PropertyNames.PUBSUB_ID_ATTRIBUTE, overriddenTransform.getIdAttribute());
       }
-      // In both cases, the transform needs to read PubsubMessage. However, in case it needs
-      // the attributes, we supply an identity "parse fn" so the worker will read PubsubMessage's
-      // from Windmill and simply pass them around; and in case it doesn't need attributes,
-      // we're already implicitly using a "Coder" that interprets the data as a PubsubMessage's
-      // payload.
+      // We use the presence of a non-null string to indicate that the reader should parse the data
+      // as a PubsubMessage, instead of a raw byte string. The naming is for legacy reasons.
       if (overriddenTransform.getNeedsAttributes()) {
-        stepContext.addInput(
-            PropertyNames.PUBSUB_SERIALIZED_ATTRIBUTES_FN,
-            byteArrayToJsonString(serializeToByteArray(new IdentityMessageFn())));
+        stepContext.addInput(PropertyNames.PUBSUB_SERIALIZED_ATTRIBUTES_FN, "PARSE_PUBSUB_MESSAGE");
       }
       stepContext.addOutput(PropertyNames.OUTPUT, context.getOutput(transform));
     }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/IncomingMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/IncomingMessage.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import com.google.auto.value.AutoValue;
+import com.google.pubsub.v1.PubsubMessage;
+import org.apache.beam.sdk.coders.DefaultCoder;
+
+/** A message received from Pubsub. */
+@AutoValue
+@DefaultCoder(IncomingMessageCoder.class)
+abstract class IncomingMessage {
+
+  /** Underlying Message. */
+  public abstract com.google.pubsub.v1.PubsubMessage message();
+
+  /**
+   * Timestamp for element (ms since epoch). Either Pubsub's processing time, or the custom
+   * timestamp associated with the message.
+   */
+  public abstract long timestampMsSinceEpoch();
+
+  /** Timestamp (in system time) at which we requested the message (ms since epoch). */
+  public abstract long requestTimeMsSinceEpoch();
+
+  /** Id to pass back to Pubsub to acknowledge receipt of this message. */
+  public abstract String ackId();
+
+  /** Id to pass to the runner to distinguish this message from all others. */
+  public abstract String recordId();
+
+  public static IncomingMessage of(
+      PubsubMessage message,
+      long timestampMsSinceEpoch,
+      long requestTimeMsSinceEpoch,
+      String ackId,
+      String recordId) {
+    return new AutoValue_IncomingMessage(
+        message, timestampMsSinceEpoch, requestTimeMsSinceEpoch, ackId, recordId);
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/IncomingMessageCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/IncomingMessageCoder.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import com.google.pubsub.v1.PubsubMessage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.sdk.coders.CoderProvider;
+import org.apache.beam.sdk.coders.CoderProviders;
+import org.apache.beam.sdk.coders.CustomCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/** A coder for IncomingMessage. */
+public class IncomingMessageCoder extends CustomCoder<IncomingMessage> {
+  public static CoderProvider getCoderProvider() {
+    return CoderProviders.forCoder(
+        TypeDescriptor.of(IncomingMessage.class), new IncomingMessageCoder());
+  }
+
+  public static IncomingMessageCoder of() {
+    return new IncomingMessageCoder();
+  }
+
+  @Override
+  public void encode(IncomingMessage value, OutputStream outStream) throws IOException {
+    ProtoCoder.of(PubsubMessage.class).encode(value.message(), outStream);
+    VarLongCoder.of().encode(value.timestampMsSinceEpoch(), outStream);
+    VarLongCoder.of().encode(value.requestTimeMsSinceEpoch(), outStream);
+    StringUtf8Coder.of().encode(value.ackId(), outStream);
+    StringUtf8Coder.of().encode(value.recordId(), outStream);
+  }
+
+  @Override
+  public IncomingMessage decode(InputStream inStream) throws IOException {
+    return IncomingMessage.of(
+        ProtoCoder.of(PubsubMessage.class).decode(inStream),
+        VarLongCoder.of().decode(inStream),
+        VarLongCoder.of().decode(inStream),
+        StringUtf8Coder.of().decode(inStream),
+        StringUtf8Coder.of().decode(inStream));
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/OutgoingMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/OutgoingMessage.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import com.google.auto.value.AutoValue;
+import com.google.protobuf.ByteString;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.DefaultCoder;
+
+/** A message to be sent to Pubsub. */
+@AutoValue
+@DefaultCoder(OutgoingMessageCoder.class)
+abstract class OutgoingMessage {
+
+  /** Underlying Message. May not have publish timestamp set. */
+  public abstract com.google.pubsub.v1.PubsubMessage message();
+
+  /** Timestamp for element (ms since epoch). */
+  public abstract long timestampMsSinceEpoch();
+
+  /**
+   * If using an id attribute, the record id to associate with this record's metadata so the
+   * receiver can reject duplicates. Otherwise {@literal null}.
+   */
+  @Nullable
+  public abstract String recordId();
+
+  public static OutgoingMessage of(
+      com.google.pubsub.v1.PubsubMessage message,
+      long timestampMsSinceEpoch,
+      @Nullable String recordId) {
+    return new AutoValue_OutgoingMessage(message, timestampMsSinceEpoch, recordId);
+  }
+
+  public static OutgoingMessage of(
+      PubsubMessage message, long timestampMsSinceEpoch, @Nullable String recordId) {
+    com.google.pubsub.v1.PubsubMessage.Builder builder =
+        com.google.pubsub.v1.PubsubMessage.newBuilder()
+            .setData(ByteString.copyFrom(message.getPayload()));
+    if (message.getAttributeMap() != null) {
+      builder.putAllAttributes(message.getAttributeMap());
+    }
+    return of(builder.build(), timestampMsSinceEpoch, recordId);
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/OutgoingMessageCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/OutgoingMessageCoder.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import com.google.pubsub.v1.PubsubMessage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.sdk.coders.CoderProvider;
+import org.apache.beam.sdk.coders.CoderProviders;
+import org.apache.beam.sdk.coders.CustomCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/** A coder for OutgoingMessage. */
+public class OutgoingMessageCoder extends CustomCoder<OutgoingMessage> {
+  public static CoderProvider getCoderProvider() {
+    return CoderProviders.forCoder(
+        TypeDescriptor.of(OutgoingMessage.class), new OutgoingMessageCoder());
+  }
+
+  public static OutgoingMessageCoder of() {
+    return new OutgoingMessageCoder();
+  }
+
+  @Override
+  public void encode(OutgoingMessage value, OutputStream outStream) throws IOException {
+    ProtoCoder.of(PubsubMessage.class).encode(value.message(), outStream);
+    VarLongCoder.of().encode(value.timestampMsSinceEpoch(), outStream);
+    NullableCoder.of(StringUtf8Coder.of()).encode(value.recordId(), outStream);
+  }
+
+  @Override
+  public OutgoingMessage decode(InputStream inStream) throws IOException {
+    return OutgoingMessage.of(
+        ProtoCoder.of(PubsubMessage.class).decode(inStream),
+        VarLongCoder.of().decode(inStream),
+        NullableCoder.of(StringUtf8Coder.of()).decode(inStream));
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubBoundedWriter.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubBoundedWriter.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.naming.SizeLimitExceededException;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO.PubsubTopic;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.display.DisplayData;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubBoundedWriter.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubBoundedWriter.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
+
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.naming.SizeLimitExceededException;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO.PubsubTopic;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+
+/** Writer to Pubsub which batches messages from bounded collections. */
+class PubsubBoundedWriter<T> extends DoFn<T, Void> {
+  /**
+   * Max batch byte size. Messages are base64 encoded which encodes each set of three bytes into
+   * four bytes.
+   */
+  private static final int MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT = ((10 * 1000 * 1000) / 4) * 3;
+
+  private static final int MAX_PUBLISH_BATCH_SIZE = 100;
+
+  private transient List<OutgoingMessage> output;
+  private transient PubsubClient pubsubClient;
+  private transient int currentOutputBytes;
+
+  private final int maxPublishBatchByteSize;
+  private final int maxPublishBatchSize;
+  private final PubsubIO.Write<T> write;
+
+  private PubsubBoundedWriter(PubsubIO.Write<T> write) {
+    Preconditions.checkNotNull(write.getTopicProvider());
+    this.maxPublishBatchSize =
+        MoreObjects.firstNonNull(write.getMaxBatchSize(), MAX_PUBLISH_BATCH_SIZE);
+    this.maxPublishBatchByteSize =
+        MoreObjects.firstNonNull(write.getMaxBatchBytesSize(), MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT);
+    this.write = write;
+  }
+
+  static <T> PubsubBoundedWriter<T> of(PubsubIO.Write<T> write) {
+    return new PubsubBoundedWriter<>(write);
+  }
+
+  @StartBundle
+  public void startBundle(StartBundleContext c) throws IOException {
+    this.output = new ArrayList<>();
+    this.currentOutputBytes = 0;
+
+    // NOTE: idAttribute is ignored.
+    this.pubsubClient =
+        write
+            .getPubsubClientFactory()
+            .newClient(
+                write.getTimestampAttribute(),
+                null,
+                c.getPipelineOptions().as(PubsubOptions.class));
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) throws IOException, SizeLimitExceededException {
+    byte[] payload;
+    PubsubMessage message = write.getFormatFn().apply(c.element());
+    payload = message.getPayload();
+    Map<String, String> attributes = message.getAttributeMap();
+
+    if (payload.length > maxPublishBatchByteSize) {
+      String msg =
+          String.format(
+              "Pub/Sub message size (%d) exceeded maximum batch size (%d)",
+              payload.length, maxPublishBatchByteSize);
+      throw new SizeLimitExceededException(msg);
+    }
+
+    // Checking before adding the message stops us from violating the max bytes
+    if (((currentOutputBytes + payload.length) >= maxPublishBatchByteSize)
+        || (output.size() >= maxPublishBatchSize)) {
+      publish();
+    }
+
+    // NOTE: The record id is always null.
+    output.add(
+        OutgoingMessage.of(
+            com.google.pubsub.v1.PubsubMessage.newBuilder()
+                .setData(ByteString.copyFrom(payload))
+                .putAllAttributes(attributes)
+                .build(),
+            c.timestamp().getMillis(),
+            null));
+    currentOutputBytes += payload.length;
+  }
+
+  @FinishBundle
+  public void finishBundle() throws IOException {
+    if (!output.isEmpty()) {
+      publish();
+    }
+    output = null;
+    currentOutputBytes = 0;
+    pubsubClient.close();
+    pubsubClient = null;
+  }
+
+  private void publish() throws IOException {
+    PubsubTopic topic = write.getTopicProvider().get();
+    int n = pubsubClient.publish(PubsubClient.topicPathFromPath(topic.asPath()), output);
+    checkState(n == output.size());
+    output.clear();
+    currentOutputBytes = 0;
+  }
+
+  @Override
+  public void populateDisplayData(DisplayData.Builder builder) {
+    super.populateDisplayData(builder);
+    builder.delegate(write);
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -83,7 +83,7 @@ public class PubsubIO {
   private static final Logger LOG = LoggerFactory.getLogger(PubsubIO.class);
 
   /** Factory for creating pubsub client to manage transport. */
-  private static final PubsubClient.PubsubClientFactory FACTORY = PubsubJsonClient.FACTORY;
+  private static final PubsubClient.PubsubClientFactory FACTORY = PubsubGrpcClient.FACTORY;
 
   /**
    * Project IDs must contain 6-63 lowercase letters, digits, or dashes. IDs must start with a

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -17,22 +17,14 @@
  */
 package org.apache.beam.sdk.io.gcp.pubsub;
 
-import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
-
 import com.google.api.client.util.Clock;
 import com.google.auto.value.AutoValue;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
-import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
-import javax.naming.SizeLimitExceededException;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.beam.sdk.PipelineRunner;
@@ -43,7 +35,6 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -52,7 +43,6 @@ import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.schemas.utils.AvroUtils;
-import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -587,10 +577,10 @@ public class PubsubIO {
     @Nullable
     abstract ValueProvider<PubsubTopic> getTopicProvider();
 
-    abstract PubsubClient.PubsubClientFactory getPubsubClientFactory();
-
     @Nullable
     abstract ValueProvider<PubsubSubscription> getSubscriptionProvider();
+
+    abstract PubsubClient.PubsubClientFactory getPubsubClientFactory();
 
     /** The name of the message attribute to read timestamps from. */
     @Nullable
@@ -858,14 +848,6 @@ public class PubsubIO {
   /** Implementation of write methods. */
   @AutoValue
   public abstract static class Write<T> extends PTransform<PCollection<T>, PDone> {
-    /**
-     * Max batch byte size. Messages are base64 encoded which encodes each set of three bytes into
-     * four bytes.
-     */
-    private static final int MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT = ((10 * 1000 * 1000) / 4) * 3;
-
-    private static final int MAX_PUBLISH_BATCH_SIZE = 100;
-
     @Nullable
     abstract ValueProvider<PubsubTopic> getTopicProvider();
 
@@ -998,15 +980,6 @@ public class PubsubIO {
       return toBuilder().setIdAttribute(idAttribute).build();
     }
 
-    /**
-     * Used to write a PubSub message together with PubSub attributes. The user-supplied format
-     * function translates the input type T to a PubsubMessage object, which is used by the sink to
-     * separately set the PubSub message's payload and attributes.
-     */
-    private Write<T> withFormatFn(SimpleFunction<T, PubsubMessage> formatFn) {
-      return toBuilder().setFormatFn(formatFn).build();
-    }
-
     @Override
     public PDone expand(PCollection<T> input) {
       if (getTopicProvider() == null) {
@@ -1015,12 +988,8 @@ public class PubsubIO {
 
       switch (input.isBounded()) {
         case BOUNDED:
-          input.apply(
-              ParDo.of(
-                  new PubsubBoundedWriter(
-                      MoreObjects.firstNonNull(getMaxBatchSize(), MAX_PUBLISH_BATCH_SIZE),
-                      MoreObjects.firstNonNull(
-                          getMaxBatchBytesSize(), MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT))));
+          // NOTE: idAttribute is ignored.
+          input.apply(ParDo.of(PubsubBoundedWriter.of(this)));
           return PDone.in(input.getPipeline());
         case UNBOUNDED:
           return input
@@ -1046,101 +1015,6 @@ public class PubsubIO {
       super.populateDisplayData(builder);
       populateCommonDisplayData(
           builder, getTimestampAttribute(), getIdAttribute(), getTopicProvider());
-    }
-
-    /**
-     * Writer to Pubsub which batches messages from bounded collections.
-     *
-     * <p>Public so can be suppressed by runners.
-     */
-    public class PubsubBoundedWriter extends DoFn<T, Void> {
-      private transient List<OutgoingMessage> output;
-      private transient PubsubClient pubsubClient;
-      private transient int currentOutputBytes;
-
-      private int maxPublishBatchByteSize;
-      private int maxPublishBatchSize;
-
-      PubsubBoundedWriter(int maxPublishBatchSize, int maxPublishBatchByteSize) {
-        this.maxPublishBatchSize = maxPublishBatchSize;
-        this.maxPublishBatchByteSize = maxPublishBatchByteSize;
-      }
-
-      PubsubBoundedWriter() {
-        this(MAX_PUBLISH_BATCH_SIZE, MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT);
-      }
-
-      @StartBundle
-      public void startBundle(StartBundleContext c) throws IOException {
-        this.output = new ArrayList<>();
-        this.currentOutputBytes = 0;
-
-        // NOTE: idAttribute is ignored.
-        this.pubsubClient =
-            getPubsubClientFactory()
-                .newClient(
-                    getTimestampAttribute(), null, c.getPipelineOptions().as(PubsubOptions.class));
-      }
-
-      @ProcessElement
-      public void processElement(ProcessContext c) throws IOException, SizeLimitExceededException {
-        byte[] payload;
-        PubsubMessage message = getFormatFn().apply(c.element());
-        payload = message.getPayload();
-        Map<String, String> attributes = message.getAttributeMap();
-
-        if (payload.length > maxPublishBatchByteSize) {
-          String msg =
-              String.format(
-                  "Pub/Sub message size (%d) exceeded maximum batch size (%d)",
-                  payload.length, maxPublishBatchByteSize);
-          throw new SizeLimitExceededException(msg);
-        }
-
-        // Checking before adding the message stops us from violating the max bytes
-        if (((currentOutputBytes + payload.length) >= maxPublishBatchByteSize)
-            || (output.size() >= maxPublishBatchSize)) {
-          publish();
-        }
-
-        // NOTE: The record id is always null.
-        output.add(
-            OutgoingMessage.of(
-                com.google.pubsub.v1.PubsubMessage.newBuilder()
-                    .setData(ByteString.copyFrom(payload))
-                    .putAllAttributes(attributes)
-                    .build(),
-                c.timestamp().getMillis(),
-                null));
-        currentOutputBytes += payload.length;
-      }
-
-      @FinishBundle
-      public void finishBundle() throws IOException {
-        if (!output.isEmpty()) {
-          publish();
-        }
-        output = null;
-        currentOutputBytes = 0;
-        pubsubClient.close();
-        pubsubClient = null;
-      }
-
-      private void publish() throws IOException {
-        PubsubTopic topic = getTopicProvider().get();
-        int n =
-            pubsubClient.publish(
-                PubsubClient.topicPathFromName(topic.project, topic.topic), output);
-        checkState(n == output.size());
-        output.clear();
-        currentOutputBytes = 0;
-      }
-
-      @Override
-      public void populateDisplayData(DisplayData.Builder builder) {
-        super.populateDisplayData(builder);
-        builder.delegate(Write.this);
-      }
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessage.java
@@ -45,6 +45,14 @@ public class PubsubMessage {
     this.messageId = messageId;
   }
 
+  public static PubsubMessage ofNoMessageId(com.google.pubsub.v1.PubsubMessage proto) {
+    return new PubsubMessage(proto.getData().toByteArray(), proto.getAttributesMap());
+  }
+
+  public static PubsubMessage of(com.google.pubsub.v1.PubsubMessage proto) {
+    return new PubsubMessage(proto.getData().toByteArray(), proto.getAttributesMap(), proto.getMessageId());
+  }
+
   /** Returns the main PubSub message. */
   public byte[] getPayload() {
     return message;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSink.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSink.java
@@ -38,7 +38,6 @@ import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.PubsubClientFactory;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.sdk.metrics.Counter;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
@@ -384,7 +384,7 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
      * Messages we have received from Pubsub and not yet delivered downstream. We preserve their
      * order.
      */
-    private final Queue<PubsubClient.IncomingMessage> notYetRead;
+    private final Queue<IncomingMessage> notYetRead;
 
     private static class InFlightState {
       /** When request which yielded message was issues. */
@@ -438,7 +438,7 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
     private long lastWatermarkMsSinceEpoch;
 
     /** The current message, or {@literal null} if none. */
-    @Nullable private PubsubClient.IncomingMessage current;
+    @Nullable private IncomingMessage current;
 
     /** Stats only: System time (ms since epoch) we last logs stats, or -1 if never. */
     private long lastLogTimestampMsSinceEpoch;
@@ -715,7 +715,7 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
 
       // Pull the next batch.
       // BLOCKs until received.
-      Collection<PubsubClient.IncomingMessage> receivedMessages =
+      Collection<IncomingMessage> receivedMessages =
           pubsubClient.get().pull(requestTimeMsSinceEpoch, subscription, PULL_BATCH_SIZE, true);
       if (receivedMessages.isEmpty()) {
         // Nothing available yet. Try again later.
@@ -725,7 +725,7 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
       lastReceivedMsSinceEpoch = requestTimeMsSinceEpoch;
 
       // Capture the received messages.
-      for (PubsubClient.IncomingMessage incomingMessage : receivedMessages) {
+      for (IncomingMessage incomingMessage : receivedMessages) {
         notYetRead.add(incomingMessage);
         notYetReadBytes += incomingMessage.message().getData().size();
         inFlight.put(
@@ -986,7 +986,7 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
       // in which case we'll double ACK messages to Pubsub. However Pubsub is fine with that.
       List<String> snapshotSafeToAckIds = Lists.newArrayList(safeToAckIds);
       List<String> snapshotNotYetReadIds = new ArrayList<>(notYetRead.size());
-      for (PubsubClient.IncomingMessage incomingMessage : notYetRead) {
+      for (IncomingMessage incomingMessage : notYetRead) {
         snapshotNotYetReadIds.add(incomingMessage.ackId());
       }
       if (outer.subscriptionPath == null) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.ProjectPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
@@ -190,7 +189,7 @@ public class TestPubsub implements TestRule {
 
   /** Publish messages to {@link #topicPath()}. */
   public void publish(List<PubsubMessage> messages) throws IOException {
-    List<PubsubClient.OutgoingMessage> outgoingMessages =
+    List<OutgoingMessage> outgoingMessages =
         messages.stream().map(this::toOutgoingMessage).collect(toList());
     pubsub.publish(eventsTopicPath, outgoingMessages);
   }
@@ -202,8 +201,7 @@ public class TestPubsub implements TestRule {
 
   /** Pull up to {@code maxBatchSize} messages from {@link #subscriptionPath()}. */
   public List<PubsubMessage> pull(int maxBatchSize) throws IOException {
-    List<PubsubClient.IncomingMessage> messages =
-        pubsub.pull(0, subscriptionPath, maxBatchSize, true);
+    List<IncomingMessage> messages = pubsub.pull(0, subscriptionPath, maxBatchSize, true);
     if (!messages.isEmpty()) {
       pubsub.acknowledge(
           subscriptionPath,
@@ -298,8 +296,8 @@ public class TestPubsub implements TestRule {
     }
   }
 
-  private PubsubClient.OutgoingMessage toOutgoingMessage(PubsubMessage message) {
-    return PubsubClient.OutgoingMessage.of(
+  private OutgoingMessage toOutgoingMessage(PubsubMessage message) {
+    return OutgoingMessage.of(
         com.google.pubsub.v1.PubsubMessage.newBuilder()
             .setData(ByteString.copyFrom(message.getPayload()))
             .putAllAttributes(message.getAttributeMap())

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsubSignal.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsubSignal.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.sdk.state.BagState;
@@ -247,7 +246,7 @@ public class TestPubsubSignal implements TestRule {
   private String pollForResultForDuration(
       SubscriptionPath signalSubscriptionPath, Duration duration) throws IOException {
 
-    List<PubsubClient.IncomingMessage> signal = null;
+    List<IncomingMessage> signal = null;
     DateTime endPolling = DateTime.now().plus(duration.getMillis());
 
     do {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClientTest.java
@@ -41,8 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -48,7 +48,6 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.AvroGeneratedUser;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO.Read;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubTestClient.PubsubTestClientFactory;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClientTest.java
@@ -41,8 +41,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.ProjectPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTestClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTestClientTest.java
@@ -25,8 +25,6 @@ import com.google.pubsub.v1.PubsubMessage;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubTestClient.PubsubTestClientFactory;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSinkTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSinkTest.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubTestClient.PubsubTestClientFactory;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubUnboundedSink.RecordIdMethod;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.util.Clock;
 import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -101,7 +102,7 @@ public class PubsubUnboundedSourceTest {
     setupOneMessage(
         ImmutableList.of(
             IncomingMessage.of(
-                com.google.pubsub.v1.PubsubMessage.newBuilder()
+                PubsubMessage.newBuilder()
                     .setData(ByteString.copyFromUtf8(DATA))
                     .build(),
                 TIMESTAMP,
@@ -120,7 +121,7 @@ public class PubsubUnboundedSourceTest {
   }
 
   private static String data(PubsubMessage message) {
-    return new String(message.getPayload(), StandardCharsets.UTF_8);
+    return message.getData().toStringUtf8();
   }
 
   @Test
@@ -226,7 +227,7 @@ public class PubsubUnboundedSourceTest {
       String ackid = String.format("ackid_%d", i);
       incoming.add(
           IncomingMessage.of(
-              com.google.pubsub.v1.PubsubMessage.newBuilder()
+              PubsubMessage.newBuilder()
                   .setData(ByteString.copyFromUtf8(data))
                   .build(),
               TIMESTAMP,
@@ -292,7 +293,7 @@ public class PubsubUnboundedSourceTest {
       String ackId = String.format("ackid_%d", messageNum);
       incoming.add(
           IncomingMessage.of(
-              com.google.pubsub.v1.PubsubMessage.newBuilder()
+              PubsubMessage.newBuilder()
                   .setData(ByteString.copyFromUtf8(data))
                   .build(),
               messageNumToTimestamp(messageNum),

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubTestClient.PubsubTestClientFactory;

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/metrics/MetricsReader.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/metrics/MetricsReader.java
@@ -19,7 +19,7 @@ package org.apache.beam.sdk.testutils.metrics;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
-import com.sun.istack.internal.NotNull;
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -175,9 +175,9 @@ public class MetricsReader {
    * @param namespace namespace is required due to fact methods uses it internally
    * @return instance of {@link MetricsReader}
    */
-  @NotNull
+  @Nonnull
   public static MetricsReader ofResults(
-      @NotNull final PipelineResult results, @NotNull final String namespace) {
+      @Nonnull final PipelineResult results, @Nonnull final String namespace) {
     checkNotNull(results);
     checkNotNull(namespace);
     return new MetricsReader(results, namespace);


### PR DESCRIPTION
Diffbased on #10807

Modifies PubsubUnboundedSource and PubsubReader to only use the proto PubsubMessage internally.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
