### PR TITLE
[BEAM-8335] Implemented Capture Size limitation

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -86,7 +86,7 @@ class BackgroundCachingJob(object):
       time.sleep(5)
 
   def _should_end_condition_checker(self):
-    if ie.current_env().options.capture_control.is_capture_size_reached():
+    if ie.current_env().options.capture_control.is_capture_size_limit_reached():
       self._condition_checker_triggered = True
       self.cancel()
       return True
@@ -202,10 +202,20 @@ def has_source_to_cache(user_pipeline):
   if has_cache:
     if not isinstance(ie.current_env().cache_manager(),
                       streaming_cache.StreamingCache):
-      # TODO(BEAM-8335): convert the cache manager into a streaming cache
-      # manager. Note this does not invalidate the current cache including the
-      # source data capture.
-      pass
+      # Wrap the cache manager into a streaming cache manager. Note this
+      # does not invalidate the current cache manager.
+      def is_cache_complete():
+        job = ie.current_env().get_background_caching_job(user_pipeline)
+        is_done = job and job.is_done()
+        cache_changed = is_source_to_cache_changed(
+            user_pipeline, update_cached_source_signature=False)
+        return is_done and not cache_changed
+
+      ie.current_env().set_cache_manager(
+          streaming_cache.StreamingCache(
+              ie.current_env().cache_manager()._cache_dir,
+              is_cache_complete=is_cache_complete,
+              sample_resolution_sec=1.0))
   return has_cache
 
 
@@ -262,13 +272,22 @@ def is_source_to_cache_changed(
     options = ie.current_env().options
     # No info needed when capture replay is disabled.
     if options.enable_capture_replay:
-      # TODO(BEAM-8335): add capture_size info when it is supported.
       if not recorded_signature:
+
+        def sizeof_fmt(num, suffix='B'):
+          for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+            if abs(num) < 1000.0:
+              return "%3.1f%s%s" % (num, unit, suffix)
+            num /= 1000.0
+          return "%.1f%s%s" % (num, 'Yi', suffix)
+
         _LOGGER.info(
             'Interactive Beam has detected unbounded sources in your pipeline. '
             'In order to have a deterministic replay, a segment of data will '
-            'be recorded from all sources for %s seconds.',
-            options.capture_duration.total_seconds())
+            'be recorded from all sources for %s seconds or until a total of '
+            '%s have been written to disk.',
+            options.capture_duration.total_seconds(),
+            sizeof_fmt(options.capture_size_limit))
       else:
         _LOGGER.info(
             'Interactive Beam has detected a new streaming source was '

--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
@@ -84,7 +84,7 @@ class StreamingCacheSink(beam.PTransform):
     """Returns the space usage in bytes of the sink."""
     try:
       return os.stat(self._path).st_size
-    except:
+    except Exception:
       _LOGGER.debug(
           'Failed to calculate cache size for file %s, the file might have not '
           'been created yet. Return 0. %s',

--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
@@ -19,10 +19,12 @@
 
 from __future__ import absolute_import
 
+import logging
 import os
 import shutil
 import tempfile
 import time
+import traceback
 from collections import OrderedDict
 
 import apache_beam as beam
@@ -39,6 +41,8 @@ try:
   from pathlib import Path
 except ImportError:
   from pathlib2 import Path  # python 2 backport
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class StreamingCacheSink(beam.PTransform):
@@ -74,6 +78,19 @@ class StreamingCacheSink(beam.PTransform):
   def path(self):
     """Returns the path the sink leads to."""
     return self._path
+
+  @property
+  def size_in_bytes(self):
+    """Returns the space usage in bytes of the sink."""
+    try:
+      return os.stat(self._path).st_size
+    except:
+      _LOGGER.debug(
+          'Failed to calculate cache size for file %s, the file might have not '
+          'been created yet. Return 0. %s',
+          self._path,
+          traceback.format_exc())
+      return 0
 
   def expand(self, pcoll):
     class StreamingWriteToText(beam.DoFn):
@@ -230,6 +247,18 @@ class StreamingCache(CacheManager):
     self._saved_pcoders = {}
     self._default_pcoder = SafeFastPrimitivesCoder()
 
+    # The sinks to capture data from capturable sources.
+    # Dict([str, StreamingCacheSink])
+    self._capture_sinks = {}
+
+  @property
+  def capture_size(self):
+    return sum([sink.size_in_bytes for _, sink in self._capture_sinks.items()])
+
+  @property
+  def capture_paths(self):
+    return list(self._capture_sinks.keys())
+
   def exists(self, *labels):
     path = os.path.join(self._cache_dir, *labels)
     return os.path.exists(path)
@@ -284,7 +313,7 @@ class StreamingCache(CacheManager):
     """
     return beam.Impulse()
 
-  def sink(self, labels):
+  def sink(self, labels, is_capture=False):
     """Returns a StreamingCacheSink to write elements to file.
 
     Note that this is assumed to only work in the DirectRunner as the underlying
@@ -293,7 +322,10 @@ class StreamingCache(CacheManager):
     """
     filename = labels[-1]
     cache_dir = os.path.join(self._cache_dir, *labels[:-1])
-    return StreamingCacheSink(cache_dir, filename, self._sample_resolution_sec)
+    sink = StreamingCacheSink(cache_dir, filename, self._sample_resolution_sec)
+    if is_capture:
+      self._capture_sinks[sink.path] = sink
+    return sink
 
   def save_pcoder(self, pcoder, *labels):
     self._saved_pcoders[os.path.join(*labels)] = pcoder

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -90,7 +90,22 @@ class Options(interactive_options.InteractiveOptions):
     assert value.total_seconds() > 0, 'Duration must be a positive value.'
     self.capture_control._capture_duration = value
 
-  # TODO(BEAM-8335): add capture_size options when they are supported.
+  @property
+  def capture_size_limit(self):
+    """The data capture of sources ends as soon as the size (in bytes) of data
+    captured from capturable sources reaches the limit."""
+    return self.capture_control._capture_size_limit
+
+  @capture_size_limit.setter
+  def capture_size_limit(self, value):
+    """Sets the capture size in bytes.
+
+    Example::
+
+      # Sets the capture size limit to 1GB.
+      interactive_beam.options.capture_size_limit = 1e9
+    """
+    self.capture_control._capture_size_limit = value
 
   @property
   def display_timestamp_format(self):

--- a/sdks/python/apache_beam/runners/interactive/options/capture_control.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_control.py
@@ -44,15 +44,13 @@ class CaptureControl(object):
         ReadFromPubSub,
     }
     self._capture_duration = timedelta(seconds=5)
-    self._capture_size = 1e9
+    self._capture_size_limit = 1e9
 
-  def is_capture_size_reached(self):
-    """Determines if the capture size has been reached."""
+  def is_capture_size_limit_reached(self):
+    """Determines if the capture size limit has been reached."""
     cache_manager = ie.current_env().cache_manager()
-    # TODO(BEAM-8335): implement the capture_size attribute when streaming_cache
-    # implements cache_manager.
     if hasattr(cache_manager, 'capture_size'):
-      return cache_manager.capture_size >= self._capture_size
+      return cache_manager.capture_size >= self._capture_size_limit
     return False
 
 

--- a/sdks/python/apache_beam/runners/interactive/options/capture_control_test.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_control_test.py
@@ -25,11 +25,15 @@ import sys
 import unittest
 
 import apache_beam as beam
+from apache_beam import coders
+from apache_beam.portability.api.beam_interactive_api_pb2 import TestStreamFileRecord
+from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 from apache_beam.runners import runner
 from apache_beam.runners.interactive import background_caching_job as bcj
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner
+from apache_beam.runners.interactive.caching.streaming_cache import StreamingCache
 from apache_beam.runners.interactive.options import capture_control
 from apache_beam.testing.test_stream_service import TestStreamServiceController
 
@@ -116,19 +120,53 @@ class CaptureControlTest(unittest.TestCase):
     self.assertTrue(ie.current_env().computed_pcollections == set())
     self.assertTrue(ie.current_env().get_cached_source_signature(p) == set())
 
-  def test_capture_size_not_reached_when_no_cache(self):
+  def test_capture_size_limit_not_reached_when_no_cache(self):
     self.assertIsNone(ie.current_env().cache_manager())
     self.assertFalse(
-        ie.current_env().options.capture_control.is_capture_size_reached())
+        ie.current_env().options.capture_control.is_capture_size_limit_reached(
+        ))
 
-  def test_capture_size_not_reached_when_no_file(self):
-    _ = _build_an_empty_streaming_pipeline()
-    self.assertIsNotNone(ie.current_env().cache_manager())
+  def test_capture_size_limit_not_reached_when_no_file(self):
+    cache = StreamingCache(cache_dir=None)
+    self.assertFalse(cache.exists('my_label'))
+    ie.current_env().set_cache_manager(cache)
     self.assertFalse(
-        ie.current_env().options.capture_control.is_capture_size_reached())
+        ie.current_env().options.capture_control.is_capture_size_limit_reached(
+        ))
 
-  # TODO(BEAM-8335): add more capture_size tests when the property is
-  # implemented in streaming_cache.
+  def test_capture_size_limit_not_reached_when_file_size_under_limit(self):
+    ib.options.capture_size_limit = 100
+    cache = StreamingCache(cache_dir=None)
+    # Build a sink object to track the label as a capture in the test.
+    cache.sink(['my_label'], is_capture=True)
+    cache.write([TestStreamFileRecord()], 'my_label')
+    self.assertTrue(cache.exists('my_label'))
+    ie.current_env().set_cache_manager(cache)
+    self.assertFalse(
+        ie.current_env().options.capture_control.is_capture_size_limit_reached(
+        ))
+
+  def test_capture_size_limit_reached_when_file_size_above_limit(self):
+    ib.options.capture_size_limit = 1
+    cache = StreamingCache(cache_dir=None)
+    cache.sink(['my_label'], is_capture=True)
+    cache.write([
+        TestStreamFileRecord(
+            recorded_event=TestStreamPayload.Event(
+                element_event=TestStreamPayload.Event.AddElements(
+                    elements=[
+                        TestStreamPayload.TimestampedElement(
+                            encoded_element=coders.FastPrimitivesCoder().encode(
+                                'a'),
+                            timestamp=0)
+                    ])))
+    ],
+                'my_label')
+    self.assertTrue(cache.exists('my_label'))
+    ie.current_env().set_cache_manager(cache)
+    self.assertTrue(
+        ie.current_env().options.capture_control.is_capture_size_limit_reached(
+        ))
 
   def test_timer_terminates_capture_size_checker(self):
     p = _build_an_empty_streaming_pipeline()

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -329,7 +329,9 @@ class PipelineInstrument(object):
     if self.has_unbounded_sources:
       for source in self._unbounded_sources:
         self._write_cache(
-            self._background_caching_pipeline, source.outputs[None])
+            self._background_caching_pipeline,
+            source.outputs[None],
+            is_capture=True)
 
     # TODO(BEAM-7760): prune sub graphs that doesn't need to be executed.
 
@@ -369,7 +371,7 @@ class PipelineInstrument(object):
     v = PreprocessVisitor(self)
     self._pipeline.visit(v)
 
-  def _write_cache(self, pipeline, pcoll):
+  def _write_cache(self, pipeline, pcoll, is_capture=False):
     """Caches a cacheable PCollection.
 
     For the given PCollection, by appending sub transform part that materialize
@@ -390,7 +392,8 @@ class PipelineInstrument(object):
     # Only need to write when the cache with expected key doesn't exist.
     if not self._cache_manager.exists('full', key):
       label = '{}{}'.format(WRITE_CACHE, key)
-      _ = pcoll | label >> cache.WriteCache(self._cache_manager, key)
+      _ = pcoll | label >> cache.WriteCache(
+          self._cache_manager, key, is_capture=is_capture)
 
   def _read_cache(self, pipeline, pcoll):
     """Reads a cached pvalue.


### PR DESCRIPTION
1. Capture cache size is calculated as a property from StreamingCacheSinks and
   should be implemented by any other sink implementations in the future.
2. For each capture cache, if it doesn't exist, the size is 0.
3. If the cache manager doesn't exist or doesn't support capture_size,
   the capture size configured in ib.options would not take effect as if
   capture cache size stays 0.
4. Captured data from sources are stored like intermediate PCollections.
   The capture cache size does not include intermediate PCollections'
   disk usages.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
