### PR TITLE
Revert "[BEAM-6522] [BEAM-7455] Unskip Avro IO tests that are now passing."

### DIFF
--- a/sdks/python/apache_beam/examples/fastavro_it_test.py
+++ b/sdks/python/apache_beam/examples/fastavro_it_test.py
@@ -49,6 +49,8 @@ from __future__ import division
 
 import json
 import logging
+import os
+import sys
 import unittest
 import uuid
 
@@ -86,6 +88,10 @@ def record(i):
   }
 
 
+@unittest.skipIf(
+    sys.version_info[0] >= 3 and os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+    'Due to a known issue in avro-python3 package, this'
+    'test is skipped until BEAM-6522 is addressed. ')
 class FastavroIT(unittest.TestCase):
 
   SCHEMA_STRING = '''
@@ -175,7 +181,7 @@ class FastavroIT(unittest.TestCase):
           if l != r:
             raise BeamAssertException('Assertion failed: %s == %s' % (l, r))
 
-        assertEqual(sorted(v.keys()), ['avro', 'fastavro'])
+        assertEqual(v.keys(), ['avro', 'fastavro'])
         avro_values = v['avro']
         fastavro_values = v['fastavro']
         assertEqual(avro_values, fastavro_values)

--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -445,6 +445,10 @@ class AvroBase(object):
         assert_that(readback, equal_to([json.dumps(r) for r in self.RECORDS]))
 
 
+@unittest.skipIf(
+    sys.version_info[0] == 3 and os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
+    'This test still needs to be fixed on Python 3. '
+    'TODO: BEAM-6522.')
 class TestAvro(AvroBase, unittest.TestCase):
   def __init__(self, methodName='runTest'):
     super(TestAvro, self).__init__(methodName)


### PR DESCRIPTION
We should keep these skipped until we upgrade to 1.9.2.1 or newer Avro version.