### PR TITLE
Run precommit portability on java 11

### DIFF
--- a/.test-infra/jenkins/CommonJobProperties.groovy
+++ b/.test-infra/jenkins/CommonJobProperties.groovy
@@ -23,6 +23,8 @@
 class CommonJobProperties {
 
   static String checkoutDir = 'src'
+  final static String JAVA_8_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
+  final static String JAVA_11_HOME = '/usr/lib/jvm/java-11-openjdk-amd64'
 
   // Sets common top-level job properties for main repository jobs.
   static void setTopLevelMainJobProperties(def context,

--- a/.test-infra/jenkins/job_PreCommit_Java_PortabilityApi_Java11.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Java_PortabilityApi_Java11.groovy
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PrecommitJobBuilder
+import CommonJobProperties as properties
+
+PrecommitJobBuilder builder = new PrecommitJobBuilder(
+    scope: this,
+    nameBase: 'JavaPortabilityApiJava11',
+    gradleTask: ':clean', // Do nothing here
+    gradleSwitches: ['-PdisableSpotlessCheck=true'], // spotless checked in separate pre-commit
+    triggerPathPatterns: [
+      '^model/.*$',
+      '^sdks/java/.*$',
+      '^runners/google-cloud-dataflow-java/worker.*$',
+      '^examples/java/.*$',
+      '^examples/kotlin/.*$',
+      '^release/.*$',
+    ]
+)
+builder.build {
+    publishers {
+        archiveJunit('**/build/test-results/**/*.xml')
+    }
+
+    steps {
+        gradle {
+            rootBuildScriptDir(properties.checkoutDir)
+            tasks 'javaPreCommitPortabilityApi'
+            switches '-Pdockerfile=Dockerfile-java11'
+            switches '-PdisableSpotlessCheck=true'
+            switches '-PrunWithJava11'
+            switches "-Pjava8Home=${properties.JAVA_8_HOME}"
+            switches "-Pjava11Home=${properties.JAVA_11_HOME}"
+            properties.setGradleSwitches(delegate, 3 * Runtime.runtime.availableProcessors())
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -335,3 +335,27 @@ if (project.hasProperty('javaLinkageArtifactIds')) {
     }
   }
 }
+
+if (project.hasProperty('runWithJava11')) {
+  allprojects {
+    plugins.withId('java') {
+
+      java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+      }
+
+      tasks.withType(JavaCompile) {
+        options.with {
+          fork = true
+          forkOptions.javaHome = java8Home as File
+        }
+      }
+
+      test {
+        useJUnitPlatform()
+        executable = "${java11Home}/bin/java"
+      }
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -352,10 +352,17 @@ if (project.hasProperty('runWithJava11')) {
         }
       }
 
-      test {
-        useJUnitPlatform()
+      tasks.withType(Test) {
+        useJUnit()
         executable = "${java11Home}/bin/java"
       }
+    }
+  }
+  project.javaPreCommitPortabilityApi.dependsOn ':sdks:java:testing:test-utils:verifyJavaVersion'
+} else {
+  allprojects {
+    tasks.withType(Test) {
+      exclude '**/JvmVerification.class'
     }
   }
 }

--- a/sdks/java/testing/test-utils/build.gradle
+++ b/sdks/java/testing/test-utils/build.gradle
@@ -39,3 +39,14 @@ dependencies {
   testCompile library.java.hamcrest_library
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadowTest")
 }
+
+task verifyJavaVersion(type: Test) {
+  filter {
+    includeTestsMatching 'org.apache.beam.sdk.testutils.jvmverification.JvmVerification.verifyCodeIsCompiledWithJava8'
+    includeTestsMatching 'org.apache.beam.sdk.testutils.jvmverification.JvmVerification.verifyTestCodeIsCompiledWithJava8'
+    includeTestsMatching 'org.apache.beam.sdk.testutils.jvmverification.JvmVerification.verifyRunningJVMVersionIs11'
+  }
+  doLast {
+    println 'Java verified'
+  }
+}

--- a/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/jvmverification/JvmVerification.java
+++ b/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/jvmverification/JvmVerification.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testutils.jvmverification;
+
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v10;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v11;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v12;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v13;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v14;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v1_1;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v1_2;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v1_3;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v1_4;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v1_5;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v1_6;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v1_7;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v1_8;
+import static org.apache.beam.sdk.testutils.jvmverification.JvmVerification.Java.v9;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.repackaged.core.org.apache.commons.compress.utils.IOUtils;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.Test;
+
+public class JvmVerification {
+
+  private static final Map<String, Java> versionMapping = new HashMap<>();
+
+  static {
+    versionMapping.put("002D", v1_1);
+    versionMapping.put("002E", v1_2);
+    versionMapping.put("002F", v1_3);
+    versionMapping.put("0030", v1_4);
+    versionMapping.put("0031", v1_5);
+    versionMapping.put("0032", v1_6);
+    versionMapping.put("0033", v1_7);
+    versionMapping.put("0034", v1_8);
+    versionMapping.put("0035", v9);
+    versionMapping.put("0036", v10);
+    versionMapping.put("0037", v11);
+    versionMapping.put("0038", v12);
+    versionMapping.put("0039", v13);
+    versionMapping.put("003A", v14);
+  }
+
+  // bytecode
+  @Test
+  public void verifyCodeIsCompiledWithJava8() throws IOException {
+    assertEquals(v1_8, getByteCodeVersion(DoFn.class));
+  }
+
+  @Test
+  public void verifyTestCodeIsCompiledWithJava8() throws IOException {
+    assertEquals(v1_8, getByteCodeVersion(JvmVerification.class));
+  }
+
+  // jvm
+  @Test
+  public void verifyRunningJVMVersionIs11() {
+    final String version = getJavaSpecification();
+    assertEquals(v11.name, version);
+  }
+
+  private static <T> Java getByteCodeVersion(final Class<T> clazz) throws IOException {
+    final InputStream stream =
+        clazz.getClassLoader().getResourceAsStream(clazz.getName().replace(".", "/") + ".class");
+    final byte[] classBytes = IOUtils.toByteArray(stream);
+    final String versionInHexString =
+        Hex.encodeHexString(new byte[] {classBytes[6], classBytes[7]});
+    return versionMapping.get(versionInHexString);
+  }
+
+  private static String getJavaSpecification() {
+    return System.getProperty("java.specification.version");
+  }
+
+  enum Java {
+    v1_1("1.1"),
+    v1_2("1.2"),
+    v1_3("1.3"),
+    v1_4("1.4"),
+    v1_5("1.5"),
+    v1_6("1.6"),
+    v1_7("1.7"),
+    v1_8("1.8"),
+    v9("9"),
+    v10("10"),
+    v11("11"),
+    v12("12"),
+    v13("13"),
+    v14("14");
+
+    final String name;
+
+    Java(final String name) {
+      this.name = name;
+    }
+  }
+}


### PR DESCRIPTION
Implement precommit portability to run on java 11

This is different approach for case presented in #10878 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
