### PR TITLE
[BEAM-8616] Make hadoop-client a provided dependency on ParquetIO

### DIFF
--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -58,6 +58,7 @@ dependencies {
   provided project(":sdks:java:io:google-cloud-platform")
   compile project(":sdks:java:io:mongodb")
   provided project(":sdks:java:io:parquet")
+  provided library.java.hadoop_client
   provided library.java.kafka_clients
   testCompile library.java.vendored_calcite_1_20_0
   testCompile library.java.vendored_guava_26_0_jre

--- a/sdks/java/io/file-based-io-tests/build.gradle
+++ b/sdks/java/io/file-based-io-tests/build.gradle
@@ -32,5 +32,6 @@ dependencies {
   testCompile project(path: ":sdks:java:testing:test-utils", configuration: "testRuntime")
   testCompile library.java.junit
   testCompile library.java.hamcrest_core
+  testCompile library.java.hadoop_client
   testCompile library.java.jaxb_api
 }

--- a/sdks/java/io/parquet/build.gradle
+++ b/sdks/java/io/parquet/build.gradle
@@ -32,8 +32,7 @@ dependencies {
   compile "org.apache.parquet:parquet-common:$parquet_version"
   compile "org.apache.parquet:parquet-hadoop:$parquet_version"
   compile library.java.avro
-  compile library.java.hadoop_client
-  compile library.java.hadoop_common
+  provided library.java.hadoop_client
   testCompile project(path: ":sdks:java:core", configuration: "shadowTest")
   testCompile library.java.junit
   testCompile library.java.hamcrest_core

--- a/sdks/java/testing/expansion-service/build.gradle
+++ b/sdks/java/testing/expansion-service/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   compile project(path: ":runners:core-construction-java")
   compile project(path: ":sdks:java:io:parquet")
   compile project(path: ":sdks:java:core", configuration: "shadow")
+  provided library.java.hadoop_client
 }
 
 task runTestExpansionService (type: JavaExec) {


### PR DESCRIPTION
Follow up of the one you were reviewing before, should be quite straight forward now.
Notice that I triggered this time in advance the SQL postcommit tests to avoid any surprises.
R: @lgajowy 