### PR TITLE
[BEAM-8019] Updates DataflowRunner to support multiple SDK environments.

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -749,6 +749,17 @@ class WorkerOptions(PipelineOptions):
             'SDK. Note: currently, only approved Google Cloud Dataflow '
             'container images may be used here.'))
     parser.add_argument(
+        '--sdk_harness_container_image_overrides',
+        action='append',
+        default=None,
+        help=(
+            'Overrides for SDK harness container images. Could be for the '
+            'local SDK or for a remote SDK that pipeline has to support due '
+            'to a cross-language transform. Each entry consist of two values '
+            'separated by a comma where first value gives a regex to '
+            'identify the container image to override and the second value '
+            'gives the replacement container image.'))
+    parser.add_argument(
         '--use_public_ips',
         default=None,
         action='store_true',

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -35,6 +35,7 @@ import sys
 import tempfile
 import time
 import warnings
+from copy import copy
 from datetime import datetime
 
 from builtins import object
@@ -53,6 +54,8 @@ from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import GoogleCloudOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.pipeline_options import WorkerOptions
+from apache_beam.portability import common_urns
+from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.runners.dataflow.internal import names
 from apache_beam.runners.dataflow.internal.clients import dataflow
 from apache_beam.runners.dataflow.internal.names import PropertyNames
@@ -62,6 +65,7 @@ from apache_beam.transforms import DataflowDistributionCounter
 from apache_beam.transforms import cy_combiners
 from apache_beam.transforms.display import DisplayData
 from apache_beam.utils import retry
+from apache_beam.utils import proto_utils
 
 # Environment version information. It is passed to the service during a
 # a job submission and is used by the service to establish what features
@@ -133,12 +137,19 @@ class Step(object):
 
 class Environment(object):
   """Wrapper for a dataflow Environment protobuf."""
-  def __init__(self, packages, options, environment_version, pipeline_url):
+  def __init__(
+      self,
+      packages,
+      options,
+      environment_version,
+      proto_pipeline_staged_url,
+      proto_pipeline=None,
+      _sdk_image_overrides=None):
     self.standard_options = options.view_as(StandardOptions)
     self.google_cloud_options = options.view_as(GoogleCloudOptions)
     self.worker_options = options.view_as(WorkerOptions)
     self.debug_options = options.view_as(DebugOptions)
-    self.pipeline_url = pipeline_url
+    self.pipeline_url = proto_pipeline_staged_url
     self.proto = dataflow.Environment()
     self.proto.clusterManagerApiService = GoogleCloudOptions.COMPUTE_API_SERVICE
     self.proto.dataset = '{}/cloud_dataflow'.format(
@@ -153,6 +164,8 @@ class Environment(object):
     # User agent information.
     self.proto.userAgent = dataflow.Environment.UserAgentValue()
     self.local = 'localhost' in self.google_cloud_options.dataflow_endpoint
+    self._proto_pipeline = proto_pipeline
+    self._sdk_image_overrides = _sdk_image_overrides or dict()
 
     if self.google_cloud_options.service_account_email:
       self.proto.serviceAccountEmail = (
@@ -259,6 +272,47 @@ class Environment(object):
       pool.subnetwork = self.worker_options.subnetwork
     pool.workerHarnessContainerImage = (
         get_container_image_from_options(options))
+
+    # Setting worker pool sdk_harness_container_images option for supported
+    # Dataflow workers.
+    # TODO: remove following guard against not having sdkHarnessContainerImages
+    # when corresponding API change for Dataflow is
+    # rollback-safe.
+    if (_use_unified_worker(options) and
+        hasattr(pool, 'sdkHarnessContainerImages')):
+      # Adding a SDK container image for the pipeline SDKs
+      container_image = dataflow.SdkHarnessContainerImage()
+      pipeline_sdk_container_image = get_container_image_from_options(options)
+      container_image.containerImage = pipeline_sdk_container_image
+      container_image.useSingleCorePerContainer = True  # True for Python SDK.
+      pool.sdkHarnessContainerImages.append(container_image)
+
+      # Adding container images for other SDKs that may be needed for
+      # cross-language pipelines.
+      environments_to_use = self._get_environments_from_tranforms()
+      for environment in environments_to_use:
+        if environment.urn != common_urns.environments.DOCKER.urn:
+          raise Exception(
+              'Dataflow can only execute pipeline steps in Docker environments.'
+              ' Received %r.' % environment)
+        environment_payload = proto_utils.parse_Bytes(
+            environment.payload, beam_runner_api_pb2.DockerPayload)
+        container_image_url = environment_payload.container_image
+        if container_image_url == pipeline_sdk_container_image:
+          # This was already added
+          continue
+        container_image = dataflow.SdkHarnessContainerImage()
+
+        # Not updating here if the image was already overriden by the user.
+        if container_image_url not in list(self._sdk_image_overrides.values()):
+          container_image_url = get_container_image_from_options(
+              options, container_image_url)
+        container_image.containerImage = container_image_url
+        # Currently we only set following to True for Python SDK.
+        # TODO: set this correctly for remote environments that might be Python.
+        container_image.useSingleCorePerContainer = False
+        pool.sdkHarnessContainerImages.append(container_image)
+
     if self.debug_options.number_of_worker_harness_threads:
       pool.numThreadsPerWorker = (
           self.debug_options.number_of_worker_harness_threads)
@@ -290,7 +344,7 @@ class Environment(object):
           k: v
           for k, v in sdk_pipeline_options.items() if v is not None
       }
-      options_dict["pipelineUrl"] = pipeline_url
+      options_dict["pipelineUrl"] = proto_pipeline_staged_url
       self.proto.sdkPipelineOptions.additionalProperties.append(
           dataflow.Environment.SdkPipelineOptionsValue.AdditionalProperty(
               key='options', value=to_json_value(options_dict)))
@@ -300,6 +354,20 @@ class Environment(object):
       self.proto.sdkPipelineOptions.additionalProperties.append(
           dataflow.Environment.SdkPipelineOptionsValue.AdditionalProperty(
               key='display_data', value=to_json_value(items)))
+
+  def _get_environments_from_tranforms(self):
+    if not self._proto_pipeline:
+      return []
+
+    environment_ids = set(
+        transform.environment_id
+        for transform in self._proto_pipeline.components.transforms.values()
+        if transform.environment_id)
+
+    return [
+        self._proto_pipeline.components.environments[id]
+        for id in environment_ids
+    ]
 
   def _get_python_sdk_name(self):
     python_version = '%d.%d' % (sys.version_info[0], sys.version_info[1])
@@ -478,6 +546,13 @@ class DataflowApplicationClient(object):
         get_credentials=(not self.google_cloud_options.no_auth),
         http=http_client,
         response_encoding=get_response_encoding())
+    self._sdk_image_overrides = self._get_sdk_image_overrides(options)
+
+  def _get_sdk_image_overrides(self, pipeline_options):
+    worker_options = pipeline_options.view_as(WorkerOptions)
+    sdk_overrides = worker_options.sdk_harness_container_image_overrides
+    if sdk_overrides:
+      return dict(override_str.split(',', 1) for override_str in sdk_overrides)
 
   # TODO(silviuc): Refactor so that retry logic can be applied.
   @retry.no_retries  # Using no_retries marks this as an integration point.
@@ -576,10 +651,24 @@ class DataflowApplicationClient(object):
         'A template was just created at location %s', template_location)
     return None
 
+  def _apply_sdk_environment_overrides(self, proto_pipeline):
+    # Update environments based on user provided overrides
+    sdk_overrides = self._sdk_image_overrides
+    if sdk_overrides:
+      for environment in proto_pipeline.components.environments.values():
+        docker_payload = proto_utils.parse_Bytes(
+            environment.payload, beam_runner_api_pb2.DockerPayload)
+        for pattern, override in sdk_overrides.items():
+          new_payload = copy(docker_payload)
+          new_payload.container_image = re.sub(
+              pattern, override, docker_payload.container_image)
+          environment.payload = new_payload.SerializeToString()
+
   def create_job_description(self, job):
     """Creates a job described by the workflow proto."""
+    self._apply_sdk_environment_overrides(job.proto_pipeline)
 
-    # Stage the pipeline for the runner harness
+    # Stage proto pipeline.
     self.stage_file(
         job.google_cloud_options.staging_location,
         shared_names.STAGED_PIPELINE_FILENAME,
@@ -589,12 +678,14 @@ class DataflowApplicationClient(object):
     resources = self._stage_resources(job.options)
 
     job.proto.environment = Environment(
-        pipeline_url=FileSystems.join(
+        proto_pipeline_staged_url=FileSystems.join(
             job.google_cloud_options.staging_location,
             shared_names.STAGED_PIPELINE_FILENAME),
         packages=resources,
         options=job.options,
-        environment_version=self.environment_version).proto
+        environment_version=self.environment_version,
+        proto_pipeline=job.proto_pipeline,
+        _sdk_image_overrides=self._sdk_image_overrides).proto
     _LOGGER.debug('JOB: %s', job)
 
   @retry.with_exponential_backoff(num_retries=3, initial_delay_secs=3)
@@ -934,18 +1025,24 @@ def _get_container_image_tag():
   return base_version
 
 
-def get_container_image_from_options(pipeline_options):
+def get_container_image_from_options(
+    pipeline_options, external_image_to_override=None):
   """For internal use only; no backwards-compatibility guarantees.
 
     Args:
       pipeline_options (PipelineOptions): A container for pipeline options.
+      external_image_to_override: container image for an external SDK
 
     Returns:
       str: Container image for remote execution.
-    """
+  """
   worker_options = pipeline_options.view_as(WorkerOptions)
   if worker_options.worker_harness_container_image:
     return worker_options.worker_harness_container_image
+  elif external_image_to_override:
+    raise NotImplementedError(
+        'Add support for determining container images for external SDKs '
+        'without user overrides')
 
   if sys.version_info[0] == 2:
     version_suffix = ''

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -315,7 +315,12 @@ class ExternalTransform(ptransform.PTransform):
         transform=transform_proto)
 
     if isinstance(self._expansion_service, str):
-      with grpc.insecure_channel(self._expansion_service) as channel:
+      # Some environments may not support unsecure channels. Hence using a
+      # secure channel with local credentials here.
+      # TODO: update this to support secure non-local channels.
+      channel_creds = grpc.local_channel_credentials()
+      with grpc.secure_channel(self._expansion_service,
+                               channel_creds) as channel:
         response = beam_expansion_api_pb2_grpc.ExpansionServiceStub(
             channel).Expand(request)
     else:


### PR DESCRIPTION
Updates DataflowRunner to set sdk_harness_container_images property.
Adds a pipeline option so that users can override SDK harness container images.
Also did an update to create a secure local gRPC channel for expansion service instead of an insecure one.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
