### PR TITLE
[BEAM-7746] Resolve typing issues in filesystem

### DIFF
--- a/sdks/python/apache_beam/io/aws/s3filesystem.py
+++ b/sdks/python/apache_beam/io/aws/s3filesystem.py
@@ -21,6 +21,8 @@
 
 from __future__ import absolute_import
 
+from typing import BinaryIO  # pylint: disable=unused-import
+
 from future.utils import iteritems
 
 from apache_beam.io.aws import s3io
@@ -134,6 +136,8 @@ class S3FileSystem(FileSystem):
       mode,
       mime_type='application/octet-stream',
       compression_type=CompressionTypes.AUTO):
+    # type: (...) -> BinaryIO
+
     """Helper functions to open a file in the provided mode.
     """
     compression_type = FileSystem._get_compression_type(path, compression_type)

--- a/sdks/python/apache_beam/io/filesystem_test.py
+++ b/sdks/python/apache_beam/io/filesystem_test.py
@@ -321,17 +321,17 @@ atomized in instants hammered around the
   def test_seekable_enabled_on_read(self):
     with open(self._create_temp_file(), 'rb') as f:
       readable = CompressedFile(f)
-      self.assertTrue(readable.seekable)
+      self.assertTrue(readable.seekable())
 
   def test_seekable_disabled_on_write(self):
     with open(self._create_temp_file(), 'wb') as f:
-      writeable = CompressedFile(f)
-      self.assertFalse(writeable.seekable)
+      writable = CompressedFile(f)
+      self.assertFalse(writable.seekable())
 
   def test_seekable_disabled_on_append(self):
     with open(self._create_temp_file(), 'ab') as f:
-      writeable = CompressedFile(f)
-      self.assertFalse(writeable.seekable)
+      writable = CompressedFile(f)
+      self.assertFalse(writable.seekable())
 
   def test_seek_set(self):
     for compression_type in [CompressionTypes.BZIP2,
@@ -461,12 +461,12 @@ atomized in instants hammered around the
     lines = [b'line%d\n' % i for i in range(10)]
     tmpfile = self._create_temp_file()
     with open(tmpfile, 'wb') as f:
-      writeable = CompressedFile(f)
+      writable = CompressedFile(f)
       current_offset = 0
       for line in lines:
-        writeable.write(line)
+        writable.write(line)
         current_offset += len(line)
-        self.assertEqual(current_offset, writeable.tell())
+        self.assertEqual(current_offset, writable.tell())
 
     with open(tmpfile, 'rb') as f:
       readable = CompressedFile(f)

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
@@ -136,6 +136,8 @@ class GCSFileSystem(FileSystem):
       mode,
       mime_type='application/octet-stream',
       compression_type=CompressionTypes.AUTO):
+    # type: (...) -> BinaryIO
+
     """Helper functions to open a file in the provided mode.
     """
     compression_type = FileSystem._get_compression_type(path, compression_type)

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -35,6 +35,7 @@ import threading
 import time
 import traceback
 from builtins import object
+from typing import BinaryIO  # pylint: disable=unused-import
 
 from apache_beam.internal.http_client import get_new_http
 from apache_beam.io.filesystemio import Downloader
@@ -141,6 +142,8 @@ class GcsIO(object):
       mode='r',
       read_buffer_size=DEFAULT_READ_BUFFER_SIZE,
       mime_type='application/octet-stream'):
+    # type: (...) -> BinaryIO
+
     """Open a GCS file path for reading or writing.
 
     Args:
@@ -158,14 +161,12 @@ class GcsIO(object):
     if mode == 'r' or mode == 'rb':
       downloader = GcsDownloader(
           self.client, filename, buffer_size=read_buffer_size)
-      return io.BufferedReader(
-          DownloaderStream(
-              downloader, read_buffer_size=read_buffer_size, mode=mode),
-          buffer_size=read_buffer_size)
+      return DownloaderStream.create_buffered(
+          downloader, read_buffer_size=read_buffer_size, mode=mode)
     elif mode == 'w' or mode == 'wb':
       uploader = GcsUploader(self.client, filename, mime_type)
-      return io.BufferedWriter(
-          UploaderStream(uploader, mode=mode), buffer_size=128 * 1024)
+      return UploaderStream.create_buffered(
+          uploader, write_buffer_size=128 * 1024, mode=mode)
     else:
       raise ValueError('Invalid file open mode: %s.' % mode)
 

--- a/sdks/python/apache_beam/io/hadoopfilesystem.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem.py
@@ -22,7 +22,6 @@ Hadoop Distributed File System files."""
 
 from __future__ import absolute_import
 
-import io
 import logging
 import posixpath
 import re
@@ -221,6 +220,7 @@ class HadoopFileSystem(FileSystem):
 
   @staticmethod
   def _add_compression(stream, path, mime_type, compression_type):
+    # type: (...) -> BinaryIO
     if mime_type != 'application/octet-stream':
       _LOGGER.warning(
           'Mime types are not supported. Got non-default mime_type:'
@@ -252,9 +252,10 @@ class HadoopFileSystem(FileSystem):
       path,
       mime_type='application/octet-stream',
       compression_type=CompressionTypes.AUTO):
-    stream = io.BufferedWriter(
-        filesystemio.UploaderStream(HdfsUploader(self._hdfs_client, path)),
-        buffer_size=_DEFAULT_BUFFER_SIZE)
+    # type: (...) -> BinaryIO
+    stream = filesystemio.UploaderStream.create_buffered(
+        HdfsUploader(self._hdfs_client, path),
+        write_buffer_size=_DEFAULT_BUFFER_SIZE)
     return self._add_compression(stream, path, mime_type, compression_type)
 
   def open(
@@ -276,9 +277,9 @@ class HadoopFileSystem(FileSystem):
       path,
       mime_type='application/octet-stream',
       compression_type=CompressionTypes.AUTO):
-    stream = io.BufferedReader(
-        filesystemio.DownloaderStream(HdfsDownloader(self._hdfs_client, path)),
-        buffer_size=_DEFAULT_BUFFER_SIZE)
+    stream = filesystemio.DownloaderStream.create_buffered(
+        HdfsDownloader(self._hdfs_client, path),
+        read_buffer_size=_DEFAULT_BUFFER_SIZE)
     return self._add_compression(stream, path, mime_type, compression_type)
 
   def copy(self, source_file_names, destination_file_names):

--- a/sdks/python/apache_beam/io/localfilesystem.py
+++ b/sdks/python/apache_beam/io/localfilesystem.py
@@ -24,7 +24,8 @@ from __future__ import absolute_import
 import os
 import shutil
 from builtins import zip
-from typing import BinaryIO  # pylint: disable=unused-import
+from typing import cast
+from typing import BinaryIO
 
 from apache_beam.io.filesystem import BeamIOError
 from apache_beam.io.filesystem import CompressedFile
@@ -136,10 +137,17 @@ class LocalFileSystem(FileSystem):
       mode,
       mime_type='application/octet-stream',
       compression_type=CompressionTypes.AUTO):
+    # type: (...) -> BinaryIO
+
     """Helper functions to open a file in the provided mode.
     """
     compression_type = FileSystem._get_compression_type(path, compression_type)
-    raw_file = open(path, mode)
+    if mode == 'r':
+      mode = 'rb'
+    elif mode == 'w':
+      mode = 'wb'
+    # we can safely assume the type will always be binary
+    raw_file = cast(BinaryIO, open(path, mode))
     if compression_type == CompressionTypes.UNCOMPRESSED:
       return raw_file
     else:


### PR DESCRIPTION
In order to properly type some of the complexities around the `filesystem` API I had to address 2 main problems:

- properly type `CompressedFile`
  - add `Compressor` and `Decompressor` protocols
  - make it a `BinaryIO` subclass.  this is necessary to guarantee that all the file-like things that are floating around these modules actually present the same interface.  unfortunately, `BinaryIO` is not a protocol, so it must be subclassed.  this required a few breaking changes:
    - `writeable` renamed to `writable`
    - `closed` method changed to a property
    - `seekable` property changed a method
    - `read` arg changed name
    - `write` arg changed name
-  add  a new `create_buffered()` classmethod to `DownloaderStream` and `UploaderStream`
   - simplifies the creation of buffered wrappers to the classes
   - this was motivated primarily by the desire to consolidate this pattern into one place so that I could handle the unfortunate need to `cast` these types to `BinaryIO`.   see notes on `DownloaderStream.create_buffered()` for why this was necessary.

--- 

This PR makes one significant runtime change that must be vetted.

`s3io.S3IO.open()` originally created a buffered `DownloaderStream` like this:

```python
      return io.BufferedReader(
          DownloaderStream(downloader, mode=mode), 
          buffer_size=read_buffer_size)
```

All other IO clients pass `read_buffer_size` to `DownloaderStream`, like this example from `gcsio`:

```python
      return io.BufferedReader(
          DownloaderStream(downloader, read_buffer_size=read_buffer_size, mode=mode),
          buffer_size=read_buffer_size)
```

In this PR I standardized on the latter behavior in order to simplify `create_buffered`, but I don't know whether this difference in `s3io` was intentional or not, or what the impact of changing it would be. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
