### PR TITLE
[BEAM-9160] Removed WebIdentityTokenCredentialsProvider explicit json (de)serialization in AWS module

### DIFF
--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsModule.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsModule.java
@@ -27,7 +27,6 @@ import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.PropertiesFileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
-import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
@@ -123,8 +122,6 @@ public class AwsModule extends SimpleModule {
         return new SystemPropertiesCredentialsProvider();
       } else if (typeName.equals(ProfileCredentialsProvider.class.getSimpleName())) {
         return new ProfileCredentialsProvider();
-      } else if (typeName.equals(WebIdentityTokenCredentialsProvider.class.getSimpleName())) {
-        return WebIdentityTokenCredentialsProvider.create();
       } else if (typeName.equals(EC2ContainerCredentialsProviderWrapper.class.getSimpleName())) {
         return new EC2ContainerCredentialsProviderWrapper();
       } else {
@@ -143,7 +140,6 @@ public class AwsModule extends SimpleModule {
             EnvironmentVariableCredentialsProvider.class,
             SystemPropertiesCredentialsProvider.class,
             ProfileCredentialsProvider.class,
-            WebIdentityTokenCredentialsProvider.class,
             EC2ContainerCredentialsProviderWrapper.class);
 
     @Override

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/options/AwsModuleTest.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/options/AwsModuleTest.java
@@ -31,7 +31,6 @@ import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.PropertiesFileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
-import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
@@ -143,12 +142,6 @@ public class AwsModuleTest {
     assertEquals(credentialsProvider.getClass(), deserializedCredentialsProvider.getClass());
 
     credentialsProvider = new ProfileCredentialsProvider();
-    serializedCredentialsProvider = objectMapper.writeValueAsString(credentialsProvider);
-    deserializedCredentialsProvider =
-        objectMapper.readValue(serializedCredentialsProvider, AWSCredentialsProvider.class);
-    assertEquals(credentialsProvider.getClass(), deserializedCredentialsProvider.getClass());
-
-    credentialsProvider = WebIdentityTokenCredentialsProvider.create();
     serializedCredentialsProvider = objectMapper.writeValueAsString(credentialsProvider);
     deserializedCredentialsProvider =
         objectMapper.readValue(serializedCredentialsProvider, AWSCredentialsProvider.class);


### PR DESCRIPTION
As discussed in https://github.com/apache/beam/pull/10825#issuecomment-584869325 this changeset eliminates the direct enumeration of WebIdentityTokenCredentialsProvider in the supported identity providers for AWS, as it is already supported via the DefaultAWSCredentialsProviderChain in the latest AWS clients.
It is enabled by specifying `--awsCredentialsProvider={"@type":"DefaultAWSCredentialsProviderChain"}` in the AwsOptions.

See https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java#L48 here for the relevant line in the AWS client.