### PR TITLE
[BEAM-7198] rename ToStringCoder to ToBytesCoder for proper representation of its role

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -445,6 +445,7 @@ class ToBytesCoder(Coder):
   def is_deterministic(self):
     return True
 
+
 # alias to the old class name for a courtesy to users who reference it
 ToStringCoder = ToBytesCoder
 

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -423,7 +423,7 @@ class StrUtf8Coder(Coder):
 Coder.register_structured_urn(common_urns.coders.STRING_UTF8.urn, StrUtf8Coder)
 
 
-class ToStringCoder(Coder):
+class ToBytesCoder(Coder):
   """A default string coder used if no sink coder is specified."""
 
   if sys.version_info.major == 2:
@@ -440,10 +440,13 @@ class ToStringCoder(Coder):
       return value if isinstance(value, bytes) else str(value).encode('utf-8')
 
   def decode(self, _):
-    raise NotImplementedError('ToStringCoder cannot be used for decoding.')
+    raise NotImplementedError('ToBytesCoder cannot be used for decoding.')
 
   def is_deterministic(self):
     return True
+
+
+ToStringCoder = ToBytesCoder
 
 
 class FastCoder(Coder):

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -445,7 +445,7 @@ class ToBytesCoder(Coder):
   def is_deterministic(self):
     return True
 
-
+# alias to the old class name for a courtesy to users who reference it
 ToStringCoder = ToBytesCoder
 
 

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -78,7 +78,7 @@ class CodersTest(unittest.TestCase):
         coders.FastCoder,
         coders.ProtoCoder,
         coders.RunnerAPICoderHolder,
-        coders.ToStringCoder
+        coders.ToBytesCoder
     ])
     assert not standard - cls.seen, standard - cls.seen
     assert not standard - cls.seen_nested, standard - cls.seen_nested

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -43,7 +43,7 @@ from apache_beam import WindowInto
 from apache_beam import coders
 from apache_beam import pvalue
 from apache_beam import typehints
-from apache_beam.coders.coders import ToStringCoder
+from apache_beam.coders.coders import ToBytesCoder
 from apache_beam.examples.snippets import snippets
 from apache_beam.metrics import Metrics
 from apache_beam.metrics.metric import MetricsFilter
@@ -468,7 +468,7 @@ class SnippetsTest(unittest.TestCase):
       def __init__(self, file_to_write):
         self.file_to_write = file_to_write
         self.file_obj = None
-        self.coder = ToStringCoder()
+        self.coder = ToBytesCoder()
 
       def start_bundle(self):
         assert self.file_to_write

--- a/sdks/python/apache_beam/io/filebasedsink_test.py
+++ b/sdks/python/apache_beam/io/filebasedsink_test.py
@@ -131,7 +131,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_file_sink_writing(self):
     temp_path = os.path.join(self._new_tempdir(), 'FileBasedSink')
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
 
     init_token, writer_results = self._common_init(sink)
 
@@ -156,7 +156,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_file_sink_display_data(self):
     temp_path = os.path.join(self._new_tempdir(), 'display')
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
     dd = DisplayData.create_from(sink)
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
@@ -170,7 +170,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_empty_write(self):
     temp_path = tempfile.NamedTemporaryFile().name
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
     with TestPipeline() as p:
       p | beam.Create([]) | beam.io.Write(sink)  # pylint: disable=expression-not-assigned
     self.assertEqual(
@@ -182,7 +182,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
     sink = MyFileBasedSink(
         temp_path,
         file_name_suffix=StaticValueProvider(value_type=str, value='.output'),
-        coder=coders.ToStringCoder())
+        coder=coders.ToBytesCoder())
     with TestPipeline() as p:
       p | beam.Create([]) | beam.io.Write(sink)  # pylint: disable=expression-not-assigned
     self.assertEqual(
@@ -195,7 +195,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
         file_name_suffix='.output',
         num_shards=3,
         shard_name_template='_NN_SSS_',
-        coder=coders.ToStringCoder())
+        coder=coders.ToBytesCoder())
     with TestPipeline() as p:
       p | beam.Create(['a', 'b']) | beam.io.Write(sink)  # pylint: disable=expression-not-assigned
 
@@ -218,7 +218,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
       sink = MyFileBasedSink(
           file_path_prefix,
           file_name_suffix='.output',
-          coder=coders.ToStringCoder())
+          coder=coders.ToBytesCoder())
       return sink.initialize_write()
 
     temp_dir = _get_temp_dir(no_dir_path)
@@ -239,7 +239,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
 
   def test_temp_dir_uniqueness(self):
     temp_path = os.path.join(self._new_tempdir(), 'unique')
-    sink = MyFileBasedSink(temp_path, coder=coders.ToStringCoder())
+    sink = MyFileBasedSink(temp_path, coder=coders.ToBytesCoder())
     init_list = [''] * 1000
     temp_dir_list = [sink._create_temp_dir(temp_path) for _ in init_list]
     temp_dir_set = set(temp_dir_list)
@@ -280,7 +280,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_file_sink_multi_shards(self):
     temp_path = os.path.join(self._new_tempdir(), 'multishard')
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
 
     # Manually invoke the generic Sink API.
     init_token = sink.initialize_write()
@@ -313,7 +313,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_file_sink_rename_error(self, rename_mock):
     temp_path = os.path.join(self._new_tempdir(), 'rename_error')
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
     init_token, writer_results = self._common_init(sink)
     pre_finalize_results = sink.pre_finalize(init_token, writer_results)
 
@@ -327,7 +327,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_file_sink_src_missing(self):
     temp_path = os.path.join(self._new_tempdir(), 'src_missing')
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
     init_token, writer_results = self._common_init(sink)
     pre_finalize_results = sink.pre_finalize(init_token, writer_results)
 
@@ -339,7 +339,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_file_sink_dst_matches_src(self):
     temp_path = os.path.join(self._new_tempdir(), 'dst_matches_src')
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
     init_token, [res1, res2] = self._common_init(sink)
 
     pre_finalize_results = sink.pre_finalize(init_token, [res1, res2])
@@ -360,7 +360,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_pre_finalize(self):
     temp_path = os.path.join(self._new_tempdir(), 'pre_finalize')
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
     init_token, [res1, res2] = self._common_init(sink)
 
     # no-op
@@ -389,7 +389,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
   def test_pre_finalize_error(self, delete_mock):
     temp_path = os.path.join(self._new_tempdir(), 'pre_finalize')
     sink = MyFileBasedSink(
-        temp_path, file_name_suffix='.output', coder=coders.ToStringCoder())
+        temp_path, file_name_suffix='.output', coder=coders.ToBytesCoder())
     init_token, [res1, res2] = self._common_init(sink)
 
     # no-op

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -348,7 +348,7 @@ class _TextSink(filebasedsink.FileBasedSink):
                append_trailing_newlines=True,
                num_shards=0,
                shard_name_template=None,
-               coder=coders.ToStringCoder(),  # type: coders.Coder
+               coder=coders.ToBytesCoder(),  # type: coders.Coder
                compression_type=CompressionTypes.AUTO,
                header=None):
     """Initialize a _TextSink.
@@ -400,7 +400,7 @@ class _TextSink(filebasedsink.FileBasedSink):
   def open(self, temp_path):
     file_handle = super(_TextSink, self).open(temp_path)
     if self._header is not None:
-      file_handle.write(coders.ToStringCoder().encode(self._header))
+      file_handle.write(coders.ToBytesCoder().encode(self._header))
       if self._append_trailing_newlines:
         file_handle.write(b'\n')
     return file_handle
@@ -586,7 +586,7 @@ class WriteToText(PTransform):
       append_trailing_newlines=True,
       num_shards=0,
       shard_name_template=None,  # type: Optional[str]
-      coder=coders.ToStringCoder(),  # type: coders.Coder
+      coder=coders.ToBytesCoder(),  # type: coders.Coder
       compression_type=CompressionTypes.AUTO,
       header=None):
     r"""Initialize a :class:`WriteToText` transform.


### PR DESCRIPTION
Renamed `ToStringCoder` to `ToBytesCoder` and `ToStringCoder` is remained as an alias to `ToBytesCoder` 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
