### PR TITLE
Exclude Unbounded PCollection tests from Flink Portable runner batch tests

### DIFF
--- a/runners/flink/job-server/flink_job_server.gradle
+++ b/runners/flink/job-server/flink_job_server.gradle
@@ -154,6 +154,7 @@ def portableValidatesRunnerTask(String name, Boolean streaming) {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithMultipleStages'
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithOutputTimestamp'
       } else {
+        excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedPCollections'
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
       }
       //SplitableDoFnTests


### PR DESCRIPTION
I discovered that the Flink batch VR runners were not excluding the `UsesUnboundedPCollections` category of tests, but I forgot to exclude this for the Portable runner in #10871 so adding this here.

R: @thw
CC: @mxm 
