### PR TITLE
[BEAM-2939] Java UnboundedSource SDF wrapper

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
@@ -19,13 +19,23 @@ package org.apache.beam.sdk.io;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
+import com.google.auto.value.AutoValue;
 import java.io.IOException;
+import java.util.List;
+import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark;
+import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark.NoopCheckpointMark;
+import org.apache.beam.sdk.io.UnboundedSource.UnboundedReader;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.transforms.Distinct;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.UnboundedPerElement;
 import org.apache.beam.sdk.transforms.Impulse;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -35,13 +45,18 @@ import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.util.NameUtils;
 import org.apache.beam.sdk.util.SerializableUtils;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.ValueWithRecordId;
+import org.apache.beam.sdk.values.ValueWithRecordId.StripIdsDoFn;
+import org.apache.beam.sdk.values.ValueWithRecordId.ValueWithRecordIdCoder;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.joda.time.Duration;
+import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -185,6 +200,37 @@ public class Read {
     @Override
     public final PCollection<T> expand(PBegin input) {
       source.validate();
+
+      if (ExperimentalOptions.hasExperiment(input.getPipeline().getOptions(), "beam_fn_api")
+          && !ExperimentalOptions.hasExperiment(
+              input.getPipeline().getOptions(), "beam_fn_api_use_deprecated_read")) {
+        // We don't use Create here since Create is defined as a BoundedSource and using it would
+        // cause an infinite expansion loop. We can reconsider this if Create is implemented
+        // directly as a SplittableDoFn.
+        PCollection<ValueWithRecordId<T>> outputWithIds =
+            input
+                .getPipeline()
+                .apply(Impulse.create())
+                .apply(
+                    MapElements.into(new TypeDescriptor<UnboundedSource<T, CheckpointMark>>() {})
+                        .via(element -> (UnboundedSource<T, CheckpointMark>) source))
+                .setCoder(
+                    SerializableCoder.of(
+                        new TypeDescriptor<UnboundedSource<T, CheckpointMark>>() {}))
+                .apply(
+                    ParDo.of(
+                        new UnboundedSourceAsSDFWrapperFn<>(
+                            (Coder<CheckpointMark>) source.getCheckpointMarkCoder())))
+                .setCoder(ValueWithRecordIdCoder.of(source.getOutputCoder()));
+        if (source.requiresDeduping()) {
+          outputWithIds.apply(
+              Distinct.<ValueWithRecordId<T>, byte[]>withRepresentativeValueFn(
+                      element -> element.getId())
+                  .withRepresentativeType(TypeDescriptor.of(byte[].class)));
+        }
+        return outputWithIds.apply(ParDo.of(new StripIdsDoFn<>()));
+      }
+
       return PCollection.createPrimitiveOutputInternal(
           input.getPipeline(),
           WindowingStrategy.globalDefault(),
@@ -343,6 +389,7 @@ public class Read {
         }
       }
 
+      /** The value is invalid if {@link #tryClaim} has ever thrown an exception. */
       @Override
       public BoundedSource<T> currentRestriction() {
         if (currentReader == null) {
@@ -372,6 +419,363 @@ public class Read {
             claimedAll,
             "Expected all records to have been claimed but finished processing "
                 + "bounded source while some records may have not been read.");
+      }
+    }
+  }
+
+  /**
+   * A splittable {@link DoFn} which executes an {@link UnboundedSource}.
+   *
+   * <p>We model the element as the original source and the restriction as a pair of the sub-source
+   * and its {@link CheckpointMark}. This allows us to split the sub-source over and over as long as
+   * the checkpoint mark is {@code null} or the {@link NoopCheckpointMark} since it does not
+   * maintain any state.
+   */
+  // TODO: Support reporting the watermark, currently the watermark never advances.
+  @UnboundedPerElement
+  static class UnboundedSourceAsSDFWrapperFn<OutputT, CheckpointT extends CheckpointMark>
+      extends DoFn<UnboundedSource<OutputT, CheckpointT>, ValueWithRecordId<OutputT>> {
+
+    private static final int DEFAULT_DESIRED_NUM_SPLITS = 20;
+    private static final int DEFAULT_BUNDLE_FINALIZATION_LIMIT_MINS = 10;
+    private final Coder<CheckpointT> restrictionCoder;
+
+    private UnboundedSourceAsSDFWrapperFn(Coder<CheckpointT> restrictionCoder) {
+      this.restrictionCoder = restrictionCoder;
+    }
+
+    @GetInitialRestriction
+    public KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT> initialRestriction(
+        @Element UnboundedSource<OutputT, CheckpointT> element) {
+      return KV.of(element, null);
+    }
+
+    @GetSize
+    public double getSize(
+        @Restriction KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT> restriction,
+        PipelineOptions pipelineOptions)
+        throws Exception {
+      if (restriction.getKey() instanceof EmptyUnboundedSource) {
+        return 1;
+      }
+
+      UnboundedReader<OutputT> reader =
+          restriction.getKey().createReader(pipelineOptions, restriction.getValue());
+      long size = reader.getSplitBacklogBytes();
+      if (size != UnboundedReader.BACKLOG_UNKNOWN) {
+        return size;
+      }
+      // TODO: Support "global" backlog reporting
+      // size = reader.getTotalBacklogBytes();
+      // if (size != UnboundedReader.BACKLOG_UNKNOWN) {
+      //   return size;
+      // }
+      return 1;
+    }
+
+    @SplitRestriction
+    public void splitRestriction(
+        @Restriction KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT> restriction,
+        OutputReceiver<KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT>> receiver,
+        PipelineOptions pipelineOptions)
+        throws Exception {
+      // The empty unbounded source is trivially done and hence we don't need to output any splits
+      // for it.
+      if (restriction.getKey() instanceof EmptyUnboundedSource) {
+        return;
+      }
+
+      // The UnboundedSource API does not support splitting after a meaningful checkpoint mark has
+      // been created.
+      if (restriction.getValue() != null
+          && !(restriction.getValue()
+              instanceof UnboundedSource.CheckpointMark.NoopCheckpointMark)) {
+        receiver.output(restriction);
+      }
+
+      try {
+        for (UnboundedSource<OutputT, CheckpointT> split :
+            restriction.getKey().split(DEFAULT_DESIRED_NUM_SPLITS, pipelineOptions)) {
+          receiver.output(KV.of(split, null));
+        }
+      } catch (Exception e) {
+        receiver.output(restriction);
+      }
+    }
+
+    @NewTracker
+    public RestrictionTracker<
+            KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT>, UnboundedSourceValue<OutputT>[]>
+        restrictionTracker(
+            @Restriction KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT> restriction,
+            PipelineOptions pipelineOptions) {
+      return new UnboundedSourceAsSDFRestrictionTracker(restriction, pipelineOptions);
+    }
+
+    @ProcessElement
+    public ProcessContinuation processElement(
+        RestrictionTracker<
+                KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT>, UnboundedSourceValue[]>
+            tracker,
+        OutputReceiver<ValueWithRecordId<OutputT>> receiver,
+        BundleFinalizer bundleFinalizer)
+        throws IOException {
+      UnboundedSourceValue<OutputT>[] out = new UnboundedSourceValue[1];
+      while (tracker.tryClaim(out)) {
+        receiver.outputWithTimestamp(
+            new ValueWithRecordId<>(out[0].getValue(), out[0].getId()), out[0].getTimestamp());
+      }
+
+      // Add the checkpoint mark to be finalized if the checkpoint mark isn't trivial.
+      KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT> currentRestriction =
+          tracker.currentRestriction();
+      if (currentRestriction.getValue() != null
+          && !(tracker.currentRestriction().getValue() instanceof NoopCheckpointMark)) {
+        bundleFinalizer.afterBundleCommit(
+            Instant.now().plus(Duration.standardMinutes(DEFAULT_BUNDLE_FINALIZATION_LIMIT_MINS)),
+            currentRestriction.getValue()::finalizeCheckpoint);
+      }
+
+      // If we have been split/checkpoint by a runner, the tracker will have been updated to the
+      // empty source and we will return stop. Otherwise the unbounded source has only temporarily
+      // run out of work.
+      if (tracker.currentRestriction().getKey() instanceof EmptyUnboundedSource) {
+        return ProcessContinuation.stop();
+      }
+      return ProcessContinuation.resume();
+    }
+
+    @GetRestrictionCoder
+    public Coder<KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT>> restrictionCoder() {
+      return KvCoder.of(
+          SerializableCoder.of(new TypeDescriptor<UnboundedSource<OutputT, CheckpointT>>() {}),
+          NullableCoder.of(restrictionCoder));
+    }
+
+    /**
+     * A named tuple representing all the values we need to pass between the {@link UnboundedReader}
+     * and the {@link org.apache.beam.sdk.transforms.DoFn.ProcessElement @ProcessElement} method of
+     * the splittable DoFn.
+     */
+    @AutoValue
+    abstract static class UnboundedSourceValue<T> {
+      public static <T> UnboundedSourceValue<T> create(
+          byte[] id, T value, Instant timestamp, Instant watermark) {
+        return new AutoValue_Read_UnboundedSourceAsSDFWrapperFn_UnboundedSourceValue<T>(
+            id, value, timestamp, watermark);
+      }
+
+      @SuppressWarnings("mutable")
+      public abstract byte[] getId();
+
+      public abstract T getValue();
+
+      public abstract Instant getTimestamp();
+
+      public abstract Instant getWatermark();
+    }
+
+    /**
+     * A marker implementation that is used to represent the primary "source" when performing a
+     * split. The methods on this object are not meant to be called and only exist to fulfill the
+     * {@link UnboundedSource} API contract.
+     */
+    private static class EmptyUnboundedSource<OutputT, CheckpointT extends CheckpointMark>
+        extends UnboundedSource<OutputT, CheckpointT> {
+      private static final EmptyUnboundedSource INSTANCE = new EmptyUnboundedSource();
+
+      @Override
+      public List<? extends UnboundedSource<OutputT, CheckpointT>> split(
+          int desiredNumSplits, PipelineOptions options) throws Exception {
+        throw new UnsupportedOperationException("split is never meant to be invoked.");
+      }
+
+      @Override
+      public UnboundedReader<OutputT> createReader(
+          PipelineOptions options, @Nullable CheckpointT checkpointMark) {
+        return new UnboundedReader<OutputT>() {
+          @Override
+          public boolean start() throws IOException {
+            return false;
+          }
+
+          @Override
+          public boolean advance() throws IOException {
+            return false;
+          }
+
+          @Override
+          public OutputT getCurrent() throws NoSuchElementException {
+            throw new UnsupportedOperationException("getCurrent is never meant to be invoked.");
+          }
+
+          @Override
+          public Instant getCurrentTimestamp() throws NoSuchElementException {
+            throw new UnsupportedOperationException(
+                "getCurrentTimestamp is never meant to be invoked.");
+          }
+
+          @Override
+          public void close() throws IOException {}
+
+          @Override
+          public Instant getWatermark() {
+            throw new UnsupportedOperationException("getWatermark is never meant to be invoked.");
+          }
+
+          @Override
+          public CheckpointMark getCheckpointMark() {
+            return checkpointMark;
+          }
+
+          @Override
+          public UnboundedSource<OutputT, ?> getCurrentSource() {
+            return EmptyUnboundedSource.INSTANCE;
+          }
+        };
+      }
+
+      @Override
+      public Coder<CheckpointT> getCheckpointMarkCoder() {
+        throw new UnsupportedOperationException(
+            "getCheckpointMarkCoder is never meant to be invoked.");
+      }
+    }
+
+    /**
+     * A fake restriction tracker which adapts to the {@link UnboundedSource} API. The restriction
+     * object is used to advance the underlying source and to "return" the current element.
+     *
+     * <p>In an {@link UnboundedReader}, both {@link UnboundedReader#start} and {@link
+     * UnboundedReader#advance} will return false when there is no data to process right now so this
+     * restriction tracker only tracks the "known" amount of outstanding work.
+     *
+     * <p>In an {@link UnboundedSource}, the {@link CheckpointMark} represents both any work that
+     * should be done when "finalizing" the bundle and also any state information that is used to
+     * resume the next portion of processing. We use the {@link #currentRestriction} to return any
+     * checkpointing information. Typically accessing the {@link #currentRestriction} is meant to be
+     * thread safe since the "restriction" is meant to represent a point in time view of the
+     * restriction tracker but this is not possible because the {@link UnboundedSource} and {@link
+     * UnboundedReader} do not provide enough visibility into their position space to be able to
+     * update a meaningful restriction space so we must be careful to not mutate the current
+     * restriction when splitting if we are done.
+     */
+    private static class UnboundedSourceAsSDFRestrictionTracker<
+            OutputT, CheckpointT extends CheckpointMark>
+        extends RestrictionTracker<
+            KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT>,
+            UnboundedSourceValue<OutputT>[]> {
+
+      private final KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT> initialRestriction;
+      private final PipelineOptions pipelineOptions;
+      private UnboundedSource.UnboundedReader<OutputT> currentReader;
+      private boolean claimedAll;
+
+      UnboundedSourceAsSDFRestrictionTracker(
+          KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT> initialRestriction,
+          PipelineOptions pipelineOptions) {
+        this.initialRestriction = initialRestriction;
+        this.pipelineOptions = pipelineOptions;
+      }
+
+      @Override
+      public boolean tryClaim(UnboundedSourceValue<OutputT>[] position) {
+        if (claimedAll) {
+          return false;
+        }
+        try {
+          if (currentReader == null) {
+            currentReader =
+                initialRestriction
+                    .getKey()
+                    .createReader(pipelineOptions, initialRestriction.getValue());
+            if (!currentReader.start()) {
+              claimedAll = true;
+              try {
+                currentReader.close();
+              } finally {
+                currentReader = null;
+              }
+              return false;
+            }
+            position[0] =
+                UnboundedSourceValue.create(
+                    currentReader.getCurrentRecordId(),
+                    currentReader.getCurrent(),
+                    currentReader.getCurrentTimestamp(),
+                    currentReader.getWatermark());
+            return true;
+          }
+          if (!currentReader.advance()) {
+            claimedAll = true;
+            try {
+              currentReader.close();
+            } finally {
+              currentReader = null;
+            }
+            return false;
+          }
+          position[0] =
+              UnboundedSourceValue.create(
+                  currentReader.getCurrentRecordId(),
+                  currentReader.getCurrent(),
+                  currentReader.getCurrentTimestamp(),
+                  currentReader.getWatermark());
+          return true;
+        } catch (IOException e) {
+          if (currentReader != null) {
+            try {
+              currentReader.close();
+            } catch (IOException closeException) {
+              e.addSuppressed(closeException);
+            } finally {
+              currentReader = null;
+            }
+          }
+          throw new RuntimeException(e);
+        }
+      }
+
+      /** The value is invalid if {@link #tryClaim} has ever thrown an exception. */
+      @Override
+      public KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT> currentRestriction() {
+        if (currentReader == null) {
+          return initialRestriction;
+        }
+        return KV.of(
+            (UnboundedSource<OutputT, CheckpointT>) currentReader.getCurrentSource(),
+            (CheckpointT) currentReader.getCheckpointMark());
+      }
+
+      @Override
+      public SplitResult<KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT>> trySplit(
+          double fractionOfRemainder) {
+        // Don't split if we have claimed all since the SDF wrapper will be finishing soon.
+        if (claimedAll) {
+          return null;
+        }
+
+        // Our split result sets the primary to have no checkpoint mark associated
+        // with it since when we resume we don't have any state but we specifically pass
+        // the checkpoint mark to the current reader so that when we finish the current bundle
+        // we may register for finalization.
+        CheckpointT checkpoint = (CheckpointT) currentReader.getCheckpointMark();
+        SplitResult<KV<UnboundedSource<OutputT, CheckpointT>, CheckpointT>> result =
+            SplitResult.of(
+                KV.of(EmptyUnboundedSource.INSTANCE, null),
+                KV.of(
+                    (UnboundedSource<OutputT, CheckpointT>) currentReader.getCurrentSource(),
+                    checkpoint));
+        currentReader = EmptyUnboundedSource.INSTANCE.createReader(null, checkpoint);
+        return result;
+      }
+
+      @Override
+      public void checkDone() throws IllegalStateException {
+        checkState(
+            claimedAll,
+            "Expected all records to have been claimed but finished processing "
+                + "unbounded source while some records may have not been read.");
       }
     }
   }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -82,6 +82,7 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -269,6 +270,12 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
 
   /** Only valid during {@link #processElementForSplitRestriction}, null otherwise. */
   private RestrictionT currentRestriction;
+
+  /**
+   * Only valid during {@link #processElementForElementAndRestriction} and {@link
+   * #processElementForSizedElementAndRestriction}, null otherwise.
+   */
+  private Instant currentOutputWatermark;
 
   /**
    * Only valid during {@code processElement...} and {@link #processTimer} methods, null otherwise.
@@ -666,6 +673,9 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
       Iterator<BoundedWindow> windowIterator =
           (Iterator<BoundedWindow>) elem.getWindows().iterator();
       while (windowIterator.hasNext()) {
+        // TODO(BEAM-2939): Ensure that the watermark we use as the lower bound comes from
+        // the previously reported watermark and doesn't reset to -infinity on each element.
+        currentOutputWatermark = GlobalWindow.TIMESTAMP_MIN_VALUE;
         currentRestriction = elem.getValue().getValue();
         currentWindow = windowIterator.next();
         currentTracker = doFnInvoker.invokeNewTracker(processContext);
@@ -698,23 +708,31 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
-        BundleApplication primaryApplication =
+        BundleApplication.Builder primaryApplication =
             BundleApplication.newBuilder()
                 .setTransformId(pTransformId)
                 .setInputId(mainInputId)
-                .setElement(primaryBytes.toByteString())
-                .build();
-        BundleApplication residualApplication =
+                .setElement(primaryBytes.toByteString());
+        BundleApplication.Builder residualApplication =
             BundleApplication.newBuilder()
                 .setTransformId(pTransformId)
                 .setInputId(mainInputId)
-                .setElement(residualBytes.toByteString())
-                .build();
+                .setElement(residualBytes.toByteString());
+        if (!currentOutputWatermark.equals(GlobalWindow.TIMESTAMP_MIN_VALUE)) {
+          for (String outputId : pTransform.getOutputsMap().keySet()) {
+            residualApplication.putOutputWatermarks(
+                outputId,
+                org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.Timestamp.newBuilder()
+                    .setSeconds(currentOutputWatermark.getMillis() / 1000)
+                    .setNanos((int) (currentOutputWatermark.getMillis() % 1000) * 1000000)
+                    .build());
+          }
+        }
         splitListener.split(
-            ImmutableList.of(primaryApplication),
+            ImmutableList.of(primaryApplication.build()),
             ImmutableList.of(
                 DelayedBundleApplication.newBuilder()
-                    .setApplication(residualApplication)
+                    .setApplication(residualApplication.build())
                     .setRequestedTimeDelay(
                         Durations.fromMillis(continuation.resumeDelay().getMillis()))
                     .build()));
@@ -724,6 +742,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
       currentRestriction = null;
       currentWindow = null;
       currentTracker = null;
+      currentOutputWatermark = null;
     }
   }
 
@@ -1213,7 +1232,15 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, OutputT> {
 
     @Override
     public void updateWatermark(Instant watermark) {
-      throw new UnsupportedOperationException("TODO: Add support for SplittableDoFn");
+      checkState(
+          currentOutputWatermark != null,
+          "Updating the watermark is only allowed for Splittable DoFns.");
+      checkArgument(
+          !watermark.isBefore(currentOutputWatermark),
+          "Watermark must be monotonically increasing. Provided watermark %s is less then current watermark %s.",
+          watermark,
+          currentOutputWatermark);
+      currentOutputWatermark = watermark;
     }
   }
 


### PR DESCRIPTION


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
