### PR TITLE
[BEAM-8335] Add PCollection to DataFrame logic for InteractiveRunner.

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/utils.py
+++ b/sdks/python/apache_beam/runners/interactive/utils.py
@@ -1,0 +1,112 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Utilities to be used in  Interactive Beam.
+"""
+
+from __future__ import absolute_import
+
+import pandas as pd
+
+from apache_beam.typehints import typehints as th
+from apache_beam.utils.windowed_value import WindowedValue
+
+COLUMN_PREFIX = 'el'
+
+
+def parse_row_(el, element_type, depth):
+  elements = []
+  columns = []
+
+  # Recurse if there are a known length of columns to parse into.
+  if isinstance(element_type, (th.TupleHint.TupleConstraint)):
+    for index, t in enumerate(element_type._inner_types()):
+      underlying_columns, underlying_elements = parse_row_(el[index], t,
+                                                           depth + 1)
+      column = '[{}]'.format(index)
+      if underlying_columns:
+        columns += [column + c for c in underlying_columns]
+      else:
+        columns += [column]
+      elements += underlying_elements
+
+  # Don't make new columns for variable length types.
+  elif isinstance(
+      element_type,
+      (th.ListHint.ListConstraint, th.TupleHint.TupleSequenceConstraint)):
+    elements = [pd.array(el)]
+
+  # For any other types, try to parse as a namedtuple, otherwise pass element
+  # through.
+  else:
+    fields = getattr(el, '_fields', None)
+    if fields:
+      columns = list(fields)
+      if depth > 0:
+        columns = ['[{}]'.format(f) for f in fields]
+      elements = [el._asdict()[f] for f in fields]
+    else:
+      elements = [el]
+  return columns, elements
+
+
+def parse_row(el, element_type, include_window_info=True, prefix=COLUMN_PREFIX):
+  # Reify the WindowedValue data to the Dataframe if asked.
+  windowed = None
+  if isinstance(el, WindowedValue):
+    if include_window_info:
+      windowed = el
+    el = el.value
+
+  # Parse the elements with the given type.
+  columns, elements = parse_row_(el, element_type, 0)
+
+  # If there are no columns returned, there is only a single column of a
+  # primitive data type.
+  if not columns:
+    columns = ['']
+
+  # Add the prefix to the columns that have an index.
+  for i in range(len(columns)):
+    if columns[i] == '' or columns[i][0] == '[':
+      columns[i] = prefix + columns[i]
+
+  # Reify the windowed columns and do a best-effort casting into Pandas DTypes.
+  if windowed:
+    columns += ['event_time', 'windows', 'pane_info']
+    elements += [
+        windowed.timestamp.micros, windowed.windows, windowed.pane_info
+    ]
+  return columns, elements
+
+
+def pcoll_to_df(
+    elements, element_type, include_window_info=False, prefix=COLUMN_PREFIX):
+  """Parses the given elements into a Dataframe.
+
+  Each column name will be prefixed with `prefix` concatenated with the nested
+  index, e.g. for a Tuple[Tuple[int, str], int], the column names will be:
+  [prefix[0][0], prefix[0][1], prefix[0]]. This is subject to change.
+  """
+  rows = []
+  columns = []
+
+  for e in elements:
+    columns, row = parse_row(e, element_type, include_window_info, prefix)
+    rows.append(row)
+
+  return pd.DataFrame(rows, columns=columns)

--- a/sdks/python/apache_beam/runners/interactive/utils_test.py
+++ b/sdks/python/apache_beam/runners/interactive/utils_test.py
@@ -1,0 +1,138 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+
+import unittest
+
+import pandas as pd
+
+from apache_beam.runners.interactive import utils
+from apache_beam.typehints.typehints import Any
+from apache_beam.typehints.typehints import Dict
+from apache_beam.typehints.typehints import List
+from apache_beam.typehints.typehints import Tuple
+from apache_beam.utils.windowed_value import WindowedValue
+
+
+class ParseToDataframeTest(unittest.TestCase):
+  def test_parse_tuple(self):
+    el = (1, 'a')
+    element_type = Tuple[int, str]
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(columns, ['el[0]', 'el[1]'])
+    self.assertEqual(elements, [1, 'a'])
+
+  def test_parse_nested_tuple(self):
+    el = ((1, 2.0, 'a'), 'b')
+    element_type = Tuple[Tuple[int, float, str], str]
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(columns, ['el[0][0]', 'el[0][1]', 'el[0][2]', 'el[1]'])
+    self.assertEqual(elements, [1, 2.0, 'a', 'b'])
+
+  def test_parse_list(self):
+    el = [1, 2, 3]
+    element_type = List[int]
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(columns, ['el'])
+    self.assertEqual(elements, [[1, 2, 3]])
+
+  def test_parse_nested_list(self):
+    el = ('k', [1, 2, 3])
+    element_type = Tuple[str, List[int]]
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(columns, ['el[0]', 'el[1]'])
+    self.assertEqual(elements, ['k', [1, 2, 3]])
+
+  def test_parse_complex(self):
+    el = (([1, 2, 3], {'b': 1, 'c': 2}), 'a')
+    element_type = Tuple[Tuple[List[int], Dict[str, int]], str]
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(columns, ['el[0][0]', 'el[0][1]', 'el[1]'])
+    self.assertEqual(elements, [[1, 2, 3], {'b': 1, 'c': 2}, 'a'])
+
+  def test_parse_singleton(self):
+    el = 1
+    element_type = int
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(columns, ['el'])
+    self.assertEqual(elements, [1])
+
+  def test_parse_namedtuple(self):
+    """Tests that namedtuple are supported and have their own columns.
+    """
+    from collections import namedtuple
+
+    KVCount = namedtuple('KeyCount', ['word', 'count'])
+
+    el = KVCount(word='a', count=2)
+    element_type = Any
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(columns, ['word', 'count'])
+    self.assertEqual(elements, ['a', 2])
+
+  def test_parse_nestednamedtuple(self):
+    """Tests that nested namedtuples are indeed.
+    """
+    from collections import namedtuple
+
+    KVCount = namedtuple('KeyCount', ['word', 'count'])
+
+    el = ('k', KVCount(word='a', count=2))
+    element_type = Tuple[str, Any]
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(columns, ['el[0]', 'el[1][word]', 'el[1][count]'])
+    self.assertEqual(elements, ['k', 'a', 2])
+
+  def test_parse_windowedvalue(self):
+    """Tests that WindowedValues are supported and have their own columns.
+    """
+    from apache_beam.transforms.window import GlobalWindow
+
+    el = WindowedValue(('a', 2), 1, [GlobalWindow()])
+    element_type = Tuple[str, int]
+
+    columns, elements = utils.parse_row(el, element_type)
+    self.assertEqual(
+        columns, ['el[0]', 'el[1]', 'event_time', 'windows', 'pane_info'])
+    self.assertEqual(elements, ['a', 2, 1e6, el.windows, el.pane_info])
+
+  def test_parse_dataframe(self):
+    from collections import namedtuple
+
+    KVCount = namedtuple('KeyCount', ['word', 'count'])
+
+    els = [('k', KVCount(word='a', count=1)), ('k', KVCount(word='b', count=2)),
+           ('k', KVCount(word='c', count=3))]
+    element_type = Tuple[str, Any]
+
+    actual_df = utils.pcoll_to_df(els, element_type)
+    expected_df = pd.DataFrame([['k', 'a', 1], ['k', 'b', 2], ['k', 'c', 3]],
+                               columns=['el[0]', 'el[1][word]', 'el[1][count]'])
+    pd.testing.assert_frame_equal(actual_df, expected_df)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/utils_test.py
+++ b/sdks/python/apache_beam/runners/interactive/utils_test.py
@@ -19,118 +19,64 @@ from __future__ import absolute_import
 
 import unittest
 
+import numpy as np
 import pandas as pd
 
 from apache_beam.runners.interactive import utils
-from apache_beam.typehints.typehints import Any
-from apache_beam.typehints.typehints import Dict
-from apache_beam.typehints.typehints import List
-from apache_beam.typehints.typehints import Tuple
 from apache_beam.utils.windowed_value import WindowedValue
 
 
 class ParseToDataframeTest(unittest.TestCase):
-  def test_parse_tuple(self):
-    el = (1, 'a')
-    element_type = Tuple[int, str]
-
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(columns, ['el[0]', 'el[1]'])
-    self.assertEqual(elements, [1, 'a'])
-
-  def test_parse_nested_tuple(self):
-    el = ((1, 2.0, 'a'), 'b')
-    element_type = Tuple[Tuple[int, float, str], str]
-
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(columns, ['el[0][0]', 'el[0][1]', 'el[0][2]', 'el[1]'])
-    self.assertEqual(elements, [1, 2.0, 'a', 'b'])
-
-  def test_parse_list(self):
-    el = [1, 2, 3]
-    element_type = List[int]
-
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(columns, ['el'])
-    self.assertEqual(elements, [[1, 2, 3]])
-
-  def test_parse_nested_list(self):
-    el = ('k', [1, 2, 3])
-    element_type = Tuple[str, List[int]]
-
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(columns, ['el[0]', 'el[1]'])
-    self.assertEqual(elements, ['k', [1, 2, 3]])
-
-  def test_parse_complex(self):
-    el = (([1, 2, 3], {'b': 1, 'c': 2}), 'a')
-    element_type = Tuple[Tuple[List[int], Dict[str, int]], str]
-
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(columns, ['el[0][0]', 'el[0][1]', 'el[1]'])
-    self.assertEqual(elements, [[1, 2, 3], {'b': 1, 'c': 2}, 'a'])
-
-  def test_parse_singleton(self):
-    el = 1
-    element_type = int
-
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(columns, ['el'])
-    self.assertEqual(elements, [1])
-
-  def test_parse_namedtuple(self):
-    """Tests that namedtuple are supported and have their own columns.
-    """
-    from collections import namedtuple
-
-    KVCount = namedtuple('KeyCount', ['word', 'count'])
-
-    el = KVCount(word='a', count=2)
-    element_type = Any
-
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(columns, ['word', 'count'])
-    self.assertEqual(elements, ['a', 2])
-
-  def test_parse_nestednamedtuple(self):
-    """Tests that nested namedtuples are indeed.
-    """
-    from collections import namedtuple
-
-    KVCount = namedtuple('KeyCount', ['word', 'count'])
-
-    el = ('k', KVCount(word='a', count=2))
-    element_type = Tuple[str, Any]
-
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(columns, ['el[0]', 'el[1][word]', 'el[1][count]'])
-    self.assertEqual(elements, ['k', 'a', 2])
-
   def test_parse_windowedvalue(self):
+    """Tests that WindowedValues are supported but not present.
+    """
+    from apache_beam.transforms.window import GlobalWindow
+
+    els = [
+        WindowedValue(('a', 2), 1, [GlobalWindow()]),
+        WindowedValue(('b', 3), 1, [GlobalWindow()])
+    ]
+
+    actual_df = utils.elements_to_df(els, include_window_info=False)
+    expected_df = pd.DataFrame([['a', 2], ['b', 3]], columns=[0, 1])
+    pd.testing.assert_frame_equal(actual_df, expected_df)
+
+  def test_parse_windowedvalue_with_window_info(self):
     """Tests that WindowedValues are supported and have their own columns.
     """
     from apache_beam.transforms.window import GlobalWindow
 
-    el = WindowedValue(('a', 2), 1, [GlobalWindow()])
-    element_type = Tuple[str, int]
+    els = [
+        WindowedValue(('a', 2), 1, [GlobalWindow()]),
+        WindowedValue(('b', 3), 1, [GlobalWindow()])
+    ]
 
-    columns, elements = utils.parse_row(el, element_type)
-    self.assertEqual(
-        columns, ['el[0]', 'el[1]', 'event_time', 'windows', 'pane_info'])
-    self.assertEqual(elements, ['a', 2, 1e6, el.windows, el.pane_info])
+    actual_df = utils.elements_to_df(els, include_window_info=True)
+    expected_df = pd.DataFrame(
+        [['a', 2, int(1e6), els[0].windows, els[0].pane_info],
+         ['b', 3, int(1e6), els[1].windows, els[1].pane_info]],
+        columns=[0, 1, 'event_time', 'windows', 'pane_info'])
+    pd.testing.assert_frame_equal(actual_df, expected_df)
 
-  def test_parse_dataframe(self):
-    from collections import namedtuple
+  def test_parse_windowedvalue_with_dicts(self):
+    """Tests that dicts play well with WindowedValues.
+    """
+    from apache_beam.transforms.window import GlobalWindow
 
-    KVCount = namedtuple('KeyCount', ['word', 'count'])
+    els = [
+        WindowedValue({
+            'b': 2, 'd': 4
+        }, 1, [GlobalWindow()]),
+        WindowedValue({
+            'a': 1, 'b': 2, 'c': 3
+        }, 1, [GlobalWindow()])
+    ]
 
-    els = [('k', KVCount(word='a', count=1)), ('k', KVCount(word='b', count=2)),
-           ('k', KVCount(word='c', count=3))]
-    element_type = Tuple[str, Any]
-
-    actual_df = utils.pcoll_to_df(els, element_type)
-    expected_df = pd.DataFrame([['k', 'a', 1], ['k', 'b', 2], ['k', 'c', 3]],
-                               columns=['el[0]', 'el[1][word]', 'el[1][count]'])
+    actual_df = utils.elements_to_df(els, include_window_info=True)
+    expected_df = pd.DataFrame(
+        [[np.nan, 2, np.nan, 4, int(1e6), els[0].windows, els[0].pane_info],
+         [1, 2, 3, np.nan, int(1e6), els[1].windows, els[1].pane_info]],
+        columns=['a', 'b', 'c', 'd', 'event_time', 'windows', 'pane_info'])
     pd.testing.assert_frame_equal(actual_df, expected_df)
 
 


### PR DESCRIPTION
This adds logic to convert materialized elements from a PCollection and a PCollection element_type into a Pandas DataFrame.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
