### PR TITLE
[BEAM-9315] Allow multiple paths via HADOOP_CONF_DIR in HadoopFileSystemOptions

### DIFF
--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptions.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptions.java
@@ -88,6 +88,19 @@ public interface HadoopFileSystemOptions extends PipelineOptions {
         }
       }
 
+      /*
+       * Explode the paths by ":" to handle the case in which the environment variables
+       * contains multiple paths.
+       *
+       * This happens on Cloudera 6.x, in which the spark-env.sh script sets
+       * HADOOP_CONF_DIR by appending also the Hive configuration folder:
+       *
+       * if [ -d "$HIVE_CONF_DIR" ]; then
+       *   HADOOP_CONF_DIR="$HADOOP_CONF_DIR:$HIVE_CONF_DIR"
+       * fi
+       * export HADOOP_CONF_DIR
+       *
+       */
       Set<String> explodedConfDirs = Sets.newHashSet();
       for (String confDir : confDirs) {
         Iterable<String> paths = Splitter.on(':').split(confDir);
@@ -96,6 +109,7 @@ public interface HadoopFileSystemOptions extends PipelineOptions {
         }
       }
 
+      // Load the configuration from paths found (if exists)
       for (String confDir : explodedConfDirs) {
         if (new File(confDir).exists()) {
           Configuration conf = new Configuration(false);

--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptions.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptions.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Splitter;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
@@ -87,7 +88,15 @@ public interface HadoopFileSystemOptions extends PipelineOptions {
         }
       }
 
+      Set<String> explodedConfDirs = Sets.newHashSet();
       for (String confDir : confDirs) {
+        Iterable<String> paths = Splitter.on(':').split(confDir);
+        for (String p : paths) {
+          explodedConfDirs.add(p);
+        }
+      }
+
+      for (String confDir : explodedConfDirs) {
         if (new File(confDir).exists()) {
           Configuration conf = new Configuration(false);
           boolean confLoaded = false;

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptionsTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptionsTest.java
@@ -239,43 +239,6 @@ public class HadoopFileSystemOptionsTest {
     assertThat(configurationList.get(1 - hadoopConfIndex).get("propertyD"), Matchers.equalTo("D"));
   }
 
-  @Test
-  public void testDefaultSetYarnConfDirAndHadoopConfDirMultiPathNotSameConfiguration()
-      throws IOException {
-    File hadoopConfDir = tmpFolder.newFolder("hadoop");
-    File yarnConfDir = tmpFolder.newFolder("yarn");
-    File otherConfDir = tmpFolder.newFolder("_other_");
-
-    Files.write(
-        createPropertyData("A"), new File(hadoopConfDir, "core-site.xml"), StandardCharsets.UTF_8);
-    Files.write(
-        createPropertyData("B"), new File(hadoopConfDir, "hdfs-site.xml"), StandardCharsets.UTF_8);
-    Files.write(
-        createPropertyData("C"), new File(yarnConfDir, "core-site.xml"), StandardCharsets.UTF_8);
-    Files.write(
-        createPropertyData("D"), new File(yarnConfDir, "hdfs-site.xml"), StandardCharsets.UTF_8);
-    HadoopFileSystemOptions.ConfigurationLocator configurationLocator =
-        spy(new HadoopFileSystemOptions.ConfigurationLocator());
-
-    String multiPathHadoop =
-        hadoopConfDir.getAbsolutePath().concat(":").concat(otherConfDir.getAbsolutePath());
-    String multiPathYarn =
-        yarnConfDir.getAbsolutePath().concat(":").concat(otherConfDir.getAbsolutePath());
-    Map<String, String> environment = Maps.newHashMap();
-    environment.put("HADOOP_CONF_DIR", multiPathHadoop);
-    environment.put("YARN_CONF_DIR", multiPathYarn);
-    when(configurationLocator.getEnvironment()).thenReturn(environment);
-
-    List<Configuration> configurationList =
-        configurationLocator.create(PipelineOptionsFactory.create());
-    assertEquals(2, configurationList.size());
-    int hadoopConfIndex = configurationList.get(0).get("propertyA") != null ? 0 : 1;
-    assertThat(configurationList.get(hadoopConfIndex).get("propertyA"), Matchers.equalTo("A"));
-    assertThat(configurationList.get(hadoopConfIndex).get("propertyB"), Matchers.equalTo("B"));
-    assertThat(configurationList.get(1 - hadoopConfIndex).get("propertyC"), Matchers.equalTo("C"));
-    assertThat(configurationList.get(1 - hadoopConfIndex).get("propertyD"), Matchers.equalTo("D"));
-  }
-
   private static String createPropertyData(String property) {
     return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
         + "<?xml-stylesheet type=\"text/xsl\" href=\"configuration.xsl\"?>\n"

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptionsTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptionsTest.java
@@ -92,6 +92,32 @@ public class HadoopFileSystemOptionsTest {
   }
 
   @Test
+  public void testDefaultJustSetHadoopConfDirMultiPathConfiguration() throws IOException {
+    File hadoopConfDir = tmpFolder.newFolder("hadoop");
+    File otherConfDir = tmpFolder.newFolder("_other_");
+
+    Files.write(
+        createPropertyData("A"), new File(hadoopConfDir, "core-site.xml"), StandardCharsets.UTF_8);
+    Files.write(
+        createPropertyData("B"), new File(hadoopConfDir, "hdfs-site.xml"), StandardCharsets.UTF_8);
+
+    HadoopFileSystemOptions.ConfigurationLocator configurationLocator =
+        spy(new HadoopFileSystemOptions.ConfigurationLocator());
+
+    String multiPath =
+        hadoopConfDir.getAbsolutePath().concat(":").concat(otherConfDir.getAbsolutePath());
+    Map<String, String> environment = Maps.newHashMap();
+    environment.put("HADOOP_CONF_DIR", multiPath);
+    when(configurationLocator.getEnvironment()).thenReturn(environment);
+
+    List<Configuration> configurationList =
+        configurationLocator.create(PipelineOptionsFactory.create());
+    assertEquals(1, configurationList.size());
+    assertThat(configurationList.get(0).get("propertyA"), Matchers.equalTo("A"));
+    assertThat(configurationList.get(0).get("propertyB"), Matchers.equalTo("B"));
+  }
+
+  @Test
   public void testDefaultJustSetYarnConfDirConfiguration() throws IOException {
     Files.write(
         createPropertyData("A"), tmpFolder.newFile("core-site.xml"), StandardCharsets.UTF_8);
@@ -101,6 +127,32 @@ public class HadoopFileSystemOptionsTest {
         spy(new HadoopFileSystemOptions.ConfigurationLocator());
     Map<String, String> environment = Maps.newHashMap();
     environment.put("YARN_CONF_DIR", tmpFolder.getRoot().getAbsolutePath());
+    when(configurationLocator.getEnvironment()).thenReturn(environment);
+
+    List<Configuration> configurationList =
+        configurationLocator.create(PipelineOptionsFactory.create());
+    assertEquals(1, configurationList.size());
+    assertThat(configurationList.get(0).get("propertyA"), Matchers.equalTo("A"));
+    assertThat(configurationList.get(0).get("propertyB"), Matchers.equalTo("B"));
+  }
+
+  @Test
+  public void testDefaultJustSetYarnConfDirMultiPathConfiguration() throws IOException {
+    File hadoopConfDir = tmpFolder.newFolder("hadoop");
+    File otherConfDir = tmpFolder.newFolder("_other_");
+
+    Files.write(
+        createPropertyData("A"), new File(hadoopConfDir, "core-site.xml"), StandardCharsets.UTF_8);
+    Files.write(
+        createPropertyData("B"), new File(hadoopConfDir, "hdfs-site.xml"), StandardCharsets.UTF_8);
+
+    HadoopFileSystemOptions.ConfigurationLocator configurationLocator =
+        spy(new HadoopFileSystemOptions.ConfigurationLocator());
+
+    String multiPath =
+        hadoopConfDir.getAbsolutePath().concat(":").concat(otherConfDir.getAbsolutePath());
+    Map<String, String> environment = Maps.newHashMap();
+    environment.put("YARN_CONF_DIR", multiPath);
     when(configurationLocator.getEnvironment()).thenReturn(environment);
 
     List<Configuration> configurationList =
@@ -131,6 +183,34 @@ public class HadoopFileSystemOptionsTest {
   }
 
   @Test
+  public void testDefaultSetYarnConfDirAndHadoopConfDirMultiPathAndSameConfiguration()
+      throws IOException {
+    File hadoopConfDir = tmpFolder.newFolder("hadoop");
+    File otherConfDir = tmpFolder.newFolder("_other_");
+
+    Files.write(
+        createPropertyData("A"), new File(hadoopConfDir, "core-site.xml"), StandardCharsets.UTF_8);
+    Files.write(
+        createPropertyData("B"), new File(hadoopConfDir, "hdfs-site.xml"), StandardCharsets.UTF_8);
+
+    HadoopFileSystemOptions.ConfigurationLocator configurationLocator =
+        spy(new HadoopFileSystemOptions.ConfigurationLocator());
+
+    String multiPath =
+        hadoopConfDir.getAbsolutePath().concat(":").concat(otherConfDir.getAbsolutePath());
+    Map<String, String> environment = Maps.newHashMap();
+    environment.put("YARN_CONF_DIR", multiPath);
+    environment.put("HADOOP_CONF_DIR", multiPath);
+    when(configurationLocator.getEnvironment()).thenReturn(environment);
+
+    List<Configuration> configurationList =
+        configurationLocator.create(PipelineOptionsFactory.create());
+    assertEquals(1, configurationList.size());
+    assertThat(configurationList.get(0).get("propertyA"), Matchers.equalTo("A"));
+    assertThat(configurationList.get(0).get("propertyB"), Matchers.equalTo("B"));
+  }
+
+  @Test
   public void testDefaultSetYarnConfDirAndHadoopConfDirNotSameConfiguration() throws IOException {
     File hadoopConfDir = tmpFolder.newFolder("hadoop");
     File yarnConfDir = tmpFolder.newFolder("yarn");
@@ -147,6 +227,43 @@ public class HadoopFileSystemOptionsTest {
     Map<String, String> environment = Maps.newHashMap();
     environment.put("YARN_CONF_DIR", hadoopConfDir.getAbsolutePath());
     environment.put("HADOOP_CONF_DIR", yarnConfDir.getAbsolutePath());
+    when(configurationLocator.getEnvironment()).thenReturn(environment);
+
+    List<Configuration> configurationList =
+        configurationLocator.create(PipelineOptionsFactory.create());
+    assertEquals(2, configurationList.size());
+    int hadoopConfIndex = configurationList.get(0).get("propertyA") != null ? 0 : 1;
+    assertThat(configurationList.get(hadoopConfIndex).get("propertyA"), Matchers.equalTo("A"));
+    assertThat(configurationList.get(hadoopConfIndex).get("propertyB"), Matchers.equalTo("B"));
+    assertThat(configurationList.get(1 - hadoopConfIndex).get("propertyC"), Matchers.equalTo("C"));
+    assertThat(configurationList.get(1 - hadoopConfIndex).get("propertyD"), Matchers.equalTo("D"));
+  }
+
+  @Test
+  public void testDefaultSetYarnConfDirAndHadoopConfDirMultiPathNotSameConfiguration()
+      throws IOException {
+    File hadoopConfDir = tmpFolder.newFolder("hadoop");
+    File yarnConfDir = tmpFolder.newFolder("yarn");
+    File otherConfDir = tmpFolder.newFolder("_other_");
+
+    Files.write(
+        createPropertyData("A"), new File(hadoopConfDir, "core-site.xml"), StandardCharsets.UTF_8);
+    Files.write(
+        createPropertyData("B"), new File(hadoopConfDir, "hdfs-site.xml"), StandardCharsets.UTF_8);
+    Files.write(
+        createPropertyData("C"), new File(yarnConfDir, "core-site.xml"), StandardCharsets.UTF_8);
+    Files.write(
+        createPropertyData("D"), new File(yarnConfDir, "hdfs-site.xml"), StandardCharsets.UTF_8);
+    HadoopFileSystemOptions.ConfigurationLocator configurationLocator =
+        spy(new HadoopFileSystemOptions.ConfigurationLocator());
+
+    String multiPathHadoop =
+        hadoopConfDir.getAbsolutePath().concat(":").concat(otherConfDir.getAbsolutePath());
+    String multiPathYarn =
+        yarnConfDir.getAbsolutePath().concat(":").concat(otherConfDir.getAbsolutePath());
+    Map<String, String> environment = Maps.newHashMap();
+    environment.put("HADOOP_CONF_DIR", multiPathHadoop);
+    environment.put("YARN_CONF_DIR", multiPathYarn);
     when(configurationLocator.getEnvironment()).thenReturn(environment);
 
     List<Configuration> configurationList =


### PR DESCRIPTION
Fix bug https://issues.apache.org/jira/browse/BEAM-9315 by allowing `HadoopFileSystemOptions` to correctly interpret the content of the `HADOOP_CONF_DIR` and `YARN_CONF_DIR` environment variables, even when they contain multiple paths, instead of a single one.

This happens, for example, when starting a process using `spark-submit` on Cloudera 6.3, which sets `HADOOP_CONF_DIR` as follows:

```
HADOOP_CONF_DIR=/opt/cloudera/parcels/CDH-6.3.2-1.cdh6.3.2.p0.1605554/lib/spark/conf/yarn-conf:/etc/hive/conf
```

R: @RyanSkraba @iemejia 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
