### PR TITLE
Store logical type values in Row instead of base values

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +33,6 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
-import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.ByteBuddy;
@@ -47,11 +47,9 @@ import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.dynamic.scaffold.I
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.FixedValue;
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.Implementation;
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.ByteCodeAppender;
+import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.ByteCodeAppender.Size;
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.Duplication;
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.StackManipulation;
-import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.StackManipulation.Compound;
-import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.TypeCreation;
-import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.collection.ArrayFactory;
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.member.FieldAccess;
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.member.MethodInvocation;
 import org.apache.beam.vendor.bytebuddy.v1_10_8.net.bytebuddy.implementation.bytecode.member.MethodReturn;
@@ -99,66 +97,98 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 @Experimental(Kind.SCHEMAS)
 public abstract class RowCoderGenerator {
   private static final ByteBuddy BYTE_BUDDY = new ByteBuddy();
-  private static final ForLoadedType CODER_TYPE = new ForLoadedType(Coder.class);
-  private static final ForLoadedType LIST_CODER_TYPE = new ForLoadedType(ListCoder.class);
-  private static final ForLoadedType ITERABLE_CODER_TYPE = new ForLoadedType(IterableCoder.class);
-  private static final ForLoadedType MAP_CODER_TYPE = new ForLoadedType(MapCoder.class);
   private static final BitSetCoder NULL_LIST_CODER = BitSetCoder.of();
   private static final VarIntCoder VAR_INT_CODER = VarIntCoder.of();
-  private static final ForLoadedType NULLABLE_CODER = new ForLoadedType(NullableCoder.class);
 
   private static final String CODERS_FIELD_NAME = "FIELD_CODERS";
 
-  // A map of primitive types -> StackManipulations to create their coders.
-  private static final Map<TypeName, StackManipulation> CODER_MAP;
-
   // Cache for Coder class that are already generated.
-  private static Map<UUID, Coder<Row>> generatedCoders = Maps.newConcurrentMap();
-
-  static {
-    // Initialize the CODER_MAP with the StackManipulations to create the primitive coders.
-    // Assumes that each class contains a static of() constructor method.
-    CODER_MAP = Maps.newHashMap();
-    for (Map.Entry<TypeName, Coder> entry : SchemaCoder.CODER_MAP.entrySet()) {
-      StackManipulation stackManipulation =
-          MethodInvocation.invoke(
-              new ForLoadedType(entry.getValue().getClass())
-                  .getDeclaredMethods()
-                  .filter(ElementMatchers.named("of"))
-                  .getOnly());
-      CODER_MAP.putIfAbsent(entry.getKey(), stackManipulation);
-    }
-  }
+  private static final Map<UUID, Coder<Row>> GENERATED_CODERS = Maps.newConcurrentMap();
 
   @SuppressWarnings("unchecked")
   public static Coder<Row> generate(Schema schema) {
     // Using ConcurrentHashMap::computeIfAbsent here would deadlock in case of nested
     // coders. Using HashMap::computeIfAbsent generates ConcurrentModificationExceptions in Java 11.
-    Coder<Row> rowCoder = generatedCoders.get(schema.getUUID());
+    Coder<Row> rowCoder = GENERATED_CODERS.get(schema.getUUID());
     if (rowCoder == null) {
       TypeDescription.Generic coderType =
           TypeDescription.Generic.Builder.parameterizedType(Coder.class, Row.class).build();
       DynamicType.Builder<Coder> builder =
           (DynamicType.Builder<Coder>) BYTE_BUDDY.subclass(coderType);
-      builder = createComponentCoders(schema, builder);
       builder = implementMethods(schema, builder);
+
+      Coder[] componentCoders = new Coder[schema.getFieldCount()];
+      for (int i = 0; i < schema.getFieldCount(); ++i) {
+        // We use withNullable(false) as nulls are handled by the RowCoder and the individual
+        // component coders therefore do not need to handle nulls.
+        componentCoders[i] =
+            SchemaCoder.coderForFieldType(schema.getField(i).getType().withNullable(false));
+      }
+
+      builder =
+          builder.defineField(
+              CODERS_FIELD_NAME, Coder[].class, Visibility.PRIVATE, FieldManifestation.FINAL);
+
+      builder =
+          builder
+              .defineConstructor(Modifier.PUBLIC)
+              .withParameters(Coder[].class)
+              .intercept(new GeneratedCoderConstructor());
+
       try {
         rowCoder =
             builder
                 .make()
                 .load(Coder.class.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
                 .getLoaded()
-                .getDeclaredConstructor()
-                .newInstance();
+                .getDeclaredConstructor(Coder[].class)
+                .newInstance((Object) componentCoders);
       } catch (InstantiationException
           | IllegalAccessException
           | NoSuchMethodException
           | InvocationTargetException e) {
-        throw new RuntimeException("Unable to generate coder for schema " + schema);
+        throw new RuntimeException("Unable to generate coder for schema " + schema, e);
       }
-      generatedCoders.put(schema.getUUID(), rowCoder);
+      GENERATED_CODERS.put(schema.getUUID(), rowCoder);
     }
     return rowCoder;
+  }
+
+  private static class GeneratedCoderConstructor implements Implementation {
+    @Override
+    public InstrumentedType prepare(InstrumentedType instrumentedType) {
+      return instrumentedType;
+    }
+
+    @Override
+    public ByteCodeAppender appender(final Target implementationTarget) {
+      return (methodVisitor, implementationContext, instrumentedMethod) -> {
+        int numLocals = 1 + instrumentedMethod.getParameters().size();
+        StackManipulation stackManipulation =
+            new StackManipulation.Compound(
+                // Call the base constructor.
+                MethodVariableAccess.loadThis(),
+                Duplication.SINGLE,
+                MethodInvocation.invoke(
+                    new ForLoadedType(Coder.class)
+                        .getDeclaredMethods()
+                        .filter(
+                            ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
+                        .getOnly()),
+                // Store the list of Coders as a member variable.
+                MethodVariableAccess.REFERENCE.loadFrom(1),
+                FieldAccess.forField(
+                        implementationTarget
+                            .getInstrumentedType()
+                            .getDeclaredFields()
+                            .filter(ElementMatchers.named(CODERS_FIELD_NAME))
+                            .getOnly())
+                    .write(),
+                MethodReturn.VOID);
+        StackManipulation.Size size = stackManipulation.apply(methodVisitor, implementationContext);
+        return new Size(size.getMaximalSize(), numLocals);
+      };
+    }
   }
 
   private static DynamicType.Builder<Coder> implementMethods(
@@ -185,6 +215,7 @@ public abstract class RowCoderGenerator {
         StackManipulation manipulation =
             new StackManipulation.Compound(
                 // Array of coders.
+                MethodVariableAccess.loadThis(),
                 FieldAccess.forField(
                         implementationContext
                             .getInstrumentedType()
@@ -272,6 +303,7 @@ public abstract class RowCoderGenerator {
                         .filter(ElementMatchers.named("getSchema"))
                         .getOnly()),
                 // Array of coders.
+                MethodVariableAccess.loadThis(),
                 FieldAccess.forField(
                         implementationContext
                             .getInstrumentedType()
@@ -313,7 +345,8 @@ public abstract class RowCoderGenerator {
           if (nullFields.get(i)) {
             fieldValues.add(null);
           } else {
-            fieldValues.add(coders[i].decode(inputStream));
+            Object fieldValue = coders[i].decode(inputStream);
+            fieldValues.add(fieldValue);
           }
         }
       }
@@ -328,121 +361,5 @@ public abstract class RowCoderGenerator {
       // some processing by simply transferring ownership of the list to the Row.
       return Row.withSchema(schema).attachValues(fieldValues).build();
     }
-  }
-
-  private static DynamicType.Builder<Coder> createComponentCoders(
-      Schema schema, DynamicType.Builder<Coder> builder) {
-    List<StackManipulation> componentCoders =
-        Lists.newArrayListWithCapacity(schema.getFieldCount());
-    for (int i = 0; i < schema.getFieldCount(); i++) {
-      // We use withNullable(false) as nulls are handled by the RowCoder and the individual
-      // component coders therefore do not need to handle nulls.
-      componentCoders.add(getCoder(schema.getField(i).getType().withNullable(false)));
-    }
-
-    return builder
-        // private static final Coder[] FIELD_CODERS;
-        .defineField(
-            CODERS_FIELD_NAME,
-            Coder[].class,
-            Visibility.PRIVATE,
-            Ownership.STATIC,
-            FieldManifestation.FINAL)
-        // Static initializer.
-        .initializer(
-            (methodVisitor, implementationContext, instrumentedMethod) -> {
-              StackManipulation manipulation =
-                  new StackManipulation.Compound(
-                      // Initialize the array of coders.
-                      ArrayFactory.forType(CODER_TYPE.asGenericType()).withValues(componentCoders),
-                      FieldAccess.forField(
-                              implementationContext
-                                  .getInstrumentedType()
-                                  .getDeclaredFields()
-                                  .filter(ElementMatchers.named(CODERS_FIELD_NAME))
-                                  .getOnly())
-                          .write());
-              StackManipulation.Size size =
-                  manipulation.apply(methodVisitor, implementationContext);
-              return new ByteCodeAppender.Size(
-                  size.getMaximalSize(), instrumentedMethod.getStackSize());
-            });
-  }
-
-  private static StackManipulation getCoder(Schema.FieldType fieldType) {
-    if (TypeName.LOGICAL_TYPE.equals(fieldType.getTypeName())) {
-      return getCoder(fieldType.getLogicalType().getBaseType());
-    } else if (TypeName.ARRAY.equals(fieldType.getTypeName())) {
-      return listCoder(fieldType.getCollectionElementType());
-    } else if (TypeName.ITERABLE.equals(fieldType.getTypeName())) {
-      return iterableCoder(fieldType.getCollectionElementType());
-    }
-    if (TypeName.MAP.equals(fieldType.getTypeName())) {;
-      return mapCoder(fieldType.getMapKeyType(), fieldType.getMapValueType());
-    } else if (TypeName.ROW.equals(fieldType.getTypeName())) {
-      checkState(fieldType.getRowSchema().getUUID() != null);
-      Coder<Row> nestedCoder = generate(fieldType.getRowSchema());
-      return rowCoder(nestedCoder.getClass());
-    } else {
-      StackManipulation primitiveCoder = coderForPrimitiveType(fieldType.getTypeName());
-
-      if (fieldType.getNullable()) {
-        primitiveCoder =
-            new Compound(
-                primitiveCoder,
-                MethodInvocation.invoke(
-                    NULLABLE_CODER
-                        .getDeclaredMethods()
-                        .filter(ElementMatchers.named("of"))
-                        .getOnly()));
-      }
-
-      return primitiveCoder;
-    }
-  }
-
-  private static StackManipulation listCoder(Schema.FieldType fieldType) {
-    StackManipulation componentCoder = getCoder(fieldType);
-    return new Compound(
-        componentCoder,
-        MethodInvocation.invoke(
-            LIST_CODER_TYPE.getDeclaredMethods().filter(ElementMatchers.named("of")).getOnly()));
-  }
-
-  private static StackManipulation iterableCoder(Schema.FieldType fieldType) {
-    StackManipulation componentCoder = getCoder(fieldType);
-    return new Compound(
-        componentCoder,
-        MethodInvocation.invoke(
-            ITERABLE_CODER_TYPE
-                .getDeclaredMethods()
-                .filter(ElementMatchers.named("of"))
-                .getOnly()));
-  }
-
-  static StackManipulation coderForPrimitiveType(Schema.TypeName typeName) {
-    return CODER_MAP.get(typeName);
-  }
-
-  static StackManipulation mapCoder(Schema.FieldType keyType, Schema.FieldType valueType) {
-    StackManipulation keyCoder = getCoder(keyType);
-    StackManipulation valueCoder = getCoder(valueType);
-    return new Compound(
-        keyCoder,
-        valueCoder,
-        MethodInvocation.invoke(
-            MAP_CODER_TYPE.getDeclaredMethods().filter(ElementMatchers.named("of")).getOnly()));
-  }
-
-  static StackManipulation rowCoder(Class coderClass) {
-    ForLoadedType loadedType = new ForLoadedType(coderClass);
-    return new Compound(
-        TypeCreation.of(loadedType),
-        Duplication.SINGLE,
-        MethodInvocation.invoke(
-            loadedType
-                .getDeclaredMethods()
-                .filter(ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
-                .getOnly()));
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
@@ -22,59 +22,26 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
-import org.apache.beam.sdk.coders.BigDecimalCoder;
-import org.apache.beam.sdk.coders.BigEndianShortCoder;
-import org.apache.beam.sdk.coders.BooleanCoder;
-import org.apache.beam.sdk.coders.ByteArrayCoder;
-import org.apache.beam.sdk.coders.ByteCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CustomCoder;
-import org.apache.beam.sdk.coders.DoubleCoder;
-import org.apache.beam.sdk.coders.FloatCoder;
-import org.apache.beam.sdk.coders.InstantCoder;
-import org.apache.beam.sdk.coders.IterableCoder;
-import org.apache.beam.sdk.coders.ListCoder;
-import org.apache.beam.sdk.coders.MapCoder;
 import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.coders.RowCoderGenerator;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.coders.VarIntCoder;
-import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
-import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 
 /** {@link SchemaCoder} is used as the coder for types that have schemas registered. */
 @Experimental(Kind.SCHEMAS)
 public class SchemaCoder<T> extends CustomCoder<T> {
-  // This contains a map of primitive types to their coders.
-  public static final Map<TypeName, Coder> CODER_MAP =
-      ImmutableMap.<TypeName, Coder>builder()
-          .put(TypeName.BYTE, ByteCoder.of())
-          .put(TypeName.BYTES, ByteArrayCoder.of())
-          .put(TypeName.INT16, BigEndianShortCoder.of())
-          .put(TypeName.INT32, VarIntCoder.of())
-          .put(TypeName.INT64, VarLongCoder.of())
-          .put(TypeName.DECIMAL, BigDecimalCoder.of())
-          .put(TypeName.FLOAT, FloatCoder.of())
-          .put(TypeName.DOUBLE, DoubleCoder.of())
-          .put(TypeName.STRING, StringUtf8Coder.of())
-          .put(TypeName.DATETIME, InstantCoder.of())
-          .put(TypeName.BOOLEAN, BooleanCoder.of())
-          .build();
-
   protected final Schema schema;
   private final TypeDescriptor<T> typeDescriptor;
   private final SerializableFunction<T, Row> toRowFunction;
@@ -117,27 +84,6 @@ public class SchemaCoder<T> extends CustomCoder<T> {
   /** Returns a {@link SchemaCoder} for {@link Row} instances with the given {@code schema}. */
   public static SchemaCoder<Row> of(Schema schema) {
     return RowCoder.of(schema);
-  }
-
-  /** Returns the coder used for a given primitive type. */
-  public static <T> Coder<T> coderForFieldType(FieldType fieldType) {
-    switch (fieldType.getTypeName()) {
-      case ROW:
-        return (Coder<T>) SchemaCoder.of(fieldType.getRowSchema());
-      case ARRAY:
-        return (Coder<T>) ListCoder.of(coderForFieldType(fieldType.getCollectionElementType()));
-      case ITERABLE:
-        return (Coder<T>) IterableCoder.of(coderForFieldType(fieldType.getCollectionElementType()));
-      case MAP:
-        return (Coder<T>)
-            MapCoder.of(
-                coderForFieldType(fieldType.getMapKeyType()),
-                coderForFieldType(fieldType.getMapValueType()));
-      case LOGICAL_TYPE:
-        return coderForFieldType(fieldType.getLogicalType().getBaseType());
-      default:
-        return (Coder<T>) CODER_MAP.get(fieldType.getTypeName());
-    }
   }
 
   /** Returns the schema associated with this type. */
@@ -186,7 +132,7 @@ public class SchemaCoder<T> extends CustomCoder<T> {
     ImmutableList<Coder<?>> coders =
         schema.getFields().stream()
             .map(Field::getType)
-            .map(SchemaCoder::coderForFieldType)
+            .map(SchemaCoderHelpers::coderForFieldType)
             .collect(ImmutableList.toImmutableList());
 
     Coder.verifyDeterministic(this, "All fields must have deterministic encoding", coders);
@@ -195,6 +141,10 @@ public class SchemaCoder<T> extends CustomCoder<T> {
   @Override
   public boolean consistentWithEquals() {
     return true;
+  }
+
+  public static <T> Coder<T> coderForFieldType(FieldType fieldType) {
+    return SchemaCoderHelpers.coderForFieldType(fieldType);
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoderHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoderHelpers.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.coders.BigDecimalCoder;
+import org.apache.beam.sdk.coders.BigEndianShortCoder;
+import org.apache.beam.sdk.coders.BooleanCoder;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.ByteCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.DoubleCoder;
+import org.apache.beam.sdk.coders.FloatCoder;
+import org.apache.beam.sdk.coders.InstantCoder;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.coders.ListCoder;
+import org.apache.beam.sdk.coders.MapCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.LogicalType;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.joda.time.ReadableInstant;
+
+class SchemaCoderHelpers {
+  // This contains a map of primitive types to their coders.
+  private static final Map<TypeName, Coder> CODER_MAP =
+      ImmutableMap.<TypeName, Coder>builder()
+          .put(TypeName.BYTE, ByteCoder.of())
+          .put(TypeName.BYTES, ByteArrayCoder.of())
+          .put(TypeName.INT16, BigEndianShortCoder.of())
+          .put(TypeName.INT32, VarIntCoder.of())
+          .put(TypeName.INT64, VarLongCoder.of())
+          .put(TypeName.DECIMAL, BigDecimalCoder.of())
+          .put(TypeName.FLOAT, FloatCoder.of())
+          .put(TypeName.DOUBLE, DoubleCoder.of())
+          .put(TypeName.STRING, StringUtf8Coder.of())
+          .put(TypeName.DATETIME, InstantCoder.of())
+          .put(TypeName.BOOLEAN, BooleanCoder.of())
+          .build();
+
+  private static class LogicalTypeCoder<InputT, BaseT> extends Coder<InputT> {
+    private final LogicalType<InputT, BaseT> logicalType;
+    private final Coder<BaseT> baseTypeCoder;
+    private final boolean isDateTime;
+
+    LogicalTypeCoder(LogicalType<InputT, BaseT> logicalType, Coder baseTypeCoder) {
+      this.logicalType = logicalType;
+      this.baseTypeCoder = baseTypeCoder;
+      this.isDateTime = logicalType.getBaseType().equals(FieldType.DATETIME);
+    }
+
+    @Override
+    public void encode(InputT value, OutputStream outStream) throws CoderException, IOException {
+      BaseT baseType = logicalType.toBaseType(value);
+      if (isDateTime) {
+        baseType = (BaseT) ((ReadableInstant) baseType).toInstant();
+      }
+      baseTypeCoder.encode(baseType, outStream);
+    }
+
+    @Override
+    public InputT decode(InputStream inStream) throws CoderException, IOException {
+      BaseT baseType = baseTypeCoder.decode(inStream);
+      return logicalType.toInputType(baseType);
+    }
+
+    @Override
+    public List<? extends Coder<?>> getCoderArguments() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public void verifyDeterministic() throws NonDeterministicException {
+      baseTypeCoder.verifyDeterministic();
+    }
+
+    @Override
+    public boolean consistentWithEquals() {
+      // we can't assume that InputT is consistent with equals.
+      // TODO: We should plumb this through to logical types.
+      return false;
+    }
+
+    @Override
+    public Object structuralValue(InputT value) {
+      if (baseTypeCoder.consistentWithEquals()) {
+        return logicalType.toBaseType(value);
+      } else {
+        return baseTypeCoder.structuralValue(logicalType.toBaseType(value));
+      }
+    }
+
+    @Override
+    public boolean isRegisterByteSizeObserverCheap(InputT value) {
+      return baseTypeCoder.isRegisterByteSizeObserverCheap(logicalType.toBaseType(value));
+    }
+
+    @Override
+    public void registerByteSizeObserver(InputT value, ElementByteSizeObserver observer)
+        throws Exception {
+      baseTypeCoder.registerByteSizeObserver(logicalType.toBaseType(value), observer);
+    }
+  }
+
+  /** Returns the coder used for a given primitive type. */
+  public static <T> Coder<T> coderForFieldType(FieldType fieldType) {
+    Coder<T> coder;
+    switch (fieldType.getTypeName()) {
+      case ROW:
+        coder = (Coder<T>) SchemaCoder.of(fieldType.getRowSchema());
+        break;
+      case ARRAY:
+        coder = (Coder<T>) ListCoder.of(coderForFieldType(fieldType.getCollectionElementType()));
+        break;
+      case ITERABLE:
+        coder =
+            (Coder<T>) IterableCoder.of(coderForFieldType(fieldType.getCollectionElementType()));
+        break;
+      case MAP:
+        coder =
+            (Coder<T>)
+                MapCoder.of(
+                    coderForFieldType(fieldType.getMapKeyType()),
+                    coderForFieldType(fieldType.getMapValueType()));
+        break;
+      case LOGICAL_TYPE:
+        coder =
+            new LogicalTypeCoder(
+                fieldType.getLogicalType(),
+                coderForFieldType(fieldType.getLogicalType().getBaseType()));
+        break;
+      default:
+        coder = (Coder<T>) CODER_MAP.get(fieldType.getTypeName());
+    }
+    Preconditions.checkNotNull(coder, "Unexpected field type " + fieldType.getTypeName());
+    if (fieldType.getNullable()) {
+      coder = NullableCoder.of(coder);
+    }
+    return coder;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/EnumerationType.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/EnumerationType.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.schemas.logicaltypes;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -74,12 +75,12 @@ public class EnumerationType implements LogicalType<Value, Integer> {
   }
   /** Return an {@link Value} corresponding to one of the enumeration strings. */
   public Value valueOf(String stringValue) {
-    return new Value(stringValue, enumValues.get(stringValue));
+    return new Value(enumValues.get(stringValue));
   }
 
   /** Return an {@link Value} corresponding to one of the enumeration integer values. */
   public Value valueOf(int value) {
-    return new Value(enumValues.inverse().get(value), value);
+    return new Value(value);
   }
 
   @Override
@@ -120,6 +121,10 @@ public class EnumerationType implements LogicalType<Value, Integer> {
     return values;
   }
 
+  public String toString(EnumerationType.Value value) {
+    return enumValues.inverse().get(value.getValue());
+  }
+
   @Override
   public String toString() {
     return "Enumeration: " + enumValues;
@@ -128,24 +133,16 @@ public class EnumerationType implements LogicalType<Value, Integer> {
   /**
    * This class represents a single enum value. It can be referenced as a String or as an integer.
    */
-  public static class Value {
-    private final String stringValue;
+  public static class Value implements Serializable {
     private final int value;
 
-    public Value(String stringValue, int value) {
-      this.stringValue = stringValue;
+    public Value(int value) {
       this.value = value;
     }
 
     /** Return the integer enum value. */
     public int getValue() {
       return value;
-    }
-
-    /** Return the String enum value. */
-    @Override
-    public String toString() {
-      return stringValue;
     }
 
     @Override
@@ -157,12 +154,17 @@ public class EnumerationType implements LogicalType<Value, Integer> {
         return false;
       }
       Value enumValue = (Value) o;
-      return value == enumValue.value && Objects.equals(stringValue, enumValue.stringValue);
+      return value == enumValue.value;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(stringValue, value);
+      return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+      return "enum value: " + value;
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/OneOfType.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/OneOfType.java
@@ -23,6 +23,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -129,13 +130,17 @@ public class OneOfType implements LogicalType<OneOfType.Value, Row> {
 
   /** Create a {@link Value} specifying which field to set and the value to set. */
   public <T> Value createValue(EnumerationType.Value caseType, T value) {
-    return new Value(caseType, oneOfSchema.getField(caseType.toString()).getType(), value);
+    return new Value(caseType, value);
+  }
+
+  public FieldType getFieldType(OneOfType.Value oneOneValue) {
+    return oneOfSchema.getField(enumerationType.toString(oneOneValue.getCaseType())).getType();
   }
 
   @Override
   public Row toBaseType(Value input) {
     EnumerationType.Value caseType = input.getCaseType();
-    int setFieldIndex = oneOfSchema.indexOf(caseType.toString());
+    int setFieldIndex = oneOfSchema.indexOf(enumerationType.toString(caseType));
     Row.Builder builder = Row.withSchema(oneOfSchema);
     for (int i = 0; i < oneOfSchema.getFieldCount(); ++i) {
       Object value = (i == setFieldIndex) ? input.getValue() : null;
@@ -171,12 +176,10 @@ public class OneOfType implements LogicalType<OneOfType.Value, Row> {
    */
   public static class Value {
     private final EnumerationType.Value caseType;
-    private final FieldType fieldType;
     private final Object value;
 
-    public Value(EnumerationType.Value caseType, FieldType fieldType, Object value) {
+    public Value(EnumerationType.Value caseType, Object value) {
       this.caseType = caseType;
-      this.fieldType = fieldType;
       this.value = value;
     }
 
@@ -195,14 +198,26 @@ public class OneOfType implements LogicalType<OneOfType.Value, Row> {
       return value;
     }
 
-    /** Return the type of this union field. */
-    public FieldType getFieldType() {
-      return fieldType;
-    }
-
     @Override
     public String toString() {
       return "caseType: " + caseType + " Value: " + value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Value value1 = (Value) o;
+      return Objects.equals(caseType, value1.caseType) && Objects.equals(value, value1.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(caseType, value);
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Group.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Group.java
@@ -168,7 +168,21 @@ public class Group {
       return new CombineFieldsGlobally<>(
           SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName));
+                  FieldAccessDescriptor.withFieldNames(inputFieldName),
+                  false,
+                  fn,
+                  outputFieldName));
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsGlobally<InputT> aggregateFieldBaseValue(
+            String inputFieldName,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            String outputFieldName) {
+      return new CombineFieldsGlobally<>(
+          SchemaAggregateFn.create()
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), true, fn, outputFieldName));
     }
 
     /** The same as {@link #aggregateField} but using field id. */
@@ -179,7 +193,18 @@ public class Group {
       return new CombineFieldsGlobally<>(
           SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName));
+                  FieldAccessDescriptor.withFieldIds(inputFieldId), false, fn, outputFieldName));
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsGlobally<InputT> aggregateFieldBaseValue(
+            int inputFieldId,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            String outputFieldName) {
+      return new CombineFieldsGlobally<>(
+          SchemaAggregateFn.create()
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldIds(inputFieldId), true, fn, outputFieldName));
     }
 
     /**
@@ -195,7 +220,18 @@ public class Group {
       return new CombineFieldsGlobally<>(
           SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField));
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), false, fn, outputField));
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsGlobally<InputT> aggregateFieldBaseValue(
+            String inputFieldName,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            Field outputField) {
+      return new CombineFieldsGlobally<>(
+          SchemaAggregateFn.create()
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), true, fn, outputField));
     }
 
     /** The same as {@link #aggregateField} but using field id. */
@@ -203,7 +239,19 @@ public class Group {
         int inputFielId, CombineFn<CombineInputT, AccumT, CombineOutputT> fn, Field outputField) {
       return new CombineFieldsGlobally<>(
           SchemaAggregateFn.create()
-              .aggregateFields(FieldAccessDescriptor.withFieldIds(inputFielId), fn, outputField));
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldIds(inputFielId), false, fn, outputField));
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsGlobally<InputT> aggregateFieldBaseValue(
+            int inputFielId,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            Field outputField) {
+      return new CombineFieldsGlobally<>(
+          SchemaAggregateFn.create()
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldIds(inputFielId), true, fn, outputField));
     }
 
     /**
@@ -249,7 +297,8 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
       return new CombineFieldsGlobally<>(
-          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, fn, outputFieldName));
+          SchemaAggregateFn.create()
+              .aggregateFields(fieldsToAggregate, false, fn, outputFieldName));
     }
 
     /**
@@ -285,7 +334,7 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
       return new CombineFieldsGlobally<>(
-          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, fn, outputField));
+          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, false, fn, outputField));
     }
 
     @Override
@@ -341,7 +390,17 @@ public class Group {
         String outputFieldName) {
       return new CombineFieldsGlobally<>(
           schemaAggregateFn.aggregateFields(
-              FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName));
+              FieldAccessDescriptor.withFieldNames(inputFieldName), false, fn, outputFieldName));
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsGlobally<InputT> aggregateFieldBaseValue(
+            String inputFieldName,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            String outputFieldName) {
+      return new CombineFieldsGlobally<>(
+          schemaAggregateFn.aggregateFields(
+              FieldAccessDescriptor.withFieldNames(inputFieldName), true, fn, outputFieldName));
     }
 
     public <CombineInputT, AccumT, CombineOutputT> CombineFieldsGlobally<InputT> aggregateField(
@@ -350,7 +409,17 @@ public class Group {
         String outputFieldName) {
       return new CombineFieldsGlobally<>(
           schemaAggregateFn.aggregateFields(
-              FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName));
+              FieldAccessDescriptor.withFieldIds(inputFieldId), false, fn, outputFieldName));
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsGlobally<InputT> aggregateFieldBaseValue(
+            int inputFieldId,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            String outputFieldName) {
+      return new CombineFieldsGlobally<>(
+          schemaAggregateFn.aggregateFields(
+              FieldAccessDescriptor.withFieldIds(inputFieldId), true, fn, outputFieldName));
     }
 
     /**
@@ -365,14 +434,34 @@ public class Group {
         Field outputField) {
       return new CombineFieldsGlobally<>(
           schemaAggregateFn.aggregateFields(
-              FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField));
+              FieldAccessDescriptor.withFieldNames(inputFieldName), false, fn, outputField));
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsGlobally<InputT> aggregateFieldBaseValue(
+            String inputFieldName,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            Field outputField) {
+      return new CombineFieldsGlobally<>(
+          schemaAggregateFn.aggregateFields(
+              FieldAccessDescriptor.withFieldNames(inputFieldName), true, fn, outputField));
     }
 
     public <CombineInputT, AccumT, CombineOutputT> CombineFieldsGlobally<InputT> aggregateField(
         int inputFieldId, CombineFn<CombineInputT, AccumT, CombineOutputT> fn, Field outputField) {
       return new CombineFieldsGlobally<>(
           schemaAggregateFn.aggregateFields(
-              FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputField));
+              FieldAccessDescriptor.withFieldIds(inputFieldId), false, fn, outputField));
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsGlobally<InputT> aggregateFieldBaseValue(
+            int inputFieldId,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            Field outputField) {
+      return new CombineFieldsGlobally<>(
+          schemaAggregateFn.aggregateFields(
+              FieldAccessDescriptor.withFieldIds(inputFieldId), true, fn, outputField));
     }
 
     /**
@@ -417,7 +506,7 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
       return new CombineFieldsGlobally<>(
-          schemaAggregateFn.aggregateFields(fieldAccessDescriptor, fn, outputFieldName));
+          schemaAggregateFn.aggregateFields(fieldAccessDescriptor, false, fn, outputFieldName));
     }
 
     /**
@@ -453,7 +542,7 @@ public class Group {
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
       return new CombineFieldsGlobally<>(
-          schemaAggregateFn.aggregateFields(fieldAccessDescriptor, fn, outputField));
+          schemaAggregateFn.aggregateFields(fieldAccessDescriptor, false, fn, outputField));
     }
 
     @Override
@@ -554,7 +643,21 @@ public class Group {
           this,
           SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName),
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), false, fn, outputFieldName),
+          getKeyField(),
+          getValueField());
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsByFields<InputT> aggregateFieldBaseValue(
+            String inputFieldName,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            String outputFieldName) {
+      return CombineFieldsByFields.of(
+          this,
+          SchemaAggregateFn.create()
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), true, fn, outputFieldName),
           getKeyField(),
           getValueField());
     }
@@ -567,7 +670,21 @@ public class Group {
           this,
           SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName),
+                  FieldAccessDescriptor.withFieldIds(inputFieldId), false, fn, outputFieldName),
+          getKeyField(),
+          getValueField());
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsByFields<InputT> aggregateFieldBaseValue(
+            int inputFieldId,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            String outputFieldName) {
+      return CombineFieldsByFields.of(
+          this,
+          SchemaAggregateFn.create()
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldIds(inputFieldId), true, fn, outputFieldName),
           getKeyField(),
           getValueField());
     }
@@ -586,7 +703,21 @@ public class Group {
           this,
           SchemaAggregateFn.create()
               .aggregateFields(
-                  FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField),
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), false, fn, outputField),
+          getKeyField(),
+          getValueField());
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsByFields<InputT> aggregateFieldBaseValue(
+            String inputFieldName,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            Field outputField) {
+      return CombineFieldsByFields.of(
+          this,
+          SchemaAggregateFn.create()
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldNames(inputFieldName), true, fn, outputField),
           getKeyField(),
           getValueField());
     }
@@ -596,7 +727,22 @@ public class Group {
       return CombineFieldsByFields.of(
           this,
           SchemaAggregateFn.create()
-              .aggregateFields(FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputField),
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldIds(inputFieldId), false, fn, outputField),
+          getKeyField(),
+          getValueField());
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsByFields<InputT> aggregateFieldBaseValue(
+            int inputFieldId,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            Field outputField) {
+      return CombineFieldsByFields.of(
+          this,
+          SchemaAggregateFn.create()
+              .aggregateFields(
+                  FieldAccessDescriptor.withFieldIds(inputFieldId), true, fn, outputField),
           getKeyField(),
           getValueField());
     }
@@ -644,7 +790,7 @@ public class Group {
         String outputFieldName) {
       return CombineFieldsByFields.of(
           this,
-          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, fn, outputFieldName),
+          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, false, fn, outputFieldName),
           getKeyField(),
           getValueField());
     }
@@ -683,7 +829,7 @@ public class Group {
         Field outputField) {
       return CombineFieldsByFields.of(
           this,
-          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, fn, outputField),
+          SchemaAggregateFn.create().aggregateFields(fieldsToAggregate, false, fn, outputField),
           getKeyField(),
           getValueField());
     }
@@ -792,7 +938,26 @@ public class Group {
           .setSchemaAggregateFn(
               getSchemaAggregateFn()
                   .aggregateFields(
-                      FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputFieldName))
+                      FieldAccessDescriptor.withFieldNames(inputFieldName),
+                      false,
+                      fn,
+                      outputFieldName))
+          .build();
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsByFields<InputT> aggregateFieldBaseValue(
+            String inputFieldName,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            String outputFieldName) {
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn()
+                  .aggregateFields(
+                      FieldAccessDescriptor.withFieldNames(inputFieldName),
+                      true,
+                      fn,
+                      outputFieldName))
           .build();
     }
 
@@ -804,7 +969,20 @@ public class Group {
           .setSchemaAggregateFn(
               getSchemaAggregateFn()
                   .aggregateFields(
-                      FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputFieldName))
+                      FieldAccessDescriptor.withFieldIds(inputFieldId), false, fn, outputFieldName))
+          .build();
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsByFields<InputT> aggregateFieldBaseValue(
+            int inputFieldId,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            String outputFieldName) {
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn()
+                  .aggregateFields(
+                      FieldAccessDescriptor.withFieldIds(inputFieldId), true, fn, outputFieldName))
           .build();
     }
 
@@ -822,7 +1000,20 @@ public class Group {
           .setSchemaAggregateFn(
               getSchemaAggregateFn()
                   .aggregateFields(
-                      FieldAccessDescriptor.withFieldNames(inputFieldName), fn, outputField))
+                      FieldAccessDescriptor.withFieldNames(inputFieldName), false, fn, outputField))
+          .build();
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsByFields<InputT> aggregateFieldBaseValue(
+            String inputFieldName,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            Field outputField) {
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn()
+                  .aggregateFields(
+                      FieldAccessDescriptor.withFieldNames(inputFieldName), true, fn, outputField))
           .build();
     }
 
@@ -832,7 +1023,20 @@ public class Group {
           .setSchemaAggregateFn(
               getSchemaAggregateFn()
                   .aggregateFields(
-                      FieldAccessDescriptor.withFieldIds(inputFieldId), fn, outputField))
+                      FieldAccessDescriptor.withFieldIds(inputFieldId), false, fn, outputField))
+          .build();
+    }
+
+    public <CombineInputT, AccumT, CombineOutputT>
+        CombineFieldsByFields<InputT> aggregateFieldBaseValue(
+            int inputFieldId,
+            CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
+            Field outputField) {
+      return toBuilder()
+          .setSchemaAggregateFn(
+              getSchemaAggregateFn()
+                  .aggregateFields(
+                      FieldAccessDescriptor.withFieldIds(inputFieldId), true, fn, outputField))
           .build();
     }
 
@@ -870,7 +1074,7 @@ public class Group {
         String outputFieldName) {
       return toBuilder()
           .setSchemaAggregateFn(
-              getSchemaAggregateFn().aggregateFields(fieldsToAggregate, fn, outputFieldName))
+              getSchemaAggregateFn().aggregateFields(fieldsToAggregate, false, fn, outputFieldName))
           .build();
     }
 
@@ -908,7 +1112,7 @@ public class Group {
         Field outputField) {
       return toBuilder()
           .setSchemaAggregateFn(
-              getSchemaAggregateFn().aggregateFields(fieldsToAggregate, fn, outputField))
+              getSchemaAggregateFn().aggregateFields(fieldsToAggregate, false, fn, outputField))
           .build();
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/SchemaAggregateFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/SchemaAggregateFn.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.FieldTypeDescriptors;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.schemas.utils.RowSelector;
 import org.apache.beam.sdk.schemas.utils.SelectHelpers;
@@ -42,6 +43,7 @@ import org.apache.beam.sdk.transforms.CombineFns.ComposedCombineFn;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 
 /** This is the builder used by {@link Group} to build up a composed {@link CombineFn}. */
@@ -59,6 +61,7 @@ class SchemaAggregateFn {
     // Represents an aggregation of one or more fields.
     static class FieldAggregation<FieldT, AccumT, OutputT> implements Serializable {
       FieldAccessDescriptor fieldsToAggregate;
+      private final boolean aggregateBaseValues;
       // The specification of the output field.
       private final Field outputField;
       // The combine function.
@@ -76,11 +79,13 @@ class SchemaAggregateFn {
 
       FieldAggregation(
           FieldAccessDescriptor fieldsToAggregate,
+          boolean aggregateBaseValues,
           Field outputField,
           CombineFn<FieldT, AccumT, OutputT> fn,
           TupleTag<Object> combineTag) {
         this(
             fieldsToAggregate,
+            aggregateBaseValues,
             outputField,
             fn,
             combineTag,
@@ -90,13 +95,18 @@ class SchemaAggregateFn {
 
       FieldAggregation(
           FieldAccessDescriptor fieldsToAggregate,
+          boolean aggregateBaseValues,
           Field outputField,
           CombineFn<FieldT, AccumT, OutputT> fn,
           TupleTag<Object> combineTag,
           Schema aggregationSchema,
           @Nullable Schema inputSchema) {
+        this.aggregateBaseValues = aggregateBaseValues;
         if (inputSchema != null) {
           this.fieldsToAggregate = fieldsToAggregate.resolve(inputSchema);
+          if (aggregateBaseValues) {
+            Preconditions.checkArgument(fieldsToAggregate.referencesSingleField());
+          }
           this.inputSubSchema = SelectHelpers.getOutputSchema(inputSchema, this.fieldsToAggregate);
           this.flattenedFieldAccessDescriptor =
               SelectHelpers.allLeavesDescriptor(inputSubSchema, SelectHelpers.CONCAT_FIELD_NAMES);
@@ -120,7 +130,13 @@ class SchemaAggregateFn {
       // is known, resolve will be called with the proper schema.
       FieldAggregation<FieldT, AccumT, OutputT> resolve(Schema schema) {
         return new FieldAggregation<>(
-            fieldsToAggregate, outputField, fn, combineTag, aggregationSchema, schema);
+            fieldsToAggregate,
+            aggregateBaseValues,
+            outputField,
+            fn,
+            combineTag,
+            aggregationSchema,
+            schema);
       }
     }
 
@@ -160,10 +176,17 @@ class SchemaAggregateFn {
         SimpleFunction<Row, ?> extractFunction;
         Coder extractOutputCoder;
         if (fieldAggregation.fieldsToAggregate.referencesSingleField()) {
-          extractFunction = new ExtractSingleFieldFunction(inputSchema, fieldAggregation);
-          extractOutputCoder =
-              SchemaCoder.coderForFieldType(
-                  fieldAggregation.flattenedInputSubSchema.getField(0).getType());
+          extractFunction =
+              new ExtractSingleFieldFunction(
+                  inputSchema, fieldAggregation.aggregateBaseValues, fieldAggregation);
+
+          FieldType fieldType = fieldAggregation.flattenedInputSubSchema.getField(0).getType();
+          if (fieldAggregation.aggregateBaseValues) {
+            while (fieldType.getTypeName().isLogicalType()) {
+              fieldType = fieldType.getLogicalType().getBaseType();
+            }
+          }
+          extractOutputCoder = SchemaCoder.coderForFieldType(fieldType);
         } else {
           extractFunction = new ExtractFieldsFunction(inputSchema, fieldAggregation);
           extractOutputCoder = SchemaCoder.of(fieldAggregation.inputSubSchema);
@@ -196,10 +219,12 @@ class SchemaAggregateFn {
     /** Aggregate all values of a set of fields into an output field. */
     <CombineInputT, AccumT, CombineOutputT> Inner aggregateFields(
         FieldAccessDescriptor fieldsToAggregate,
+        boolean aggregateBaseValues,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         String outputFieldName) {
       return aggregateFields(
           fieldsToAggregate,
+          aggregateBaseValues,
           fn,
           Field.of(outputFieldName, FieldTypeDescriptors.fieldTypeForJavaType(fn.getOutputType())));
     }
@@ -207,12 +232,14 @@ class SchemaAggregateFn {
     /** Aggregate all values of a set of fields into an output field. */
     <CombineInputT, AccumT, CombineOutputT> Inner aggregateFields(
         FieldAccessDescriptor fieldsToAggregate,
+        boolean aggregateBaseValues,
         CombineFn<CombineInputT, AccumT, CombineOutputT> fn,
         Field outputField) {
       List<FieldAggregation> fieldAggregations = getFieldAggregations();
       TupleTag<Object> combineTag = new TupleTag<>(Integer.toString(fieldAggregations.size()));
       FieldAggregation fieldAggregation =
-          new FieldAggregation<>(fieldsToAggregate, outputField, fn, combineTag);
+          new FieldAggregation<>(
+              fieldsToAggregate, aggregateBaseValues, outputField, fn, combineTag);
       fieldAggregations.add(fieldAggregation);
 
       return toBuilder()
@@ -232,12 +259,15 @@ class SchemaAggregateFn {
     /** Extract a single field from an input {@link Row}. */
     private static class ExtractSingleFieldFunction<OutputT> extends SimpleFunction<Row, OutputT> {
       private final RowSelector rowSelector;
+      private final boolean extractBaseValue;
       @Nullable private final RowSelector flatteningSelector;
       private final FieldAggregation fieldAggregation;
 
-      private ExtractSingleFieldFunction(Schema inputSchema, FieldAggregation fieldAggregation) {
+      private ExtractSingleFieldFunction(
+          Schema inputSchema, boolean extractBaseValue, FieldAggregation fieldAggregation) {
         rowSelector =
             new RowSelectorContainer(inputSchema, fieldAggregation.fieldsToAggregate, true);
+        this.extractBaseValue = extractBaseValue;
         flatteningSelector =
             fieldAggregation.needsFlattening
                 ? new RowSelectorContainer(
@@ -253,6 +283,10 @@ class SchemaAggregateFn {
         Row selected = rowSelector.select(row);
         if (fieldAggregation.needsFlattening) {
           selected = flatteningSelector.select(selected);
+        }
+        if (extractBaseValue
+            && selected.getSchema().getField(0).getType().getTypeName().isLogicalType()) {
+          return (OutputT) selected.getBaseValue(0, Object.class);
         }
         return selected.getValue(0);
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -910,7 +910,8 @@ public class AvroUtils {
             EnumerationType enumerationType = fieldType.getLogicalType(EnumerationType.class);
             return GenericData.get()
                 .createEnum(
-                    enumerationType.valueOf((int) value).toString(), typeWithNullability.type);
+                    enumerationType.toString((EnumerationType.Value) value),
+                    typeWithNullability.type);
           default:
             throw new RuntimeException(
                 "Unhandled logical type " + fieldType.getLogicalType().getIdentifier());

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import javax.annotation.Nullable;
@@ -377,8 +378,6 @@ public class ByteBuddyUtils {
 
     @Override
     protected Type convertEnum(TypeDescriptor<?> type) {
-      // We represent enums in the Row as Integers. The EnumerationType handles the mapping to the
-      // actual enum type.
       return Integer.class;
     }
 
@@ -576,6 +575,28 @@ public class ByteBuddyUtils {
     @Override
     public Set<Entry<K2, V2>> entrySet() {
       return delegateMap.entrySet();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TransformingMap<?, ?, ?, ?> that = (TransformingMap<?, ?, ?, ?>) o;
+      return Objects.equals(delegateMap, that.delegateMap);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(delegateMap);
+    }
+
+    @Override
+    public String toString() {
+      return delegateMap.toString();
     }
   }
 
@@ -1445,7 +1466,7 @@ public class ByteBuddyUtils {
                   stackManipulation,
                   typeConversionsFactory
                       .createSetterConversions(readParameter)
-                      .convert(TypeDescriptor.of(parameter.getType())));
+                      .convert(TypeDescriptor.of(parameter.getParameterizedType())));
         }
         stackManipulation =
             new StackManipulation.Compound(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
@@ -144,7 +144,7 @@ public class ConvertHelpers {
     }
 
     Type expectedInputType =
-        typeConversionsFactory.createTypeConversion(true).convert(outputTypeDescriptor);
+        typeConversionsFactory.createTypeConversion(false).convert(outputTypeDescriptor);
 
     TypeDescriptor<?> outputType = outputTypeDescriptor;
     if (outputType.getRawType().isPrimitive()) {
@@ -160,6 +160,7 @@ public class ConvertHelpers {
             .build();
     DynamicType.Builder<SerializableFunction> builder =
         (DynamicType.Builder<SerializableFunction>) new ByteBuddy().subclass(genericType);
+
     try {
       return builder
           .visit(new AsmVisitorWrapper.ForDeclaredMethods().writerFlags(ClassWriter.COMPUTE_FRAMES))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -431,7 +431,7 @@ public class POJOUtils {
             new StackManipulation.Compound(
                 typeConversionsFactory
                     .createGetterConversions(readValue)
-                    .convert(TypeDescriptor.of(field.getType())),
+                    .convert(TypeDescriptor.of(field.getGenericType())),
                 MethodReturn.REFERENCE);
 
         StackManipulation.Size size = stackManipulation.apply(methodVisitor, implementationContext);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -32,12 +32,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.Factory;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
@@ -72,6 +75,13 @@ public abstract class Row implements Serializable {
   public abstract int getFieldCount();
   /** Return the list of data values. */
   public abstract List<Object> getValues();
+
+  /** Return a list of data values. Any LogicalType values are returned as base values. * */
+  public List<Object> getBaseValues() {
+    return IntStream.range(0, getFieldCount())
+        .mapToObj(i -> getBaseValue(i))
+        .collect(Collectors.toList());
+  }
 
   /** Get value by field name, {@link ClassCastException} is thrown if type doesn't match. */
   @Nullable
@@ -205,13 +215,30 @@ public abstract class Row implements Serializable {
     return getMap(getSchema().indexOf(fieldName));
   }
 
-  /**
-   * Returns the Logical Type input type for this field. {@link IllegalStateException} is thrown if
+  /* Returns the Logical Type input type for this field. {@link IllegalStateException} is thrown if
    * schema doesn't match.
    */
   @Nullable
   public <T> T getLogicalTypeValue(String fieldName, Class<T> clazz) {
     return getLogicalTypeValue(getSchema().indexOf(fieldName), clazz);
+  }
+
+  /**
+   * Returns the base type for this field. If this is a logical type, we convert to the base value.
+   * Otherwise the field itself is returned.
+   */
+  @Nullable
+  public <T> T getBaseValue(String fieldName, Class<T> clazz) {
+    return getBaseValue(getSchema().indexOf(fieldName), clazz);
+  }
+
+  /**
+   * Returns the base type for this field. If this is a logical type, we convert to the base value.
+   * Otherwise the field itself is returned.
+   */
+  @Nullable
+  public Object getBaseValue(String fieldName) {
+    return getBaseValue(fieldName, Object.class);
   }
 
   /**
@@ -357,7 +384,33 @@ public abstract class Row implements Serializable {
   @Nullable
   public <T> T getLogicalTypeValue(int idx, Class<T> clazz) {
     LogicalType logicalType = checkNotNull(getSchema().getField(idx).getType().getLogicalType());
-    return (T) logicalType.toInputType(getValue(idx));
+    return (T) getValue(idx);
+  }
+
+  /**
+   * Returns the base type for this field. If this is a logical type, we convert to the base value.
+   * Otherwise the field itself is returned.
+   */
+  @Nullable
+  public <T> T getBaseValue(int idx, Class<T> clazz) {
+    Object value = getValue(idx);
+    FieldType fieldType = getSchema().getField(idx).getType();
+    if (fieldType.getTypeName().isLogicalType() && value != null) {
+      while (fieldType.getTypeName().isLogicalType()) {
+        value = fieldType.getLogicalType().toBaseType(value);
+        fieldType = fieldType.getLogicalType().getBaseType();
+      }
+    }
+    return (T) value;
+  }
+
+  /**
+   * Returns the base type for this field. If this is a logical type, we convert to the base value.
+   * Otherwise the field itself is returned.
+   */
+  @Nullable
+  public Object getBaseValue(int idx) {
+    return getBaseValue(idx, Object.class);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -41,7 +41,6 @@ import org.apache.beam.sdk.schemas.Factory;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
-import org.apache.beam.sdk.schemas.Schema.LogicalType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
@@ -383,7 +382,6 @@ public abstract class Row implements Serializable {
    */
   @Nullable
   public <T> T getLogicalTypeValue(int idx, Class<T> clazz) {
-    LogicalType logicalType = checkNotNull(getSchema().getField(idx).getType().getLogicalType());
     return (T) getValue(idx);
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
@@ -130,10 +130,11 @@ public class RowWithGetters extends Row {
         OneOfType oneOfType = type.getLogicalType(OneOfType.class);
         OneOfType.Value oneOfValue = (OneOfType.Value) fieldValue;
         Object convertedOneOfField =
-            getValue(oneOfValue.getFieldType(), oneOfValue.getValue(), null);
-        return (T)
-            oneOfType.toBaseType(
-                oneOfType.createValue(oneOfValue.getCaseType(), convertedOneOfField));
+            getValue(oneOfType.getFieldType(oneOfValue), oneOfValue.getValue(), null);
+        return (T) oneOfType.createValue(oneOfValue.getCaseType(), convertedOneOfField);
+      } else if (type.getTypeName().isLogicalType()) {
+        // Getters are assumed to return the base type.
+        return (T) type.getLogicalType().toInputType(fieldValue);
       }
       return (T) fieldValue;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/SchemaVerification.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/SchemaVerification.java
@@ -78,7 +78,8 @@ public abstract class SchemaVerification implements Serializable {
   }
 
   private static Object verifyLogicalType(Object value, LogicalType logicalType, String fieldName) {
-    return verifyFieldValue(logicalType.toBaseType(value), logicalType.getBaseType(), fieldName);
+    // TODO: this isn't guaranteed to clone the object.
+    return logicalType.toInputType(logicalType.toBaseType(value));
   }
 
   private static List<Object> verifyArray(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
@@ -477,7 +477,7 @@ public class AvroSchemaTest {
   @Test
   @Category(ValidatesRunner.class)
   public void testAvroPipelineGroupBy() {
-    PCollection<Row> input = pipeline.apply(Create.of(ROW_FOR_POJO)).setRowSchema(POJO_SCHEMA);
+    PCollection<Row> input = pipeline.apply(Create.of(ROW_FOR_POJO).withRowSchema(POJO_SCHEMA));
 
     PCollection<Row> output = input.apply(Group.byFieldNames("string"));
     Schema keySchema = Schema.builder().addStringField("string").build();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaFieldSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaFieldSchemaTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.schemas;
 
+import static org.apache.beam.sdk.schemas.utils.TestPOJOs.ENUMERATION;
 import static org.apache.beam.sdk.schemas.utils.TestPOJOs.NESTED_ARRAYS_POJO_SCHEMA;
 import static org.apache.beam.sdk.schemas.utils.TestPOJOs.NESTED_ARRAY_POJO_SCHEMA;
 import static org.apache.beam.sdk.schemas.utils.TestPOJOs.NESTED_MAP_POJO_SCHEMA;
@@ -592,20 +593,32 @@ public class JavaFieldSchemaTest {
     SchemaRegistry registry = SchemaRegistry.createDefault();
     Schema schema = registry.getSchema(PojoWithEnum.class);
     SchemaTestUtils.assertSchemaEquivalent(POJO_WITH_ENUM_SCHEMA, schema);
-    EnumerationType enumerationType =
-        POJO_WITH_ENUM_SCHEMA.getField(0).getType().getLogicalType(EnumerationType.class);
+    EnumerationType enumerationType = ENUMERATION;
 
+    List<EnumerationType.Value> allColors =
+        Lists.newArrayList(
+            enumerationType.valueOf("RED"),
+            enumerationType.valueOf("GREEN"),
+            enumerationType.valueOf("BLUE"));
     Row redRow =
-        Row.withSchema(POJO_WITH_ENUM_SCHEMA).addValue(enumerationType.valueOf("RED")).build();
+        Row.withSchema(POJO_WITH_ENUM_SCHEMA)
+            .addValues(enumerationType.valueOf("RED"), allColors)
+            .build();
     Row greenRow =
-        Row.withSchema(POJO_WITH_ENUM_SCHEMA).addValue(enumerationType.valueOf("GREEN")).build();
+        Row.withSchema(POJO_WITH_ENUM_SCHEMA)
+            .addValues(enumerationType.valueOf("GREEN"), allColors)
+            .build();
     Row blueRow =
-        Row.withSchema(POJO_WITH_ENUM_SCHEMA).addValue(enumerationType.valueOf("BLUE")).build();
+        Row.withSchema(POJO_WITH_ENUM_SCHEMA)
+            .addValues(enumerationType.valueOf("BLUE"), allColors)
+            .build();
+
+    List<Color> allColorsJava = Lists.newArrayList(Color.RED, Color.GREEN, Color.BLUE);
 
     SerializableFunction<PojoWithEnum, Row> toRow = registry.getToRowFunction(PojoWithEnum.class);
-    assertEquals(redRow, toRow.apply(new PojoWithEnum(Color.RED)));
-    assertEquals(greenRow, toRow.apply(new PojoWithEnum(Color.GREEN)));
-    assertEquals(blueRow, toRow.apply(new PojoWithEnum(Color.BLUE)));
+    assertEquals(redRow, toRow.apply(new PojoWithEnum(Color.RED, allColorsJava)));
+    assertEquals(greenRow, toRow.apply(new PojoWithEnum(Color.GREEN, allColorsJava)));
+    assertEquals(blueRow, toRow.apply(new PojoWithEnum(Color.BLUE, allColorsJava)));
   }
 
   @Test
@@ -613,20 +626,32 @@ public class JavaFieldSchemaTest {
     SchemaRegistry registry = SchemaRegistry.createDefault();
     Schema schema = registry.getSchema(PojoWithEnum.class);
     SchemaTestUtils.assertSchemaEquivalent(POJO_WITH_ENUM_SCHEMA, schema);
-    EnumerationType enumerationType =
-        POJO_WITH_ENUM_SCHEMA.getField(0).getType().getLogicalType(EnumerationType.class);
+    EnumerationType enumerationType = ENUMERATION;
+
+    List<EnumerationType.Value> allColors =
+        Lists.newArrayList(
+            enumerationType.valueOf("RED"),
+            enumerationType.valueOf("GREEN"),
+            enumerationType.valueOf("BLUE"));
 
     Row redRow =
-        Row.withSchema(POJO_WITH_ENUM_SCHEMA).addValue(enumerationType.valueOf("RED")).build();
+        Row.withSchema(POJO_WITH_ENUM_SCHEMA)
+            .addValues(enumerationType.valueOf("RED"), allColors)
+            .build();
     Row greenRow =
-        Row.withSchema(POJO_WITH_ENUM_SCHEMA).addValue(enumerationType.valueOf("GREEN")).build();
+        Row.withSchema(POJO_WITH_ENUM_SCHEMA)
+            .addValues(enumerationType.valueOf("GREEN"), allColors)
+            .build();
     Row blueRow =
-        Row.withSchema(POJO_WITH_ENUM_SCHEMA).addValue(enumerationType.valueOf("BLUE")).build();
+        Row.withSchema(POJO_WITH_ENUM_SCHEMA)
+            .addValues(enumerationType.valueOf("BLUE"), allColors)
+            .build();
 
     SerializableFunction<Row, PojoWithEnum> fromRow =
         registry.getFromRowFunction(PojoWithEnum.class);
-    assertEquals(new PojoWithEnum(Color.RED), fromRow.apply(redRow));
-    assertEquals(new PojoWithEnum(Color.GREEN), fromRow.apply(greenRow));
-    assertEquals(new PojoWithEnum(Color.BLUE), fromRow.apply(blueRow));
+    List<Color> allColorsJava = Lists.newArrayList(Color.RED, Color.GREEN, Color.BLUE);
+    assertEquals(new PojoWithEnum(Color.RED, allColorsJava), fromRow.apply(redRow));
+    assertEquals(new PojoWithEnum(Color.GREEN, allColorsJava), fromRow.apply(greenRow));
+    assertEquals(new PojoWithEnum(Color.BLUE, allColorsJava), fromRow.apply(blueRow));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
@@ -38,9 +38,9 @@ public class LogicalTypesTest {
     EnumerationType enumeration = EnumerationType.create(enumMap);
     assertEquals(enumeration.valueOf(1), enumeration.valueOf("FIRST"));
     assertEquals(enumeration.valueOf(2), enumeration.valueOf("SECOND"));
-    assertEquals("FIRST", enumeration.valueOf(1).toString());
+    assertEquals("FIRST", enumeration.toString(enumeration.valueOf(1)));
     assertEquals(1, enumeration.valueOf("FIRST").getValue());
-    assertEquals("SECOND", enumeration.valueOf(2).toString());
+    assertEquals("SECOND", enumeration.toString(enumeration.valueOf(2)));
     assertEquals(2, enumeration.valueOf("SECOND").getValue());
 
     Schema schema =
@@ -65,12 +65,12 @@ public class LogicalTypesTest {
     Row stringOneOf =
         Row.withSchema(schema).addValue(oneOf.createValue("string", "stringValue")).build();
     Value union = stringOneOf.getLogicalTypeValue(0, OneOfType.Value.class);
-    assertEquals("string", union.getCaseType().toString());
+    assertEquals("string", oneOf.getCaseEnumType().toString(union.getCaseType()));
     assertEquals("stringValue", union.getValue());
 
     Row intOneOf = Row.withSchema(schema).addValue(oneOf.createValue("int32", 42)).build();
     union = intOneOf.getLogicalTypeValue(0, OneOfType.Value.class);
-    assertEquals("int32", union.getCaseType().toString());
+    assertEquals("int32", oneOf.getCaseEnumType().toString(union.getCaseType()));
     assertEquals(42, (int) union.getValue());
   }
 
@@ -83,7 +83,7 @@ public class LogicalTypesTest {
     Schema schema = Schema.builder().addLogicalTypeField("now", new NanosInstant()).build();
     Row row = Row.withSchema(schema).addValues(now).build();
     assertEquals(now, row.getLogicalTypeValue(0, NanosInstant.class));
-    assertEquals(nowAsRow, row.getValue(0));
+    assertEquals(nowAsRow, row.getBaseValue(0, Row.class));
   }
 
   @Test
@@ -95,6 +95,6 @@ public class LogicalTypesTest {
     Schema schema = Schema.builder().addLogicalTypeField("duration", new NanosDuration()).build();
     Row row = Row.withSchema(schema).addValues(duration).build();
     assertEquals(duration, row.getLogicalTypeValue(0, NanosDuration.class));
-    assertEquals(durationAsRow, row.getValue(0));
+    assertEquals(durationAsRow, row.getBaseValue(0, Row.class));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaTestUtils.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaTestUtils.java
@@ -21,9 +21,16 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
@@ -36,6 +43,135 @@ public class SchemaTestUtils {
   // (recursively) contain the same fields with the same names, but possibly different orders.
   public static void assertSchemaEquivalent(Schema expected, Schema actual) {
     assertTrue("Expected: " + expected + "  Got: " + actual, actual.equivalent(expected));
+  }
+
+  public static class RowEquivalent extends BaseMatcher<Row> {
+    private final Row expected;
+
+    public RowEquivalent(Row expected) {
+      this.expected = expected;
+    }
+
+    @Override
+    public boolean matches(Object actual) {
+      if (actual == null) {
+        return expected == null;
+      }
+      if (!(actual instanceof Row)) {
+        return false;
+      }
+      Row actualRow = (Row) actual;
+      return rowsEquivalent(expected, actualRow);
+    }
+
+    private static boolean rowsEquivalent(Row expected, Row actual) {
+      if (!actual.getSchema().equivalent(expected.getSchema())) {
+        return false;
+      }
+      if (expected.getFieldCount() != actual.getFieldCount()) {
+        return false;
+      }
+      for (int i = 0; i < expected.getFieldCount(); ++i) {
+        Field field = expected.getSchema().getField(i);
+        int actualIndex = actual.getSchema().indexOf(field.getName());
+        if (!fieldsEquivalent(
+            expected.getValue(i), actual.getValue(actualIndex), field.getType())) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private static boolean fieldsEquivalent(Object expected, Object actual, FieldType fieldType) {
+      if (expected == null || actual == null) {
+        return expected == actual;
+      } else if (fieldType.getTypeName() == TypeName.LOGICAL_TYPE) {
+        return fieldsEquivalent(expected, actual, fieldType.getLogicalType().getBaseType());
+      } else if (fieldType.getTypeName() == Schema.TypeName.BYTES) {
+        return Arrays.equals((byte[]) expected, (byte[]) actual);
+      } else if (fieldType.getTypeName() == TypeName.ARRAY) {
+        return collectionsEquivalent(
+            (Collection<Object>) expected,
+            (Collection<Object>) actual,
+            fieldType.getCollectionElementType());
+      } else if (fieldType.getTypeName() == TypeName.ITERABLE) {
+        return iterablesEquivalent(
+            (Iterable<Object>) expected,
+            (Iterable<Object>) actual,
+            fieldType.getCollectionElementType());
+      } else if (fieldType.getTypeName() == Schema.TypeName.MAP) {
+        return mapsEquivalent(
+            (Map<Object, Object>) expected,
+            (Map<Object, Object>) actual,
+            fieldType.getMapValueType());
+      } else {
+        return Objects.equals(expected, actual);
+      }
+    }
+
+    static boolean collectionsEquivalent(
+        Collection<Object> expected, Collection<Object> actual, Schema.FieldType elementType) {
+      if (expected == actual) {
+        return true;
+      }
+
+      if (expected.size() != actual.size()) {
+        return false;
+      }
+
+      return iterablesEquivalent(expected, actual, elementType);
+    }
+
+    static boolean iterablesEquivalent(
+        Iterable<Object> expected, Iterable<Object> actual, Schema.FieldType elementType) {
+      if (expected == actual) {
+        return true;
+      }
+      Iterator<Object> actualIter = actual.iterator();
+      for (Object currentExpected : expected) {
+        if (!actualIter.hasNext()) {
+          return false;
+        }
+        if (!fieldsEquivalent(currentExpected, actualIter.next(), elementType)) {
+          return false;
+        }
+      }
+      return !actualIter.hasNext();
+    }
+
+    static <K, V> boolean mapsEquivalent(
+        Map<K, V> expected, Map<K, V> actual, Schema.FieldType valueType) {
+      if (expected == actual) {
+        return true;
+      }
+
+      if (expected.size() != actual.size()) {
+        return false;
+      }
+
+      for (Map.Entry<K, V> expectedElement : expected.entrySet()) {
+        K key = expectedElement.getKey();
+        V value = expectedElement.getValue();
+        V otherValue = actual.get(key);
+
+        if (value == null) {
+          if (otherValue != null || !actual.containsKey(key)) {
+            return false;
+          }
+        } else {
+          if (!fieldsEquivalent(value, otherValue, valueType)) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendValue(expected);
+    }
   }
 
   public static class RowFieldMatcherIterableFieldAnyOrder extends BaseMatcher<Row> {
@@ -67,7 +203,7 @@ public class SchemaTestUtils {
             return false;
           }
           Row actualRow = row.getRow(fieldIndex);
-          return equalTo((Row) expected).matches(actualRow);
+          return new RowEquivalent((Row) expected).matches(actualRow);
         case ARRAY:
           Row[] expectedArray = ((List<Row>) expected).toArray(new Row[0]);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
@@ -872,10 +872,12 @@ public class TestPOJOs {
     };
 
     public final Color color;
+    public final List<Color> colors;
 
     @SchemaCreate
-    public PojoWithEnum(Color color) {
+    public PojoWithEnum(Color color, List<Color> colors) {
       this.color = color;
+      this.colors = colors;
     }
 
     @Override
@@ -887,19 +889,22 @@ public class TestPOJOs {
         return false;
       }
       PojoWithEnum that = (PojoWithEnum) o;
-      return color == that.color;
+      return color == that.color && Objects.equals(colors, that.colors);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(color);
+      return Objects.hash(color, colors);
     }
   }
 
   /** The schema for {@link PojoWithEnum}. */
+  public static final EnumerationType ENUMERATION = EnumerationType.create("RED", "GREEN", "BLUE");
+
   public static final Schema POJO_WITH_ENUM_SCHEMA =
       Schema.builder()
-          .addLogicalTypeField("color", EnumerationType.create("RED", "GREEN", "BLUE"))
+          .addLogicalTypeField("color", ENUMERATION)
+          .addArrayField("colors", FieldType.logicalType(ENUMERATION))
           .build();
 
   /** A simple POJO containing nullable basic types. * */

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoDynamicMessageSchema.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoDynamicMessageSchema.java
@@ -441,10 +441,10 @@ public class ProtoDynamicMessageSchema<T> implements Serializable {
 
     @Override
     Object convertToProtoValue(FieldDescriptor fieldDescriptor, Object value) {
-      Row row = (Row) value;
+      Instant ts = (Instant) value;
       return com.google.protobuf.Timestamp.newBuilder()
-          .setSeconds(row.getInt64(0))
-          .setNanos(row.getInt32(1))
+          .setSeconds(ts.getEpochSecond())
+          .setNanos(ts.getNano())
           .build();
     }
   }
@@ -486,10 +486,10 @@ public class ProtoDynamicMessageSchema<T> implements Serializable {
 
     @Override
     Object convertToProtoValue(FieldDescriptor fieldDescriptor, Object value) {
-      Row row = (Row) value;
+      Duration duration = (Duration) value;
       return com.google.protobuf.Duration.newBuilder()
-          .setSeconds(row.getInt64(0))
-          .setNanos(row.getInt32(1))
+          .setSeconds(duration.getSeconds())
+          .setNanos(duration.getNano())
           .build();
     }
   }
@@ -689,12 +689,12 @@ public class ProtoDynamicMessageSchema<T> implements Serializable {
     @Override
     Object convertToProtoValue(FieldDescriptor fieldDescriptor, Object value) {
       Descriptors.EnumDescriptor enumType = fieldDescriptor.getEnumType();
-      return enumType.findValueByNumber((Integer) value);
+      return enumType.findValueByNumber(((EnumerationType.Value) value).getValue());
     }
   }
 
   /** Convert Proto oneOf fields into the {@link OneOfType} logical type. */
-  static class OneOfConvert extends Convert<OneOfType.Value, Row> {
+  static class OneOfConvert extends Convert<OneOfType.Value, OneOfType.Value> {
     OneOfType logicalType;
     Map<Integer, Convert> oneOfConvert = new HashMap<>();
 
@@ -726,8 +726,7 @@ public class ProtoDynamicMessageSchema<T> implements Serializable {
     }
 
     @Override
-    void setOnProtoMessage(Message.Builder message, Row value) {
-      OneOfType.Value oneOf = logicalType.toInputType(value);
+    void setOnProtoMessage(Message.Builder message, OneOfType.Value oneOf) {
       int caseIndex = oneOf.getCaseType().getValue();
       oneOfConvert.get(caseIndex).setOnProtoMessage(message, oneOf.getValue());
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -287,7 +287,7 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
     Object[] convertedColumns = new Object[schema.getFields().size()];
     int i = 0;
     for (Schema.Field field : schema.getFields()) {
-      convertedColumns[i] = fieldToAvatica(field.getType(), row.getValue(i));
+      convertedColumns[i] = fieldToAvatica(field.getType(), row.getBaseValue(i, Object.class));
       ++i;
     }
     return convertedColumns;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
@@ -345,8 +345,8 @@ public class BeamSortRel extends Sort implements BeamRelNode {
             case VARCHAR:
             case DATE:
             case TIMESTAMP:
-              Comparable v1 = (Comparable) row1.getValue(fieldIndex);
-              Comparable v2 = (Comparable) row2.getValue(fieldIndex);
+              Comparable v1 = row1.getBaseValue(fieldIndex, Comparable.class);
+              Comparable v2 = row2.getBaseValue(fieldIndex, Comparable.class);
               fieldRet = v1.compareTo(v2);
               break;
             default:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
@@ -103,7 +103,7 @@ public class BeamUncollectRel extends Uncollect implements BeamRelNode {
       for (Object element : inputRow.getArray(0)) {
         if (element instanceof Row) {
           Row nestedRow = (Row) element;
-          output.output(Row.withSchema(schema).addValues(nestedRow.getValues()).build());
+          output.output(Row.withSchema(schema).addValues(nestedRow.getBaseValues()).build());
         } else {
           output.output(Row.withSchema(schema).addValue(element).build());
         }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
@@ -142,13 +142,13 @@ public class BeamUnnestRel extends Uncollect implements BeamRelNode {
           Row nestedRow = (Row) uncollectedValue;
           out.output(
               Row.withSchema(outputSchema)
-                  .addValues(row.getValues())
-                  .addValues(nestedRow.getValues())
+                  .addValues(row.getBaseValues())
+                  .addValues(nestedRow.getBaseValues())
                   .build());
         } else {
           out.output(
               Row.withSchema(outputSchema)
-                  .addValues(row.getValues())
+                  .addValues(row.getBaseValues())
                   .addValue(uncollectedValue)
                   .build());
         }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
@@ -84,7 +84,7 @@ public final class BeamTableUtils {
     StringWriter writer = new StringWriter();
     try (CSVPrinter printer = csvFormat.print(writer)) {
       for (int i = 0; i < row.getFieldCount(); i++) {
-        printer.print(row.getValue(i).toString());
+        printer.print(row.getBaseValue(i, Object.class).toString());
       }
       printer.println();
     } catch (IOException e) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
@@ -86,8 +86,8 @@ public class BeamJoinTransforms {
   /** As the method name suggests: combine two rows into one wide row. */
   private static Row combineTwoRowsIntoOneHelper(Row leftRow, Row rightRow, Schema ouputSchema) {
     return Row.withSchema(ouputSchema)
-        .addValues(leftRow.getValues())
-        .addValues(rightRow.getValues())
+        .addValues(leftRow.getBaseValues())
+        .addValues(rightRow.getBaseValues())
         .build();
   }
 
@@ -170,7 +170,9 @@ public class BeamJoinTransforms {
 
                     private Row extractJoinSubRow(Row factRow) {
                       List<Object> joinSubsetValues =
-                          factJoinIdx.stream().map(factRow::getValue).collect(toList());
+                          factJoinIdx.stream()
+                              .map(i -> factRow.getBaseValue(i, Object.class))
+                              .collect(toList());
 
                       return Row.withSchema(joinSubsetType).addValues(joinSubsetValues).build();
                     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/CovarianceFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/CovarianceFn.java
@@ -94,8 +94,8 @@ public class CovarianceFn<T extends Number>
 
     return currentVariance.combineWith(
         CovarianceAccumulator.ofSingleElement(
-            SqlFunctions.toBigDecimal((Object) rawInput.getValue(0)),
-            SqlFunctions.toBigDecimal((Object) rawInput.getValue(1))));
+            SqlFunctions.toBigDecimal((Object) rawInput.getBaseValue(0, Object.class)),
+            SqlFunctions.toBigDecimal((Object) rawInput.getBaseValue(1, Object.class))));
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
@@ -396,8 +396,8 @@ public class BeamComplexTypeTest {
 
     PCollection<Row> outputRow =
         pipeline
-            .apply(Create.of(row))
-            .setRowSchema(outputRowSchema)
+            .apply(Create.of(row).withRowSchema(inputRowSchema))
+            //  .setRowSchema(outputRowSchema)
             .apply(
                 SqlTransform.query(
                     "SELECT timeTypeField, dateTypeField FROM PCOLLECTION GROUP BY timeTypeField, dateTypeField"));

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
@@ -397,7 +397,6 @@ public class BeamComplexTypeTest {
     PCollection<Row> outputRow =
         pipeline
             .apply(Create.of(row).withRowSchema(inputRowSchema))
-            //  .setRowSchema(outputRowSchema)
             .apply(
                 SqlTransform.query(
                     "SELECT timeTypeField, dateTypeField FROM PCOLLECTION GROUP BY timeTypeField, dateTypeField"));

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamSqlRowCoderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamSqlRowCoderTest.java
@@ -65,8 +65,8 @@ public class BeamSqlRowCoderTest {
                 1.1,
                 BigDecimal.ZERO,
                 "hello",
-                DateTime.now(),
-                DateTime.now(),
+                DateTime.now().toInstant(),
+                DateTime.now().toInstant(),
                 true)
             .build();
     Coder<Row> coder = SchemaCoder.of(beamSchema);

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
@@ -174,7 +174,7 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
         columns.put(
             columnName(i),
             ZetaSqlUtils.javaObjectToZetaSqlValue(
-                row.getValue(i), inputSchema.getField(i).getType()));
+                row.getBaseValue(i, Object.class), inputSchema.getField(i).getType()));
       }
 
       // TODO[BEAM-8630]: support parameters in expression evaluation

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
@@ -181,7 +181,9 @@ public final class ZetaSqlUtils {
     List<Value> values = new ArrayList<>(row.getFieldCount());
 
     for (int i = 0; i < row.getFieldCount(); i++) {
-      values.add(javaObjectToZetaSqlValue(row.getValue(i), schema.getField(i).getType()));
+      values.add(
+          javaObjectToZetaSqlValue(
+              row.getBaseValue(i, Object.class), schema.getField(i).getType()));
     }
     return Value.createStructValue(createZetaSqlStructTypeFromBeamSchema(schema), values);
   }


### PR DESCRIPTION
@kanterov @alexvanboxel I believe this PR will fix the issues you've both had with logical types.

After some thought, I think we're better off storing the logical type value in the Row object. It potentially makes SchemaCoder a tiny bit slower, but unlikely this is noticeable. One bonus: it means that storage for OneOf types is far more memory efficient, as we no longer need to store the entire row.