### PR TITLE
[BEAM-9382] Clean up of TestStreamTranscriptTests.

### DIFF
--- a/sdks/python/apache_beam/testing/data/trigger_transcripts.yaml
+++ b/sdks/python/apache_beam/testing/data/trigger_transcripts.yaml
@@ -53,7 +53,7 @@ transcript:
   - input: [1, 2, 10, 11, 80, 81]
   - watermark: 100
   - expect:
-      - {window: [0, 9], values: [1, 2], timestamp: 9, final: false}
+      - {window: [0, 9], values: [1, 2], timestamp: 9}
       - {window: [10, 19], values: [10, 11], timestamp: 19}
       - {window: [80, 89], values: [80, 81], timestamp: 89, late: false}
   - input: [7, 8] # no output
@@ -71,7 +71,7 @@ transcript:
   - input: [1, 2, 3, 10, 11, 25]
   - watermark: 100
   - expect:
-      - {window: [0, 9], values: [1, 2, 3], timestamp: 1, final: false}
+      - {window: [0, 9], values: [1, 2, 3], timestamp: 1}
       - {window: [10, 19], values: [10, 11], timestamp: 10}
       - {window: [20, 29], values: [25], timestamp: 25, late: false}
 
@@ -84,7 +84,7 @@ transcript:
   - input: [1, 2, 3, 10, 11, 25]
   - watermark: 100
   - expect:
-      - {window: [0, 9], values: [1, 2, 3], timestamp: 3, final: false}
+      - {window: [0, 9], values: [1, 2, 3], timestamp: 3}
       - {window: [10, 19], values: [10, 11], timestamp: 11}
       - {window: [20, 29], values: [25], timestamp: 25, late: false}
 
@@ -98,7 +98,7 @@ transcript:
   - input: [1, 2, 3, 10, 11, 25]
   - watermark: 100
   - expect:
-      - {window: [0, 9], values: [1, 2, 3], timestamp: 9, final: false}
+      - {window: [0, 9], values: [1, 2, 3], timestamp: 9}
       - {window: [10, 19], values: [10, 11], timestamp: 19}
       - {window: [20, 29], values: [25], timestamp: 29, late: false}
 
@@ -112,7 +112,7 @@ transcript:
   - input: [1, 2, 3, 10, 11, 25]
   - watermark: 100
   - expect:
-      - {window: [0, 9], values: [1, 2, 3], timestamp: 1, final: false}
+      - {window: [0, 9], values: [1, 2, 3], timestamp: 1}
       - {window: [10, 19], values: [10, 11], timestamp: 10}
       - {window: [20, 29], values: [25], timestamp: 25, late: false}
 
@@ -128,7 +128,7 @@ transcript:
   - input: [1, 2, 3, 10, 11, 25]
   - watermark: 100
   - expect:
-      - {window: [0, 9], values: [1, 2, 3], timestamp: 101, final: false}
+      - {window: [0, 9], values: [1, 2, 3], timestamp: 101}
       - {window: [10, 19], values: [10, 11], timestamp: 110}
       - {window: [20, 29], values: [25], timestamp: 125, late: false}
 
@@ -142,23 +142,23 @@ trigger_fn: AfterWatermark(early=AfterCount(2), late=AfterCount(3))
 allowed_lateness: 100
 timestamp_combiner: OUTPUT_AT_EOW
 transcript:
-    - input: [1, 2, 3]
+    - input: [1, 2]
     - expect:
-        - {window: [1, 12], values: [1, 2, 3], timestamp: 12, early: true, index: 0}
-    - input: [4]    # no output
+        - {window: [1, 11], values: [1, 2], timestamp: 11, early: true, index: 0}
+    - input: [3]    # no output
+    - input: [4]
+    - expect:
+        - {window: [1, 13], values: [1, 2, 3, 4], timestamp: 13, early: true, index: 0}
     - input: [5]
-    - expect:
-        - {window: [1, 14], values: [1, 2, 3, 4, 5], timestamp: 14, early: true, index: 1}
-    - input: [6]
     - watermark: 100
     - expect:
-        - {window: [1, 15], values:[1, 2, 3, 4, 5, 6], timestamp: 15,
-           index: 2, nonspeculative_index: 0}
+        - {window: [1, 14], values:[1, 2, 3, 4, 5], timestamp: 14,
+           index: 0, nonspeculative_index: 0}
     - input: [1]
     - input: [3, 4]
     - expect:
-        - {window: [1, 15], values: [1, 1, 2, 3, 3, 4, 4, 5, 6], timestamp: 15,
-           final: false, index: 3, nonspeculative_index: 1}
+        - {window: [1, 14], values: [1, 1, 2, 3, 3, 4, 4, 5], timestamp: 14,
+           final: false, index: 1, nonspeculative_index: 1}
 
 ---
 name: discarding_early_fixed

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -1169,6 +1169,10 @@ class GeneralTriggerDriver(TriggerDriver):
             for window in to_be_merged:
               if window != merge_result:
                 merged_away[window] = merge_result
+                # Clear state associated with PaneInfo since it is
+                # not preserved across merges.
+                state.clear_state(window, self.INDEX)
+                state.clear_state(window, self.NONSPECULATIVE_INDEX)
             state.merge(to_be_merged, merge_result)
             # using the outer self argument.
             self.trigger_fn.on_merge(


### PR DESCRIPTION
Removes check for final field in PaneInfo since it is not reported properly by direct runner. Updates index for session panes and changes test with Count(2) early trigger to only inject two elements since behavior with 3 is non-deterministic.

Added changes to trigger driver to delete pane info index and nonspeculative index when merging since otherwise the newly created window would inherit it from the merged away window resulting in incorrect values.

R: @robertwb 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
