### PR TITLE
Pin Avro dependency in Python SDK to be consistent with Avro versioning

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -135,8 +135,12 @@ else:
     cythonize = lambda *args, **kwargs: []
 
 REQUIRED_PACKAGES = [
-    'avro>=1.8.1,<2.0.0; python_version < "3.0"',
-    'avro-python3>=1.8.1,!=1.9.2,<2.0.0; python_version >= "3.0"',
+    # Apache Avro does not follow semantic versioning, so we should not auto
+    # upgrade on minor versions. However, due to an issue on Dataflow we need
+    # to still include the previous version (1.8.x).
+    'avro>=1.8.1,<1.10.0; python_version < "3.0"',
+    # Avro 1.9.2 for python3 was broken. The issue was fixed in version 1.9.2.1
+    'avro-python3>=1.8.1,!=1.9.2,<1.10.0; python_version >= "3.0"',
     'crcmod>=1.7,<2.0',
     # Dill doesn't have forwards-compatibility guarantees within minor version.
     # Pickles created with a new version of dill may not unpickle using older


### PR DESCRIPTION
Avro does not follow semver so we should not be automatically upgrade on minor versions.
R: @tvalentyn 
CC: @aaltay 