### PR TITLE
[BEAM-7923] Streaming support and pipeline pruning when instrumenting a pipeline with interactivity

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/README.md
+++ b/sdks/python/apache_beam/runners/interactive/README.md
@@ -68,7 +68,7 @@ exploration much faster and easier. It provides nice features including
     |                          | Caching locally | Caching on GCS |
     | ------------------------ | --------------- | -------------- |
     | Running on local machine | supported       | supported      |
-    | Running on Flink         | /               | supported      |
+    | Running on Flink         | supported       | supported      |
 
 ## Getting Started
 
@@ -84,23 +84,24 @@ a quick reference). For a more general and complete getting started guide, see
 *   Install [GraphViz](https://www.graphviz.org/download/) with your favorite
     system package manager.
 
--   Install [Jupyter](https://jupyter.org/). You can either use the one that's
-    included in [Anaconda](https://www.anaconda.com/download/) or
+-   Install [JupyterLab](https://jupyter.org/install.html). You can use
+    either **conda** or **pip**.
 
-    ```bash
-    $ pip2 install --upgrade jupyter
-    ```
+    * conda
+        ```bash
+        conda install -c conda-forge jupyterlab
+        ```
+    * pip
+        ```bash
+        pip install jupyterlab
+        ```
 
-    Make sure you have **Python2 Jupyter** since Apache Beam only supports
-    Python 2 at the time being.
-
--   Install, create and activate your [virtualenv](https://virtualenv.pypa.io/).
+-   Install, create and activate your [venv](https://docs.python.org/3/library/venv.html).
     (optional but recommended)
 
     ```bash
-    $ pip2 install --upgrade virtualenv
-    $ virtualenv -p python2 beam_venv_dir
-    $ source beam_venv_dir/bin/activate
+    python3 -m venv /path/to/beam_venv_dir
+    source /path/to/beam_venv_dir/bin/activate
     ```
 
     If you are using shells other than bash (e.g. fish, csh), check
@@ -110,34 +111,51 @@ a quick reference). For a more general and complete getting started guide, see
     **CHECK** that the virtual environment is activated by running
 
     ```bash
-    $ echo $VIRTUAL_ENV  # This should point to beam_venv_dir
-    # or
-    $ which python  # This sould point to beam_venv_dir/bin/python
+    which python  # This sould point to beam_venv_dir/bin/python
     ```
 
 *   Set up Apache Beam Python. **Make sure the virtual environment is activated
     when you run `setup.py`**
 
 *   ```bash
-    $ git clone https://github.com/apache/beam
-    $ cd beam/sdks/python
-    $ python setup.py install
+    git clone https://github.com/apache/beam
+    cd beam/sdks/python
+    python setup.py install
     ```
 
--   Install a IPython kernel for the virtual environment you've just created.
+-   Install an IPython kernel for the virtual environment you've just created.
     **Make sure the virtual environment is activate when you do this.** You can
-    skip this step if not using virtualenv.
+    skip this step if not using venv.
 
     ```bash
-    $ python -m pip install ipykernel
-    $ python -m ipykernel install --user --name beam_venv_kernel --display-name "Python (beam_venv)"
+    pip install ipykernel
+    python -m ipykernel install --user --name beam_venv_kernel --display-name "Python3 (beam_venv)"
     ```
 
     **CHECK** that IPython kernel `beam_venv_kernel` is available for Jupyter to
     use.
 
     ```bash
-    $ jupyter kernelspec list
+    jupyter kernelspec list
+    ```
+
+-   Extend JupyterLab through labextension. **Note**: labextension is different from nbextension
+    from pre-lab jupyter notebooks.
+
+    All jupyter labextensions need nodejs
+
+    ```bash
+    # Homebrew users do
+    brew install node
+    # Or Conda users do
+    conda install -c conda-forge nodejs
+    ```
+
+    Enable ipywidgets
+
+    ```bash
+    pip install ipywidgets
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager
     ```
 
 ### Start the notebook
@@ -145,19 +163,36 @@ a quick reference). For a more general and complete getting started guide, see
 To start the notebook, simply run
 
 ```bash
-$ jupyter notebook
+jupyter lab
 ```
 
+Optionally increase the iopub broadcast data rate limit of jupyterlab
+
+```bash
+jupyter lab --NotebookApp.iopub_data_rate_limit=10000000
+```
+
+
 This automatically opens your default web browser pointing to
-http://localhost:8888.
+http://localhost:8888/lab.
 
-You can create a new notebook file by clicking `New` > `Notebook: Python
-(beam_venv)`.
+You can create a new notebook file by clicking `Python3 (beam_venv)` from the launcher
+page of jupyterlab.
 
-Or after you've already opend a notebook, change the kernel by clicking
-`Kernel` > `Change Kernel` > `Python (beam_venv)`.
+Or after you've already opened a notebook, change the kernel by clicking
+`Kernel` > `Change Kernel` > `Python3 (beam_venv)`.
 
 Voila! You can now run Beam pipelines interactively in your Jupyter notebook!
+
+In the notebook, you can use `tab` key on the keyboard for auto-completion.
+To turn on greedy auto-completion, you can run such ipython magic
+
+```
+%config IPCompleter.greedy=True
+```
+
+You can also use `shift` + `tab` keys on the keyboard for a popup of docstrings at the
+current cursor position.
 
 **See [Interactive Beam Example.ipynb](examples/Interactive%20Beam%20Example.ipynb)
 for more examples.**
@@ -231,13 +266,8 @@ You can choose to run Interactive Beam on Flink with the following settings.
 [Interactive Beam Running on Flink.ipynb](examples/Interactive%20Beam%20Running%20on%20Flink.ipynb)
 capture the status of the world when it's last updated.
 
-## TL;DR;
-
-You can now interactively run Beam Python pipeline! Check out the Youtube demo
-
-[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/c5CjA1e3Cqw/0.jpg)](https://www.youtube.com/watch?v=c5CjA1e3Cqw)
-
 ## More Information
 
 *   [Apache Beam Python SDK Quickstart](https://beam.apache.org/get-started/quickstart-py/)
-*   [Interactive Beam Design Doc](https://docs.google.com/document/d/10bTc97GN5Wk-nhwncqNq9_XkJFVVy0WLT4gPFqP6Kmw/edit?usp=sharing)
+*   [Interactive Beam Design Doc V2](https://docs.google.com/document/d/1DYWrT6GL_qDCXhRMoxpjinlVAfHeVilK5Mtf8gO6zxQ/edit?usp=sharing)
+*   [Interactive Beam Design Doc V1](https://docs.google.com/document/d/10bTc97GN5Wk-nhwncqNq9_XkJFVVy0WLT4gPFqP6Kmw/edit?usp=sharing)

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -47,6 +47,7 @@ import time
 import apache_beam as beam
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive.caching import streaming_cache
+from apache_beam.runners.interactive.options import capture_control
 from apache_beam.runners.runner import PipelineState
 
 _LOGGER = logging.getLogger(__name__)
@@ -166,6 +167,11 @@ def is_background_caching_job_needed(user_pipeline):
   # If this is True, we can invalidate a previous done/running job if there is
   # one.
   cache_changed = is_source_to_cache_changed(user_pipeline)
+  # When capture replay is disabled, cache is always needed for capturable
+  # sources (if any).
+  if need_cache and not ie.current_env().options.enable_capture_replay:
+    capture_control.evict_captured_data()
+    return True
   return (
       need_cache and
       # Checks if it's the first time running a job from the pipeline.

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -47,7 +47,6 @@ import time
 import apache_beam as beam
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive.caching import streaming_cache
-from apache_beam.runners.interactive.options import capture_control
 from apache_beam.runners.runner import PipelineState
 
 _LOGGER = logging.getLogger(__name__)
@@ -170,6 +169,7 @@ def is_background_caching_job_needed(user_pipeline):
   # When capture replay is disabled, cache is always needed for capturable
   # sources (if any).
   if need_cache and not ie.current_env().options.enable_capture_replay:
+    from apache_beam.runners.interactive.options import capture_control
     capture_control.evict_captured_data()
     return True
   return (

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
@@ -31,16 +31,16 @@ import logging
 from datetime import timedelta
 
 from dateutil import tz
-from pandas.io.json import json_normalize
 
 from apache_beam import pvalue
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import pipeline_instrument as instr
+from apache_beam.runners.interactive.utils import elements_to_df
+from apache_beam.runners.interactive.utils import to_element_list
 from apache_beam.transforms.window import GlobalWindow
 from apache_beam.transforms.window import IntervalWindow
 
 try:
-  import jsons  # pylint: disable=import-error
   from IPython import get_ipython  # pylint: disable=import-error
   from IPython.core.display import HTML  # pylint: disable=import-error
   from IPython.core.display import Javascript  # pylint: disable=import-error
@@ -58,9 +58,6 @@ except ImportError:
   _pcoll_visualization_ready = False
 
 _LOGGER = logging.getLogger(__name__)
-
-# 1-d types that need additional normalization to be compatible with DataFrame.
-_one_dimension_types = (int, float, str, bool, list, tuple)
 
 _CSS = """
             <style>
@@ -243,6 +240,11 @@ class PCollectionVisualization(object):
     # With only the constructor of PipelineInstrument, any interactivity related
     # pre-process or instrument is not triggered for performance concerns.
     self._pin = instr.PipelineInstrument(pcoll.pipeline)
+    # Variable name as the title for element value in the rendered data table.
+    self._pcoll_var = self._pin.cacheable_var_by_pcoll_id(
+        self._pin.pcolls_to_pcoll_id.get(str(pcoll), None))
+    if not self._pcoll_var:
+      self._pcoll_var = 'Value'
     self._cache_key = self._pin.cache_key(self._pcoll)
     self._dive_display_id = 'facets_dive_{}_{}'.format(
         self._cache_key, id(self))
@@ -286,6 +288,12 @@ class PCollectionVisualization(object):
     # Ensures that dive, overview and table render the same data because the
     # materialized PCollection data might being updated continuously.
     data = self._to_dataframe()
+    # Give the numbered column names when visualizing.
+    data.columns = [
+        self._pcoll_var + '.' +
+        str(column) if isinstance(column, int) else column
+        for column in data.columns
+    ]
     # String-ify the dictionaries for display because elements of type dict
     # cannot be ordered.
     data = data.applymap(lambda x: str(x) if isinstance(x, dict) else x)
@@ -325,6 +333,9 @@ class PCollectionVisualization(object):
         all(column in data.columns
             for column in ('event_time', 'windows', 'pane_info'))):
       data = data.drop(['event_time', 'windows', 'pane_info'], axis=1)
+
+    # GFSG expects all column names to be strings.
+    data.columns = data.columns.astype(str)
 
     gfsg = GenericFeatureStatisticsGenerator()
     proto = gfsg.ProtoFromDataFrames([{'name': 'data', 'table': data}])
@@ -383,34 +394,15 @@ class PCollectionVisualization(object):
         if not data.empty:
           self._is_datatable_empty = False
 
-  def _to_element_list(self):
-    pcoll_list = []
-    if ie.current_env().cache_manager().exists('full', self._cache_key):
-      pcoll_list, _ = ie.current_env().cache_manager().read('full',
-                                                            self._cache_key)
-    return pcoll_list
-
-  # TODO(BEAM-7926): Refactor to new non-flatten dataframe conversion logic.
   def _to_dataframe(self):
-    normalized_list = []
-    # Column name for _one_dimension_types if presents.
-    normalized_column = str(self._pcoll)
-    # Normalization needs to be done for each element because they might be of
-    # different types. The check is only done on the root level, pandas json
-    # normalization I/O would take care of the nested levels.
-    for el in self._to_element_list():
-      if self._is_one_dimension_type(el):
-        # Makes such data structured.
-        normalized_list.append({normalized_column: el})
-      else:
-        normalized_list.append(jsons.load(jsons.dump(el)))
-    # Creates a dataframe that str() 1-d iterable elements after
-    # normalization so that facets_overview can treat such data as categorical.
-    return json_normalize(normalized_list).applymap(
-        lambda x: str(x) if type(x) in (list, tuple) else x)
+    results = []
+    cache_manager = ie.current_env().cache_manager()
+    if cache_manager.exists('full', self._cache_key):
+      coder = cache_manager.load_pcoder('full', self._cache_key)
+      reader, _ = cache_manager.read('full', self._cache_key)
+      results = list(to_element_list(reader, coder, include_window_info=True))
 
-  def _is_one_dimension_type(self, val):
-    return type(val) in _one_dimension_types
+    return elements_to_df(results, self._include_window_info)
 
 
 def format_window_info_in_dataframe(data):

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
@@ -63,13 +63,13 @@ class PCollectionVisualizationTest(unittest.TestCase):
     # Generally test the logic where notebook is connected to the assumed
     # ipython kernel by forcefully setting notebook check to True.
     ie.current_env()._is_in_notebook = True
+    ib.options.display_timezone = pytz.timezone('US/Pacific')
 
     self._p = beam.Pipeline(ir.InteractiveRunner())
     # pylint: disable=range-builtin-not-iterating
     self._pcoll = self._p | 'Create' >> beam.Create(range(5))
     ib.watch(self)
     self._p.run()
-    ib.options.display_timezone = pytz.timezone('US/Pacific')
 
   def test_raise_error_for_non_pcoll_input(self):
     class Foo(object):
@@ -177,9 +177,16 @@ class PCollectionVisualizationTest(unittest.TestCase):
         '2020-03-02 15:14:54.000000-0800 (2h 31m 46s)',
         pv.windows_formatter([iw]))
 
-  def pane_info_formatter(self):
-    PaneInfo(is_last=True, timing=PaneInfoTiming.EARLY)
-    self.assertEqual('Pane Final EARLY')
+  def test_pane_info_formatter(self):
+    self.assertEqual(
+        'Pane 0: Final Early',
+        pv.pane_info_formatter(
+            PaneInfo(
+                is_first=False,
+                is_last=True,
+                timing=PaneInfoTiming.EARLY,
+                index=0,
+                nonspeculative_index=0)))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import apache_beam as beam
 from apache_beam.pipeline import PipelineVisitor
+from apache_beam.testing.test_stream import TestStream
 
 
 class PipelineFragment(object):
@@ -201,6 +202,8 @@ class PipelineFragment(object):
       self, runner_pipeline, necessary_transforms):
     class PruneVisitor(PipelineVisitor):
       def enter_composite_transform(self, transform_node):
+        if isinstance(transform_node.transform, TestStream):
+          return
         pruned_parts = list(transform_node.parts)
         for part in transform_node.parts:
           if part not in necessary_transforms:

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment_test.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 import unittest
 
 import apache_beam as beam
+from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner as ir
@@ -28,6 +29,7 @@ from apache_beam.runners.interactive import pipeline_fragment as pf
 from apache_beam.runners.interactive.testing.mock_ipython import mock_get_ipython
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_equal
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_proto_equal
+from apache_beam.testing.test_stream import TestStream
 
 # TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
 # unittest.mock module.
@@ -116,6 +118,24 @@ class PipelineFragmentTest(unittest.TestCase):
     ib.watch(locals())
     result = pf.PipelineFragment([square]).run()
     self.assertEqual([0, 1, 4, 9, 16], list(result.get(square)))
+
+  def test_fragment_does_not_prune_teststream(self):
+    """Tests that the fragment does not prune the TestStream composite parts.
+    """
+    options = StandardOptions(streaming=True)
+    p = beam.Pipeline(ir.InteractiveRunner(), options)
+
+    test_stream = p | TestStream(output_tags=['a', 'b'])
+
+    # pylint: disable=unused-variable
+    a = test_stream['a'] | 'a' >> beam.Map(lambda _: _)
+    b = test_stream['b'] | 'b' >> beam.Map(lambda _: _)
+
+    fragment = pf.PipelineFragment([b]).deduce_fragment()
+
+    # If the fragment does prune the TestStreawm composite parts, then the
+    # resulting graph is invalid and the following call will raise an exception.
+    fragment.to_runner_api()
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -30,6 +30,10 @@ from apache_beam.pipeline import PipelineVisitor
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.runners.interactive import cache_manager as cache
 from apache_beam.runners.interactive import interactive_environment as ie
+from apache_beam.runners.interactive import pipeline_fragment as pf
+from apache_beam.runners.interactive import background_caching_job
+from apache_beam.testing import test_stream
+from apache_beam.transforms.window import WindowedValue
 
 READ_CACHE = "_ReadCache_"
 WRITE_CACHE = "_WriteCache_"
@@ -99,22 +103,48 @@ class PipelineInstrument(object):
     # corresponding PCollections in the user pipeline instance. Populated
     # after preprocess().
     self._runner_pcoll_to_user_pcoll = {}
+    self._pruned_pipeline_proto = None
+
+    # Refers target pcolls output by instrumented write cache transforms, used
+    # by pruning logic as supplemental targets to build pipeline fragment up
+    # from.
+    self._extended_targets = set()
+
+    # Refers pcolls used as inputs but got replaced by outputs of read cache
+    # transforms instrumented, used by pruning logic as targets no longer need
+    # to be produced during pipeline runs.
+    self._ignored_targets = set()
 
   def instrumented_pipeline_proto(self):
     """Always returns a new instance of portable instrumented proto."""
+    targets = set(self._runner_pcoll_to_user_pcoll.keys())
+    targets.update(self._extended_targets)
+    targets = targets.difference(self._ignored_targets)
+    if len(targets) > 0:
+      # Prunes upstream transforms that don't contribute to the targets the
+      # instrumented pipeline run cares.
+      return pf.PipelineFragment(
+          list(targets)).deduce_fragment().to_runner_api(use_fake_coders=True)
     return self._pipeline.to_runner_api(use_fake_coders=True)
 
-  def _required_components(self, pipeline_proto, required_transforms_ids):
+  def _required_components(
+      self,
+      pipeline_proto,
+      required_transforms_ids,
+      visited,
+      follow_outputs=False,
+      follow_inputs=False):
     """Returns the components and subcomponents of the given transforms.
 
-    This method returns all the components (transforms, PCollections, coders,
-    and windowing stratgies) related to the given transforms and to all of their
-    subtransforms. This method accomplishes this recursively.
+    This method returns required components such as transforms and PCollections
+    related to the given transforms and to all of their subtransforms. This
+    method accomplishes this recursively.
     """
+    if not required_transforms_ids:
+      return ({}, {})
+
     transforms = pipeline_proto.components.transforms
     pcollections = pipeline_proto.components.pcollections
-    coders = pipeline_proto.components.coders
-    windowing_strategies = pipeline_proto.components.windowing_strategies
 
     # Cache the transforms that will be copied into the new pipeline proto.
     required_transforms = {k: transforms[k] for k in required_transforms_ids}
@@ -128,47 +158,115 @@ class PipelineInstrument(object):
         for pc_id in pcollection_ids
     }
 
-    # Cache all the PCollection coders.
-    coder_ids = [pc.coder_id for pc in required_pcollections.values()]
-    required_coders = {c_id: coders[c_id] for c_id in coder_ids}
-
-    # Cache all the windowing strategy ids.
-    windowing_strategies_ids = [
-        pc.windowing_strategy_id for pc in required_pcollections.values()
-    ]
-    required_windowing_strategies = {
-        ws_id: windowing_strategies[ws_id]
-        for ws_id in windowing_strategies_ids
-    }
-
     subtransforms = {}
     subpcollections = {}
-    subcoders = {}
-    subwindowing_strategies = {}
 
     # Recursively go through all the subtransforms and add their components.
     for transform_id, transform in required_transforms.items():
       if transform_id in pipeline_proto.root_transform_ids:
         continue
-      (t, pc, c,
-       ws) = self._required_components(pipeline_proto, transform.subtransforms)
+      (t, pc) = self._required_components(
+          pipeline_proto,
+          transform.subtransforms,
+          visited,
+          follow_outputs=False,
+          follow_inputs=False)
       subtransforms.update(t)
       subpcollections.update(pc)
-      subcoders.update(c)
-      subwindowing_strategies.update(ws)
+
+    if follow_outputs:
+      outputs = [
+          pc_id for t in required_transforms.values()
+          for pc_id in t.outputs.values()
+      ]
+      visited_copy = visited.copy()
+      consuming_transforms = {
+          t_id: t
+          for t_id,
+          t in transforms.items()
+          if set(outputs).intersection(set(t.inputs.values()))
+      }
+      consuming_transforms = set(consuming_transforms.keys())
+      visited.update(consuming_transforms)
+      consuming_transforms = consuming_transforms - visited_copy
+      (t, pc) = self._required_components(
+          pipeline_proto,
+          list(consuming_transforms),
+          visited,
+          follow_outputs,
+          follow_inputs)
+      subtransforms.update(t)
+      subpcollections.update(pc)
+
+    if follow_inputs:
+      inputs = [
+          pc_id for t in required_transforms.values()
+          for pc_id in t.inputs.values()
+      ]
+      producing_transforms = {
+          t_id: t
+          for t_id,
+          t in transforms.items()
+          if set(inputs).intersection(set(t.outputs.values()))
+      }
+      (t, pc) = self._required_components(
+          pipeline_proto,
+          list(producing_transforms.keys()),
+          visited,
+          follow_outputs,
+          follow_inputs)
+      subtransforms.update(t)
+      subpcollections.update(pc)
 
     # Now we got all the components and their subcomponents, so return the
     # complete collection.
     required_transforms.update(subtransforms)
     required_pcollections.update(subpcollections)
-    required_coders.update(subcoders)
-    required_windowing_strategies.update(subwindowing_strategies)
 
-    return (
-        required_transforms,
-        required_pcollections,
-        required_coders,
-        required_windowing_strategies)
+    return (required_transforms, required_pcollections)
+
+  def prune_subgraph_for(self, pipeline, required_transform_ids):
+    # Create the pipeline_proto to read all the components from. It will later
+    # create a new pipeline proto from the cut out components.
+    pipeline_proto, context = pipeline.to_runner_api(
+      return_context=True, use_fake_coders=False)
+
+    # Get all the root transforms. The caching transforms will be subtransforms
+    # of one of these roots.
+    roots = [root for root in pipeline_proto.root_transform_ids]
+
+    (t, p) = self._required_components(
+        pipeline_proto,
+        roots + required_transform_ids,
+        set(),
+        follow_outputs=True,
+        follow_inputs=True)
+
+    def set_proto_map(proto_map, new_value):
+      proto_map.clear()
+      for key, value in new_value.items():
+        proto_map[key].CopyFrom(value)
+
+    # Copy the transforms into the new pipeline.
+    pipeline_to_execute = beam_runner_api_pb2.Pipeline()
+    pipeline_to_execute.root_transform_ids[:] = roots
+    set_proto_map(pipeline_to_execute.components.transforms, t)
+    set_proto_map(pipeline_to_execute.components.pcollections, p)
+    set_proto_map(
+        pipeline_to_execute.components.coders, context.to_runner_api().coders)
+    set_proto_map(
+        pipeline_to_execute.components.windowing_strategies,
+        context.to_runner_api().windowing_strategies)
+
+    # Cut out all subtransforms in the root that aren't the required transforms.
+    for root_id in roots:
+      root = pipeline_to_execute.components.transforms[root_id]
+      root.subtransforms[:] = [
+          transform_id for transform_id in root.subtransforms
+          if transform_id in pipeline_to_execute.components.transforms
+      ]
+
+    return pipeline_to_execute
 
   def background_caching_pipeline_proto(self):
     """Returns the background caching pipeline.
@@ -180,8 +278,8 @@ class PipelineInstrument(object):
     """
     # Create the pipeline_proto to read all the components from. It will later
     # create a new pipeline proto from the cut out components.
-    pipeline_proto = self._background_caching_pipeline.to_runner_api(
-        return_context=False, use_fake_coders=True)
+    pipeline_proto, context = self._background_caching_pipeline.to_runner_api(
+        return_context=True, use_fake_coders=False)
 
     # Get all the sources we want to cache.
     sources = unbounded_sources(self._background_caching_pipeline)
@@ -211,8 +309,8 @@ class PipelineInstrument(object):
     # the pipeline_proto and insert into a new pipeline to return.
     required_transform_ids = (
         roots + caching_transform_ids + unbounded_source_ids)
-    (t, p, c,
-     w) = self._required_components(pipeline_proto, required_transform_ids)
+    (t, p) = self._required_components(
+        pipeline_proto, required_transform_ids, set())
 
     def set_proto_map(proto_map, new_value):
       proto_map.clear()
@@ -224,8 +322,11 @@ class PipelineInstrument(object):
     pipeline_to_execute.root_transform_ids[:] = roots
     set_proto_map(pipeline_to_execute.components.transforms, t)
     set_proto_map(pipeline_to_execute.components.pcollections, p)
-    set_proto_map(pipeline_to_execute.components.coders, c)
-    set_proto_map(pipeline_to_execute.components.windowing_strategies, w)
+    set_proto_map(
+        pipeline_to_execute.components.coders, context.to_runner_api().coders)
+    set_proto_map(
+        pipeline_to_execute.components.windowing_strategies,
+        context.to_runner_api().windowing_strategies)
 
     # Cut out all subtransforms in the root that aren't the required transforms.
     for root_id in roots:
@@ -302,6 +403,7 @@ class PipelineInstrument(object):
       self._pipeline
     """
     cacheable_inputs = set()
+    unbounded_source_pcolls = set()
 
     class InstrumentVisitor(PipelineVisitor):
       """Visitor utilizes cache to instrument the pipeline."""
@@ -312,18 +414,29 @@ class PipelineInstrument(object):
         self.visit_transform(transform_node)
 
       def visit_transform(self, transform_node):
+        if isinstance(transform_node.transform,
+                      tuple(ie.current_env().options.capturable_sources)):
+          unbounded_source_pcolls.update(transform_node.outputs.values())
         cacheable_inputs.update(self._pin._cacheable_inputs(transform_node))
 
     v = InstrumentVisitor(self)
     self._pipeline.visit(v)
+
+    # Add the unbounded source pcollections to the cacheable inputs. This allows
+    # for the caching of unbounded sources without a variable reference.
+    cacheable_inputs.update(unbounded_source_pcolls)
     # Create ReadCache transforms.
     for cacheable_input in cacheable_inputs:
-      self._read_cache(self._pipeline, cacheable_input)
+      self._read_cache(
+          self._pipeline,
+          cacheable_input,
+          cacheable_input in unbounded_source_pcolls)
     # Replace/wire inputs w/ cached PCollections from ReadCache transforms.
     self._replace_with_cached_inputs(self._pipeline)
     # Write cache for all cacheables.
     for _, cacheable in self.cacheables.items():
-      self._write_cache(self._pipeline, cacheable['pcoll'])
+      self._write_cache(
+          self._pipeline, cacheable['pcoll'], ignore_unbounded_reads=True)
 
     # Instrument the background caching pipeline if we can.
     if self.has_unbounded_sources:
@@ -331,9 +444,36 @@ class PipelineInstrument(object):
         self._write_cache(
             self._background_caching_pipeline,
             source.outputs[None],
+            output_as_extended_target=False,
             is_capture=True)
 
-    # TODO(BEAM-7760): prune sub graphs that doesn't need to be executed.
+      class TestStreamVisitor(PipelineVisitor):
+        def __init__(self):
+          self.test_stream = None
+
+        def enter_composite_transform(self, transform_node):
+          self.visit_transform(transform_node)
+
+        def visit_transform(self, transform_node):
+          if (self.test_stream is None and
+              isinstance(transform_node.transform, test_stream.TestStream)):
+            self.test_stream = transform_node.full_label
+
+      v = TestStreamVisitor()
+      self._pipeline.visit(v)
+      pipeline_proto = self._pipeline.to_runner_api(
+          return_context=False, use_fake_coders=True)
+      test_stream_id = ''
+      for t_id, t in pipeline_proto.components.transforms.items():
+        if t.unique_name == v.test_stream:
+          test_stream_id = t_id
+          break
+      self._pruned_pipeline_proto = self.prune_subgraph_for(
+          self._pipeline, [test_stream_id])
+      self._pipeline = beam.Pipeline.from_runner_api(
+          proto=self._pruned_pipeline_proto,
+          runner=self._pipeline.runner,
+          options=self._pipeline._options)
 
   def preprocess(self):
     """Pre-processes the pipeline.
@@ -365,13 +505,27 @@ class PipelineInstrument(object):
             if not self._pin._user_pipeline:
               # Retrieve a reference to the user defined pipeline instance.
               self._pin._user_pipeline = user_pcoll.pipeline
+              # Once user_pipeline is retrieved, check if the user pipeline
+              # contains any source to cache. If so, current cache manager held
+              # by current interactive environment might get wrapped into a
+              # streaming cache, thus re-assign the reference to that cache
+              # manager.
+              if background_caching_job.has_source_to_cache(
+                  self._pin._user_pipeline):
+                self._pin._cache_manager = ie.current_env().cache_manager()
             self._pin._runner_pcoll_to_user_pcoll[pcoll] = user_pcoll
             self._pin.cacheables[cacheable_key]['pcoll'] = pcoll
 
     v = PreprocessVisitor(self)
     self._pipeline.visit(v)
 
-  def _write_cache(self, pipeline, pcoll, is_capture=False):
+  def _write_cache(
+      self,
+      pipeline,
+      pcoll,
+      output_as_extended_target=True,
+      ignore_unbounded_reads=False,
+      is_capture=False):
     """Caches a cacheable PCollection.
 
     For the given PCollection, by appending sub transform part that materialize
@@ -387,15 +541,51 @@ class PipelineInstrument(object):
     # Makes sure the pcoll belongs to the pipeline being instrumented.
     if pcoll.pipeline is not pipeline:
       return
+
+    # Ignore the unbounded reads from capturable sources as these will be pruned
+    # out using the PipelineFragment later on.
+    if ignore_unbounded_reads:
+      ignore = False
+      producer = pcoll.producer
+      while producer:
+        if isinstance(producer.transform,
+                      tuple(ie.current_env().options.capturable_sources)):
+          ignore = True
+          break
+        producer = producer.parent
+      if ignore:
+        self._ignored_targets.add(pcoll)
+        return
+
     # The keyed cache is always valid within this instrumentation.
     key = self.cache_key(pcoll)
     # Only need to write when the cache with expected key doesn't exist.
     if not self._cache_manager.exists('full', key):
       label = '{}{}'.format(WRITE_CACHE, key)
-      _ = pcoll | label >> cache.WriteCache(
-          self._cache_manager, key, is_capture=is_capture)
 
-  def _read_cache(self, pipeline, pcoll):
+      # Read the windowing information and cache it along with the element. This
+      # caches the arguments to a WindowedValue object because Python has logic
+      # that detects if a DoFn returns a WindowedValue. When it detecs one, it
+      # puts the element into the correct window then emits the value to
+      # downstream transforms.
+      class Reify(beam.DoFn):
+        def process(
+            self,
+            e,
+            w=beam.DoFn.WindowParam,
+            p=beam.DoFn.PaneInfoParam,
+            t=beam.DoFn.TimestampParam):
+          yield test_stream.WindowedValueHolder(WindowedValue(e, t, [w], p))
+
+      extended_target = (
+          pcoll
+          | label + 'reify' >> beam.ParDo(Reify())
+          | label >> cache.WriteCache(
+              self._cache_manager, key, is_capture=is_capture))
+      if output_as_extended_target:
+        self._extended_targets.add(extended_target)
+
+  def _read_cache(self, pipeline, pcoll, is_unbounded_source_output):
     """Reads a cached pvalue.
 
     A noop will cause the pipeline to execute the transform as
@@ -411,16 +601,28 @@ class PipelineInstrument(object):
     key = self.cache_key(pcoll)
     # Can only read from cache when the cache with expected key exists and its
     # computation has been completed.
-    if (self._cache_manager.exists('full', key) and
-        (self._runner_pcoll_to_user_pcoll[pcoll] in
-         ie.current_env().computed_pcollections)):
+
+    is_cached = self._cache_manager.exists('full', key)
+    is_computed = (
+        pcoll in self._runner_pcoll_to_user_pcoll and
+        self._runner_pcoll_to_user_pcoll[pcoll] in
+        ie.current_env().computed_pcollections)
+    if ((is_cached and is_computed) or is_unbounded_source_output):
       if key not in self._cached_pcoll_read:
         # Mutates the pipeline with cache read transform attached
         # to root of the pipeline.
+
+        # To put the cached value into the correct window, simply return a
+        # WindowedValue constructed from the element.
+        class Unreify(beam.DoFn):
+          def process(self, e):
+            yield e.windowed_value
+
         pcoll_from_cache = (
             pipeline
             | '{}{}'.format(READ_CACHE, key) >> cache.ReadCache(
-                self._cache_manager, key))
+                self._cache_manager, key)
+            | '{}{}unreify'.format(READ_CACHE, key) >> beam.ParDo(Unreify()))
         self._cached_pcoll_read[key] = pcoll_from_cache
     # else: NOOP when cache doesn't exist, just compute the original graph.
 
@@ -432,6 +634,55 @@ class PipelineInstrument(object):
     AppliedPtransform that sources pvalue from the cache. If there is no valid
     cache, noop.
     """
+
+    # Find all cached unbounded PCollections.
+
+    # If the pipeline has unbounded sources, then we want to force all cache
+    # reads to go through the TestStream (even if they are bounded sources).
+    if self.has_unbounded_sources:
+
+      class CacheableUnboundedPCollectionVisitor(PipelineVisitor):
+        def __init__(self, pin):
+          self._pin = pin
+          self.unbounded_pcolls = set()
+
+        def enter_composite_transform(self, transform_node):
+          self.visit_transform(transform_node)
+
+        def visit_transform(self, transform_node):
+          if transform_node.outputs:
+            for output_pcoll in transform_node.outputs.values():
+              key = self._pin.cache_key(output_pcoll)
+              if key in self._pin._cached_pcoll_read:
+                self.unbounded_pcolls.add(key)
+
+          if transform_node.inputs:
+            for input_pcoll in transform_node.inputs:
+              key = self._pin.cache_key(input_pcoll)
+              if key in self._pin._cached_pcoll_read:
+                self.unbounded_pcolls.add(key)
+
+      v = CacheableUnboundedPCollectionVisitor(self)
+      pipeline.visit(v)
+
+      # The set of keys from the cached unbounded PCollections will be used as
+      # the output tags for the TestStream. This is to remember what cache-key
+      # is associated with which PCollection.
+      output_tags = v.unbounded_pcolls
+
+      # Take the PCollections that will be read from the TestStream and insert
+      # them back into the dictionary of cached PCollections. The next step will
+      # replace the downstream consumer of the non-cached PCollections with
+      # these PCollections.
+      if output_tags:
+        output_pcolls = pipeline | test_stream.TestStream(
+            output_tags=output_tags, coder=self._cache_manager._default_pcoder)
+        if len(output_tags) == 1:
+          self._cached_pcoll_read[list(output_tags)[0]] = output_pcolls
+        else:
+          for tag, pcoll in output_pcolls.items():
+            self._cached_pcoll_read[tag] = pcoll
+
     class ReadCacheWireVisitor(PipelineVisitor):
       """Visitor wires cache read as inputs to replace corresponding original
       input PCollections in pipeline.
@@ -446,10 +697,16 @@ class PipelineInstrument(object):
       def visit_transform(self, transform_node):
         if transform_node.inputs:
           input_list = list(transform_node.inputs)
-          for i in range(len(input_list)):
-            key = self._pin.cache_key(input_list[i])
+          for i, input_pcoll in enumerate(input_list):
+            key = self._pin.cache_key(input_pcoll)
+
+            # Replace the input pcollection with the cached pcollection (if it
+            # has been cached).
             if key in self._pin._cached_pcoll_read:
+              # Ignore this pcoll in the final pruned instrumented pipeline.
+              self._pin._ignored_targets.add(input_pcoll)
               input_list[i] = self._pin._cached_pcoll_read[key]
+          # Update the transform with its new inputs.
           transform_node.inputs = tuple(input_list)
 
     v = ReadCacheWireVisitor(self)
@@ -517,6 +774,21 @@ def build_pipeline_instrument(pipeline, options=None):
   pi.preprocess()
   pi.instrument()  # Instruments the pipeline only once.
   return pi
+
+
+def user_pipeline(pipeline):
+  _, context = pipeline.to_runner_api(return_context=True)
+  pcoll_ids = pcolls_to_pcoll_id(pipeline, context)
+
+  for watching in ie.current_env().watching():
+    for _, v in watching:
+      # TODO(BEAM-8288): cleanup the attribute check when py2 is not supported.
+      if hasattr(v, '__class__') and isinstance(v, beam.pvalue.PCollection):
+        pcoll_id = pcoll_ids.get(str(v), None)
+        if (pcoll_id in context.pcollections and
+            context.pcollections[pcoll_id] != v):
+          return v.pipeline
+  return pipeline
 
 
 def cacheables(pcolls_to_pcoll_id):
@@ -627,3 +899,29 @@ def pcolls_to_pcoll_id(pipeline, original_context):
   v = PCollVisitor()
   pipeline.visit(v)
   return v.pcolls_to_pcoll_id
+
+
+def watch_sources(pipeline):
+  """Watches the unbounded sources in the pipeline.
+
+  Sources can output to a PCollection without a user variable reference. In
+  this case the source is not cached. We still want to cache the data so we
+  synthetically create a variable to the intermediate PCollection.
+  """
+
+  retrieved_user_pipeline = user_pipeline(pipeline)
+
+  class CacheableUnboundedPCollectionVisitor(PipelineVisitor):
+    def __init__(self):
+      self.unbounded_pcolls = set()
+
+    def enter_composite_transform(self, transform_node):
+      self.visit_transform(transform_node)
+
+    def visit_transform(self, transform_node):
+      if isinstance(transform_node.transform,
+                    tuple(ie.current_env().options.capturable_sources)):
+        for pcoll in transform_node.outputs.values():
+          ie.current_env().watch({'synthetic_var_' + str(id(pcoll)): pcoll})
+
+  retrieved_user_pipeline.visit(CacheableUnboundedPCollectionVisitor())

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -26,14 +26,20 @@ import unittest
 import apache_beam as beam
 from apache_beam import coders
 from apache_beam.pipeline import PipelineVisitor
+from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 from apache_beam.runners.interactive import cache_manager as cache
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import pipeline_instrument as instr
 from apache_beam.runners.interactive import interactive_runner
+from apache_beam.runners.interactive.caching import streaming_cache
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_equal
+from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_proto_contain_top_level_transform
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_proto_equal
+from apache_beam.runners.interactive.testing.pipeline_assertion import \
+    assert_pipeline_proto_not_contain_top_level_transform
 from apache_beam.runners.interactive.testing.test_cache_manager import InMemoryCache
+from apache_beam.testing.test_stream import TestStream
 
 
 class PipelineInstrumentTest(unittest.TestCase):
@@ -154,6 +160,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     self.assertFalse(instr.has_unbounded_sources(p))
 
   def test_background_caching_pipeline_proto(self):
+    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
 
     # Test that the two ReadFromPubSub are correctly cut out.
@@ -176,34 +183,46 @@ class PipelineInstrumentTest(unittest.TestCase):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
     a = p | 'ReadUnboundedSourceA' >> beam.io.ReadFromPubSub(
         subscription='projects/fake-project/subscriptions/fake_sub')
-    _ = a | 'a' >> cache.WriteCache(ie.current_env().cache_manager(), '')
+    _ = (
+        a
+        | 'reify a' >> beam.Map(lambda _: _)
+        | 'a' >> cache.WriteCache(ie.current_env().cache_manager(), ''))
 
     b = p | 'ReadUnboundedSourceB' >> beam.io.ReadFromPubSub(
         subscription='projects/fake-project/subscriptions/fake_sub')
-    _ = b | 'b' >> cache.WriteCache(ie.current_env().cache_manager(), '')
+    _ = (
+        b
+        | 'reify b' >> beam.Map(lambda _: _)
+        | 'b' >> cache.WriteCache(ie.current_env().cache_manager(), ''))
 
     expected_pipeline = p.to_runner_api(
         return_context=False, use_fake_coders=True)
 
     assert_pipeline_proto_equal(self, expected_pipeline, actual_pipeline)
 
-  def _example_pipeline(self, watch=True):
+  def _example_pipeline(self, watch=True, bounded=True):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
     # pylint: disable=range-builtin-not-iterating
-    init_pcoll = p | 'Init Create' >> beam.Create(range(10))
+    if bounded:
+      source = beam.Create(range(10))
+    else:
+      source = beam.io.ReadFromPubSub(
+          subscription='projects/fake-project/subscriptions/fake_sub')
+
+    init_pcoll = p | 'Init Source' >> source
     second_pcoll = init_pcoll | 'Second' >> beam.Map(lambda x: x * x)
     if watch:
       ib.watch(locals())
     return (p, init_pcoll, second_pcoll)
 
-  def _mock_write_cache(self, pcoll, cache_key):
+  def _mock_write_cache(self, values, cache_key):
     """Cache the PCollection where cache.WriteCache would write to."""
     labels = ['full', cache_key]
 
     # Usually, the pcoder will be inferred from `pcoll.element_type`
     pcoder = coders.registry.get_coder(object)
     ie.current_env().cache_manager().save_pcoder(pcoder, *labels)
-    ie.current_env().cache_manager().write([b''], *labels)
+    ie.current_env().cache_manager().write(values, *labels)
 
   def test_instrument_example_pipeline_to_write_cache(self):
     # Original instance defined by user code has all variables handlers.
@@ -214,12 +233,16 @@ class PipelineInstrumentTest(unittest.TestCase):
     pipeline_instrument = instr.build_pipeline_instrument(p_copy)
     # Manually instrument original pipeline with expected pipeline transforms.
     init_pcoll_cache_key = pipeline_instrument.cache_key(init_pcoll)
-    _ = init_pcoll | (
-        ('_WriteCache_' + init_pcoll_cache_key) >> cache.WriteCache(
+    _ = (
+        init_pcoll
+        | 'reify init' >> beam.Map(lambda _: _)
+        | '_WriteCache_' + init_pcoll_cache_key >> cache.WriteCache(
             ie.current_env().cache_manager(), init_pcoll_cache_key))
     second_pcoll_cache_key = pipeline_instrument.cache_key(second_pcoll)
-    _ = second_pcoll | (
-        ('_WriteCache_' + second_pcoll_cache_key) >> cache.WriteCache(
+    _ = (
+        second_pcoll
+        | 'reify second' >> beam.Map(lambda _: _)
+        | '_WriteCache_' + second_pcoll_cache_key >> cache.WriteCache(
             ie.current_env().cache_manager(), second_pcoll_cache_key))
     # The 2 pipelines should be the same now.
     assert_pipeline_equal(self, p_copy, p_origin)
@@ -231,18 +254,20 @@ class PipelineInstrumentTest(unittest.TestCase):
     # Mock as if cacheable PCollections are cached.
     init_pcoll_cache_key = 'init_pcoll_' + str(id(init_pcoll)) + '_' + str(
         id(init_pcoll.producer))
-    self._mock_write_cache(init_pcoll, init_pcoll_cache_key)
+    self._mock_write_cache([b'1', b'2', b'3'], init_pcoll_cache_key)
     second_pcoll_cache_key = 'second_pcoll_' + str(
         id(second_pcoll)) + '_' + str(id(second_pcoll.producer))
-    self._mock_write_cache(second_pcoll, second_pcoll_cache_key)
+    self._mock_write_cache([b'1', b'4', b'9'], second_pcoll_cache_key)
     # Mark the completeness of PCollections from the original(user) pipeline.
     ie.current_env().mark_pcollection_computed(
         (p_origin, init_pcoll, second_pcoll))
     instr.build_pipeline_instrument(p_copy)
 
-    cached_init_pcoll = p_origin | (
-        '_ReadCache_' + init_pcoll_cache_key) >> cache.ReadCache(
+    cached_init_pcoll = (
+        p_origin
+        | '_ReadCache_' + init_pcoll_cache_key >> cache.ReadCache(
             ie.current_env().cache_manager(), init_pcoll_cache_key)
+        | 'unreify' >> beam.Map(lambda _: _))
 
     # second_pcoll is never used as input and there is no need to read cache.
 
@@ -278,7 +303,502 @@ class PipelineInstrumentTest(unittest.TestCase):
     ib.watch({'irrelevant_user_pipeline': irrelevant_user_pipeline})
     # Build instrument from the runner pipeline.
     pipeline_instrument = instr.build_pipeline_instrument(runner_pipeline)
-    self.assertTrue(pipeline_instrument.user_pipeline is user_pipeline)
+    self.assertIs(pipeline_instrument.user_pipeline, user_pipeline)
+
+  def test_instrument_example_unbounded_pipeline_to_read_cache(self):
+    """Tests that the instrumenter works for a single unbounded source.
+        """
+    # Create a new interactive environment to make the test idempotent.
+    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+
+    # Create the pipeline that will be instrumented.
+    p_original = beam.Pipeline(interactive_runner.InteractiveRunner())
+    source_1 = p_original | 'source1' >> beam.io.ReadFromPubSub(
+        subscription='projects/fake-project/subscriptions/fake_sub')
+    # pylint: disable=possibly-unused-variable
+    pcoll_1 = source_1 | 'square1' >> beam.Map(lambda x: x * x)
+
+    # Mock as if cacheable PCollections are cached.
+    ib.watch(locals())
+
+    def cache_key_of(name, pcoll):
+      return name + '_' + str(id(pcoll)) + '_' + str(id(pcoll.producer))
+
+    for name, pcoll in locals().items():
+      if not isinstance(pcoll, beam.pvalue.PCollection):
+        continue
+      cache_key = cache_key_of(name, pcoll)
+      self._mock_write_cache([TestStreamPayload()], cache_key)
+
+    # Instrument the original pipeline to create the pipeline the user will see.
+    instrumenter = instr.build_pipeline_instrument(p_original)
+    actual_pipeline = beam.Pipeline.from_runner_api(
+        proto=instrumenter.instrumented_pipeline_proto(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=None)
+
+    # Now, build the expected pipeline which replaces the unbounded source with
+    # a TestStream.
+    source_1_cache_key = cache_key_of('source_1', source_1)
+    p_expected = beam.Pipeline()
+    test_stream = (
+        p_expected
+        | TestStream(output_tags=[cache_key_of('source_1', source_1)]))
+    # pylint: disable=expression-not-assigned
+    test_stream | 'square1' >> beam.Map(lambda x: x * x)
+
+    # Test that the TestStream is outputting to the correct PCollection.
+    class TestStreamVisitor(PipelineVisitor):
+      def __init__(self):
+        self.output_tags = set()
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        transform = transform_node.transform
+        if isinstance(transform, TestStream):
+          self.output_tags = transform.output_tags
+
+    v = TestStreamVisitor()
+    actual_pipeline.visit(v)
+    expected_output_tags = set([source_1_cache_key])
+    actual_output_tags = v.output_tags
+    self.assertSetEqual(expected_output_tags, actual_output_tags)
+
+    # Test that the pipeline is as expected.
+    assert_pipeline_proto_equal(
+        self,
+        p_expected.to_runner_api(),
+        instrumenter.instrumented_pipeline_proto())
+
+  def test_able_to_cache_intermediate_unbounded_source_pcollection(self):
+    """Tests being able to cache an intermediate source PCollection.
+
+    In the following pipeline, the source doesn't have a reference and so is
+    not automatically cached in the watch() command. This tests that this case
+    is taken care of.
+    """
+    # Create a new interactive environment to make the test idempotent.
+    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+
+    # Create the pipeline that will be instrumented.
+    from apache_beam.options.pipeline_options import StandardOptions
+    options = StandardOptions(streaming=True)
+    p_original = beam.Pipeline(interactive_runner.InteractiveRunner(), options)
+
+    # pylint: disable=possibly-unused-variable
+    source_1 = (
+        p_original
+        | 'source1' >> beam.io.ReadFromPubSub(
+            subscription='projects/fake-project/subscriptions/fake_sub')
+        | beam.Map(lambda e: e))
+
+    # Watch but do not cache the PCollections.
+    ib.watch(locals())
+
+    def cache_key_of(name, pcoll):
+      return name + '_' + str(id(pcoll)) + '_' + str(id(pcoll.producer))
+
+    # Make sure that sources without a user reference are still cached.
+    instr.watch_sources(p_original)
+
+    intermediate_source_pcoll = None
+    for watching in ie.current_env().watching():
+      watching = list(watching)
+      for var, watchable in watching:
+        if 'synthetic' in var:
+          intermediate_source_pcoll = watchable
+          break
+
+    # Instrument the original pipeline to create the pipeline the user will see.
+    p_copy = beam.Pipeline.from_runner_api(
+        p_original.to_runner_api(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=options)
+    instrumenter = instr.build_pipeline_instrument(p_copy)
+    actual_pipeline = beam.Pipeline.from_runner_api(
+        proto=instrumenter.instrumented_pipeline_proto(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=options)
+
+    # Now, build the expected pipeline which replaces the unbounded source with
+    # a TestStream.
+    intermediate_source_pcoll_cache_key = \
+        cache_key_of('synthetic_var_' + str(id(intermediate_source_pcoll)),
+                     intermediate_source_pcoll)
+    p_expected = beam.Pipeline()
+
+    test_stream = (
+        p_expected
+        | TestStream(output_tags=[intermediate_source_pcoll_cache_key]))
+    # pylint: disable=expression-not-assigned
+    (
+        test_stream
+        | 'square1' >> beam.Map(lambda e: e)
+        | 'reify' >> beam.Map(lambda _: _)
+        | cache.WriteCache(ie.current_env().cache_manager(), 'unused'))
+
+    # Test that the TestStream is outputting to the correct PCollection.
+    class TestStreamVisitor(PipelineVisitor):
+      def __init__(self):
+        self.output_tags = set()
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        transform = transform_node.transform
+        if isinstance(transform, TestStream):
+          self.output_tags = transform.output_tags
+
+    v = TestStreamVisitor()
+    actual_pipeline.visit(v)
+    expected_output_tags = set([intermediate_source_pcoll_cache_key])
+    actual_output_tags = v.output_tags
+    self.assertSetEqual(expected_output_tags, actual_output_tags)
+
+    # Test that the pipeline is as expected.
+    assert_pipeline_proto_equal(
+        self,
+        p_expected.to_runner_api(use_fake_coders=True),
+        instrumenter.instrumented_pipeline_proto())
+
+  def test_instrument_mixed_streaming_batch(self):
+    """Tests caching for both batch and streaming sources in the same pipeline.
+
+        This ensures that cached bounded and unbounded sources are read from the
+        TestStream.
+        """
+    # Create a new interactive environment to make the test idempotent.
+    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+
+    # Create the pipeline that will be instrumented.
+    from apache_beam.options.pipeline_options import StandardOptions
+    options = StandardOptions(streaming=True)
+    p_original = beam.Pipeline(interactive_runner.InteractiveRunner(), options)
+    source_1 = p_original | 'source1' >> beam.io.ReadFromPubSub(
+        subscription='projects/fake-project/subscriptions/fake_sub')
+    source_2 = p_original | 'source2' >> beam.Create([1, 2, 3, 4, 5])
+
+    # pylint: disable=possibly-unused-variable
+    pcoll_1 = ((source_1, source_2)
+               | beam.Flatten()
+               | 'square1' >> beam.Map(lambda x: x * x))
+
+    # Watch but do not cache the PCollections.
+    ib.watch(locals())
+
+    def cache_key_of(name, pcoll):
+      return name + '_' + str(id(pcoll)) + '_' + str(id(pcoll.producer))
+
+    self._mock_write_cache([TestStreamPayload()],
+                           cache_key_of('source_2', source_2))
+    ie.current_env().mark_pcollection_computed([source_2])
+
+    # Instrument the original pipeline to create the pipeline the user will see.
+    p_copy = beam.Pipeline.from_runner_api(
+        p_original.to_runner_api(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=options)
+    instrumenter = instr.build_pipeline_instrument(p_copy)
+    actual_pipeline = beam.Pipeline.from_runner_api(
+        proto=instrumenter.instrumented_pipeline_proto(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=options)
+
+    # Now, build the expected pipeline which replaces the unbounded source with
+    # a TestStream.
+    source_1_cache_key = cache_key_of('source_1', source_1)
+    source_2_cache_key = cache_key_of('source_2', source_2)
+    p_expected = beam.Pipeline()
+
+    test_stream = (
+        p_expected
+        | TestStream(output_tags=[source_1_cache_key, source_2_cache_key]))
+    # pylint: disable=expression-not-assigned
+    ((
+        test_stream[cache_key_of('source_1', source_1)],
+        test_stream[cache_key_of('source_2', source_2)])
+     | beam.Flatten()
+     | 'square1' >> beam.Map(lambda x: x * x)
+     | 'reify' >> beam.Map(lambda _: _)
+     | cache.WriteCache(ie.current_env().cache_manager(), 'unused'))
+
+    # Test that the TestStream is outputting to the correct PCollection.
+    class TestStreamVisitor(PipelineVisitor):
+      def __init__(self):
+        self.output_tags = set()
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        transform = transform_node.transform
+        if isinstance(transform, TestStream):
+          self.output_tags = transform.output_tags
+
+    v = TestStreamVisitor()
+    actual_pipeline.visit(v)
+    expected_output_tags = set([source_1_cache_key, source_2_cache_key])
+    actual_output_tags = v.output_tags
+    self.assertSetEqual(expected_output_tags, actual_output_tags)
+
+    # Test that the pipeline is as expected.
+    assert_pipeline_proto_equal(
+        self,
+        p_expected.to_runner_api(use_fake_coders=True),
+        instrumenter.instrumented_pipeline_proto())
+
+  def test_instrument_example_unbounded_pipeline_direct_from_source(self):
+    """Tests that the it caches PCollections from a source.
+        """
+    # Create a new interactive environment to make the test idempotent.
+    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+
+    # Create the pipeline that will be instrumented.
+    from apache_beam.options.pipeline_options import StandardOptions
+    options = StandardOptions(streaming=True)
+    p_original = beam.Pipeline(interactive_runner.InteractiveRunner(), options)
+    source_1 = p_original | 'source1' >> beam.io.ReadFromPubSub(
+        subscription='projects/fake-project/subscriptions/fake_sub')
+    # pylint: disable=possibly-unused-variable
+
+    # Watch but do not cache the PCollections.
+    ib.watch(locals())
+
+    def cache_key_of(name, pcoll):
+      return name + '_' + str(id(pcoll)) + '_' + str(id(pcoll.producer))
+
+    # Instrument the original pipeline to create the pipeline the user will see.
+    p_copy = beam.Pipeline.from_runner_api(
+        p_original.to_runner_api(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=options)
+    instrumenter = instr.build_pipeline_instrument(p_copy)
+    actual_pipeline = beam.Pipeline.from_runner_api(
+        proto=instrumenter.instrumented_pipeline_proto(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=options)
+
+    # Now, build the expected pipeline which replaces the unbounded source with
+    # a TestStream.
+    source_1_cache_key = cache_key_of('source_1', source_1)
+    p_expected = beam.Pipeline()
+
+    # pylint: disable=unused-variable
+    test_stream = (
+        p_expected
+        | TestStream(output_tags=[cache_key_of('source_1', source_1)]))
+
+    # Test that the TestStream is outputting to the correct PCollection.
+    class TestStreamVisitor(PipelineVisitor):
+      def __init__(self):
+        self.output_tags = set()
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        transform = transform_node.transform
+        if isinstance(transform, TestStream):
+          self.output_tags = transform.output_tags
+
+    v = TestStreamVisitor()
+    actual_pipeline.visit(v)
+    expected_output_tags = set([source_1_cache_key])
+    actual_output_tags = v.output_tags
+    self.assertSetEqual(expected_output_tags, actual_output_tags)
+
+    # Test that the pipeline is as expected.
+    assert_pipeline_proto_equal(
+        self,
+        p_expected.to_runner_api(use_fake_coders=True),
+        instrumenter.instrumented_pipeline_proto())
+
+  def test_instrument_example_unbounded_pipeline_to_read_cache_not_cached(self):
+    """Tests that the instrumenter works when the PCollection is not cached.
+        """
+    # Create a new interactive environment to make the test idempotent.
+    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+
+    # Create the pipeline that will be instrumented.
+    from apache_beam.options.pipeline_options import StandardOptions
+    options = StandardOptions(streaming=True)
+    p_original = beam.Pipeline(interactive_runner.InteractiveRunner(), options)
+    source_1 = p_original | 'source1' >> beam.io.ReadFromPubSub(
+        subscription='projects/fake-project/subscriptions/fake_sub')
+    # pylint: disable=possibly-unused-variable
+    pcoll_1 = source_1 | 'square1' >> beam.Map(lambda x: x * x)
+
+    # Watch but do not cache the PCollections.
+    ib.watch(locals())
+
+    def cache_key_of(name, pcoll):
+      return name + '_' + str(id(pcoll)) + '_' + str(id(pcoll.producer))
+
+    # Instrument the original pipeline to create the pipeline the user will see.
+    p_copy = beam.Pipeline.from_runner_api(
+        p_original.to_runner_api(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=options)
+    instrumenter = instr.build_pipeline_instrument(p_copy)
+    actual_pipeline = beam.Pipeline.from_runner_api(
+        proto=instrumenter.instrumented_pipeline_proto(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=options)
+
+    # Now, build the expected pipeline which replaces the unbounded source with
+    # a TestStream.
+    source_1_cache_key = cache_key_of('source_1', source_1)
+    p_expected = beam.Pipeline()
+    test_stream = (
+        p_expected
+        | TestStream(output_tags=[cache_key_of('source_1', source_1)]))
+    # pylint: disable=expression-not-assigned
+    (
+        test_stream
+        | 'square1' >> beam.Map(lambda x: x * x)
+        | 'reify' >> beam.Map(lambda _: _)
+        | cache.WriteCache(ie.current_env().cache_manager(), 'unused'))
+
+    # Test that the TestStream is outputting to the correct PCollection.
+    class TestStreamVisitor(PipelineVisitor):
+      def __init__(self):
+        self.output_tags = set()
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        transform = transform_node.transform
+        if isinstance(transform, TestStream):
+          self.output_tags = transform.output_tags
+
+    v = TestStreamVisitor()
+    actual_pipeline.visit(v)
+    expected_output_tags = set([source_1_cache_key])
+    actual_output_tags = v.output_tags
+    self.assertSetEqual(expected_output_tags, actual_output_tags)
+
+    # Test that the pipeline is as expected.
+    assert_pipeline_proto_equal(
+        self,
+        p_expected.to_runner_api(use_fake_coders=True),
+        instrumenter.instrumented_pipeline_proto())
+
+  def test_instrument_example_unbounded_pipeline_to_multiple_read_cache(self):
+    """Tests that the instrumenter works for multiple unbounded sources.
+        """
+    # Create a new interactive environment to make the test idempotent.
+    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+
+    # Create the pipeline that will be instrumented.
+    p_original = beam.Pipeline(interactive_runner.InteractiveRunner())
+    source_1 = p_original | 'source1' >> beam.io.ReadFromPubSub(
+        subscription='projects/fake-project/subscriptions/fake_sub')
+    source_2 = p_original | 'source2' >> beam.io.ReadFromPubSub(
+        subscription='projects/fake-project/subscriptions/fake_sub')
+    # pylint: disable=possibly-unused-variable
+    pcoll_1 = source_1 | 'square1' >> beam.Map(lambda x: x * x)
+    # pylint: disable=possibly-unused-variable
+    pcoll_2 = source_2 | 'square2' >> beam.Map(lambda x: x * x)
+
+    # Mock as if cacheable PCollections are cached.
+    ib.watch(locals())
+
+    def cache_key_of(name, pcoll):
+      return name + '_' + str(id(pcoll)) + '_' + str(id(pcoll.producer))
+
+    for name, pcoll in locals().items():
+      if not isinstance(pcoll, beam.pvalue.PCollection):
+        continue
+      cache_key = cache_key_of(name, pcoll)
+      self._mock_write_cache([TestStreamPayload()], cache_key)
+
+    # Instrument the original pipeline to create the pipeline the user will see.
+    instrumenter = instr.build_pipeline_instrument(p_original)
+    actual_pipeline = beam.Pipeline.from_runner_api(
+        proto=instrumenter.instrumented_pipeline_proto(),
+        runner=interactive_runner.InteractiveRunner(),
+        options=None)
+
+    # Now, build the expected pipeline which replaces the unbounded source with
+    # a TestStream.
+    source_1_cache_key = cache_key_of('source_1', source_1)
+    source_2_cache_key = cache_key_of('source_2', source_2)
+    p_expected = beam.Pipeline()
+    test_stream = (
+        p_expected
+        | TestStream(
+            output_tags=[
+                cache_key_of('source_1', source_1),
+                cache_key_of('source_2', source_2)
+            ]))
+    # pylint: disable=expression-not-assigned
+    test_stream[source_1_cache_key] | 'square1' >> beam.Map(lambda x: x * x)
+    # pylint: disable=expression-not-assigned
+    test_stream[source_2_cache_key] | 'square2' >> beam.Map(lambda x: x * x)
+
+    # Test that the TestStream is outputting to the correct PCollection.
+    class TestStreamVisitor(PipelineVisitor):
+      def __init__(self):
+        self.output_tags = set()
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        transform = transform_node.transform
+        if isinstance(transform, TestStream):
+          self.output_tags = transform.output_tags
+
+    v = TestStreamVisitor()
+    actual_pipeline.visit(v)
+    expected_output_tags = set([source_1_cache_key, source_2_cache_key])
+    actual_output_tags = v.output_tags
+    self.assertSetEqual(expected_output_tags, actual_output_tags)
+
+    # Test that the pipeline is as expected.
+    assert_pipeline_proto_equal(
+        self,
+        p_expected.to_runner_api(),
+        instrumenter.instrumented_pipeline_proto())
+
+  def test_pipeline_pruned_when_input_pcoll_is_cached(self):
+    user_pipeline, init_pcoll, _ = self._example_pipeline()
+    runner_pipeline = beam.Pipeline.from_runner_api(
+        user_pipeline.to_runner_api(use_fake_coders=True),
+        user_pipeline.runner,
+        None)
+
+    # Mock as if init_pcoll is cached.
+    init_pcoll_cache_key = 'init_pcoll_' + str(id(init_pcoll)) + '_' + str(
+        id(init_pcoll.producer))
+    self._mock_write_cache([b'1', b'2', b'3'], init_pcoll_cache_key)
+    ie.current_env().mark_pcollection_computed([init_pcoll])
+    # Build an instrument from the runner pipeline.
+    pipeline_instrument = instr.build_pipeline_instrument(runner_pipeline)
+
+    pruned_proto = pipeline_instrument.instrumented_pipeline_proto()
+    # Skip the prune step for comparison, it should contain the sub-graph that
+    # produces init_pcoll but not useful anymore.
+    full_proto = pipeline_instrument._pipeline.to_runner_api(
+        use_fake_coders=True)
+    self.assertEqual(
+        len(
+            pruned_proto.components.transforms[
+                'ref_AppliedPTransform_AppliedPTransform_1'].subtransforms),
+        5)
+    assert_pipeline_proto_not_contain_top_level_transform(
+        self, pruned_proto, 'Init Source')
+    self.assertEqual(
+        len(
+            full_proto.components.transforms[
+                'ref_AppliedPTransform_AppliedPTransform_1'].subtransforms),
+        6)
+    assert_pipeline_proto_contain_top_level_transform(
+        self, full_proto, 'Init Source')
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/testing/pipeline_assertion.py
+++ b/sdks/python/apache_beam/runners/interactive/testing/pipeline_assertion.py
@@ -30,11 +30,11 @@ mutates user code within transforms in pipelines.
 def assert_pipeline_equal(test_case, expected_pipeline, actual_pipeline):
   """Asserts the equivalence between two given apache_beam.Pipeline instances.
 
-  Args:
-    test_case: (unittest.TestCase) the unittest testcase where it asserts.
-    expected_pipeline: (Pipeline) the pipeline instance expected.
-    actual_pipeline: (Pipeline) the actual pipeline instance to be asserted.
-  """
+    Args:
+      test_case: (unittest.TestCase) the unittest testcase where it asserts.
+      expected_pipeline: (Pipeline) the pipeline instance expected.
+      actual_pipeline: (Pipeline) the actual pipeline instance to be asserted.
+    """
   expected_pipeline_proto = expected_pipeline.to_runner_api(
       use_fake_coders=True)
   actual_pipeline_proto = actual_pipeline.to_runner_api(use_fake_coders=True)
@@ -64,6 +64,34 @@ def assert_pipeline_proto_equal(
       actual_pipeline_proto.root_transform_ids[0],
       expected_pipeline_proto,
       expected_pipeline_proto.root_transform_ids[0])
+
+
+def assert_pipeline_proto_contain_top_level_transform(
+    test_case, pipeline_proto, transform_label):
+  """Asserts the top level transforms contain a transform with the given
+     transform label."""
+  _assert_pipeline_proto_contains_top_level_transform(
+      test_case, pipeline_proto, transform_label, True)
+
+
+def assert_pipeline_proto_not_contain_top_level_transform(
+    test_case, pipeline_proto, transform_label):
+  """Asserts the top level transforms do not contain a transform with the given
+     transform label."""
+  _assert_pipeline_proto_contains_top_level_transform(
+      test_case, pipeline_proto, transform_label, False)
+
+
+def _assert_pipeline_proto_contains_top_level_transform(
+    test_case, pipeline_proto, transform_label, contain):
+  top_level_transform_labels = pipeline_proto.components.transforms[
+      pipeline_proto.root_transform_ids[0]].subtransforms
+  test_case.assertEqual(
+      contain,
+      any([
+          transform_label in top_level_transform_label
+          for top_level_transform_label in top_level_transform_labels
+      ]))
 
 
 def _assert_transform_equal(

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -219,9 +219,7 @@ GCP_REQUIREMENTS = [
 
 INTERACTIVE_BEAM = [
     'facets-overview>=1.0.0,<2',
-    'ipython>=5.8.0,<6',
-    # jsons is supported by Python 3.5.3+.
-    'jsons>=1.0.0,<2; python_version >= "3.5.3"',
+    'ipython>=5.8.0,<8',
     'timeloop>=1.0.2,<2',
 ]
 AWS_REQUIREMENTS = [


### PR DESCRIPTION
1. Updated pipeline_fragment to not prune newly added TestStream
transforms.
2. Updated pipeline_instrument to support streaming pipeline and prune
transforms that don't contribute to the desired outputs.
3. Updated ipython version upperbound to <8. We are targeting ipython >
7.3 for the introduction of cell magic `%pip`. Note `%pip` has different
behavior than `!pip` because the previous one guaranteees the
installation in the kernel not arbitrary environment the notebook is
running in.
4. Updated the README for Interactive Beam. The main change is
recommending using Jupyterlab over old Jupyter notebook and setup
instructions such as setting virtual env through Python3 venv module, installing
new labextensions over nbextensions and install extra dependencies.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
