### PR TITLE
[BEAM-8280] Enable and improve IOTypeHints debug_str traceback

### DIFF
--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -430,14 +430,14 @@ class PTransform(WithTypeHints, HasDisplayData):
       if hint and not typehints.is_consistent_with(pvalue_.element_type, hint):
         at_context = ' %s %s' % (input_or_output, context) if context else ''
         raise TypeCheckError(
-            '%s type hint violation at %s%s: expected %s, got %s\n'
-            'Full type hint:\n%s' % (
-                input_or_output.title(),
-                self.label,
-                at_context,
-                hint,
-                pvalue_.element_type,
-                type_hints.debug_str()))
+            '{type} type hint violation at {label}{context}: expected {hint}, '
+            'got {actual_type}\nFull type hint:\n{debug_str}'.format(
+                type=input_or_output.title(),
+                label=self.label,
+                context=at_context,
+                hint=hint,
+                actual_type=pvalue_.element_type,
+                debug_str=type_hints.debug_str()))
 
   def _infer_output_coder(self, input_type=None, input_coder=None):
     # type: (...) -> Optional[coders.Coder]
@@ -854,9 +854,13 @@ class PTransformWithSideInputs(PTransform):
         if not typehints.is_consistent_with(bindings.get(arg, typehints.Any),
                                             hint):
           raise TypeCheckError(
-              'Type hint violation for \'%s\': requires %s but got %s for %s\n'
-              'Full type hint:\n%s' %
-              (self.label, hint, bindings[arg], arg, type_hints.debug_str()))
+              'Type hint violation for \'{label}\': requires {hint} but got '
+              '{actual_type} for {arg}\nFull type hint:\n{debug_str}'.format(
+                  label=self.label,
+                  hint=hint,
+                  actual_type=bindings[arg],
+                  arg=arg,
+                  debug_str=type_hints.debug_str()))
 
   def _process_argspec_fn(self):
     """Returns an argspec of the function actually consuming the data.

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -411,7 +411,8 @@ class PTransform(WithTypeHints, HasDisplayData):
     self.type_check_inputs_or_outputs(pvalueish, 'output')
 
   def type_check_inputs_or_outputs(self, pvalueish, input_or_output):
-    hints = getattr(self.get_type_hints(), input_or_output + '_types')
+    type_hints = self.get_type_hints()
+    hints = getattr(type_hints, input_or_output + '_types')
     if hints is None or not any(hints):
       return
     arg_hints, kwarg_hints = hints
@@ -429,12 +430,14 @@ class PTransform(WithTypeHints, HasDisplayData):
       if hint and not typehints.is_consistent_with(pvalue_.element_type, hint):
         at_context = ' %s %s' % (input_or_output, context) if context else ''
         raise TypeCheckError(
-            '%s type hint violation at %s%s: expected %s, got %s' % (
+            '%s type hint violation at %s%s: expected %s, got %s\n'
+            'Full type hints: %s' % (
                 input_or_output.title(),
                 self.label,
                 at_context,
                 hint,
-                pvalue_.element_type))
+                pvalue_.element_type,
+                type_hints.debug_str()))
 
   def _infer_output_coder(self, input_type=None, input_coder=None):
     # type: (...) -> Optional[coders.Coder]
@@ -827,8 +830,9 @@ class PTransformWithSideInputs(PTransform):
         self, input_type_hint, *side_inputs_arg_hints, **side_input_kwarg_hints)
 
   def type_check_inputs(self, pvalueish):
-    type_hints = self.get_type_hints().input_types
-    if type_hints:
+    type_hints = self.get_type_hints()
+    input_types = type_hints.input_types
+    if input_types:
       args, kwargs = self.raw_side_inputs
 
       def element_type(side_input):
@@ -840,7 +844,8 @@ class PTransformWithSideInputs(PTransform):
       kwargs_types = {k: element_type(v) for (k, v) in kwargs.items()}
       argspec_fn = self._process_argspec_fn()
       bindings = getcallargs_forhints(argspec_fn, *arg_types, **kwargs_types)
-      hints = getcallargs_forhints(argspec_fn, *type_hints[0], **type_hints[1])
+      hints = getcallargs_forhints(
+          argspec_fn, *input_types[0], **input_types[1])
       for arg, hint in hints.items():
         if arg.startswith('__unknown__'):
           continue
@@ -849,8 +854,9 @@ class PTransformWithSideInputs(PTransform):
         if not typehints.is_consistent_with(bindings.get(arg, typehints.Any),
                                             hint):
           raise TypeCheckError(
-              'Type hint violation for \'%s\': requires %s but got %s for %s' %
-              (self.label, hint, bindings[arg], arg))
+              'Type hint violation for \'%s\': requires %s but got %s for %s\n'
+              'Full type hint: %s' %
+              (self.label, hint, bindings[arg], arg, type_hints.debug_str()))
 
   def _process_argspec_fn(self):
     """Returns an argspec of the function actually consuming the data.

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -431,7 +431,7 @@ class PTransform(WithTypeHints, HasDisplayData):
         at_context = ' %s %s' % (input_or_output, context) if context else ''
         raise TypeCheckError(
             '%s type hint violation at %s%s: expected %s, got %s\n'
-            'Full type hints: %s' % (
+            'Full type hint:\n%s' % (
                 input_or_output.title(),
                 self.label,
                 at_context,
@@ -855,7 +855,7 @@ class PTransformWithSideInputs(PTransform):
                                             hint):
           raise TypeCheckError(
               'Type hint violation for \'%s\': requires %s but got %s for %s\n'
-              'Full type hint: %s' %
+              'Full type hint:\n%s' %
               (self.label, hint, bindings[arg], arg, type_hints.debug_str()))
 
   def _process_argspec_fn(self):

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1004,10 +1004,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | 'T' >> beam.Create([1, 2, 3]).with_output_types(int)
           | 'Upper' >> beam.ParDo(ToUpperCaseWithPrefix(), 'hello'))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'Upper': "
-        "requires {} but got {} for element".format(str, int),
-        e.exception.args[0])
+        "requires {} but got {} for element".format(str, int))
 
   def test_do_fn_pipeline_runtime_type_check_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -1042,10 +1042,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | 'Add' >> beam.ParDo(AddWithNum(), 5))
       self.p.run()
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'Add': "
-        "requires {} but got {} for element".format(int, str),
-        e.exception.args[0])
+        "requires {} but got {} for element".format(int, str))
 
   def test_pardo_does_not_type_check_using_type_hint_decorators(self):
     @with_input_types(a=int)
@@ -1061,10 +1061,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | 'S' >> beam.Create(['b', 'a', 'r']).with_output_types(str)
           | 'ToStr' >> beam.FlatMap(int_to_str))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'ToStr': "
-        "requires {} but got {} for a".format(int, str),
-        e.exception.args[0])
+        "requires {} but got {} for a".format(int, str))
 
   def test_pardo_properly_type_checks_using_type_hint_decorators(self):
     @with_input_types(a=str)
@@ -1098,10 +1098,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
               'Upper' >> beam.FlatMap(lambda x: [x.upper()]).with_input_types(
                   str).with_output_types(str)))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'Upper': "
-        "requires {} but got {} for x".format(str, int),
-        e.exception.args[0])
+        "requires {} but got {} for x".format(str, int))
 
   def test_pardo_properly_type_checks_using_type_hint_methods(self):
     # Pipeline should be created successfully without an error
@@ -1126,10 +1126,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | 'Upper' >> beam.Map(lambda x: x.upper()).with_input_types(
               str).with_output_types(str))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'Upper': "
-        "requires {} but got {} for x".format(str, int),
-        e.exception.args[0])
+        "requires {} but got {} for x".format(str, int))
 
   def test_map_properly_type_checks_using_type_hints_methods(self):
     # No error should be raised if this type-checks properly.
@@ -1155,10 +1155,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | 'S' >> beam.Create([1, 2, 3, 4]).with_output_types(int)
           | 'Upper' >> beam.Map(upper))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'Upper': "
-        "requires {} but got {} for s".format(str, int),
-        e.exception.args[0])
+        "requires {} but got {} for s".format(str, int))
 
   def test_map_properly_type_checks_using_type_hints_decorator(self):
     @with_input_types(a=bool)
@@ -1186,10 +1186,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
               str).with_output_types(str)
           | 'Below 3' >> beam.Filter(lambda x: x < 3).with_input_types(int))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'Below 3': "
-        "requires {} but got {} for x".format(int, str),
-        e.exception.args[0])
+        "requires {} but got {} for x".format(int, str))
 
   def test_filter_type_checks_using_type_hints_method(self):
     # No error should be raised if this type-checks properly.
@@ -1214,10 +1214,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | 'Ints' >> beam.Create([1, 2, 3, 4]).with_output_types(int)
           | 'Half' >> beam.Filter(more_than_half))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'Half': "
-        "requires {} but got {} for a".format(float, int),
-        e.exception.args[0])
+        "requires {} but got {} for a".format(float, int))
 
   def test_filter_type_checks_using_type_hints_decorator(self):
     @with_input_types(b=int)
@@ -1270,11 +1270,11 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | beam.Create([1, 2, 3]).with_output_types(int)
           | 'F' >> _GroupByKeyOnly())
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Input type hint violation at F: "
         "expected Tuple[TypeVariable[K], TypeVariable[V]], "
-        "got {}".format(int),
-        e.exception.args[0])
+        "got {}".format(int))
 
   def test_group_by_does_not_type_check(self):
     # Create is returning a List[int, str], rather than a Tuple[int, str]
@@ -1285,11 +1285,11 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | (beam.Create([[1], [2]]).with_output_types(typing.Iterable[int]))
           | 'T' >> beam.GroupByKey())
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Input type hint violation at T: "
         "expected Tuple[TypeVariable[K], TypeVariable[V]], "
-        "got Iterable[int]",
-        e.exception.args[0])
+        "got Iterable[int]")
 
   def test_pipeline_checking_pardo_insufficient_type_information(self):
     self.p._options.view_as(TypeOptions).type_check_strictness = 'ALL_REQUIRED'
@@ -1709,10 +1709,10 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
               'SortJoin' >> beam.CombineGlobally(lambda s: ''.join(sorted(s))).
               with_input_types(str).with_output_types(str)))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Input type hint violation at SortJoin: "
-        "expected {}, got {}".format(str, int),
-        e.exception.args[0])
+        "expected {}, got {}".format(str, int))
 
   def test_combine_runtime_type_check_violation_using_methods(self):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
@@ -1780,7 +1780,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "requires Tuple[TypeVariable[K], Union[float, int, long]] " \
         "but got Tuple[None, str] for element"
 
-    self.assertEqual(expected_msg, e.exception.args[0])
+    self.assertStartswith(e.exception.args[0], expected_msg)
 
   def test_mean_globally_runtime_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -1852,7 +1852,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "requires Tuple[TypeVariable[K], Union[float, int, long]] " \
         "but got Tuple[str, str] for element"
 
-    self.assertEqual(expected_msg, e.exception.args[0])
+    self.assertStartswith(e.exception.args[0], expected_msg)
 
   def test_mean_per_key_runtime_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -1946,11 +1946,11 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | beam.Create(range(5)).with_output_types(int)
           | 'CountInt' >> combine.Count.PerKey())
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'CombinePerKey(CountCombineFn)': "
         "requires Tuple[TypeVariable[K], Any] "
-        "but got {} for element".format(int),
-        e.exception.args[0])
+        "but got {} for element".format(int))
 
   def test_count_perkey_runtime_type_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -2033,11 +2033,11 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | 'Num + 1' >> beam.Map(lambda x: x + 1).with_output_types(int)
           | 'TopMod' >> combine.Top.PerKey(1))
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'CombinePerKey(TopCombineFn)': "
         "requires Tuple[TypeVariable[K], TypeVariable[T]] "
-        "but got {} for element".format(int),
-        e.exception.args[0])
+        "but got {} for element".format(int))
 
   def test_per_key_pipeline_checking_satisfied(self):
     d = (
@@ -2192,12 +2192,12 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | beam.Create([1, 2, 3, 4]).with_output_types(int)
           | combine.ToDict())
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         "Type hint violation for 'CombinePerKey': "
         "requires "
         "Tuple[TypeVariable[K], Tuple[TypeVariable[K], TypeVariable[V]]] "
-        "but got Tuple[None, int] for element",
-        e.exception.args[0])
+        "but got Tuple[None, int] for element")
 
   def test_to_dict_pipeline_check_satisfied(self):
     d = (
@@ -2270,11 +2270,11 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           | 'Ungroupable' >> beam.Map(lambda x: (x, 0, 1.0))
           | beam.GroupByKey())
 
-    self.assertEqual(
+    self.assertStartswith(
+        e.exception.args[0],
         'Input type hint violation at GroupByKey: '
         'expected Tuple[TypeVariable[K], TypeVariable[V]], '
-        'got Tuple[str, int, float]',
-        e.exception.args[0])
+        'got Tuple[str, int, float]')
 
   def test_type_inference_command_line_flag_toggle(self):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -416,7 +416,7 @@ class IOTypeHints(NamedTuple(
     res = IOTypeHints(
         input_types,
         output_types,
-        self._make_origin([hints, self], tb=False, msg=['with_defaults()']))
+        self._make_origin([self, hints], tb=False, msg=['with_defaults()']))
     if res == self:
       return self  # Don't needlessly increase origin traceback length.
     else:

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -88,6 +88,7 @@ defined, or before importing a module containing type-hinted functions.
 from __future__ import absolute_import
 
 import inspect
+import itertools
 import logging
 import sys
 import traceback
@@ -243,16 +244,26 @@ class IOTypeHints(NamedTuple(
   traceback_limit = 5
 
   @classmethod
-  def _make_traceback(cls, base):
-    # type: (Optional[IOTypeHints]) -> List[str]
+  def _make_traceback(cls, bases):
+    # type: (List[IOTypeHints]) -> List[str]
     # Omit this method and the IOTypeHints method that called it.
     num_frames_skip = 2
-    tb = traceback.format_stack(limit=cls.traceback_limit + num_frames_skip)
-    tb_lines = 'TH>' + ''.join(tb[:-num_frames_skip]).replace('\n', '\nTH>')
+    tb = traceback.format_stack(limit=cls.traceback_limit +
+                                num_frames_skip)[:-num_frames_skip]
+    # tb is a list of strings in the form of 'File ...\n[code]\n'. Split into
+    # single lines and flatten.
+    tb_lines = list(
+        itertools.chain.from_iterable(s.strip().split('\n') for s in tb))
 
-    res = [tb_lines + '\nbased on: ' + str(base)]
-    if base is not None:
-      res += base.origin
+    res = tb_lines
+    bases = [base for base in bases if base.origin]
+    if bases:
+      res += ['', 'based on:']
+      for i, base in enumerate(bases):
+        if i > 0:
+          res += ['', 'and:']
+        res += ['  ' + str(base)]
+        res += ['  ' + s for s in base.origin]
     return res
 
   @classmethod
@@ -311,17 +322,17 @@ class IOTypeHints(NamedTuple(
     return IOTypeHints(
         input_types=(tuple(input_args), input_kwargs),
         output_types=(tuple(output_args), {}),
-        origin=cls._make_traceback(None))
+        origin=cls._make_traceback([]))
 
   def with_input_types(self, *args, **kwargs):
     # type: (...) -> IOTypeHints
     return self._replace(
-        input_types=(args, kwargs), origin=self._make_traceback(self))
+        input_types=(args, kwargs), origin=self._make_traceback([self]))
 
   def with_output_types(self, *args, **kwargs):
     # type: (...) -> IOTypeHints
     return self._replace(
-        output_types=(args, kwargs), origin=self._make_traceback(self))
+        output_types=(args, kwargs), origin=self._make_traceback([self]))
 
   def simple_output_type(self, context):
     if self._has_output_types():
@@ -376,7 +387,8 @@ class IOTypeHints(NamedTuple(
 
     yielded_type = typehints.get_yielded_type(output_type)
     return self._replace(
-        output_types=((yielded_type, ), {}), origin=self._make_traceback(self))
+        output_types=((yielded_type, ), {}),
+        origin=self._make_traceback([self]))
 
   def with_defaults(self, hints):
     # type: (Optional[IOTypeHints]) -> IOTypeHints
@@ -390,7 +402,8 @@ class IOTypeHints(NamedTuple(
       output_types = self.output_types
     else:
       output_types = hints.output_types
-    res = IOTypeHints(input_types, output_types, self._make_traceback(self))
+    res = IOTypeHints(
+        input_types, output_types, self._make_traceback([hints, self]))
     if res == self:
       return self  # Don't needlessly increase origin traceback length.
     else:
@@ -769,7 +782,7 @@ def with_input_types(*positional_hints, **keyword_hints):
   del positional_hints
   del keyword_hints
 
-  def annotate(f):
+  def annotate_input_types(f):
     if isinstance(f, types.FunctionType):
       for t in (list(converted_positional_hints) +
                 list(converted_keyword_hints.values())):
@@ -781,7 +794,7 @@ def with_input_types(*positional_hints, **keyword_hints):
     f._type_hints = th  # pylint: disable=protected-access
     return f
 
-  return annotate
+  return annotate_input_types
 
 
 def with_output_types(*return_type_hint, **kwargs):
@@ -862,12 +875,12 @@ def with_output_types(*return_type_hint, **kwargs):
   validate_composite_type_param(
       return_type_hint, error_msg_prefix='All type hint arguments')
 
-  def annotate(f):
+  def annotate_output_types(f):
     th = getattr(f, '_type_hints', IOTypeHints.empty())
     f._type_hints = th.with_output_types(return_type_hint)  # pylint: disable=protected-access
     return f
 
-  return annotate
+  return annotate_output_types
 
 
 def _check_instance_type(

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -131,6 +131,11 @@ class IOTypeHintsTest(unittest.TestCase):
     th = th.with_output_types(str)
     self.assertRegex(th.debug_str(), r'(?s)with_output_types.*with_input_types')
 
+    th = decorators.IOTypeHints.empty().with_output_types(str)
+    th2 = decorators.IOTypeHints.empty().with_input_types(int)
+    th = th.with_defaults(th2)
+    self.assertRegex(th.debug_str(), r'(?s)based on:.*\'str\'.*and:.*\'int\'')
+
   def test_with_defaults_noop_does_not_grow_origin(self):
     th = decorators.IOTypeHints.empty()
     expected_id = id(th)

--- a/sdks/python/apache_beam/typehints/decorators_test_py3.py
+++ b/sdks/python/apache_beam/typehints/decorators_test_py3.py
@@ -27,6 +27,7 @@ import unittest
 # patches unittest.TestCase to be python3 compatible
 import future.tests.base  # pylint: disable=unused-import
 
+from apache_beam import Map
 from apache_beam.typehints import Any
 from apache_beam.typehints import Dict
 from apache_beam.typehints import List
@@ -152,6 +153,19 @@ class IOTypeHintsTest(unittest.TestCase):
       decorators.getcallargs_forhints(fn, foo=List[int])
     with self.assertRaisesRegex(decorators.TypeCheckError, "missing.*'foo'"):
       decorators.getcallargs_forhints(fn, 5)
+
+  def test_origin(self):
+    def annotated(e: str) -> str:
+      return e
+
+    t = Map(annotated)
+    th = t.get_type_hints()
+    th = th.with_input_types(str)
+    self.assertRegex(th.debug_str(), r'with_input_types')
+    th = th.with_output_types(str)
+    self.assertRegex(
+        th.debug_str(),
+        r'(?s)with_output_types.*with_input_types.*Map.annotated')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Improve format
- Add multiple bases (in `.with_defaults()`)
- Include debug_str output in ptransform.py TypeCheckErrors.

Example format: https://gist.github.com/udim/9638eac962b0d89893c4a88c14be0476#file-less_verbose

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
