### PR TITLE
Make logger naming consistent with Apache Beam LOG standard

### DIFF
--- a/learning/katas/java/util/src/org/apache/beam/learning/katas/util/Log.java
+++ b/learning/katas/java/util/src/org/apache/beam/learning/katas/util/Log.java
@@ -29,10 +29,9 @@ import org.slf4j.LoggerFactory;
 
 public class Log {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(Log.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Log.class);
 
-  private Log() {
-  }
+  private Log() {}
 
   public static <T> PTransform<PCollection<T>, PCollection<T>> ofElements() {
     return new LoggingTransform<>();
@@ -56,26 +55,25 @@ public class Log {
 
     @Override
     public PCollection<T> expand(PCollection<T> input) {
-      return input.apply(ParDo.of(new DoFn<T, T>() {
+      return input.apply(
+          ParDo.of(
+              new DoFn<T, T>() {
 
-        @ProcessElement
-        public void processElement(@Element T element, OutputReceiver<T> out,
-            BoundedWindow window) {
+                @ProcessElement
+                public void processElement(
+                    @Element T element, OutputReceiver<T> out, BoundedWindow window) {
 
-          String message = prefix + element.toString();
+                  String message = prefix + element.toString();
 
-          if (!(window instanceof GlobalWindow)) {
-            message = message + "  Window:" + window.toString();
-          }
+                  if (!(window instanceof GlobalWindow)) {
+                    message = message + "  Window:" + window.toString();
+                  }
 
-          LOGGER.info(message);
+                  LOG.info(message);
 
-          out.output(element);
-        }
-
-      }));
+                  out.output(element);
+                }
+              }));
     }
-
   }
-
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/BeamFnControlService.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/BeamFnControlService.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BeamFnControlService extends BeamFnControlGrpc.BeamFnControlImplBase
     implements BeamFnService, Supplier<FnApiControlClient> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(BeamFnControlService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BeamFnControlService.class);
   private final Endpoints.ApiServiceDescriptor apiServiceDescriptor;
   private final Function<
           StreamObserver<BeamFnApi.InstructionRequest>,
@@ -57,7 +57,7 @@ public class BeamFnControlService extends BeamFnControlGrpc.BeamFnControlImplBas
     this.newClients = new SynchronousQueue<>(true /* fair */);
     this.streamObserverFactory = streamObserverFactory;
     this.apiServiceDescriptor = serviceDescriptor;
-    LOGGER.info("Launched Beam Fn Control service {}", this.apiServiceDescriptor);
+    LOG.info("Launched Beam Fn Control service {}", this.apiServiceDescriptor);
   }
 
   @Override
@@ -68,7 +68,7 @@ public class BeamFnControlService extends BeamFnControlGrpc.BeamFnControlImplBas
   @Override
   public StreamObserver<BeamFnApi.InstructionResponse> control(
       StreamObserver<BeamFnApi.InstructionRequest> outboundObserver) {
-    LOGGER.info("Beam Fn Control client connected with id {}", headerAccessor.getSdkWorkerId());
+    LOG.info("Beam Fn Control client connected with id {}", headerAccessor.getSdkWorkerId());
     FnApiControlClient newClient =
         FnApiControlClient.forRequestObserver(
             headerAccessor.getSdkWorkerId(), streamObserverFactory.apply(outboundObserver));

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/logging/BeamFnLoggingService.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/logging/BeamFnLoggingService.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BeamFnLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBase
     implements BeamFnService {
-  private static final Logger LOGGER = LoggerFactory.getLogger(BeamFnLoggingService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BeamFnLoggingService.class);
   private final Endpoints.ApiServiceDescriptor apiServiceDescriptor;
   private final Consumer<BeamFnApi.LogEntry> clientLogger;
   private final Function<StreamObserver<BeamFnApi.LogControl>, StreamObserver<BeamFnApi.LogControl>>
@@ -64,7 +64,7 @@ public class BeamFnLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBas
     this.headerAccessor = headerAccessor;
     this.connectedClients = new ConcurrentHashMap<>();
     this.apiServiceDescriptor = apiServiceDescriptor;
-    LOGGER.info("Launched Beam Fn Logging service {}", this.apiServiceDescriptor);
+    LOG.info("Launched Beam Fn Logging service {}", this.apiServiceDescriptor);
   }
 
   @Override
@@ -76,7 +76,7 @@ public class BeamFnLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBas
   public void close() throws Exception {
     Set<InboundObserver> remainingClients = ImmutableSet.copyOf(connectedClients.keySet());
     if (!remainingClients.isEmpty()) {
-      LOGGER.info(
+      LOG.info(
           "{} Beam Fn Logging clients still connected during shutdown.", remainingClients.size());
 
       // Signal server shutting down to all remaining connected clients.
@@ -92,7 +92,7 @@ public class BeamFnLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBas
   @Override
   public StreamObserver<BeamFnApi.LogEntry.List> logging(
       StreamObserver<BeamFnApi.LogControl> outboundObserver) {
-    LOGGER.info("Beam Fn Logging client connected for client {}", headerAccessor.getSdkWorkerId());
+    LOG.info("Beam Fn Logging client connected for client {}", headerAccessor.getSdkWorkerId());
     InboundObserver inboundObserver = new InboundObserver(headerAccessor.getSdkWorkerId());
     connectedClients.put(inboundObserver, streamObserverFactory.apply(outboundObserver));
     return inboundObserver;
@@ -104,7 +104,7 @@ public class BeamFnLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBas
         outboundObserver.onCompleted();
       } catch (RuntimeException ignored) {
         // Completing outbound observer failed, ignoring failure and continuing
-        LOGGER.warn("Beam Fn Logging client failed to be complete.", ignored);
+        LOG.warn("Beam Fn Logging client failed to be complete.", ignored);
       }
     }
   }
@@ -133,7 +133,7 @@ public class BeamFnLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBas
 
     @Override
     public void onError(Throwable t) {
-      LOGGER.warn("Logging client failed unexpectedly. ClientId: {}", t, sdkWorkerId);
+      LOG.warn("Logging client failed unexpectedly. ClientId: {}", t, sdkWorkerId);
       // We remove these from the connected clients map to prevent a race between
       // the close method and this InboundObserver calling a terminal method on the
       // StreamObserver. If we removed it, then we are responsible for the terminal call.
@@ -142,7 +142,7 @@ public class BeamFnLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBas
 
     @Override
     public void onCompleted() {
-      LOGGER.info("Logging client hanged up. ClientId: {}", sdkWorkerId);
+      LOG.info("Logging client hanged up. ClientId: {}", sdkWorkerId);
       // We remove these from the connected clients map to prevent a race between
       // the close method and this InboundObserver calling a terminal method on the
       // StreamObserver. If we removed it, then we are responsible for the terminal call.

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 /** A Fn API control service which adds incoming SDK harness connections to a sink. */
 public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnControlImplBase
     implements FnService {
-  private static final Logger LOGGER = LoggerFactory.getLogger(FnApiControlClientPoolService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FnApiControlClientPoolService.class);
 
   private final Object lock = new Object();
   private final ControlClientPool.Sink clientSink;
@@ -78,10 +78,10 @@ public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnContr
     final String workerId = headerAccessor.getSdkWorkerId();
     if (Strings.isNullOrEmpty(workerId)) {
       // TODO(BEAM-4149): Enforce proper worker id.
-      LOGGER.warn("No worker_id header provided in control request");
+      LOG.warn("No worker_id header provided in control request");
     }
 
-    LOGGER.info("Beam Fn Control client connected with id {}", workerId);
+    LOG.info("Beam Fn Control client connected with id {}", workerId);
     FnApiControlClient newClient = FnApiControlClient.forRequestObserver(workerId, requestObserver);
     try {
       // Add the client to the pool of vended clients before making it available - we should close

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/logging/GrpcLoggingService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/logging/GrpcLoggingService.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 /** An implementation of the Beam Fn Logging Service over gRPC. */
 public class GrpcLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBase
     implements FnService {
-  private static final Logger LOGGER = LoggerFactory.getLogger(GrpcLoggingService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GrpcLoggingService.class);
 
   public static GrpcLoggingService forWriter(LogWriter writer) {
     return new GrpcLoggingService(writer);
@@ -50,7 +50,7 @@ public class GrpcLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBase
   public void close() throws Exception {
     Set<InboundObserver> remainingClients = ImmutableSet.copyOf(connectedClients.keySet());
     if (!remainingClients.isEmpty()) {
-      LOGGER.info(
+      LOG.info(
           "{} Beam Fn Logging clients still connected during shutdown.", remainingClients.size());
 
       // Signal server shutting down to all remaining connected clients.
@@ -66,7 +66,7 @@ public class GrpcLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBase
   @Override
   public StreamObserver<BeamFnApi.LogEntry.List> logging(
       StreamObserver<BeamFnApi.LogControl> outboundObserver) {
-    LOGGER.info("Beam Fn Logging client connected.");
+    LOG.info("Beam Fn Logging client connected.");
     InboundObserver inboundObserver = new InboundObserver();
     connectedClients.put(inboundObserver, outboundObserver);
     return inboundObserver;
@@ -78,7 +78,7 @@ public class GrpcLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBase
         outboundObserver.onCompleted();
       } catch (RuntimeException ignored) {
         // Completing outbound observer failed, ignoring failure and continuing
-        LOGGER.warn("Beam Fn Logging client failed to be complete.", ignored);
+        LOG.warn("Beam Fn Logging client failed to be complete.", ignored);
       }
     }
   }
@@ -98,7 +98,7 @@ public class GrpcLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBase
 
     @Override
     public void onError(Throwable t) {
-      LOGGER.warn("Logging client failed unexpectedly.", t);
+      LOG.warn("Logging client failed unexpectedly.", t);
       // We remove these from the connected clients map to prevent a race between
       // the close method and this InboundObserver calling a terminal method on the
       // StreamObserver. If we removed it, then we are responsible for the terminal call.
@@ -107,7 +107,7 @@ public class GrpcLoggingService extends BeamFnLoggingGrpc.BeamFnLoggingImplBase
 
     @Override
     public void onCompleted() {
-      LOGGER.info("Logging client hanged up.");
+      LOG.info("Logging client hanged up.");
       // We remove these from the connected clients map to prevent a race between
       // the close method and this InboundObserver calling a terminal method on the
       // StreamObserver. If we removed it, then we are responsible for the terminal call.

--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -122,6 +122,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="message" value="You should not use org.spark_project classes in Beam."/>
     </module>
 
+    <!-- Forbid calling Loggers different than LOG. -->
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="LoggerNamingStyle"/>
+      <property name="format" value="(\sprivate static final Logger )(?!LOG )"/>
+      <property name="severity" value="error"/>
+      <property name="message" value="You should name sfl4j Loggers as LOG."/>
+    </module>
+
     <!-- Forbid TestNG imports that may leak because of dependencies. -->
     <module name="RegexpSinglelineJava">
       <property name="id" value="ForbidTestNG"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
@@ -218,7 +218,7 @@ public class Read {
    * allows us to split the sub-source over and over yet still receive "source" objects as inputs.
    */
   static class BoundedSourceAsSDFWrapperFn<T> extends DoFn<BoundedSource<T>, T> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(BoundedSourceAsSDFWrapperFn.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BoundedSourceAsSDFWrapperFn.class);
     private static final long DEFAULT_DESIRED_BUNDLE_SIZE_BYTES = 64 * (1 << 20);
 
     @GetInitialRestriction
@@ -338,7 +338,7 @@ public class Read {
           try {
             currentReader.close();
           } catch (IOException e) {
-            LOGGER.error("Failed to close BoundedReader due to failure processing bundle.", e);
+            LOG.error("Failed to close BoundedReader due to failure processing bundle.", e);
           }
         }
       }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryTable.java
@@ -68,7 +68,7 @@ class BigQueryTable extends SchemaBaseBeamTable implements Serializable {
   @VisibleForTesting final String bqLocation;
   private final ConversionOptions conversionOptions;
   private BeamTableStatistics rowCountStatistics = null;
-  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryTable.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BigQueryTable.class);
   @VisibleForTesting final Method method;
 
   BigQueryTable(Table table, BigQueryUtils.ConversionOptions options) {
@@ -98,7 +98,7 @@ class BigQueryTable extends SchemaBaseBeamTable implements Serializable {
       method = Method.DEFAULT;
     }
 
-    LOGGER.info("BigQuery method is set to: " + method.toString());
+    LOG.info("BigQuery method is set to: " + method.toString());
   }
 
   @Override
@@ -125,7 +125,7 @@ class BigQueryTable extends SchemaBaseBeamTable implements Serializable {
   public PCollection<Row> buildIOReader(
       PBegin begin, BeamSqlTableFilter filters, List<String> fieldNames) {
     if (!method.equals(Method.DIRECT_READ)) {
-      LOGGER.info("Predicate/project push-down only available for `DIRECT_READ` method, skipping.");
+      LOG.info("Predicate/project push-down only available for `DIRECT_READ` method, skipping.");
       return buildIOReader(begin);
     }
 
@@ -140,7 +140,7 @@ class BigQueryTable extends SchemaBaseBeamTable implements Serializable {
       if (!bigQueryFilter.getSupported().isEmpty()) {
         String rowRestriction = generateRowRestrictions(getSchema(), bigQueryFilter.getSupported());
         if (!rowRestriction.isEmpty()) {
-          LOGGER.info("Pushing down the following filter: " + rowRestriction);
+          LOG.info("Pushing down the following filter: " + rowRestriction);
           typedRead = typedRead.withRowRestriction(rowRestriction);
         }
       }
@@ -225,7 +225,7 @@ class BigQueryTable extends SchemaBaseBeamTable implements Serializable {
       return BeamTableStatistics.createBoundedTableStatistics(rowCount.doubleValue());
 
     } catch (IOException | InterruptedException e) {
-      LOGGER.warn("Could not get the row count for the table " + bqLocation, e);
+      LOG.warn("Could not get the row count for the table " + bqLocation, e);
     }
 
     return BeamTableStatistics.BOUNDED_UNKNOWN;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datastore/DataStoreV1Table.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datastore/DataStoreV1Table.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
 class DataStoreV1Table extends SchemaBaseBeamTable implements Serializable {
   public static final String KEY_FIELD_PROPERTY = "keyField";
   @VisibleForTesting static final String DEFAULT_KEY_FIELD = "__key__";
-  private static final Logger LOGGER = LoggerFactory.getLogger(DataStoreV1Table.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DataStoreV1Table.class);
   // Should match: `projectId/kind`.
   private static final Pattern locationPattern = Pattern.compile("(?<projectId>.+)/(?<kind>.+)");
   @VisibleForTesting final String keyField;
@@ -166,7 +166,7 @@ class DataStoreV1Table extends SchemaBaseBeamTable implements Serializable {
                   + "` should of type `VARBINARY`. Please change the type or specify a field to"
                   + " store the KEY value.");
         }
-        LOGGER.info("Entity KEY will be stored under `" + keyField + "` field.");
+        LOG.info("Entity KEY will be stored under `" + keyField + "` field.");
       }
     }
 
@@ -300,7 +300,7 @@ class DataStoreV1Table extends SchemaBaseBeamTable implements Serializable {
                   + "` should of type `VARBINARY`. Please change the type or specify a field to"
                   + " write the KEY value from via TableProperties.");
         }
-        LOGGER.info("Field to use as Entity KEY is set to: `" + keyField + "`.");
+        LOG.info("Field to use as Entity KEY is set to: `" + keyField + "`.");
       }
       return input.apply(ParDo.of(new RowToEntityConverter(isFieldPresent)));
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaTable.java
@@ -59,7 +59,7 @@ public abstract class BeamKafkaTable extends SchemaBaseBeamTable {
   private List<TopicPartition> topicPartitions;
   private Map<String, Object> configUpdates;
   private BeamTableStatistics rowCountStatistics = null;
-  private static final Logger LOGGER = LoggerFactory.getLogger(BeamKafkaTable.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BeamKafkaTable.class);
   // This is the number of records looked from each partition when the rate is estimated
   protected int numberOfRecordsForRate = 50;
 
@@ -163,7 +163,7 @@ public abstract class BeamKafkaTable extends SchemaBaseBeamTable {
             BeamTableStatistics.createUnboundedTableStatistics(
                 this.computeRate(numberOfRecordsForRate));
       } catch (Exception e) {
-        LOGGER.warn("Could not get the row count for the topics " + getTopics(), e);
+        LOG.warn("Could not get the row count for the topics " + getTopics(), e);
         rowCountStatistics = BeamTableStatistics.UNBOUNDED_UNKNOWN;
       }
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/mongodb/MongoDbTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/mongodb/MongoDbTable.java
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory;
 
 @Experimental
 public class MongoDbTable extends SchemaBaseBeamTable implements Serializable {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbTable.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MongoDbTable.class);
   // Should match: mongodb://username:password@localhost:27017/database/collection
   @VisibleForTesting
   final Pattern locationPattern =
@@ -134,7 +134,7 @@ public class MongoDbTable extends SchemaBaseBeamTable implements Serializable {
       MongoDbFilter mongoFilter = (MongoDbFilter) filters;
       if (!mongoFilter.getSupported().isEmpty()) {
         Bson filter = constructPredicate(mongoFilter.getSupported());
-        LOGGER.info("Pushing down the following filter: " + filter.toString());
+        LOG.info("Pushing down the following filter: " + filter.toString());
         findQuery = findQuery.withFilters(filter);
       }
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTable.java
@@ -52,7 +52,7 @@ public class TextTable extends SchemaBaseBeamTable {
       new TextRowCountEstimator.LimitNumberOfTotalBytes(1024 * 1024L);
   private final String filePattern;
   private BeamTableStatistics rowCountStatistics = null;
-  private static final Logger LOGGER = LoggerFactory.getLogger(TextTable.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TextTable.class);
 
   /** Text table with the specified read and write transforms. */
   public TextTable(
@@ -90,7 +90,7 @@ public class TextTable extends SchemaBaseBeamTable {
       Double rows = textRowCountEstimator.estimateRowCount(options);
       return BeamTableStatistics.createBoundedTableStatistics(rows);
     } catch (IOException | TextRowCountEstimator.NoEstimationException e) {
-      LOGGER.warn("Could not get the row count for the text table " + filePattern, e);
+      LOG.warn("Could not get the row count for the text table " + filePattern, e);
     }
     return BeamTableStatistics.BOUNDED_UNKNOWN;
   }

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLPlannerImpl.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLPlannerImpl.java
@@ -54,7 +54,7 @@ import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.util.Util;
 
 /** ZetaSQLPlannerImpl. */
 public class ZetaSQLPlannerImpl implements Planner {
-  private static final Logger logger = Logger.getLogger(ZetaSQLPlannerImpl.class.getName());
+  private static final Logger LOG = Logger.getLogger(ZetaSQLPlannerImpl.class.getName());
 
   private final SchemaPlus defaultSchemaPlus;
 

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/stream/DirectStreamObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/stream/DirectStreamObserver.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 @ThreadSafe
 public final class DirectStreamObserver<T> implements StreamObserver<T> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DirectStreamObserver.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DirectStreamObserver.class);
   private static final int DEFAULT_MAX_MESSAGES_BEFORE_CHECK = 100;
 
   private final Phaser phaser;
@@ -80,14 +80,14 @@ public final class DirectStreamObserver<T> implements StreamObserver<T> {
         // If the phase didn't change, this means that the installed onReady callback had not
         // been invoked.
         if (phase == phaser.getPhase()) {
-          LOGGER.info(
+          LOG.info(
               "Output channel stalled for {}s, outbound thread {}. See: "
                   + "https://issues.apache.org/jira/browse/BEAM-4280 for the history for "
                   + "this issue.",
               totalTimeWaited,
               Thread.currentThread().getName());
         } else {
-          LOGGER.debug(
+          LOG.debug(
               "Output channel stalled for {}s, outbound thread {}.",
               totalTimeWaited,
               Thread.currentThread().getName());

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/FinalizeBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/FinalizeBundleHandler.java
@@ -62,7 +62,7 @@ public class FinalizeBundleHandler {
     public abstract BundleFinalizer.Callback getCallback();
   }
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FinalizeBundleHandler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FinalizeBundleHandler.class);
   private final ConcurrentMap<String, Collection<CallbackRegistration>> bundleFinalizationCallbacks;
   private final PriorityQueue<TimestampedValue<String>> cleanUpQueue;
   private final Future<Void> cleanUpResult;

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -98,7 +98,7 @@ public class CassandraIOTest implements Serializable {
   private static final String CASSANDRA_KEYSPACE = "beam_ks";
   private static final String CASSANDRA_HOST = "127.0.0.1";
   private static final String CASSANDRA_TABLE = "scientist";
-  private static final Logger LOGGER = LoggerFactory.getLogger(CassandraIOTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraIOTest.class);
   private static final String STORAGE_SERVICE_MBEAN = "org.apache.cassandra.db:type=StorageService";
   private static final float ACCEPTABLE_EMPTY_SPLITS_PERCENTAGE = 0.5f;
   private static final int FLUSH_TIMEOUT = 30000;
@@ -174,7 +174,7 @@ public class CassandraIOTest implements Serializable {
   }
 
   private static void insertData() throws Exception {
-    LOGGER.info("Create Cassandra tables");
+    LOG.info("Create Cassandra tables");
     session.execute(
         String.format(
             "CREATE TABLE IF NOT EXISTS %s.%s(person_id int, person_name text, PRIMARY KEY"
@@ -186,7 +186,7 @@ public class CassandraIOTest implements Serializable {
                 + "(person_id));",
             CASSANDRA_KEYSPACE, CASSANDRA_TABLE_WRITE));
 
-    LOGGER.info("Insert records");
+    LOG.info("Insert records");
     String[] scientists = {
       "Einstein",
       "Darwin",

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 @Experimental(Kind.SOURCE_SINK)
 abstract class BigQueryStorageSourceBase<T> extends BoundedSource<T> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryStorageSourceBase.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BigQueryStorageSourceBase.class);
 
   /**
    * The maximum number of streams which will be requested when creating a read session, regardless
@@ -138,7 +138,7 @@ abstract class BigQueryStorageSourceBase<T> extends BoundedSource<T> {
     try (StorageClient client = bqServices.getStorageClient(bqOptions)) {
       CreateReadSessionRequest request = requestBuilder.build();
       readSession = client.createReadSession(request);
-      LOGGER.info(
+      LOG.info(
           "Sent BigQuery Storage API CreateReadSession request '{}'; received response '{}'.",
           request,
           readSession);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
 @Experimental(Kind.SOURCE_SINK)
 public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryStorageStreamSource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BigQueryStorageStreamSource.class);
 
   public static <T> BigQueryStorageStreamSource<T> create(
       ReadSession readSession,
@@ -201,7 +201,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
 
       responseStream = storageClient.readRows(request);
       responseIterator = responseStream.iterator();
-      LOGGER.info("Started BigQuery Storage API read from stream {}.", source.stream.getName());
+      LOG.info("Started BigQuery Storage API read from stream {}.", source.stream.getName());
       return readNextRecord();
     }
 
@@ -283,7 +283,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     @Override
     public BoundedSource<T> splitAtFraction(double fraction) {
       Metrics.counter(BigQueryStorageStreamReader.class, "split-at-fraction-calls").inc();
-      LOGGER.debug(
+      LOG.debug(
           "Received BigQuery Storage API split request for stream {} at fraction {}.",
           source.stream.getName(),
           fraction);
@@ -301,7 +301,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
                 BigQueryStorageStreamReader.class,
                 "split-at-fraction-calls-failed-due-to-impossible-split-point")
             .inc();
-        LOGGER.info(
+        LOG.info(
             "BigQuery Storage API stream {} cannot be split at {}.",
             source.stream.getName(),
             fraction);
@@ -332,7 +332,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
                   BigQueryStorageStreamReader.class,
                   "split-at-fraction-calls-failed-due-to-bad-split-point")
               .inc();
-          LOGGER.info(
+          LOG.info(
               "BigQuery Storage API split of stream {} abandoned because the primary stream is to "
                   + "the left of the split fraction {}.",
               source.stream.getName(),
@@ -343,7 +343,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
                   BigQueryStorageStreamReader.class,
                   "split-at-fraction-calls-failed-due-to-other-reasons")
               .inc();
-          LOGGER.error("BigQuery Storage API stream split failed.", e);
+          LOG.error("BigQuery Storage API stream split failed.", e);
           return null;
         }
 
@@ -367,7 +367,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
 
       Metrics.counter(BigQueryStorageStreamReader.class, "split-at-fraction-calls-successful")
           .inc();
-      LOGGER.info(
+      LOG.info(
           "Successfully split BigQuery Storage API stream at {}. Split response: {}",
           fraction,
           splitResponse);

--- a/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/HDFSSynchronization.java
+++ b/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/HDFSSynchronization.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HDFSSynchronization implements ExternalSynchronization {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(HDFSSynchronization.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HDFSSynchronization.class);
 
   private static final String LOCKS_DIR_PATTERN = "%s/";
   private static final String LOCKS_DIR_TASK_PATTERN = LOCKS_DIR_PATTERN + "%s";
@@ -94,15 +94,15 @@ public class HDFSSynchronization implements ExternalSynchronization {
 
     try (FileSystem fileSystem = fileSystemFactory.apply(conf)) {
       if (fileSystem.delete(path, true)) {
-        LOGGER.info("Delete of lock directory {} was successful", path);
+        LOG.info("Delete of lock directory {} was successful", path);
       } else {
-        LOGGER.warn("Delete of lock directory {} was unsuccessful", path);
+        LOG.warn("Delete of lock directory {} was unsuccessful", path);
       }
 
     } catch (IOException e) {
       String formattedExceptionMessage =
           String.format("Delete of lock directory %s was unsuccessful", path);
-      LOGGER.warn(formattedExceptionMessage, e);
+      LOG.warn(formattedExceptionMessage, e);
       throw new IllegalStateException(formattedExceptionMessage, e);
     }
   }

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/StartingPointShardsFinder.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/StartingPointShardsFinder.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 class StartingPointShardsFinder implements Serializable {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(StartingPointShardsFinder.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StartingPointShardsFinder.class);
 
   /**
    * Finds all the shards at the given startingPoint. This method starts by gathering the oldest
@@ -116,7 +116,7 @@ class StartingPointShardsFinder implements Serializable {
       startingPointShards.addAll(validShards);
       expiredShards = Sets.difference(initialShards, validShards);
       if (!expiredShards.isEmpty()) {
-        LOGGER.info(
+        LOG.info(
             "Following shards expired for {} stream at '{}' starting point: {}",
             streamName,
             startingPoint,
@@ -158,7 +158,7 @@ class StartingPointShardsFinder implements Serializable {
     for (Shard shard : allShards) {
       shardIds.add(shard.getShardId());
     }
-    LOGGER.info("Stream {} has following shards: {}", streamName, shardIds);
+    LOG.info("Stream {} has following shards: {}", streamName, shardIds);
     Set<Shard> shardsWithoutParents = new HashSet<>();
     for (Shard shard : allShards) {
       if (!shardIds.contains(shard.getParentShardId())) {


### PR DESCRIPTION
By convention Beam Java code uses `Logger LOG` but we have not been enforcing this so we have now new occurrences of `Logger logger` or `Logger LOGGER` around. This PR fixes this and adds a checkstyle rule to prevent this from happening in the future.

R: @pabloem 
