### PR TITLE
[BEAM-9228] Support further partition for FnApi ListBuffer

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -285,11 +285,50 @@ class PartitionableBuffer(Buffer, Protocol):
     pass
 
 
-class _ListBuffer(List[bytes]):
+class _ListBuffer():
   """Used to support parititioning of a list."""
+  def __init__(self, input_coder):
+    self._input_coder = input_coder
+    self._inputs = []
+    self._grouped_output = None
+    self.cleared = False
+
+  def append(self, element):
+    if self._grouped_output:
+      raise RuntimeError('ListBuffer append after read.')
+    self._inputs.append(element)
+
   def partition(self, n):
     # type: (int) -> List[List[bytes]]
-    return [self[k::n] for k in range(n)]
+    if len(self._inputs) >= n or len(self._inputs) == 0:
+      return [self._inputs[k::n] for k in range(n)]
+    else:
+      if not self._grouped_output:
+        self._grouped_output = [[] for _ in range(n)]
+        coder_impl = self._input_coder.get_impl()
+        decoded_input = []
+        output_stream_list = []
+        for _ in range(n):
+          output_stream_list.append(create_OutputStream())
+        for input in self._inputs:
+          input_stream = create_InputStream(input)
+          while input_stream.size() > 0:
+            decoded_value = coder_impl.decode_from_stream(input_stream, True)
+            decoded_input.append(decoded_value)
+        for idx, v in enumerate(decoded_input):
+          coder_impl.encode_to_stream(v, output_stream_list[idx % n], True)
+        for ix, output_stream in enumerate(output_stream_list):
+          self._grouped_output[ix] = [output_stream.get()]
+        decoded_input = None
+      return self._grouped_output
+
+  def __iter__(self):
+    return itertools.chain(*self.partition(1))
+
+  def clear(self):
+    self.cleared = True
+    self._inputs = []
+    self._grouped_output = None
 
 
 class _GroupingBuffer(object):
@@ -610,8 +649,7 @@ class FnApiRunner(runner.PipelineRunner):
 
     try:
       with self.maybe_profile():
-        pcoll_buffers = collections.defaultdict(
-            _ListBuffer)  # type: DefaultDict[bytes, PartitionableBuffer]
+        pcoll_buffers = {}
         for stage in stages:
           stage_results = self._run_stage(
               worker_handler_manager.get_worker_handlers,
@@ -641,6 +679,8 @@ class FnApiRunner(runner.PipelineRunner):
       value_coder = context.coders[safe_coders[
           pipeline_components.pcollections[pcoll_id].coder_id]]
       elements_by_window = _WindowGroupingBuffer(si, value_coder)
+      if buffer_id not in pcoll_buffers:
+        pcoll_buffers[buffer_id] = _ListBuffer(input_coder=value_coder)
       for element_data in pcoll_buffers[buffer_id]:
         elements_by_window.append(element_data)
 
@@ -683,7 +723,7 @@ class FnApiRunner(runner.PipelineRunner):
         worker_handler.state.checkpoint()
         testing_bundle_manager = ParallelBundleManager(
             worker_handler_list,
-            lambda pcoll_id: _ListBuffer(),
+            lambda pcoll_id, transform_id: _ListBuffer(input_coder=None),
             get_input_coder_callable,
             process_bundle_descriptor,
             self._progress_frequency,
@@ -707,11 +747,12 @@ class FnApiRunner(runner.PipelineRunner):
     for transform_id, timer_writes in stage.timer_pcollections:
 
       # Queue any set timers as new inputs.
-      windowed_timer_coder_impl = context.coders[
-          pipeline_components.pcollections[timer_writes].coder_id].get_impl()
+      coder = context.coders[
+        pipeline_components.pcollections[timer_writes].coder_id]
+      windowed_timer_coder_impl = coder.get_impl()
       written_timers = get_buffer_callable(
-          create_buffer_id(timer_writes, kind='timers'))
-      if written_timers:
+          create_buffer_id(timer_writes, kind='timers'), transform_id)
+      if not written_timers.cleared:
         # Keep only the "last" timer set per key and window.
         timers_by_key_and_window = {}
         for elements_data in written_timers:
@@ -728,28 +769,33 @@ class FnApiRunner(runner.PipelineRunner):
         for windowed_key_timer in timers_by_key_and_window.values():
           windowed_timer_coder_impl.encode_to_stream(
               windowed_key_timer, out, True)
-        deferred_inputs[transform_id] = _ListBuffer([out.get()])
-        written_timers[:] = []
+        deferred_inputs[transform_id] = _ListBuffer(input_coder=coder)
+        deferred_inputs[transform_id].append(out.get())
+        written_timers.clear()
 
   def _add_residuals_and_channel_splits_to_deferred_inputs(
       self,
       splits,  # type: List[beam_fn_api_pb2.ProcessBundleSplitResponse]
-      get_input_coder_callable,
+      get_input_coder_impl_callable,
       input_for_callable,
       last_sent,
-      deferred_inputs  # type: DefaultDict[str, PartitionableBuffer]
+      deferred_inputs,  # type: DefaultDict[str, PartitionableBuffer]
+      get_input_coder_callable
   ):
     # type: (...) -> None
 
     prev_stops = {}  # type: Dict[str, int]
     for split in splits:
       for delayed_application in split.residual_roots:
-        deferred_inputs[input_for_callable(
+        name = input_for_callable(
             delayed_application.application.transform_id,
-            delayed_application.application.input_id)].append(
-                delayed_application.application.element)
+            delayed_application.application.input_id)
+        if name not in deferred_inputs:
+          coder = get_input_coder_callable(delayed_application.application.transform_id)
+          deferred_inputs[name] = _ListBuffer(input_coder=coder)
+        deferred_inputs[name].append(delayed_application.application.element)
       for channel_split in split.channel_splits:
-        coder_impl = get_input_coder_callable(channel_split.transform_id)
+        coder_impl = get_input_coder_impl_callable(channel_split.transform_id)
         # TODO(SDF): This requires determanistic ordering of buffer iteration.
         # TODO(SDF): The return split is in terms of indices.  Ideally,
         # a runner could map these back to actual positions to effectively
@@ -770,6 +816,9 @@ class FnApiRunner(runner.PipelineRunner):
             channel_split.first_residual_element:prev_stops.
             get(channel_split.transform_id, len(all_elements)) + 1]
         if residual_elements:
+          if channel_split.transform_id not in deferred_inputs:
+            coder = get_input_coder_callable(channel_split.transform_id)
+            deferred_inputs[channel_split.transform_id] = _ListBuffer(input_coder=coder)
           deferred_inputs[channel_split.transform_id].append(
               coder_impl.encode_all(residual_elements))
         prev_stops[
@@ -795,12 +844,16 @@ class FnApiRunner(runner.PipelineRunner):
         pcoll_id = transform.spec.payload
         if transform.spec.urn == bundle_processor.DATA_INPUT_URN:
           target = transform.unique_name, only_element(transform.outputs)
+          coder_id = pipeline_components.pcollections[
+            only_element(transform.outputs.values())].coder_id
+          coder = stage.context.coders[coder_id]
           if pcoll_id == fn_api_runner_transforms.IMPULSE_BUFFER:
-            data_input[target] = _ListBuffer([ENCODED_IMPULSE_VALUE])
+            data_input[target] = _ListBuffer(input_coder=coder)
+            data_input[target].append(ENCODED_IMPULSE_VALUE)
           else:
+            if pcoll_id not in pcoll_buffers:
+              data_input[target] = _ListBuffer(input_coder=coder)
             data_input[target] = pcoll_buffers[pcoll_id]
-          coder_id = pipeline_components.pcollections[only_element(
-              transform.outputs.values())].coder_id
         elif transform.spec.urn == bundle_processor.DATA_OUTPUT_URN:
           target = transform.unique_name, only_element(transform.inputs)
           data_output[target] = pcoll_id
@@ -866,7 +919,8 @@ class FnApiRunner(runner.PipelineRunner):
 
     _LOGGER.info('Running %s', stage.name)
     data_input, data_side_input, data_output = self._extract_endpoints(
-        stage, pipeline_components, data_api_service_descriptor, pcoll_buffers)
+        stage, pipeline_components, data_api_service_descriptor, pcoll_buffers,
+        context)
 
     process_bundle_descriptor = beam_fn_api_pb2.ProcessBundleDescriptor(
         id=self._next_uid(),
@@ -895,7 +949,7 @@ class FnApiRunner(runner.PipelineRunner):
         pcoll_buffers,
         safe_coders)
 
-    def get_buffer(buffer_id):
+    def get_buffer(buffer_id, transform_id):
       # type: (bytes) -> PartitionableBuffer
 
       """Returns the buffer for a given (operation_type, PCollection ID).
@@ -907,6 +961,12 @@ class FnApiRunner(runner.PipelineRunner):
       if kind in ('materialize', 'timers'):
         # If `buffer_id` is not a key in `pcoll_buffers`, it will be added by
         # the `defaultdict`.
+        if buffer_id not in pcoll_buffers:
+          coder_id = beam_fn_api_pb2.RemoteGrpcPort.FromString(
+              process_bundle_descriptor.transforms[transform_id].spec.payload
+          ).coder_id
+          coder = context.coders[coder_id]
+          pcoll_buffers[buffer_id] = _ListBuffer(input_coder=coder)
         return pcoll_buffers[buffer_id]
       elif kind == 'group':
         # This is a grouping write, create a grouping buffer if needed.
@@ -936,6 +996,12 @@ class FnApiRunner(runner.PipelineRunner):
           safe_coders[beam_fn_api_pb2.RemoteGrpcPort.FromString(
               process_bundle_descriptor.transforms[transform_id].spec.payload).
                       coder_id]].get_impl()
+
+    def get_input_coder(transform_id):
+      coder_id = beam_fn_api_pb2.RemoteGrpcPort.FromString(
+          process_bundle_descriptor.transforms[transform_id].spec.payload
+      ).coder_id
+      return context.coders[coder_id]
 
     # Change cache token across bundle repeats
     cache_token_generator = FnApiRunner.get_cache_token_generator(static=False)
@@ -973,28 +1039,38 @@ class FnApiRunner(runner.PipelineRunner):
     last_sent = data_input
 
     while True:
-      deferred_inputs = collections.defaultdict(
-          _ListBuffer)  # type: DefaultDict[str, PartitionableBuffer]
+      deferred_inputs = {}
 
       self._collect_written_timers_and_add_to_deferred_inputs(
           context, pipeline_components, stage, get_buffer, deferred_inputs)
 
       # Queue any process-initiated delayed bundle applications.
       for delayed_application in last_result.process_bundle.residual_roots:
-        deferred_inputs[input_for(
+        name = input_for(
             delayed_application.application.transform_id,
-            delayed_application.application.input_id)].append(
-                delayed_application.application.element)
-
+            delayed_application.application.input_id)
+        if name not in deferred_inputs:
+          input_pcoll = process_bundle_descriptor.transforms[
+            delayed_application.application.transform_id].inputs[delayed_application.application.input_id]
+          coder = context.coders[safe_coders[
+            pipeline_components.pcollections[input_pcoll].coder_id]]
+          deferred_inputs[name] = _ListBuffer(input_coder=coder)
+        deferred_inputs[name].append(delayed_application.application.element)
       # Queue any runner-initiated delayed bundle applications.
       self._add_residuals_and_channel_splits_to_deferred_inputs(
-          splits, get_input_coder_impl, input_for, last_sent, deferred_inputs)
+          splits, get_input_coder_impl, input_for, last_sent, deferred_inputs,
+          get_input_coder)
 
       if deferred_inputs:
         # The worker will be waiting on these inputs as well.
         for other_input in data_input:
           if other_input not in deferred_inputs:
-            deferred_inputs[other_input] = _ListBuffer([])
+            outputs = process_bundle_descriptor.transforms[
+              other_input].outputs.values()
+            coder_id = process_bundle_descriptor.pcollections[
+              only_element(outputs)].coder_id
+            coder = context.coders[coder_id]
+            deferred_inputs[other_input] = _ListBuffer(input_coder=coder)
         # TODO(robertwb): merge results
         # We cannot split deferred_input until we include residual_roots to
         # merged results. Without residual_roots, pipeline stops earlier and we
@@ -1021,8 +1097,9 @@ class FnApiRunner(runner.PipelineRunner):
   def _extract_endpoints(stage,  # type: fn_api_runner_transforms.Stage
                          pipeline_components,  # type: beam_runner_api_pb2.Components
                          data_api_service_descriptor, # type: Optional[endpoints_pb2.ApiServiceDescriptor]
-                         pcoll_buffers  # type: DefaultDict[bytes, PartitionableBuffer]
-                        ):
+                         pcoll_buffers,  # type: DefaultDict[bytes, PartitionableBuffer]
+                         context
+  ):
     # type: (...) -> Tuple[Dict[str, PartitionableBuffer], DataSideInput, DataOutput]
 
     """Returns maps of transform names to PCollection identifiers.
@@ -1051,13 +1128,16 @@ class FnApiRunner(runner.PipelineRunner):
                                 bundle_processor.DATA_OUTPUT_URN):
         pcoll_id = transform.spec.payload
         if transform.spec.urn == bundle_processor.DATA_INPUT_URN:
+          coder_id = pipeline_components.pcollections[
+            only_element(transform.outputs.values())].coder_id
+          coder = context.coders[coder_id]
           if pcoll_id == fn_api_runner_transforms.IMPULSE_BUFFER:
-            data_input[transform.unique_name] = _ListBuffer(
-                [ENCODED_IMPULSE_VALUE])
+            data_input[transform.unique_name] = _ListBuffer(input_coder=coder)
+            data_input[transform.unique_name].append(ENCODED_IMPULSE_VALUE)
           else:
+            if pcoll_id not in pcoll_buffers:
+              pcoll_buffers[pcoll_id] = _ListBuffer(input_coder=coder)
             data_input[transform.unique_name] = pcoll_buffers[pcoll_id]
-          coder_id = pipeline_components.pcollections[only_element(
-              transform.outputs.values())].coder_id
         elif transform.spec.urn == bundle_processor.DATA_OUTPUT_URN:
           data_output[transform.unique_name] = pcoll_id
           coder_id = pipeline_components.pcollections[only_element(
@@ -2112,7 +2192,7 @@ class BundleManager(object):
           (result_future.is_done() and result_future.get().error)):
         if output.transform_id in expected_outputs:
           with BundleManager._lock:
-            self._get_buffer(expected_outputs[output.transform_id]).append(
+            self._get_buffer(expected_outputs[output.transform_id], output.transform_id).append(
                 output.data)
 
       _LOGGER.debug('Wait for the bundle %s to finish.' % process_bundle_id)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -1619,6 +1619,9 @@ class FnApiRunnerSplitTestWithMultiWorkers(FnApiRunnerSplitTest):
   def test_split_half(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
+  def test_split_half_sdf(self):
+    raise unittest.SkipTest("This test is for a single worker only.")
+
 
 class FnApiBasedLullLoggingTest(unittest.TestCase):
   def create_pipeline(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -1603,26 +1603,6 @@ class ExpandStringsProvider(beam.transforms.core.RestrictionProvider):
     return restriction.size()
 
 
-class FnApiRunnerSplitTestWithMultiWorkers(FnApiRunnerSplitTest):
-  def create_pipeline(self):
-    pipeline_options = PipelineOptions(
-        direct_num_workers=2, direct_running_mode='multi_threading')
-    p = beam.Pipeline(
-        runner=fn_api_runner.FnApiRunner(), options=pipeline_options)
-    #TODO(BEAM-8444): Fix these tests..
-    p.options.view_as(DebugOptions).experiments.remove('beam_fn_api')
-    return p
-
-  def test_checkpoint(self):
-    raise unittest.SkipTest("This test is for a single worker only.")
-
-  def test_split_half(self):
-    raise unittest.SkipTest("This test is for a single worker only.")
-
-  def test_split_half_sdf(self):
-    raise unittest.SkipTest("This test is for a single worker only.")
-
-
 class FnApiBasedLullLoggingTest(unittest.TestCase):
   def create_pipeline(self):
     return beam.Pipeline(


### PR DESCRIPTION
A ListBuffer is partitioned when len(input) >= number of workers. This prevents parallelism for some transforms, like SDF. The PR supports further partitioning of the ListBuffer when len(input) < number of workers. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
