### PR TITLE
[BEAM-8335] Display rather than logging when is_in_notebook.

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -260,7 +260,6 @@ def is_source_to_cache_changed(
   # change by default.
   if is_changed and update_cached_source_signature:
     if ie.current_env().options.enable_capture_replay:
-      # TODO(BEAM-8335): display rather than logging when is_in_notebook.
       if not recorded_signature:
         _LOGGER.info(
             'Interactive Beam has detected you have unbounded sources '

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -35,6 +35,7 @@ import apache_beam as beam
 from apache_beam.runners import runner
 from apache_beam.utils.interactive_utils import is_in_ipython
 from apache_beam.utils.interactive_utils import is_in_notebook
+from apache_beam.utils.interactive_utils import register_ipython_log_handler
 
 # Interactive Beam user flow is data-centric rather than pipeline-centric, so
 # there is only one global interactive environment instance that manages
@@ -138,6 +139,8 @@ class InteractiveEnvironment(object):
       _LOGGER.warning(
           'You have limited Interactive Beam features since your '
           'ipython kernel is not connected any notebook frontend.')
+    if self._is_in_notebook:
+      register_ipython_log_handler()
 
   @property
   def options(self):

--- a/sdks/python/apache_beam/runners/interactive/options/capture_control.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_control.py
@@ -68,7 +68,6 @@ def evict_captured_data():
   Interactive Beam. In future PCollection evaluation/visualization and pipeline
   runs, Interactive Beam will capture fresh data."""
   if ie.current_env().options.enable_capture_replay:
-    # TODO(BEAM-8335): display rather than logging when is_in_notebook.
     _LOGGER.info(
         'You have requested Interactive Beam to evict all captured '
         'data that could be deterministically replayed among multiple '

--- a/sdks/python/apache_beam/utils/interactive_utils.py
+++ b/sdks/python/apache_beam/utils/interactive_utils.py
@@ -103,6 +103,8 @@ def _extract_pipeline_of_pvalueish(pvalueish):
   return None
 
 
+# TODO(BEAM-8335): Move this function and the IPythonLogHandler to a util class
+# under interactive package when streaming cache changes are merged.
 def register_ipython_log_handler():
   """Adds the IPython handler to a dummy parent logger (named
   'apache_beam.runners.interactive') of all interactive modules' loggers so that

--- a/sdks/python/apache_beam/utils/interactive_utils.py
+++ b/sdks/python/apache_beam/utils/interactive_utils.py
@@ -101,3 +101,53 @@ def _extract_pipeline_of_pvalueish(pvalueish):
   if hasattr(pvalue, 'pipeline'):
     return pvalue.pipeline
   return None
+
+
+def register_ipython_log_handler():
+  """Adds the IPython handler to a dummy parent logger (named
+  'apache_beam.runners.interactive') of all interactive modules' loggers so that
+  if is_in_notebook, logging displays the logs as HTML in frontends."""
+  # apache_beam.runners.interactive is not a module, thus this "root" logger is
+  # a dummy one created to hold the IPython log handler. When children loggers
+  # have propagate as True (by default) and logging level as NOTSET (by default,
+  # so the "root" logger's logging level takes effect), the IPython log handler
+  # will be triggered at the "root"'s own logging level. And if a child logger
+  # sets its logging level, it can take control back.
+  interactive_root_logger = logging.getLogger('apache_beam.runners.interactive')
+  if any([isinstance(h, IPythonLogHandler)
+          for h in interactive_root_logger.handlers]):
+    return
+  interactive_root_logger.setLevel(logging.INFO)
+  interactive_root_logger.addHandler(IPythonLogHandler())
+  # Disable the propagation so that logs emitted from interactive modules should
+  # only be handled by loggers and handlers defined within interactive packages.
+  interactive_root_logger.propagate = False
+
+
+class IPythonLogHandler(logging.Handler):
+  """A logging handler to display logs as HTML in IPython backed frontends."""
+  log_template = """
+            <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+            <div class="alert alert-{level}">{msg}</div>"""
+
+  logging_to_alert_level_map = {
+      logging.CRITICAL: 'danger',
+      logging.ERROR: 'danger',
+      logging.WARNING: 'warning',
+      logging.INFO: 'info',
+      logging.DEBUG: 'dark',
+      logging.NOTSET: 'light'
+  }
+
+  def emit(self, record):
+    try:
+      from html import escape
+      from IPython.core.display import HTML
+      from IPython.core.display import display
+      display(
+          HTML(
+              self.log_template.format(
+                  level=self.logging_to_alert_level_map[record.levelno],
+                  msg=escape(record.msg))))
+    except ImportError:
+      pass  # NOOP when dependencies are not available.

--- a/sdks/python/apache_beam/utils/interactive_utils_test.py
+++ b/sdks/python/apache_beam/utils/interactive_utils_test.py
@@ -21,9 +21,8 @@
 
 from __future__ import absolute_import
 
-import sys
-
 import logging
+import sys
 import unittest
 
 from apache_beam.runners.interactive import interactive_environment as ie
@@ -66,7 +65,7 @@ class InteractiveUtilsTest(unittest.TestCase):
     # handler IPythonLogHandler which is set to NOTSET. The effect will be
     # everything >= info level will be logged through IPython.core.display to
     # all frontends connected to current kernel.
-    dummy_logger = logging.getLogger('apache_beam.runners.interactive.dummy')
+    dummy_logger = logging.getLogger('apache_beam.runners.interactive.dummy1')
     dummy_logger.info('info')
     mock_emit.assert_called_once()
     dummy_logger.debug('debug')
@@ -78,7 +77,7 @@ class InteractiveUtilsTest(unittest.TestCase):
     # When a child logger's logging level is configured to something that is not
     # NOTSET, it takes back the logging control from the interactive "root"
     # logger by not propagating anything.
-    dummy_logger = logging.getLogger('apache_beam.runners.interactive.dummy')
+    dummy_logger = logging.getLogger('apache_beam.runners.interactive.dummy2')
     dummy_logger.setLevel(logging.DEBUG)
     mock_emit.assert_not_called()
     dummy_logger.debug('debug')

--- a/sdks/python/apache_beam/utils/interactive_utils_test.py
+++ b/sdks/python/apache_beam/utils/interactive_utils_test.py
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pytype: skip-file
+
+"""Tests for apache_beam.utils.interactive_utils."""
+
+from __future__ import absolute_import
+
+import sys
+
+import logging
+import unittest
+
+from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.utils.interactive_utils import IPythonLogHandler
+from apache_beam.utils.interactive_utils import register_ipython_log_handler
+
+# TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
+# unittest.mock module.
+try:
+  from unittest.mock import patch
+except ImportError:
+  from mock import patch
+
+
+@unittest.skipIf(
+    not ie.current_env().is_interactive_ready,
+    '[interactive] dependency is not installed.')
+@unittest.skipIf(
+    sys.version_info < (3, 6), 'The tests require at least Python 3.6 to work.')
+class InteractiveUtilsTest(unittest.TestCase):
+  def setUp(self):
+    register_ipython_log_handler()
+    self._interactive_root_logger = logging.getLogger(
+        'apache_beam.runners.interactive')
+
+  def test_ipython_log_handler_not_double_registered(self):
+    register_ipython_log_handler()
+    ipython_log_handlers = list(
+        filter(
+            lambda x: isinstance(x, IPythonLogHandler),
+            [handler for handler in self._interactive_root_logger.handlers]))
+    self.assertEqual(1, len(ipython_log_handlers))
+
+  @patch('apache_beam.utils.interactive_utils.IPythonLogHandler.emit')
+  def test_default_logging_level_is_info(self, mock_emit):
+    # By default the logging level of loggers and log handlers are NOTSET. Also,
+    # the propagation is default to true for all loggers. In this scenario, all
+    # loggings from child loggers will be propagated to the interactive "root"
+    # logger which is set to INFO level that gets handled by the sole log
+    # handler IPythonLogHandler which is set to NOTSET. The effect will be
+    # everything >= info level will be logged through IPython.core.display to
+    # all frontends connected to current kernel.
+    dummy_logger = logging.getLogger('apache_beam.runners.interactive.dummy')
+    dummy_logger.info('info')
+    mock_emit.assert_called_once()
+    dummy_logger.debug('debug')
+    # Emit is not called, so it's still called once.
+    mock_emit.assert_called_once()
+
+  @patch('apache_beam.utils.interactive_utils.IPythonLogHandler.emit')
+  def test_child_module_logger_can_override_logging_level(self, mock_emit):
+    # When a child logger's logging level is configured to something that is not
+    # NOTSET, it takes back the logging control from the interactive "root"
+    # logger by not propagating anything.
+    dummy_logger = logging.getLogger('apache_beam.runners.interactive.dummy')
+    dummy_logger.setLevel(logging.DEBUG)
+    mock_emit.assert_not_called()
+    dummy_logger.debug('debug')
+    # Because the dummy child logger is configured to log at DEBUG level, it
+    # now propagates DEBUG loggings to the interactive "root" logger.
+    mock_emit.assert_called_once()
+    # When the dummy child logger is configured to log at CRITICAL level, it
+    # will only propagate CRITICAL loggings to the interactive "root" logger.
+    dummy_logger.setLevel(logging.CRITICAL)
+    # Error loggings will not be handled now.
+    dummy_logger.error('error')
+    # Emit is not called, so it's still called once.
+    mock_emit.assert_called_once()
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
1. Added an IPythonLogHandler to display logs as styled HTMLs to
   frontends connected to current IPython kernel. The implementation
   works with all IPython notebooks.
2. The user can control the logging with native Python logging APIs.
3. The log handler is only registered when current environment is in a
   notebook and it only affects module loggers under interactive
   package.
4. The log handler is added to a dummy interactive "root" logger and
    doesn't change any real logger's default configuration.

Change-Id: Iaec9272e0ee61d091979822680615791f1a57cd6

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
