### PR TITLE
[BEAM-9342] Exclude module-info.class from vendored Byte Buddy 1.10.8

### DIFF
--- a/vendor/bytebuddy-1_10_8/build.gradle
+++ b/vendor/bytebuddy-1_10_8/build.gradle
@@ -28,6 +28,9 @@ vendorJava(
   relocations: [
     "net.bytebuddy": "org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy"
   ],
+  exclusions: [
+    "META-INF/versions/9/module-info.class"
+  ],
   groupId: group,
   artifactId: "beam-vendor-bytebuddy-1_10_8",
   version: version


### PR DESCRIPTION
R: @lukecwik 