### PR TITLE
[BEAM-8965] Remove duplicate sideinputs in ConsumerTrackingPipelineVisitor

### DIFF
--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor.py
@@ -50,6 +50,7 @@ class ConsumerTrackingPipelineVisitor(PipelineVisitor):
     self.step_names = {}  # type: Dict[AppliedPTransform, str]
 
     self._num_transforms = 0
+    self._side_input_views = {}
 
   def visit_transform(self, applied_ptransform):
     # type: (AppliedPTransform) -> None
@@ -65,5 +66,10 @@ class ConsumerTrackingPipelineVisitor(PipelineVisitor):
       self.root_transforms.add(applied_ptransform)
     self.step_names[applied_ptransform] = 's%d' % (self._num_transforms)
     self._num_transforms += 1
+
     for side_input in applied_ptransform.side_inputs:
-      self.views.append(side_input)
+      if side_input not in self._side_input_views:
+        self._side_input_views[side_input] = side_input
+    self.views = [
+        side_input for side_input in self._side_input_views
+    ]

--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor.py
@@ -46,11 +46,19 @@ class ConsumerTrackingPipelineVisitor(PipelineVisitor):
     self.value_to_consumers = {
     }  # type: Dict[pvalue.PValue, List[AppliedPTransform]]
     self.root_transforms = set()  # type: Set[AppliedPTransform]
-    self.views = []  # type: List[pvalue.AsSideInput]
     self.step_names = {}  # type: Dict[AppliedPTransform, str]
 
     self._num_transforms = 0
-    self._side_input_views = {}
+    self._views = set()
+
+  @property
+  def views(self):
+    """Returns a list of side intputs extracted from the graph.
+
+    Returns:
+      A list of pvalue.AsSideInput.
+    """
+    return list(self._views)
 
   def visit_transform(self, applied_ptransform):
     # type: (AppliedPTransform) -> None
@@ -68,8 +76,4 @@ class ConsumerTrackingPipelineVisitor(PipelineVisitor):
     self._num_transforms += 1
 
     for side_input in applied_ptransform.side_inputs:
-      if side_input not in self._side_input_views:
-        self._side_input_views[side_input] = side_input
-    self.views = [
-        side_input for side_input in self._side_input_views
-    ]
+      self._views.add(side_input)

--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
@@ -107,8 +107,7 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
         | 'read' >> root_read
         | ParDo(SplitNumbersFn()).with_outputs('tag_negative', main='positive'))
     positive, negative = result
-    negative_pvalue = AsList(negative)
-    _process_numbers(positive, negative_pvalue)
+    _process_numbers(positive, AsList(negative))
 
     self.pipeline.visit(self.visitor)
 

--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
@@ -85,19 +85,15 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
 
     def _process_numbers(pcoll, negatives):
       first_output = (
-        pcoll
-        | 'process numbers step 1' >> ParDo(ProcessNumbersFn(), negatives)
-      )
+          pcoll
+          | 'process numbers step 1' >> ParDo(ProcessNumbersFn(), negatives))
 
       second_output = (
-        first_output
-        | 'process numbers step 2' >> ParDo(ProcessNumbersFn(), negatives)
-      )
+          first_output
+          | 'process numbers step 2' >> ParDo(ProcessNumbersFn(), negatives))
 
-      output_pc = (
-        (first_output, second_output)
-        | 'flatten results' >> beam.Flatten()
-      )
+      output_pc = ((first_output, second_output)
+                   | 'flatten results' >> beam.Flatten())
       return output_pc
 
     root_read = beam.Impulse()

--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
@@ -83,6 +83,23 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
       def process(self, element, negatives):
         yield element
 
+    def _process_numbers(pcoll, negatives):
+      first_output = (
+        pcoll
+        | 'process numbers step 1' >> ParDo(ProcessNumbersFn(), negatives)
+      )
+
+      second_output = (
+        first_output
+        | 'process numbers step 2' >> ParDo(ProcessNumbersFn(), negatives)
+      )
+
+      output_pc = (
+        (first_output, second_output)
+        | 'flatten results' >> beam.Flatten()
+      )
+      return output_pc
+
     root_read = beam.Impulse()
 
     result = (
@@ -90,13 +107,14 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
         | 'read' >> root_read
         | ParDo(SplitNumbersFn()).with_outputs('tag_negative', main='positive'))
     positive, negative = result
-    positive | ParDo(ProcessNumbersFn(), AsList(negative))
+    negative_pvalue = AsList(negative)
+    _process_numbers(positive, negative_pvalue)
 
     self.pipeline.visit(self.visitor)
 
     root_transforms = [t.transform for t in self.visitor.root_transforms]
     self.assertEqual(root_transforms, [root_read])
-    self.assertEqual(len(self.visitor.step_names), 3)
+    self.assertEqual(len(self.visitor.step_names), 5)
     self.assertEqual(len(self.visitor.views), 1)
     self.assertTrue(isinstance(self.visitor.views[0], pvalue.AsList))
 


### PR DESCRIPTION
## Summary
This PR is mainly preventing `BundleBasedDirectRunner` evaluates single side_input more than once.

To achieve this, this PR changes the logic to get side_input views in `ConsumerTrackingPipelineVisitor`, and modify the unit tests to make sure that when one single side_input is used in two different PTransforms, it will be evaluated once.

## Check List
Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
