### PR TITLE
[BEAM-7092] Fix invalid import of Guava coming from transitive Spark dep

### DIFF
--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/TransformTranslatorTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/TransformTranslatorTest.java
@@ -30,10 +30,10 @@ import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterators;
 import org.joda.time.Instant;
 import org.junit.Test;
-import org.spark_project.guava.collect.Iterables;
 import scala.Tuple2;
 
 /** Test suite for {@link TransformTranslator}. */

--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -114,6 +114,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="message" value="You are using raw guava, please use vendored guava classes."/>
     </module>
 
+    <!-- Forbid org.spark_project imports. -->
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="ForbidSparkProject"/>
+      <property name="format" value="(\sorg\.spark_project)"/>
+      <property name="severity" value="error"/>
+      <property name="message" value="You should not use org.spark_project classes in Beam."/>
+    </module>
+
     <!-- Forbid TestNG imports that may leak because of dependencies. -->
     <module name="RegexpSinglelineJava">
       <property name="id" value="ForbidTestNG"/>


### PR DESCRIPTION
This import is not available in the transitive dependencies of Spark 3
anymore, and we should not be using non-vendored guava.

R: @je-ik