### PR TITLE
[BEAM-9393] Support schemas in state API

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -404,13 +404,22 @@ public class ParDo {
   }
 
   private static void finishSpecifyingStateSpecs(
-      DoFn<?, ?> fn, CoderRegistry coderRegistry, Coder<?> inputCoder) {
+      DoFn<?, ?> fn,
+      CoderRegistry coderRegistry,
+      SchemaRegistry schemaRegistry,
+      Coder<?> inputCoder) {
     DoFnSignature signature = DoFnSignatures.getSignature(fn.getClass());
     Map<String, DoFnSignature.StateDeclaration> stateDeclarations = signature.stateDeclarations();
     for (DoFnSignature.StateDeclaration stateDeclaration : stateDeclarations.values()) {
       try {
         StateSpec<?> stateSpec = (StateSpec<?>) stateDeclaration.field().get(fn);
-        stateSpec.offerCoders(codersForStateSpecTypes(stateDeclaration, coderRegistry, inputCoder));
+        Coder[] coders;
+        try {
+          coders = schemasForStateSpecTypes(stateDeclaration, schemaRegistry);
+        } catch (NoSuchSchemaException e) {
+          coders = codersForStateSpecTypes(stateDeclaration, coderRegistry, inputCoder);
+        }
+        stateSpec.offerCoders(coders);
         stateSpec.finishSpecifying();
       } catch (IllegalAccessException e) {
         throw new RuntimeException(e);
@@ -492,6 +501,32 @@ public class ParDo {
       }
     }
     return fieldAccessDescriptor.resolve(inputSchema);
+  }
+
+  private static SchemaCoder[] schemasForStateSpecTypes(
+      DoFnSignature.StateDeclaration stateDeclaration, SchemaRegistry schemaRegistry)
+      throws NoSuchSchemaException {
+    Type stateType = stateDeclaration.stateType().getType();
+
+    if (!(stateType instanceof ParameterizedType)) {
+      // No type arguments means no coders to infer.
+      return new SchemaCoder[0];
+    }
+
+    Type[] typeArguments = ((ParameterizedType) stateType).getActualTypeArguments();
+    SchemaCoder[] coders = new SchemaCoder[typeArguments.length];
+
+    for (int i = 0; i < typeArguments.length; i++) {
+      Type typeArgument = typeArguments[i];
+      TypeDescriptor typeDescriptor = TypeDescriptor.of(typeArgument);
+      coders[i] =
+          SchemaCoder.of(
+              schemaRegistry.getSchema(typeDescriptor),
+              typeDescriptor,
+              schemaRegistry.getToRowFunction(typeDescriptor),
+              schemaRegistry.getFromRowFunction(typeDescriptor));
+    }
+    return coders;
   }
 
   /**
@@ -741,8 +776,8 @@ public class ParDo {
     @Override
     public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
       SchemaRegistry schemaRegistry = input.getPipeline().getSchemaRegistry();
-      CoderRegistry registry = input.getPipeline().getCoderRegistry();
-      finishSpecifyingStateSpecs(fn, registry, input.getCoder());
+      CoderRegistry coderRegistry = input.getPipeline().getCoderRegistry();
+      finishSpecifyingStateSpecs(fn, coderRegistry, schemaRegistry, input.getCoder());
       TupleTag<OutputT> mainOutput = new TupleTag<>(MAIN_OUTPUT_TAG);
       PCollection<OutputT> res =
           input.apply(withOutputTags(mainOutput, TupleTagList.empty())).get(mainOutput);
@@ -757,7 +792,7 @@ public class ParDo {
       } catch (NoSuchSchemaException e) {
         try {
           res.setCoder(
-              registry.getCoder(
+              coderRegistry.getCoder(
                   outputTypeDescriptor,
                   getFn().getInputTypeDescriptor(),
                   ((PCollection<InputT>) input).getCoder()));
@@ -895,8 +930,9 @@ public class ParDo {
       validateWindowType(input, fn);
 
       // Use coder registry to determine coders for all StateSpec defined in the fn signature.
-      CoderRegistry registry = input.getPipeline().getCoderRegistry();
-      finishSpecifyingStateSpecs(fn, registry, input.getCoder());
+      CoderRegistry coderRegistry = input.getPipeline().getCoderRegistry();
+      SchemaRegistry schemaRegistry = input.getPipeline().getSchemaRegistry();
+      finishSpecifyingStateSpecs(fn, coderRegistry, schemaRegistry, input.getCoder());
 
       DoFnSignature signature = DoFnSignatures.getSignature(fn.getClass());
       if (signature.usesState() || signature.usesTimers()) {
@@ -923,7 +959,7 @@ public class ParDo {
         try {
           out.setCoder(
               (Coder)
-                  registry.getCoder(
+                  coderRegistry.getCoder(
                       out.getTypeDescriptor(), getFn().getInputTypeDescriptor(), inputCoder));
         } catch (CannotProvideCoderException e) {
           // Ignore and let coder inference happen later.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
@@ -23,23 +23,42 @@ import static org.junit.Assert.assertTrue;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
+import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.state.BagState;
+import org.apache.beam.sdk.state.CombiningState;
+import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.SetState;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.testing.DataflowPortabilityApiUnsupported;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.UsesMapState;
 import org.apache.beam.sdk.testing.UsesSchema;
+import org.apache.beam.sdk.testing.UsesStatefulParDo;
 import org.apache.beam.sdk.testing.ValidatesRunner;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.junit.Rule;
 import org.junit.Test;
@@ -630,6 +649,260 @@ public class ParDoSchemaTest implements Serializable {
                       }
                     }));
     PAssert.that(output).containsInAnyOrder("a:1:[1, 2]", "b:2:[2, 3]", "c:3:[3, 4]");
+    pipeline.run();
+  }
+
+  @Test
+  @Category({NeedsRunner.class, UsesStatefulParDo.class, DataflowPortabilityApiUnsupported.class})
+  public void testRowBagState() {
+    final String stateId = "foo";
+
+    Schema type =
+        Stream.of(Schema.Field.of("f_string", FieldType.STRING)).collect(Schema.toSchema());
+    Schema outputType = Schema.of(Field.of("values", FieldType.array(FieldType.row(type))));
+
+    DoFn<KV<String, Row>, Row> fn =
+        new DoFn<KV<String, Row>, Row>() {
+
+          @StateId(stateId)
+          private final StateSpec<BagState<Row>> bufferState = StateSpecs.rowBag(type);
+
+          @ProcessElement
+          public void processElement(
+              @Element KV<String, Row> element,
+              @StateId(stateId) BagState<Row> state,
+              OutputReceiver<Row> o) {
+            state.add(element.getValue());
+            Iterable<Row> currentValue = state.read();
+            if (Iterables.size(currentValue) >= 4) {
+              List<Row> sorted = Lists.newArrayList(currentValue);
+              Collections.sort(sorted, Comparator.comparing(r -> r.getString(0)));
+              o.output(Row.withSchema(outputType).addArray(sorted).build());
+            }
+          }
+        };
+
+    PCollection<Row> output =
+        pipeline
+            .apply(
+                Create.of(
+                    KV.of("hello", Row.withSchema(type).addValue("a").build()),
+                    KV.of("hello", Row.withSchema(type).addValue("b").build()),
+                    KV.of("hello", Row.withSchema(type).addValue("c").build()),
+                    KV.of("hello", Row.withSchema(type).addValue("d").build())))
+            .apply(ParDo.of(fn))
+            .setRowSchema(outputType);
+    PAssert.that(output)
+        .containsInAnyOrder(
+            Row.withSchema(outputType)
+                .addArray(
+                    Lists.newArrayList(
+                        Row.withSchema(type).addValue("a").build(),
+                        Row.withSchema(type).addValue("b").build(),
+                        Row.withSchema(type).addValue("c").build(),
+                        Row.withSchema(type).addValue("d").build()))
+                .build());
+
+    pipeline.run();
+  }
+
+  @DefaultSchema(AutoValueSchema.class)
+  @AutoValue
+  abstract static class TestStateSchemaValue {
+    abstract String getName();
+  }
+
+  @DefaultSchema(AutoValueSchema.class)
+  @AutoValue
+  abstract static class TestStateSchemaValues {
+    abstract List<TestStateSchemaValue> getValues();
+  }
+
+  @Test
+  @Category({NeedsRunner.class, UsesStatefulParDo.class, DataflowPortabilityApiUnsupported.class})
+  public void tesBagStateSchemaInference() throws NoSuchSchemaException {
+    final String stateId = "foo";
+
+    DoFn<KV<String, TestStateSchemaValue>, TestStateSchemaValues> fn =
+        new DoFn<KV<String, TestStateSchemaValue>, TestStateSchemaValues>() {
+
+          // This should infer the schema.
+          @StateId(stateId)
+          private final StateSpec<BagState<TestStateSchemaValue>> bufferState = StateSpecs.bag();
+
+          @ProcessElement
+          public void processElement(
+              @Element KV<String, TestStateSchemaValue> element,
+              @StateId(stateId) BagState<TestStateSchemaValue> state,
+              OutputReceiver<TestStateSchemaValues> o) {
+            state.add(element.getValue());
+            Iterable<TestStateSchemaValue> currentValue = state.read();
+            if (Iterables.size(currentValue) >= 4) {
+              List<TestStateSchemaValue> sorted = Lists.newArrayList(currentValue);
+              Collections.sort(sorted, Comparator.comparing(TestStateSchemaValue::getName));
+              o.output(new AutoValue_ParDoSchemaTest_TestStateSchemaValues(sorted));
+            }
+          }
+        };
+
+    PCollection<TestStateSchemaValue> input =
+        pipeline.apply(
+            Create.of(
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("a"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("b"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("c"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("d")));
+
+    PCollection<TestStateSchemaValues> output =
+        input.apply(WithKeys.of("hello")).apply(ParDo.of(fn));
+
+    PAssert.that(output)
+        .containsInAnyOrder(
+            new AutoValue_ParDoSchemaTest_TestStateSchemaValues(
+                Lists.newArrayList(
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("a"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("b"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("c"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("d"))));
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category({NeedsRunner.class, UsesStatefulParDo.class, DataflowPortabilityApiUnsupported.class})
+  public void testSetStateSchemaInference() throws NoSuchSchemaException {
+    final String stateId = "foo";
+
+    DoFn<KV<String, TestStateSchemaValue>, TestStateSchemaValues> fn =
+        new DoFn<KV<String, TestStateSchemaValue>, TestStateSchemaValues>() {
+
+          // This should infer the schema.
+          @StateId(stateId)
+          private final StateSpec<SetState<TestStateSchemaValue>> bufferState = StateSpecs.set();
+
+          @ProcessElement
+          public void processElement(
+              @Element KV<String, TestStateSchemaValue> element,
+              @StateId(stateId) SetState<TestStateSchemaValue> state,
+              OutputReceiver<TestStateSchemaValues> o) {
+            state.add(element.getValue());
+            Iterable<TestStateSchemaValue> currentValue = state.read();
+            if (Iterables.size(currentValue) >= 4) {
+              List<TestStateSchemaValue> sorted = Lists.newArrayList(currentValue);
+              Collections.sort(sorted, Comparator.comparing(TestStateSchemaValue::getName));
+              o.output(new AutoValue_ParDoSchemaTest_TestStateSchemaValues(sorted));
+            }
+          }
+        };
+
+    PCollection<TestStateSchemaValue> input =
+        pipeline.apply(
+            Create.of(
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("a"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("b"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("c"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("d")));
+
+    PCollection<TestStateSchemaValues> output =
+        input.apply(WithKeys.of("hello")).apply(ParDo.of(fn));
+
+    PAssert.that(output)
+        .containsInAnyOrder(
+            new AutoValue_ParDoSchemaTest_TestStateSchemaValues(
+                Lists.newArrayList(
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("a"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("b"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("c"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("d"))));
+
+    pipeline.run();
+  }
+
+  @DefaultSchema(AutoValueSchema.class)
+  @AutoValue
+  abstract static class TestStateSchemaValue2 {
+    abstract Integer getInteger();
+  }
+
+  @DefaultSchema(AutoValueSchema.class)
+  @AutoValue
+  abstract static class TestStateSchemaMapEntry {
+    abstract TestStateSchemaValue getKey();
+
+    abstract TestStateSchemaValue2 getValue();
+  }
+
+  @Test
+  @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesMapState.class})
+  public void testMapStateSchemaInference() throws NoSuchSchemaException {
+    final String stateId = "foo";
+    final String countStateId = "count";
+
+    DoFn<KV<String, TestStateSchemaMapEntry>, TestStateSchemaMapEntry> fn =
+        new DoFn<KV<String, TestStateSchemaMapEntry>, TestStateSchemaMapEntry>() {
+
+          @StateId(stateId)
+          private final StateSpec<MapState<TestStateSchemaValue, TestStateSchemaValue2>> mapState =
+              StateSpecs.map();
+
+          @StateId(countStateId)
+          private final StateSpec<CombiningState<Integer, int[], Integer>> countState =
+              StateSpecs.combiningFromInputInternal(VarIntCoder.of(), Sum.ofIntegers());
+
+          @ProcessElement
+          public void processElement(
+              @Element KV<String, TestStateSchemaMapEntry> element,
+              @StateId(stateId) MapState<TestStateSchemaValue, TestStateSchemaValue2> state,
+              @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
+              OutputReceiver<TestStateSchemaMapEntry> o) {
+            TestStateSchemaMapEntry value = element.getValue();
+            state.put(value.getKey(), value.getValue());
+            count.add(1);
+            if (count.read() >= 4) {
+              Iterable<Map.Entry<TestStateSchemaValue, TestStateSchemaValue2>> iterate =
+                  state.entries().read();
+              for (Map.Entry<TestStateSchemaValue, TestStateSchemaValue2> entry : iterate) {
+                o.output(
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                        entry.getKey(), entry.getValue()));
+              }
+            }
+          }
+        };
+
+    PCollection<TestStateSchemaMapEntry> input =
+        pipeline.apply(
+            Create.of(
+                new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("a"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue2(1)),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("b"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue2(2)),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("c"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue2(3)),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue("d"),
+                    new AutoValue_ParDoSchemaTest_TestStateSchemaValue2(4))));
+
+    PCollection<TestStateSchemaMapEntry> output =
+        input.apply(WithKeys.of("hello")).apply(ParDo.of(fn));
+
+    PAssert.that(output)
+        .containsInAnyOrder(
+            new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("a"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue2(1)),
+            new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("b"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue2(2)),
+            new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("c"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue2(3)),
+            new AutoValue_ParDoSchemaTest_TestStateSchemaMapEntry(
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue("d"),
+                new AutoValue_ParDoSchemaTest_TestStateSchemaValue2(4)));
     pipeline.run();
   }
 }


### PR DESCRIPTION
Add schema inference for types used in the state API.

Add state overrides for Row types.

Disable Coder inference for Row types, as we should only use Row with schemas.

R: @dpmills 