### PR TITLE
[BEAM-8335] Final PR to merge the InteractiveBeam feature branch

### DIFF
--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor.py
@@ -23,7 +23,6 @@ from __future__ import absolute_import
 
 from typing import TYPE_CHECKING
 from typing import Dict
-from typing import List
 from typing import Set
 
 from apache_beam import pvalue
@@ -44,7 +43,7 @@ class ConsumerTrackingPipelineVisitor(PipelineVisitor):
   """
   def __init__(self):
     self.value_to_consumers = {
-    }  # type: Dict[pvalue.PValue, List[AppliedPTransform]]
+    }  # type: Dict[pvalue.PValue, Set[AppliedPTransform]]
     self.root_transforms = set()  # type: Set[AppliedPTransform]
     self.step_names = {}  # type: Dict[AppliedPTransform, str]
 
@@ -68,8 +67,8 @@ class ConsumerTrackingPipelineVisitor(PipelineVisitor):
         if isinstance(input_value, pvalue.PBegin):
           self.root_transforms.add(applied_ptransform)
         if input_value not in self.value_to_consumers:
-          self.value_to_consumers[input_value] = []
-        self.value_to_consumers[input_value].append(applied_ptransform)
+          self.value_to_consumers[input_value] = set()
+        self.value_to_consumers[input_value].add(applied_ptransform)
     else:
       self.root_transforms.add(applied_ptransform)
     self.step_names[applied_ptransform] = 's%d' % (self._num_transforms)

--- a/sdks/python/apache_beam/runners/direct/test_stream_impl.py
+++ b/sdks/python/apache_beam/runners/direct/test_stream_impl.py
@@ -106,7 +106,8 @@ class _ExpandableTestStream(PTransform):
         | _TestStream(
             self.test_stream.output_tags,
             events=self.test_stream._events,
-            coder=self.test_stream.coder)
+            coder=self.test_stream.coder,
+            endpoint=self.test_stream._endpoint)
         | 'TestStream Multiplexer' >> ParDo(mux).with_outputs())
 
     # Apply a way to control the watermark per output. It is necessary to

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -56,7 +56,7 @@ class BackgroundCachingJob(object):
   """A simple abstraction that controls necessary components of a timed and
   space limited background caching job.
 
-  A background caching job successfully complete source data capture in 2
+  A background caching job successfully completes source data capture in 2
   conditions:
 
     #. The job is finite and runs into DONE state;

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
@@ -30,7 +30,9 @@ from apache_beam.runners.interactive import background_caching_job as bcj
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner
+from apache_beam.runners.interactive.caching.streaming_cache import StreamingCache
 from apache_beam.runners.interactive.testing.mock_ipython import mock_get_ipython
+from apache_beam.runners.interactive.testing.test_cache_manager import FileRecordsBuilder
 from apache_beam.testing.test_stream import TestStream
 from apache_beam.testing.test_stream_service import TestStreamServiceController
 from apache_beam.transforms.window import TimestampedValue
@@ -44,6 +46,7 @@ except ImportError:
 
 _FOO_PUBSUB_SUB = 'projects/test-project/subscriptions/foo'
 _BAR_PUBSUB_SUB = 'projects/test-project/subscriptions/bar'
+_TEST_CACHE_KEY = 'test'
 
 
 def _build_a_test_stream_pipeline():
@@ -68,6 +71,19 @@ def _build_an_empty_stream_pipeline():
   return p
 
 
+def _setup_test_streaming_cache():
+  cache_manager = StreamingCache(cache_dir=None)
+  ie.current_env().set_cache_manager(cache_manager)
+  builder = FileRecordsBuilder(tag=_TEST_CACHE_KEY)
+  (builder
+      .advance_watermark(watermark_secs=0)
+      .advance_processing_time(5)
+      .add_element(element='a', event_time_secs=1)
+      .advance_watermark(watermark_secs=100)
+      .advance_processing_time(10)) # yapf: disable
+  cache_manager.write(builder.build(), _TEST_CACHE_KEY)
+
+
 @unittest.skipIf(
     not ie.current_env().is_interactive_ready,
     '[interactive] dependency is not installed.')
@@ -85,8 +101,14 @@ class BackgroundCachingJobTest(unittest.TestCase):
       'apache_beam.runners.interactive.background_caching_job'
       '.has_source_to_cache',
       lambda x: True)
+  # Disable the clean up so that we can keep the test streaming cache.
+  @patch(
+      'apache_beam.runners.interactive.interactive_environment'
+      '.InteractiveEnvironment.cleanup',
+      lambda x: None)
   def test_background_caching_job_starts_when_none_such_job_exists(self):
     p = _build_a_test_stream_pipeline()
+    _setup_test_streaming_cache()
     p.run()
     self.assertIsNotNone(ie.current_env().get_background_caching_job(p))
     expected_cached_source_signature = bcj.extract_source_to_cache_signature(p)
@@ -109,8 +131,14 @@ class BackgroundCachingJobTest(unittest.TestCase):
       'apache_beam.runners.interactive.background_caching_job'
       '.has_source_to_cache',
       lambda x: True)
+  # Disable the clean up so that we can keep the test streaming cache.
+  @patch(
+      'apache_beam.runners.interactive.interactive_environment'
+      '.InteractiveEnvironment.cleanup',
+      lambda x: None)
   def test_background_caching_job_not_start_when_such_job_exists(self):
     p = _build_a_test_stream_pipeline()
+    _setup_test_streaming_cache()
     a_running_background_caching_job = bcj.BackgroundCachingJob(
         runner.PipelineResult(runner.PipelineState.RUNNING))
     ie.current_env().set_background_caching_job(
@@ -127,8 +155,14 @@ class BackgroundCachingJobTest(unittest.TestCase):
       'apache_beam.runners.interactive.background_caching_job'
       '.has_source_to_cache',
       lambda x: True)
+  # Disable the clean up so that we can keep the test streaming cache.
+  @patch(
+      'apache_beam.runners.interactive.interactive_environment'
+      '.InteractiveEnvironment.cleanup',
+      lambda x: None)
   def test_background_caching_job_not_start_when_such_job_is_done(self):
     p = _build_a_test_stream_pipeline()
+    _setup_test_streaming_cache()
     a_done_background_caching_job = bcj.BackgroundCachingJob(
         runner.PipelineResult(runner.PipelineState.DONE))
     ie.current_env().set_background_caching_job(

--- a/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
@@ -121,6 +121,7 @@ class PipelineGraph(object):
     return self._get_graph().to_string()
 
   def display_graph(self):
+    """Displays the graph generated."""
     rendered_graph = self._renderer.render_pipeline_graph(self)
     if ie.current_env().is_in_notebook:
       try:

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -31,6 +31,7 @@ import logging
 import apache_beam as beam
 from apache_beam import runners
 from apache_beam.options.pipeline_options import DebugOptions
+from apache_beam.pipeline import PipelineVisitor
 from apache_beam.runners.direct import direct_runner
 from apache_beam.runners.interactive import cache_manager as cache
 from apache_beam.runners.interactive import interactive_environment as ie
@@ -39,6 +40,7 @@ from apache_beam.runners.interactive import background_caching_job
 from apache_beam.runners.interactive.display import pipeline_graph
 from apache_beam.runners.interactive.options import capture_control
 from apache_beam.runners.interactive.utils import to_element_list
+from apache_beam.testing.test_stream_service import TestStreamServiceController
 
 # size of PCollection samples cached.
 SAMPLE_SIZE = 8
@@ -148,6 +150,10 @@ class InteractiveRunner(runners.PipelineRunner):
     if self._force_compute:
       ie.current_env().evict_computed_pcollections()
 
+    # Make sure that sources without a user reference are still cached.
+    inst.watch_sources(pipeline)
+
+    user_pipeline = inst.user_pipeline(pipeline)
     pipeline_instrument = inst.build_pipeline_instrument(pipeline, options)
 
     # The user_pipeline analyzed might be None if the pipeline given has nothing
@@ -155,16 +161,40 @@ class InteractiveRunner(runners.PipelineRunner):
     # When it's None, there is no need to cache including the background
     # caching job and no result to track since no background caching job is
     # started at all.
-    user_pipeline = pipeline_instrument.user_pipeline
     if user_pipeline:
       # Should use the underlying runner and run asynchronously.
       background_caching_job.attempt_to_run_background_caching_job(
           self._underlying_runner, user_pipeline, options)
+      if (background_caching_job.has_source_to_cache(user_pipeline) and
+          not background_caching_job.is_a_test_stream_service_running(
+              user_pipeline)):
+        streaming_cache_manager = ie.current_env().cache_manager()
+        if streaming_cache_manager:
+          test_stream_service = TestStreamServiceController(
+              streaming_cache_manager)
+          test_stream_service.start()
+          ie.current_env().set_test_stream_service_controller(
+              user_pipeline, test_stream_service)
 
     pipeline_to_execute = beam.pipeline.Pipeline.from_runner_api(
         pipeline_instrument.instrumented_pipeline_proto(),
         self._underlying_runner,
         options)
+
+    if ie.current_env().get_test_stream_service_controller(user_pipeline):
+      endpoint = ie.current_env().get_test_stream_service_controller(
+          user_pipeline).endpoint
+
+      # TODO: make the StreamingCacheManager and TestStreamServiceController
+      # constructed when the InteractiveEnvironment is imported.
+      class TestStreamVisitor(PipelineVisitor):
+        def visit_transform(self, transform_node):
+          from apache_beam.testing.test_stream import TestStream
+          if (isinstance(transform_node.transform, TestStream) and
+              not transform_node.transform._events):
+            transform_node.transform._endpoint = endpoint
+
+      pipeline_to_execute.visit(TestStreamVisitor())
 
     if not self._skip_display:
       a_pipeline_graph = pipeline_graph.PipelineGraph(
@@ -216,6 +246,7 @@ class PipelineResult(beam.runners.runner.PipelineResult):
 
   def get(self, pcoll, include_window_info=False):
     """Materializes the PCollection into a list.
+
     If include_window_info is True, then returns the elements as
     WindowedValues. Otherwise, return the element as itself.
     """
@@ -223,6 +254,7 @@ class PipelineResult(beam.runners.runner.PipelineResult):
 
   def read(self, pcoll, include_window_info=False):
     """Reads the PCollection one element at a time from cache.
+
     If include_window_info is True, then returns the elements as
     WindowedValues. Otherwise, return the element as itself.
     """

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -28,12 +28,19 @@ from __future__ import print_function
 
 import unittest
 
+import pandas as pd
+
 import apache_beam as beam
 from apache_beam.runners.direct import direct_runner
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner
 from apache_beam.runners.interactive.testing.mock_ipython import mock_get_ipython
+from apache_beam.transforms.window import GlobalWindow
+from apache_beam.utils.timestamp import Timestamp
+from apache_beam.utils.windowed_value import PaneInfo
+from apache_beam.utils.windowed_value import PaneInfoTiming
+from apache_beam.utils.windowed_value import WindowedValue
 
 # TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
 # unittest.mock module.
@@ -98,19 +105,47 @@ class InteractiveRunnerTest(unittest.TestCase):
     result = p.run()
     result.wait_until_finish()
 
-    actual = dict(result.get(counts))
-    self.assertDictEqual(
-        actual,
-        {
-            'to': 2,
-            'be': 2,
-            'or': 1,
-            'not': 1,
-            'that': 1,
-            'is': 1,
-            'the': 1,
-            'question': 1
-        })
+    actual = list(result.get(counts))
+    self.assertSetEqual(
+        set(actual),
+        set([
+            ('or', 1),
+            ('that', 1),
+            ('be', 2),
+            ('is', 1),
+            ('question', 1),
+            ('to', 2),
+            ('the', 1),
+            ('not', 1),
+        ]))
+
+    # Truncate the precision to millis because the window coder uses millis
+    # as units then gets upcast to micros.
+    end_of_window = (GlobalWindow().max_timestamp().micros // 1000) * 1000
+    df_counts = ib.collect(counts, include_window_info=True)
+    df_expected = pd.DataFrame({
+        0: [e[0] for e in actual],
+        1: [e[1] for e in actual],
+        'event_time': [end_of_window for _ in actual],
+        'windows': [[GlobalWindow()] for _ in actual],
+        'pane_info': [
+            PaneInfo(True, True, PaneInfoTiming.ON_TIME, 0, 0) for _ in actual
+        ]
+    },
+                               columns=[
+                                   0, 1, 'event_time', 'windows', 'pane_info'
+                               ])
+
+    pd.testing.assert_frame_equal(df_expected, df_counts)
+
+    actual_reified = result.get(counts, include_window_info=True)
+    expected_reified = [
+        WindowedValue(
+            e,
+            Timestamp(micros=end_of_window), [GlobalWindow()],
+            PaneInfo(True, True, PaneInfoTiming.ON_TIME, 0, 0)) for e in actual
+    ]
+    self.assertEqual(actual_reified, expected_reified)
 
   def test_session(self):
     class MockPipelineRunner(object):

--- a/sdks/python/apache_beam/runners/interactive/options/capture_control.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_control.py
@@ -42,7 +42,7 @@ class CaptureControl(object):
     self._enable_capture_replay = True
     self._capturable_sources = {
         ReadFromPubSub,
-    }
+    }  # yapf: disable
     self._capture_duration = timedelta(seconds=5)
     self._capture_size_limit = 1e9
 

--- a/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_fragment.py
@@ -204,6 +204,9 @@ class PipelineFragment(object):
       def enter_composite_transform(self, transform_node):
         if isinstance(transform_node.transform, TestStream):
           return
+        if isinstance(transform_node.transform, TestStream):
+          return
+
         pruned_parts = list(transform_node.parts)
         for part in transform_node.parts:
           if part not in necessary_transforms:

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -229,7 +229,7 @@ class PipelineInstrument(object):
     # Create the pipeline_proto to read all the components from. It will later
     # create a new pipeline proto from the cut out components.
     pipeline_proto, context = pipeline.to_runner_api(
-      return_context=True, use_fake_coders=False)
+        return_context=True, use_fake_coders=False)
 
     # Get all the root transforms. The caching transforms will be subtransforms
     # of one of these roots.
@@ -433,6 +433,7 @@ class PipelineInstrument(object):
           cacheable_input in unbounded_source_pcolls)
     # Replace/wire inputs w/ cached PCollections from ReadCache transforms.
     self._replace_with_cached_inputs(self._pipeline)
+
     # Write cache for all cacheables.
     for _, cacheable in self.cacheables.items():
       self._write_cache(

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -26,7 +26,6 @@ import unittest
 import apache_beam as beam
 from apache_beam import coders
 from apache_beam.pipeline import PipelineVisitor
-from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 from apache_beam.runners.interactive import cache_manager as cache
 from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
@@ -307,7 +306,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
   def test_instrument_example_unbounded_pipeline_to_read_cache(self):
     """Tests that the instrumenter works for a single unbounded source.
-        """
+    """
     # Create a new interactive environment to make the test idempotent.
     ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
 
@@ -328,7 +327,7 @@ class PipelineInstrumentTest(unittest.TestCase):
       if not isinstance(pcoll, beam.pvalue.PCollection):
         continue
       cache_key = cache_key_of(name, pcoll)
-      self._mock_write_cache([TestStreamPayload()], cache_key)
+      self._mock_write_cache([b''], cache_key)
 
     # Instrument the original pipeline to create the pipeline the user will see.
     instrumenter = instr.build_pipeline_instrument(p_original)
@@ -467,9 +466,9 @@ class PipelineInstrumentTest(unittest.TestCase):
   def test_instrument_mixed_streaming_batch(self):
     """Tests caching for both batch and streaming sources in the same pipeline.
 
-        This ensures that cached bounded and unbounded sources are read from the
-        TestStream.
-        """
+    This ensures that cached bounded and unbounded sources are read from the
+    TestStream.
+    """
     # Create a new interactive environment to make the test idempotent.
     ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
 
@@ -492,8 +491,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     def cache_key_of(name, pcoll):
       return name + '_' + str(id(pcoll)) + '_' + str(id(pcoll.producer))
 
-    self._mock_write_cache([TestStreamPayload()],
-                           cache_key_of('source_2', source_2))
+    self._mock_write_cache([b''], cache_key_of('source_2', source_2))
     ie.current_env().mark_pcollection_computed([source_2])
 
     # Instrument the original pipeline to create the pipeline the user will see.
@@ -552,7 +550,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
   def test_instrument_example_unbounded_pipeline_direct_from_source(self):
     """Tests that the it caches PCollections from a source.
-        """
+    """
     # Create a new interactive environment to make the test idempotent.
     ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
 
@@ -618,7 +616,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
   def test_instrument_example_unbounded_pipeline_to_read_cache_not_cached(self):
     """Tests that the instrumenter works when the PCollection is not cached.
-        """
+    """
     # Create a new interactive environment to make the test idempotent.
     ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
 
@@ -689,7 +687,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
   def test_instrument_example_unbounded_pipeline_to_multiple_read_cache(self):
     """Tests that the instrumenter works for multiple unbounded sources.
-        """
+    """
     # Create a new interactive environment to make the test idempotent.
     ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
 
@@ -714,7 +712,7 @@ class PipelineInstrumentTest(unittest.TestCase):
       if not isinstance(pcoll, beam.pvalue.PCollection):
         continue
       cache_key = cache_key_of(name, pcoll)
-      self._mock_write_cache([TestStreamPayload()], cache_key)
+      self._mock_write_cache([b''], cache_key)
 
     # Instrument the original pipeline to create the pipeline the user will see.
     instrumenter = instr.build_pipeline_instrument(p_original)

--- a/sdks/python/apache_beam/runners/interactive/testing/pipeline_assertion.py
+++ b/sdks/python/apache_beam/runners/interactive/testing/pipeline_assertion.py
@@ -69,7 +69,7 @@ def assert_pipeline_proto_equal(
 def assert_pipeline_proto_contain_top_level_transform(
     test_case, pipeline_proto, transform_label):
   """Asserts the top level transforms contain a transform with the given
-     transform label."""
+   transform label."""
   _assert_pipeline_proto_contains_top_level_transform(
       test_case, pipeline_proto, transform_label, True)
 
@@ -77,7 +77,7 @@ def assert_pipeline_proto_contain_top_level_transform(
 def assert_pipeline_proto_not_contain_top_level_transform(
     test_case, pipeline_proto, transform_label):
   """Asserts the top level transforms do not contain a transform with the given
-     transform label."""
+   transform label."""
   _assert_pipeline_proto_contains_top_level_transform(
       test_case, pipeline_proto, transform_label, False)
 

--- a/sdks/python/apache_beam/runners/interactive/utils.py
+++ b/sdks/python/apache_beam/runners/interactive/utils.py
@@ -26,10 +26,10 @@ from apache_beam.portability.api.beam_runner_api_pb2 import TestStreamPayload
 
 
 def to_element_list(
-        reader, # type: Generator[Union[TestStreamPayload.Event, WindowedValueHolder]]
-        coder, # type: Coder
-        include_window_info # type: bool
-):
+    reader, # type: Generator[Union[TestStreamPayload.Event, WindowedValueHolder]]
+    coder, # type: Coder
+    include_window_info # type: bool
+    ):
   # type: (...) -> List[WindowedValue]
 
   """Returns an iterator that properly decodes the elements from the reader.


### PR DESCRIPTION
Final PR to merge everything from the InteractiveBeam feature branch

consumer_tracking_pipeline_visitor.py:
  - This has the assumption that the pipeline proto is in topological order. The PipelineProto has no guarantee for this. This changes a key part to a set instead of a list.

consumer_tracking_pipeline_visitor_test.py:
  - This adds a test that fails if the class has an order guarantee.

test_stream_impl.py
  - Adds an endpoint to a forgotten constructor.

background_caching_job.py
  - Fixes grammar mistake

background_caching_job_test.py
  - Adds the StreamingCache to the test

streaming_cache.py:
  - Small cleanup
  - The values in the cache can either be protos or not in the case of testing.

pcoll_visualization:
  - Adds ability to read from a StreamingCache
  - Refactors _to_dataframe implementation with elements_to_df

pipeline_graph.py:
  - Add a comment

interactive_beam.py:
  - Add the collect/head methods which take in a PCollection and outputs a Dataframe representation
  - Adds logic to not recompute PCollections already in the cache

interactive_runner.py
  - Adds the TestStreamServiceController
  - Adds ability for the result.get method to read from the StreamingCache

interactive_runner_test.py
  - Add a small integration test for the new DataFrame

capture_control.py
  - formatting

pipeline_fragment.py
  - Add logic to stop pruning the pipeline fragment if it hits a TestStream

pipeline_instrument.py
  - Change dictionary usage to WindowedValueHolder

pipeline_instrumnet_test.py
  - formatting

pipeline_assertion.py:
  - formatting

utils.py:
  - Small refactor, moving the to_element_list from the pcoll_visualization and the PipelineResult.get methods to here. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
