### PR TITLE
Add spark structured streaming runner to load tests

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_CoGBK_Java_spark_structured_streaming.groovy
+++ b/.test-infra/jenkins/job_LoadTests_CoGBK_Java_spark_structured_streaming.groovy
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonTestProperties
+import CronJobBuilder
+import LoadTestsBuilder as loadTestsBuilder
+import PhraseTriggeringPostCommitBuilder
+
+def loadTestConfigurations = { mode, isStreaming, datasetName ->
+    [
+            [
+                    title          : 'Load test: CoGBK 2GB 100  byte records - single key',
+                    test           : 'org.apache.beam.sdk.loadtests.CoGroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_CoGBK_1",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_sparkstructuredstreaming_${mode}_CoGBK_1",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 20000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 1
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            coSourceOptions       : """
+                                            {
+                                              "numRecords": 2000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 1000
+                                            }
+                                        """.trim().replaceAll("\\s", ""),
+                            iterations            : 1,
+                            streaming             : isStreaming
+                    ]
+            ],
+            [
+                    title          : 'Load test: CoGBK 2GB 100 byte records - multiple keys',
+                    test           : 'org.apache.beam.sdk.loadtests.CoGroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_CoGBK_2",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_sparkstructuredstreaming_${mode}_CoGBK_2",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 20000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 5
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            coSourceOptions       : """
+                                            {
+                                              "numRecords": 2000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 1000
+                                            }
+                                        """.trim().replaceAll("\\s", ""),
+                            iterations            : 1,
+                            streaming             : isStreaming
+                    ]
+            ],
+            [
+
+                    title          : 'Load test: CoGBK 2GB reiteration 10kB value',
+                    test           : 'org.apache.beam.sdk.loadtests.CoGroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_CoGBK_3",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_sparkstructuredstreaming_${mode}_CoGBK_3",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 2000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 200000
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            coSourceOptions       : """
+                                            {
+                                              "numRecords": 2000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 1000
+                                            }
+                                        """.trim().replaceAll("\\s", ""),
+                            iterations            : 4,
+                            streaming             : isStreaming
+                    ]
+
+            ],
+            [
+                    title          : 'Load test: CoGBK 2GB reiteration 2MB value',
+                    test           : 'org.apache.beam.sdk.loadtests.CoGroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_CoGBK_4",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_sparkstructuredstreaming_${mode}_CoGBK_4",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 2000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 1000
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            coSourceOptions       : """
+                                            {
+                                              "numRecords": 2000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 1000
+                                            }
+                                        """.trim().replaceAll("\\s", ""),
+                            iterations            : 4,
+                            streaming             : isStreaming
+                    ]
+            ]
+    ]
+}
+
+
+
+
+
+def batchLoadTestJob = { scope, triggeringContext ->
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, loadTestConfigurations('batch', false, datasetName), "CoGBK", "batch")
+}
+
+CronJobBuilder.cronJob('beam_LoadTests_Java_CoGBK_SparkStructuredStreaming_Batch', 'H 14 * * *', this) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT)
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_LoadTests_Java_CoGBK_SparkStructuredStreaming_Batch',
+        'Run Load Tests Java CoGBK SparkStructuredStreaming Batch',
+        'Load Tests Java CoGBK SparkStructuredStreaming Batch suite',
+        this
+) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.PR)
+}

--- a/.test-infra/jenkins/job_LoadTests_Combine_Java_spark_structured_streaming.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Java_spark_structured_streaming.groovy
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonTestProperties
+import CronJobBuilder
+import LoadTestsBuilder as loadTestsBuilder
+import PhraseTriggeringPostCommitBuilder
+
+def commonLoadTestConfig = { jobType, isStreaming, datasetName ->
+  [
+          [
+                  title          : 'Load test: 2GB of 10B records',
+                  test           : 'org.apache.beam.sdk.loadtests.CombineLoadTest',
+                  runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                  pipelineOptions: [
+                          project             : 'apache-beam-testing',
+                          appName             : "load_tests_Java_SparkStructuredStreaming_${jobType}_Combine_1",
+                          tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                          publishToBigQuery   : true,
+                          bigQueryDataset     : datasetName,
+                          bigQueryTable       : "java_sparkstructuredstreaming_${jobType}_Combine_1",
+                          sourceOptions       : """
+                                            {
+                                              "numRecords": 200000000,
+                                              "keySizeBytes": 1,
+                                              "valueSizeBytes": 9
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                          fanout              : 1,
+                          iterations          : 1,
+                          topCount            : 20,
+                          perKeyCombiner      : "TOP_LARGEST",
+                          streaming           : isStreaming
+                  ]
+          ],
+          [
+                    title          : 'Load test: fanout 4 times with 2GB 10-byte records total',
+                    test           : 'org.apache.beam.sdk.loadtests.CombineLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project             : 'apache-beam-testing',
+                            appName             : "load_tests_Java_SparkStructuredStreaming_${jobType}_Combine_4",
+                            tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery   : true,
+                            bigQueryDataset     : datasetName,
+                            bigQueryTable       : "java_sparkstructuredstreaming_${jobType}_Combine_4",
+                            sourceOptions       : """
+                                                    {
+                                                      "numRecords": 5000000,
+                                                      "keySizeBytes": 10,
+                                                      "valueSizeBytes": 90
+                                                    }
+                                               """.trim().replaceAll("\\s", ""),
+                            fanout              : 4,
+                            iterations          : 1,
+                            topCount            : 20,
+                            perKeyCombiner      : "TOP_LARGEST",
+                            streaming           : isStreaming
+                    ]
+            ],
+            [
+                    title          : 'Load test: fanout 8 times with 2GB 10-byte records total',
+                    test           : 'org.apache.beam.sdk.loadtests.CombineLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project             : 'apache-beam-testing',
+                            appName             : "load_tests_Java_SparkStructuredStreaming_${jobType}_Combine_5",
+                            tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery   : true,
+                            bigQueryDataset     : datasetName,
+                            bigQueryTable       : "java_sparkstructuredstreaming_${jobType}_Combine_5",
+                            sourceOptions       : """
+                                                    {
+                                                      "numRecords": 2500000,
+                                                      "keySizeBytes": 10,
+                                                      "valueSizeBytes": 90
+                                                    }
+                                               """.trim().replaceAll("\\s", ""),
+                            fanout              : 8,
+                            iterations          : 1,
+                            topCount            : 20,
+                            perKeyCombiner      : "TOP_LARGEST",
+                            streaming           : isStreaming
+                    ]
+            ]
+    ]
+}
+
+
+def batchLoadTestJob = { scope, triggeringContext ->
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, commonLoadTestConfig('batch', false, datasetName), "Combine", "batch")
+}
+
+CronJobBuilder.cronJob('beam_LoadTests_Java_Combine_SparkStructuredStreaming_Batch', 'H 12 * * *', this) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT)
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_LoadTests_Java_Combine_SparkStructuredStreaming_Batch',
+        'Run Load Tests Java Combine SparkStructuredStreaming Batch',
+        'Load Tests Java Combine SparkStructuredStreaming Batch suite',
+        this
+) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.PR)
+}

--- a/.test-infra/jenkins/job_LoadTests_GBK_Java_spark_structured_streaming.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Java_spark_structured_streaming.groovy
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonTestProperties
+import CronJobBuilder
+import LoadTestsBuilder as loadTestsBuilder
+import PhraseTriggeringPostCommitBuilder
+
+def loadTestConfigurations = { mode, isStreaming, datasetName ->
+    [
+            [
+                    title          : 'Load test: 2GB of 10B records',
+                    test           : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_GBK_1",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_sparkstructuredstreaming_${mode}_GBK_1",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 200000000,
+                                              "keySizeBytes": 1,
+                                              "valueSizeBytes": 9
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            fanout                : 1,
+                            iterations            : 1,
+                            streaming             : isStreaming
+                    ]
+            ],
+            [
+                    title          : 'Load test: 2GB of 100B records',
+                    test           : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_GBK_2",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_SparkStructuredStreaming_${mode}_GBK_2",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 20000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            fanout                : 1,
+                            iterations            : 1,
+                            streaming             : isStreaming
+                    ]
+            ],
+            [
+
+                    title          : 'Load test: 2GB of 100kB records',
+                    test           : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_GBK_3",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_SparkStructuredStreaming_${mode}_GBK_3",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 20000,
+                                              "keySizeBytes": 10000,
+                                              "valueSizeBytes": 90000
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            fanout                : 1,
+                            iterations            : 1,
+                            streaming             : isStreaming
+                    ]
+
+            ],
+            [
+                    title          : 'Load test: fanout 4 times with 2GB 10-byte records total',
+                    test           : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : 'load_tests_Java_SparkStructuredStreaming_${mode}_GBK_4',
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_SparkStructuredStreaming_${mode}_GBK_4",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 5000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            fanout                : 4,
+                            iterations            : 1,
+                            streaming             : isStreaming
+                    ]
+            ],
+            [
+                    title          : 'Load test: fanout 8 times with 2GB 10-byte records total',
+                    test           : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_GBK_5",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_SparkStructuredStreaming_${mode}_GBK_5",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 2500000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            fanout                : 8,
+                            iterations            : 1,
+                            streaming             : isStreaming
+                    ]
+            ],
+            [
+                    title          : 'Load test: reiterate 4 times 10kB values',
+                    test           : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_GBK_6",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_SparkStructuredStreaming_${mode}_GBK_6",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 20000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 200,
+                                              "hotKeyFraction": 1
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            fanout                : 1,
+                            iterations            : 4,
+                            streaming             : isStreaming
+                    ]
+            ],
+            [
+                    title          : 'Load test: reiterate 4 times 2MB values',
+                    test           : 'org.apache.beam.sdk.loadtests.GroupByKeyLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project               : 'apache-beam-testing',
+                            appName               : "load_tests_Java_SparkStructuredStreaming_${mode}_GBK_7",
+                            tempLocation          : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery     : true,
+                            bigQueryDataset       : datasetName,
+                            bigQueryTable         : "java_SparkStructuredStreaming_${mode}_GBK_7",
+                            sourceOptions         : """
+                                            {
+                                              "numRecords": 20000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90,
+                                              "numHotKeys": 10,
+                                              "hotKeyFraction": 1
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                            fanout                : 1,
+                            iterations            : 4,
+                            streaming             : isStreaming
+                    ]
+            ]
+    ]
+}
+
+def batchLoadTestJob = { scope, triggeringContext ->
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, loadTestConfigurations('batch', false, datasetName), "GBK", "batch")
+}
+CronJobBuilder.cronJob('beam_LoadTests_Java_GBK_SparkStructuredStreaming_Batch', 'H 12 * * *', this) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT)
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_LoadTests_Java_GBK_SparkStructuredStreaming_Batch',
+        'Run Load Tests Java GBK SparkStructuredStreaming Batch',
+        'Load Tests Java GBK SparkStructuredStreaming Batch suite',
+        this
+) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.PR)
+}

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Java_spark_structured_streaming.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Java_spark_structured_streaming.groovy
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonTestProperties
+import CronJobBuilder
+import LoadTestsBuilder as loadTestsBuilder
+import PhraseTriggeringPostCommitBuilder
+
+def commonLoadTestConfig = { jobType, isStreaming, datasetName ->
+    [
+            [
+            title          : 'Load test: ParDo 2GB 100 byte records 10 times',
+            test           : 'org.apache.beam.sdk.loadtests.ParDoLoadTest',
+            runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+            pipelineOptions: [
+                    project             : 'apache-beam-testing',
+                    appName             : "load_tests_Java_SparkStructuredStreaming_${jobType}_ParDo_1",
+                    tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                    publishToBigQuery   : true,
+                    bigQueryDataset     : datasetName,
+                    bigQueryTable       : "java_sparkstructuredstreaming_${jobType}_ParDo_1",
+                    sourceOptions       : """
+                                            {
+                                              "numRecords": 20000000,
+                                              "keySizeBytes": 10,
+                                              "valueSizeBytes": 90
+                                            }
+                                       """.trim().replaceAll("\\s", ""),
+                    iterations          : 10,
+                    numberOfCounters    : 1,
+                    numberOfCounterOperations: 0,
+                    streaming           : isStreaming
+            ]
+            ],
+            [
+                    title          : 'Load test: ParDo 2GB 100 byte records 200  times',
+                    test           : 'org.apache.beam.sdk.loadtests.ParDoLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project             : 'apache-beam-testing',
+                            appName             : "load_tests_Java_SparkStructuredStreaming_${jobType}_ParDo_2",
+                            tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery   : true,
+                            bigQueryDataset     : datasetName,
+                            bigQueryTable       : "java_sparkstructuredstreaming_${jobType}_ParDo_2",
+                            sourceOptions       : """
+                                                    {
+                                                      "numRecords": 20000000,
+                                                      "keySizeBytes": 10,
+                                                      "valueSizeBytes": 90
+                                                    }
+                                               """.trim().replaceAll("\\s", ""),
+                            iterations          : 200,
+                            numberOfCounters    : 1,
+                            numberOfCounterOperations: 0,
+                            streaming           : isStreaming
+                    ]
+            ],
+            [
+
+                    title          : 'Load test: ParDo 2GB 100 byte records 10 counters',
+                    test           : 'org.apache.beam.sdk.loadtests.ParDoLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project             : 'apache-beam-testing',
+                            appName             : "load_tests_Java_SparkStructuredStreaming_${jobType}_ParDo_3",
+                            tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery   : true,
+                            bigQueryDataset     : datasetName,
+                            bigQueryTable       : "java_sparkstructuredstreaming_${jobType}_ParDo_3",
+                            sourceOptions       : """
+                                                    {
+                                                      "numRecords": 20000000,
+                                                      "keySizeBytes": 10,
+                                                      "valueSizeBytes": 90
+                                                    }
+                                               """.trim().replaceAll("\\s", ""),
+                            iterations          : 1,
+                            numberOfCounters    : 1,
+                            numberOfCounterOperations: 10,
+                            streaming           : isStreaming
+                    ]
+
+            ],
+            [
+                    title          : 'Load test: ParDo 2GB 100 byte records 100 counters',
+                    test           : 'org.apache.beam.sdk.loadtests.ParDoLoadTest',
+                    runner         : CommonTestProperties.Runner.SPARK_STRUCTURED_STREAMING,
+                    pipelineOptions: [
+                            project             : 'apache-beam-testing',
+                            appName             : "load_tests_Java_SparkStructuredStreaming_${jobType}_ParDo_4",
+                            tempLocation        : 'gs://temp-storage-for-perf-tests/loadtests',
+                            publishToBigQuery   : true,
+                            bigQueryDataset     : datasetName,
+                            bigQueryTable       : "java_sparkstructuredstreaming_${jobType}_ParDo_4",
+                            sourceOptions       : """
+                                                    {
+                                                      "numRecords": 20000000,
+                                                      "keySizeBytes": 10,
+                                                      "valueSizeBytes": 90
+                                                    }
+                                               """.trim().replaceAll("\\s", ""),
+                            iterations          : 1,
+                            numberOfCounters    : 1,
+                            numberOfCounterOperations: 100,
+                            streaming           : isStreaming
+                    ]
+            ]
+    ]
+}
+
+
+def batchLoadTestJob = { scope, triggeringContext ->
+    def datasetName = loadTestsBuilder.getBigQueryDataset('load_test', triggeringContext)
+    loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.JAVA, commonLoadTestConfig('batch', false, datasetName), "ParDo", "batch")
+}
+
+
+CronJobBuilder.cronJob('beam_LoadTests_Java_ParDo_SparkStructuredStreaming_Batch', 'H 12 * * *', this) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT)
+}
+
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+        'beam_LoadTests_Java_ParDo_SparkStructuredStreaming_Batch',
+        'Run Load Tests Java ParDo SparkStructuredStreaming Batch',
+        'Load Tests Java ParDo SparkStructuredStreaming Batch suite',
+        this
+) {
+    batchLoadTestJob(delegate, CommonTestProperties.TriggeringContext.PR)
+}
+


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
