### PR TITLE
[BEAM-8335] TeststreamService integration with DirectRunner

### DIFF
--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -376,24 +376,24 @@ class BundleBasedDirectRunner(PipelineRunner):
     from apache_beam.runners.direct.executor import Executor
     from apache_beam.runners.direct.transform_evaluator import \
       TransformEvaluatorRegistry
-    from apache_beam.runners.direct.test_stream_impl import _TestStream
-
-    # Performing configured PTransform overrides.
-    pipeline.replace_all(_get_transform_overrides(options))
+    from apache_beam.testing.test_stream import TestStream
 
     # If the TestStream I/O is used, use a mock test clock.
-    class _TestStreamUsageVisitor(PipelineVisitor):
+    class TestStreamUsageVisitor(PipelineVisitor):
       """Visitor determining whether a Pipeline uses a TestStream."""
       def __init__(self):
         self.uses_test_stream = False
 
       def visit_transform(self, applied_ptransform):
-        if isinstance(applied_ptransform.transform, _TestStream):
+        if isinstance(applied_ptransform.transform, TestStream):
           self.uses_test_stream = True
 
-    visitor = _TestStreamUsageVisitor()
+    visitor = TestStreamUsageVisitor()
     pipeline.visit(visitor)
     clock = TestClock() if visitor.uses_test_stream else RealClock()
+
+    # Performing configured PTransform overrides.
+    pipeline.replace_all(_get_transform_overrides(options))
 
     _LOGGER.info('Running pipeline with DirectRunner.')
     self.consumer_tracking_visitor = ConsumerTrackingPipelineVisitor()

--- a/sdks/python/apache_beam/runners/direct/test_stream_impl.py
+++ b/sdks/python/apache_beam/runners/direct/test_stream_impl.py
@@ -27,14 +27,25 @@ tagged PCollection.
 
 from __future__ import absolute_import
 
+import itertools
+
+import grpc
+
 from apache_beam import ParDo
 from apache_beam import coders
 from apache_beam import pvalue
+from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.portability.api import beam_runner_api_pb2_grpc
+from apache_beam.testing.test_stream import ElementEvent
+from apache_beam.testing.test_stream import ProcessingTimeEvent
 from apache_beam.testing.test_stream import WatermarkEvent
 from apache_beam.transforms import PTransform
 from apache_beam.transforms import core
 from apache_beam.transforms import window
+from apache_beam.transforms.window import TimestampedValue
 from apache_beam.utils import timestamp
+from apache_beam.utils.timestamp import Duration
+from apache_beam.utils.timestamp import Timestamp
 
 
 class _WatermarkController(PTransform):
@@ -79,7 +90,8 @@ class _ExpandableTestStream(PTransform):
           | _TestStream(
               self.test_stream.output_tags,
               events=self.test_stream._events,
-              coder=self.test_stream.coder)
+              coder=self.test_stream.coder,
+              endpoint=self.test_stream._endpoint)
           | _WatermarkController(list(self.test_stream.output_tags)[0]))
 
     # Multiplex to the correct PCollection based upon the event tag.
@@ -131,12 +143,17 @@ class _TestStream(PTransform):
   WATERMARK_CONTROL_TAG = '_TestStream_Watermark'
 
   def __init__(
-      self, output_tags, coder=coders.FastPrimitivesCoder(), events=None):
+      self,
+      output_tags,
+      coder=coders.FastPrimitivesCoder(),
+      events=None,
+      endpoint=None):
     assert coder is not None
     self.coder = coder
     self._raw_events = events
     self._events = self._add_watermark_advancements(output_tags, events)
     self.output_tags = output_tags
+    self.endpoint = endpoint
 
   def _watermark_starts(self, output_tags):
     """Sentinel values to hold the watermark of outputs to -inf.
@@ -226,17 +243,50 @@ class _TestStream(PTransform):
   def _infer_output_coder(self, input_type=None, input_coder=None):
     return self.coder
 
-  def _events_from_script(self, index):
-    yield self._events[index]
+  @staticmethod
+  def events_from_script(events):
+    """Yields the in-memory events.
+    """
+    return itertools.chain(events)
 
-  def events(self, index):
-    return self._events_from_script(index)
+  @staticmethod
+  def events_from_rpc(endpoint, output_tags, coder):
+    """Yields the events received from the given endpoint.
+    """
+    stub_channel = grpc.insecure_channel(endpoint)
+    stub = beam_runner_api_pb2_grpc.TestStreamServiceStub(stub_channel)
 
-  def begin(self):
-    return 0
+    # Request the PCollections that we are looking for from the service.
+    event_request = beam_runner_api_pb2.EventsRequest(
+        output_ids=[str(tag) for tag in output_tags])
 
-  def end(self, index):
-    return index >= len(self._events)
+    event_stream = stub.Events(event_request)
+    for e in event_stream:
+      yield _TestStream.test_stream_payload_to_events(e, coder)
 
-  def next(self, index):
-    return index + 1
+  @staticmethod
+  def test_stream_payload_to_events(payload, coder):
+    """Returns a TestStream Python event object from a TestStream event Proto.
+    """
+    if payload.HasField('element_event'):
+      element_event = payload.element_event
+      elements = [
+          TimestampedValue(
+              coder.decode(e.encoded_element), Timestamp(micros=e.timestamp))
+          for e in element_event.elements
+      ]
+      return ElementEvent(timestamped_values=elements, tag=element_event.tag)
+
+    if payload.HasField('watermark_event'):
+      watermark_event = payload.watermark_event
+      return WatermarkEvent(
+          Timestamp(micros=watermark_event.new_watermark),
+          tag=watermark_event.tag)
+
+    if payload.HasField('processing_time_event'):
+      processing_time_event = payload.processing_time_event
+      return ProcessingTimeEvent(
+          Duration(micros=processing_time_event.advance_duration))
+
+    raise RuntimeError(
+        'Received a proto without the specified fields: {}'.format(payload))

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
@@ -267,14 +267,14 @@ class BackgroundCachingJobTest(unittest.TestCase):
 
   def test_determine_a_test_stream_service_running(self):
     pipeline = _build_an_empty_stream_pipeline()
-    test_stream_service = TestStreamServiceController(events=iter([]))
+    test_stream_service = TestStreamServiceController(reader=None)
     ie.current_env().set_test_stream_service_controller(
         pipeline, test_stream_service)
     self.assertTrue(bcj.is_a_test_stream_service_running(pipeline))
 
   def test_stop_a_running_test_stream_service(self):
     pipeline = _build_an_empty_stream_pipeline()
-    test_stream_service = TestStreamServiceController(events=iter([]))
+    test_stream_service = TestStreamServiceController(reader=None)
     test_stream_service.start()
     ie.current_env().set_test_stream_service_controller(
         pipeline, test_stream_service)

--- a/sdks/python/apache_beam/testing/test_stream_service.py
+++ b/sdks/python/apache_beam/testing/test_stream_service.py
@@ -28,19 +28,23 @@ from apache_beam.portability.api.beam_runner_api_pb2_grpc import TestStreamServi
 
 
 class TestStreamServiceController(TestStreamServiceServicer):
-  def __init__(self, events, endpoint=None):
+  """A server that streams TestStreamPayload.Events from a single EventRequest.
+
+  This server is used as a way for TestStreams to receive events from file.
+  """
+  def __init__(self, reader, endpoint=None):
     self._server = grpc.server(ThreadPoolExecutor(max_workers=10))
 
     if endpoint:
       self.endpoint = endpoint
       self._server.add_insecure_port(self.endpoint)
     else:
-      port = self._server.add_insecure_port('[::]:0')
-      self.endpoint = '[::]:{}'.format(port)
+      port = self._server.add_insecure_port('localhost:0')
+      self.endpoint = 'localhost:{}'.format(port)
 
     beam_runner_api_pb2_grpc.add_TestStreamServiceServicer_to_server(
         self, self._server)
-    self._events = events
+    self._reader = reader
 
   def start(self):
     self._server.start()
@@ -52,5 +56,9 @@ class TestStreamServiceController(TestStreamServiceServicer):
   def Events(self, request, context):
     """Streams back all of the events from the streaming cache."""
 
-    for e in self._events:
+    # TODO(srohde): Once we get rid of the CacheManager, get rid of this 'full'
+    # label.
+    tags = [None if tag == 'None' else tag for tag in request.output_ids]
+    reader = self._reader.read_multiple([('full', tag) for tag in tags])
+    for e in reader:
       yield e


### PR DESCRIPTION
Adds the TestStreamService to the DirectRunner which allows for reading TestStream Events remotely via RPC.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
