### PR TITLE
[BEAM-8335] Update StreamingCache with new Protos

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import
 
 from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 from apache_beam.utils import timestamp
-from apache_beam.utils.timestamp import Timestamp
 
 
 class StreamingCache(object):
@@ -87,9 +86,7 @@ class StreamingCache(object):
 
     def _merge_sort(self, previous_events, new_events):
       return sorted(
-          previous_events + new_events,
-          key=lambda x: x[2],
-          reverse=True)
+          previous_events + new_events, key=lambda x: x[2], reverse=True)
 
     def _min_timestamp_of(self, events):
       return events[-1][2] if events else timestamp.MAX_TIMESTAMP

--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
@@ -53,12 +53,9 @@ class StreamingCache(object):
       self._headers = {r.header().tag: r.header() for r in readers}
       self._readers = {r.header().tag: r.read() for r in readers}
 
-      # The watermarks per tag. Useful for introspection in the stream.
-      self._watermarks = {tag: timestamp.MIN_TIMESTAMP for tag in self._headers}
-
       # The most recently read timestamp per tag.
       self._stream_times = {
-          tag: timestamp.MIN_TIMESTAMP
+          tag: timestamp.Timestamp(seconds=0)
           for tag in self._headers
       }
 
@@ -79,9 +76,11 @@ class StreamingCache(object):
         if self._stream_times[tag] >= target_timestamp:
           continue
         try:
-          record = next(r)
-          records.append((tag, record))
-          self._stream_times[tag] = Timestamp.from_proto(record.processing_time)
+          record = next(r).recorded_event
+          if record.HasField('processing_time_event'):
+            self._stream_times[tag] += timestamp.Duration(
+                micros=record.processing_time_event.advance_duration)
+          records.append((tag, record, self._stream_times[tag]))
         except StopIteration:
           pass
       return records
@@ -89,13 +88,11 @@ class StreamingCache(object):
     def _merge_sort(self, previous_events, new_events):
       return sorted(
           previous_events + new_events,
-          key=lambda x: Timestamp.from_proto(x[1].processing_time),
+          key=lambda x: x[2],
           reverse=True)
 
     def _min_timestamp_of(self, events):
-      return (
-          Timestamp.from_proto(events[-1][1].processing_time)
-          if events else timestamp.MAX_TIMESTAMP)
+      return events[-1][2] if events else timestamp.MAX_TIMESTAMP
 
     def _event_stream_caught_up_to_target(self, events, target_timestamp):
       empty_events = not events
@@ -107,7 +104,7 @@ class StreamingCache(object):
       """
 
       # The largest timestamp read from the different streams.
-      target_timestamp = timestamp.Timestamp.of(0)
+      target_timestamp = timestamp.MAX_TIMESTAMP
 
       # The events from last iteration that are past the target timestamp.
       unsent_events = []
@@ -130,19 +127,20 @@ class StreamingCache(object):
         # Loop through the elements with the correct timestamp.
         while not self._event_stream_caught_up_to_target(events_to_send,
                                                          target_timestamp):
-          tag, r = events_to_send.pop()
 
           # First advance the clock to match the time of the stream. This has
           # a side-effect of also advancing this cache's clock.
-          curr_timestamp = Timestamp.from_proto(r.processing_time)
+          tag, r, curr_timestamp = events_to_send.pop()
           if curr_timestamp > self._monotonic_clock:
             yield self._advance_processing_time(curr_timestamp)
 
           # Then, send either a new element or watermark.
-          if r.HasField('element'):
-            yield self._add_element(r.element, tag)
-          elif r.HasField('watermark'):
-            yield self._advance_watermark(r.watermark, tag)
+          if r.HasField('element_event'):
+            r.element_event.tag = tag
+            yield r
+          elif r.HasField('watermark_event'):
+            r.watermark_event.tag = tag
+            yield r
         unsent_events = events_to_send
         target_timestamp = self._min_timestamp_of(unsent_events)
 
@@ -161,15 +159,6 @@ class StreamingCache(object):
           processing_time_event=TestStreamPayload.Event.AdvanceProcessingTime(
               advance_duration=advancy_by))
       self._monotonic_clock = new_timestamp
-      return e
-
-    def _advance_watermark(self, watermark, tag):
-      """Advances the watermark for tag and returns AdvanceWatermark event.
-      """
-      self._watermarks[tag] = Timestamp.from_proto(watermark)
-      e = TestStreamPayload.Event(
-          watermark_event=TestStreamPayload.Event.AdvanceWatermark(
-              new_watermark=self._watermarks[tag].micros, tag=tag))
       return e
 
   def reader(self):

--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache_test.py
@@ -26,6 +26,7 @@ from apache_beam.portability.api.beam_interactive_api_pb2 import TestStreamFileH
 from apache_beam.portability.api.beam_interactive_api_pb2 import TestStreamFileRecord
 from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 from apache_beam.runners.interactive.caching.streaming_cache import StreamingCache
+from apache_beam.utils.timestamp import Duration
 from apache_beam.utils.timestamp import Timestamp
 
 # Nose automatically detects tests if they match a regex. Here, it mistakens
@@ -42,19 +43,28 @@ class InMemoryReader(object):
     self._records = []
     self._coder = coders.FastPrimitivesCoder()
 
-  def add_element(self, element, event_time, processing_time):
+  def add_element(self, element, event_time):
     element_payload = TestStreamPayload.TimestampedElement(
         encoded_element=self._coder.encode(element),
         timestamp=Timestamp.of(event_time).micros)
     record = TestStreamFileRecord(
-        element=element_payload,
-        processing_time=Timestamp.of(processing_time).to_proto())
+        recorded_event=TestStreamPayload.Event(
+        element_event=TestStreamPayload.Event.AddElements(
+            elements=[element_payload])))
     self._records.append(record)
 
-  def advance_watermark(self, watermark, processing_time):
+  def advance_watermark(self, watermark):
     record = TestStreamFileRecord(
-        watermark=Timestamp.of(watermark).to_proto(),
-        processing_time=Timestamp.of(processing_time).to_proto())
+        recorded_event=TestStreamPayload.Event(
+            watermark_event=TestStreamPayload.Event.AdvanceWatermark(
+                new_watermark=Timestamp.of(watermark).micros)))
+    self._records.append(record)
+
+  def advance_processing_time(self, processing_time_delta):
+    record = TestStreamFileRecord(
+        recorded_event=TestStreamPayload.Event(
+            processing_time_event=TestStreamPayload.Event.AdvanceProcessingTime(
+                advance_duration=Duration.of(processing_time_delta).micros)))
     self._records.append(record)
 
   def header(self):
@@ -80,9 +90,11 @@ class StreamingCacheTest(unittest.TestCase):
     """Tests that we expect to see all the correctly emitted TestStreamPayloads.
     """
     in_memory_reader = InMemoryReader()
-    in_memory_reader.add_element(element=0, event_time=0, processing_time=0)
-    in_memory_reader.add_element(element=1, event_time=1, processing_time=1)
-    in_memory_reader.add_element(element=2, event_time=2, processing_time=2)
+    in_memory_reader.add_element(element=0, event_time=0)
+    in_memory_reader.advance_processing_time(1)
+    in_memory_reader.add_element(element=1, event_time=1)
+    in_memory_reader.advance_processing_time(1)
+    in_memory_reader.add_element(element=2, event_time=2)
     cache = StreamingCache([in_memory_reader])
     reader = cache.reader()
     coder = coders.FastPrimitivesCoder()
@@ -120,18 +132,24 @@ class StreamingCacheTest(unittest.TestCase):
     """Tests that the service advances the clock with multiple outputs."""
 
     letters = InMemoryReader('letters')
-    letters.advance_watermark(0, 1)
-    letters.add_element(element='a', event_time=0, processing_time=1)
-    letters.advance_watermark(10, 11)
-    letters.add_element(element='b', event_time=10, processing_time=11)
+    letters.advance_processing_time(1)
+    letters.advance_watermark(0)
+    letters.add_element(element='a', event_time=0)
+    letters.advance_processing_time(10)
+    letters.advance_watermark(10)
+    letters.add_element(element='b', event_time=10)
 
     numbers = InMemoryReader('numbers')
-    numbers.add_element(element=1, event_time=0, processing_time=2)
-    numbers.add_element(element=2, event_time=0, processing_time=3)
-    numbers.add_element(element=2, event_time=0, processing_time=4)
+    numbers.advance_processing_time(2)
+    numbers.add_element(element=1, event_time=0)
+    numbers.advance_processing_time(1)
+    numbers.add_element(element=2, event_time=0)
+    numbers.advance_processing_time(1)
+    numbers.add_element(element=2, event_time=0)
 
     late = InMemoryReader('late')
-    late.add_element(element='late', event_time=0, processing_time=101)
+    late.advance_processing_time(101)
+    late.add_element(element='late', event_time=0)
 
     cache = StreamingCache([letters, numbers, late])
     reader = cache.reader()

--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache_test.py
@@ -49,8 +49,8 @@ class InMemoryReader(object):
         timestamp=Timestamp.of(event_time).micros)
     record = TestStreamFileRecord(
         recorded_event=TestStreamPayload.Event(
-        element_event=TestStreamPayload.Event.AddElements(
-            elements=[element_payload])))
+            element_event=TestStreamPayload.Event.AddElements(
+                elements=[element_payload])))
     self._records.append(record)
 
   def advance_watermark(self, watermark):


### PR DESCRIPTION
This fixes the breakage from https://github.com/apache/beam/pull/10826.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
