### PR TITLE
[BEAM-8910] Make custom BQ source read from Avro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,10 @@
 * Support for X source added (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 * Support for reading from Snowflake added (Java) ([BEAM-9722](https://issues.apache.org/jira/browse/BEAM-9722)).
 * Support for writing to Splunk added (Java) ([BEAM-8596](https://issues.apache.org/jira/browse/BEAM-8596)).
+* A new transform to read from BigQuery has been added: `apache_beam.io.gcp.bigquery.ReadFromBigQuery`. This transform
+  is experimental. It reads data from BigQuery by exporting data to Avro files, and reading those files. It also supports
+  reading data by exporting to JSON files. This has small differences in behavior for Time and Date-related fields. See
+  Pydoc for more information.
 
 ## New Features / Improvements
 

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -173,7 +173,8 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         'output_schema': DIALECT_OUTPUT_SCHEMA,
         'use_standard_sql': False,
         'wait_until_finish_duration': WAIT_UNTIL_FINISH_DURATION_MS,
-        'on_success_matcher': all_of(*pipeline_verifiers)
+        'on_success_matcher': all_of(*pipeline_verifiers),
+        'experiments': 'use_beam_bq_sink',
     }
     options = self.test_pipeline.get_full_options_as_args(**extra_opts)
     big_query_query_to_table_pipeline.run_bq_pipeline(options)
@@ -196,7 +197,8 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         'output_schema': DIALECT_OUTPUT_SCHEMA,
         'use_standard_sql': True,
         'wait_until_finish_duration': WAIT_UNTIL_FINISH_DURATION_MS,
-        'on_success_matcher': all_of(*pipeline_verifiers)
+        'on_success_matcher': all_of(*pipeline_verifiers),
+        'experiments': 'use_beam_bq_sink',
     }
     options = self.test_pipeline.get_full_options_as_args(**extra_opts)
     big_query_query_to_table_pipeline.run_bq_pipeline(options)
@@ -254,7 +256,8 @@ class BigQueryQueryToTableIT(unittest.TestCase):
         'output_schema': NEW_TYPES_OUTPUT_SCHEMA,
         'use_standard_sql': False,
         'wait_until_finish_duration': WAIT_UNTIL_FINISH_DURATION_MS,
-        'on_success_matcher': all_of(*pipeline_verifiers)
+        'on_success_matcher': all_of(*pipeline_verifiers),
+        'experiments': 'use_beam_bq_sink',
     }
     options = self.test_pipeline.get_full_options_as_args(**extra_opts)
     big_query_query_to_table_pipeline.run_bq_pipeline(options)

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -239,7 +239,7 @@ class BigQueryQueryToTableIT(unittest.TestCase):
     self.assertEqual(kms_key, table.encryptionConfiguration.kmsKeyName)
 
   @attr('IT')
-  def test_big_query_new_types_json(self):
+  def test_big_query_new_types(self):
     expected_checksum = test_utils.compute_hash(NEW_TYPES_OUTPUT_EXPECTED)
     verify_query = NEW_TYPES_OUTPUT_VERIFY_QUERY % self.output_table
     pipeline_verifiers = [
@@ -263,7 +263,7 @@ class BigQueryQueryToTableIT(unittest.TestCase):
     big_query_query_to_table_pipeline.run_bq_pipeline(options)
 
   @attr('IT')
-  def test_big_query_new_types(self):
+  def test_big_query_new_types_avro(self):
     expected_checksum = test_utils.compute_hash(NEW_TYPES_OUTPUT_EXPECTED)
     verify_query = NEW_TYPES_OUTPUT_VERIFY_QUERY % self.output_table
     pipeline_verifiers = [

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_it_test.py
@@ -239,6 +239,30 @@ class BigQueryQueryToTableIT(unittest.TestCase):
     self.assertEqual(kms_key, table.encryptionConfiguration.kmsKeyName)
 
   @attr('IT')
+  def test_big_query_new_types_json(self):
+    expected_checksum = test_utils.compute_hash(NEW_TYPES_OUTPUT_EXPECTED)
+    verify_query = NEW_TYPES_OUTPUT_VERIFY_QUERY % self.output_table
+    pipeline_verifiers = [
+        PipelineStateMatcher(),
+        BigqueryMatcher(
+            project=self.project,
+            query=verify_query,
+            checksum=expected_checksum)
+    ]
+    self._setup_new_types_env()
+    extra_opts = {
+        'query': NEW_TYPES_QUERY % (self.dataset_id, NEW_TYPES_INPUT_TABLE),
+        'output': self.output_table,
+        'output_schema': NEW_TYPES_OUTPUT_SCHEMA,
+        'use_standard_sql': False,
+        'wait_until_finish_duration': WAIT_UNTIL_FINISH_DURATION_MS,
+        'use_json_exports': True,
+        'on_success_matcher': all_of(*pipeline_verifiers)
+    }
+    options = self.test_pipeline.get_full_options_as_args(**extra_opts)
+    big_query_query_to_table_pipeline.run_bq_pipeline(options)
+
+  @attr('IT')
   def test_big_query_new_types(self):
     expected_checksum = test_utils.compute_hash(NEW_TYPES_OUTPUT_EXPECTED)
     verify_query = NEW_TYPES_OUTPUT_VERIFY_QUERY % self.output_table

--- a/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
+++ b/sdks/python/apache_beam/io/gcp/big_query_query_to_table_pipeline.py
@@ -63,6 +63,11 @@ def run_bq_pipeline(argv=None):
       default=False,
       action='store_true',
       help='Use NativeSources and Sinks.')
+  parser.add_argument(
+      '--use_json_exports',
+      default=False,
+      action='store_true',
+      help='Use JSON as the file format for exports.')
   known_args, pipeline_args = parser.parse_known_args(argv)
 
   table_schema = parse_table_schema_from_json(known_args.output_schema)
@@ -84,6 +89,7 @@ def run_bq_pipeline(argv=None):
         query=known_args.query,
         project=options.view_as(GoogleCloudOptions).project,
         use_standard_sql=known_args.use_standard_sql,
+        use_json_exports=known_args.use_json_exports,
         kms_key=kms_key)
   if known_args.native:
     _ = data | 'write' >> beam.io.Write(
@@ -94,11 +100,14 @@ def run_bq_pipeline(argv=None):
             write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY,
             kms_key=kms_key))
   else:
+    temp_file_format = (
+        'NEWLINE_DELIMITED_JSON' if known_args.use_json_exports else 'AVRO')
     _ = data | 'write' >> beam.io.WriteToBigQuery(
         known_args.output,
         schema=table_schema,
         create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
         write_disposition=beam.io.BigQueryDisposition.WRITE_EMPTY,
+        temp_file_format=temp_file_format,
         kms_key=kms_key)
 
   result = p.run()

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -700,7 +700,7 @@ class _CustomBigQuerySource(BoundedSource):
 
       unused_schema, metadata_list = self._export_files(bq)
       self.split_result = [
-          create_avro_source(metadata.path, 0, True)
+          create_avro_source(metadata.path, 0, True, use_fastavro=True)
           for metadata in metadata_list
       ]
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -611,7 +611,7 @@ class _CustomBigQuerySource(BoundedSource):
       flatten_results=True,
       kms_key=None,
       bigquery_job_labels=None,
-      backwards_compatible_data_format=None):
+      backwards_compatible_data_format=False):
     if table is not None and query is not None:
       raise ValueError(
           'Both a BigQuery table and a query were specified.'
@@ -1689,8 +1689,8 @@ class ReadFromBigQuery(PTransform):
               Job#JobConfiguration
     backwards_compatible_data_format (bool): By default, this transform reads
       data in native Python types that come from Avro-exports of BigQuery. By
-      setting this flag to True, the transform will return JSON-types, like
-      the older BigQuerySource.
+      setting this flag to True, the transform will return the types from
+      exports to JSON files, much like the older BigQuerySource.
    """
   def __init__(self, gcs_location=None, validate=False, *args, **kwargs):
     if gcs_location:

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -252,7 +252,6 @@ from apache_beam import pvalue
 from apache_beam.internal.gcp.json_value import from_json_value
 from apache_beam.internal.gcp.json_value import to_json_value
 from apache_beam.io.avroio import _create_avro_source as create_avro_source
-from apache_beam.io.filesystems import CompressionTypes
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.io.gcp import bigquery_tools
 from apache_beam.io.gcp.internal.clients import bigquery
@@ -699,10 +698,11 @@ class _CustomBigQuerySource(BoundedSource):
         self._setup_temporary_dataset(bq)
         self.table_reference = self._execute_query(bq)
 
-      schema, metadata_list = self._export_files(bq)
+      unused_schema, metadata_list = self._export_files(bq)
       self.split_result = [
           create_avro_source(metadata.path, 0, True)
-          for metadata in metadata_list]
+          for metadata in metadata_list
+      ]
 
       if self.query is not None:
         bq.clean_up_temporary_dataset(self._get_project())
@@ -757,7 +757,8 @@ class _CustomBigQuerySource(BoundedSource):
                                      bigquery_tools.FileFormat.AVRO,
                                      project=self._get_project(),
                                      include_header=False,
-                                     job_labels=self.bigquery_job_labels)
+                                     job_labels=self.bigquery_job_labels,
+                                     use_avro_logical_types=True)
     bq.wait_for_bq_job(job_ref)
     metadata_list = FileSystems.match([self.gcs_location])[0].metadata_list
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1649,7 +1649,8 @@ class ReadFromBigQuery(PTransform):
   """Read data from BigQuery.
 
     This PTransform uses a BigQuery export job to take a snapshot of the table
-    on GCS, and then reads from each produced JSON file.
+    on GCS, and then reads from each produced file. File format is Avro by
+    default.
 
   Args:
     table (str, callable, ValueProvider): The ID of the table, or a callable

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -761,10 +761,15 @@ class _CustomBigQuerySource(BoundedSource):
       bigquery.TableSchema instance, a list of FileMetadata instances
     """
     job_id = uuid.uuid4().hex
+    if self.backwards_compatible:
+      file_format = bigquery_tools.FileFormat.AVRO
+    else:
+      file_format = bigquery_tools.FileFormat.JSON
+
     job_ref = bq.perform_extract_job([self.gcs_location],
                                      job_id,
                                      self.table_reference,
-                                     bigquery_tools.FileFormat.AVRO,
+                                     file_format,
                                      project=self._get_project(),
                                      include_header=False,
                                      job_labels=self.bigquery_job_labels,

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -762,18 +762,22 @@ class _CustomBigQuerySource(BoundedSource):
     """
     job_id = uuid.uuid4().hex
     if self.backwards_compatible:
-      file_format = bigquery_tools.FileFormat.AVRO
+      job_ref = bq.perform_extract_job([self.gcs_location],
+                                       job_id,
+                                       self.table_reference,
+                                       bigquery_tools.FileFormat.JSON,
+                                       project=self._get_project(),
+                                       job_labels=self.bigquery_job_labels,
+                                       include_header=False)
     else:
-      file_format = bigquery_tools.FileFormat.JSON
-
-    job_ref = bq.perform_extract_job([self.gcs_location],
-                                     job_id,
-                                     self.table_reference,
-                                     file_format,
-                                     project=self._get_project(),
-                                     include_header=False,
-                                     job_labels=self.bigquery_job_labels,
-                                     use_avro_logical_types=True)
+      job_ref = bq.perform_extract_job([self.gcs_location],
+                                       job_id,
+                                       self.table_reference,
+                                       bigquery_tools.FileFormat.AVRO,
+                                       project=self._get_project(),
+                                       include_header=False,
+                                       job_labels=self.bigquery_job_labels,
+                                       use_avro_logical_types=True)
     bq.wait_for_bq_job(job_ref)
     metadata_list = FileSystems.match([self.gcs_location])[0].metadata_list
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -697,11 +697,8 @@ class _CustomBigQuerySource(BoundedSource):
     if not self.backwards_compatible:
       return create_avro_source(path, 0, True, use_fastavro=True)
     else:
-      return TextSource(path,
-                        0,
-                        CompressionTypes.UNCOMPRESSED,
-                        True,
-                        self.coder(schema))
+      return TextSource(
+          path, 0, CompressionTypes.UNCOMPRESSED, True, self.coder(schema))
 
   def split(self, desired_bundle_size, start_position=None, stop_position=None):
     if self.split_result is None:

--- a/sdks/python/apache_beam/io/gcp/bigquery_read_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_read_it_test.py
@@ -73,6 +73,10 @@ def skip(runners):
 
 def datetime_to_utc(element):
   for k, v in element.items():
+    if isinstance(v, datetime.time):
+      element[k] = str(v)
+    if isinstance(v, datetime.date):
+      element[k] = str(v)
     if isinstance(v, datetime.datetime) and v.tzinfo:
       # For datetime objects, we'll
       offset = v.utcoffset()
@@ -253,7 +257,7 @@ class ReadNewTypesTests(BigQueryReadIntegrationTests):
     expected_row = {
         'float': 0.33,
         'numeric': Decimal('10'),
-        'bytes': base64.b64encode(b'\xab\xac'),
+        'bytes': b'\xab\xac',
         'date': '3000-12-31',
         'time': '23:59:59',
         'datetime': '2018-12-31T12:44:31',

--- a/sdks/python/apache_beam/io/gcp/bigquery_read_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_read_it_test.py
@@ -73,9 +73,7 @@ def skip(runners):
 
 def datetime_to_utc(element):
   for k, v in element.items():
-    if isinstance(v, datetime.time):
-      element[k] = str(v)
-    if isinstance(v, datetime.date):
+    if isinstance(v, (datetime.time, datetime.date)):
       element[k] = str(v)
     if isinstance(v, datetime.datetime) and v.tzinfo:
       # For datetime objects, we'll
@@ -290,11 +288,12 @@ class ReadNewTypesTests(BigQueryReadIntegrationTests):
   def test_iobase_source(self):
     with beam.Pipeline(argv=self.args) as p:
       result = (
-          p | 'read' >> beam.io.ReadFromBigQuery(
+          p
+          | 'read' >> beam.io.ReadFromBigQuery(
               query=self.query,
               use_standard_sql=True,
               project=self.project,
-              bigquery_job_labels={'launcher': 'apache_beam_tests'}))
+              bigquery_job_labels={'launcher': 'apache_beam_tests'})
           | beam.Map(datetime_to_utc))
       assert_that(result, equal_to(self.get_expected_data(native=False)))
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -95,6 +95,12 @@ def default_encoder(obj):
     # on python 3 base64-encoded bytes are decoded to strings
     # before being sent to BigQuery
     return obj.decode('utf-8')
+  elif isinstance(obj, (datetime.date, datetime.time)):
+    return str(obj)
+  elif isinstance(obj, datetime.datetime):
+    return obj.isoformat()
+
+  _LOGGER.error("Unable to serialize %r to JSON", obj)
   raise TypeError(
       "Object of type '%s' is not JSON serializable" % type(obj).__name__)
 
@@ -1207,7 +1213,8 @@ class RowAsDictJsonCoder(coders.Coder):
       return json.dumps(
           table_row, allow_nan=False, default=default_encoder).encode('utf-8')
     except ValueError as e:
-      raise ValueError('%s. %s' % (e, JSON_COMPLIANCE_ERROR))
+      raise ValueError(
+          '%s. %s. Row: %r' % (e, JSON_COMPLIANCE_ERROR, table_row))
 
   def decode(self, encoded_table_row):
     return json.loads(encoded_table_row.decode('utf-8'))

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -720,6 +720,7 @@ class BigQueryWrapper(object):
       project=None,
       include_header=True,
       compression=ExportCompression.NONE,
+      use_avro_logical_types=False,
       job_labels=None):
     """Starts a job to export data from BigQuery.
 
@@ -738,6 +739,7 @@ class BigQueryWrapper(object):
                     printHeader=include_header,
                     destinationFormat=destination_format,
                     compression=compression,
+                    useAvroLogicalTypes=use_avro_logical_types,
                 ),
                 labels=_build_job_labels(job_labels),
             ),


### PR DESCRIPTION
This adds support for reading data from BigQuery using FastAvro in the new BigQuery source transform: `_ReadFromBigQuery`.

This creates a few subtle changes in the way that data is returned by BigQuery. These changes are the following:

- All the time-specific data types in BigQuery (`DATE`, `DATETIME`, `TIMESTAMP`) are converted into Python-specific types (`datetime.date`, `datetime.datetime`, `datetime.datetime`).
  - This is different from `BigQuerySource`, where we export JSON data, and all of these datatypes are returned as strings.

- The BigQuery `BYTES` type is returned as Python `bytes`.
  - This is different from `BigQuerySource`, where we export JSON data. For JSON, BigQuery (and beam's BigQuerySource) returns base64-encoded bytes.

Note that in tests, the behavior of BigQuerySource **remains the same**, while _ReadFromBigQuery has different behavior.

This transform does not need to honor backwards compatibility, as it is a new transform, and **it will not replace** BigQuerySource automatically. Nonetheless, we should definitely note the subtle API differences for it.

r: @chamikaramj @tvalentyn @kamilwu 

cc: @mwalenia 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
