### PR TITLE
[BEAM-3301] Perform SDF validation (missing RestrictionTrackers).

### DIFF
--- a/sdks/go/pkg/beam/core/graph/fn.go
+++ b/sdks/go/pkg/beam/core/graph/fn.go
@@ -152,6 +152,10 @@ const (
 	finishBundleName   = "FinishBundle"
 	teardownName       = "Teardown"
 
+	createInitialRestrictionName = "CreateInitialRestriction"
+	splitRestrictionName         = "SplitRestriction"
+	restrictionSizeName          = "RestrictionSize"
+
 	createAccumulatorName = "CreateAccumulator"
 	addInputName          = "AddInput"
 	mergeAccumulatorsName = "MergeAccumulators"
@@ -160,6 +164,23 @@ const (
 
 	// TODO: ViewFn, etc.
 )
+
+var doFnNames = []string{
+	setupName,
+	startBundleName,
+	processElementName,
+	finishBundleName,
+	teardownName,
+	createInitialRestrictionName,
+	splitRestrictionName,
+	restrictionSizeName,
+}
+
+var sdfNames = []string{
+	createInitialRestrictionName,
+	splitRestrictionName,
+	restrictionSizeName,
+}
 
 // DoFn represents a DoFn.
 type DoFn Fn
@@ -196,13 +217,33 @@ func (f *DoFn) Name() string {
 
 // IsSplittable returns whether the DoFn is a valid Splittable DoFn.
 func (f *DoFn) IsSplittable() bool {
-	return false // TODO(BEAM-3301): Implement this when we add SDFs.
+	// Validation already passed, so if one SDF method is present they should
+	// all be present.
+	_, ok := f.methods[createInitialRestrictionName]
+	return ok
 }
 
-// RestrictionT returns the restriction type from the DoFn if it's splittable.
-// Otherwise, returns nil.
-func (f *DoFn) RestrictionT() *reflect.Type {
-	return nil // TODO(BEAM-3301): Implement this when we add SDFs.
+type SplittableDoFn DoFn
+
+func (f *SplittableDoFn) CreateInitialRestrictionFn() *funcx.Fn {
+	return f.methods[createInitialRestrictionName]
+}
+
+func (f *SplittableDoFn) SplitRestrictionFn() *funcx.Fn {
+	return f.methods[splitRestrictionName]
+}
+
+func (f *SplittableDoFn) RestrictionSizeFn() *funcx.Fn {
+	return f.methods[restrictionSizeName]
+}
+
+func (f *SplittableDoFn) Name() string {
+	return (*Fn)(f).Name()
+}
+
+// RestrictionT returns the restriction type from the SDF.
+func (f *SplittableDoFn) RestrictionT() reflect.Type {
+	return f.CreateInitialRestrictionFn().Ret[0].T
 }
 
 // TODO(herohde) 5/19/2017: we can sometimes detect whether the main input must be
@@ -270,7 +311,7 @@ func AsDoFn(fn *Fn, numMainIn mainInputs) (*DoFn, error) {
 	if fn.Fn != nil {
 		fn.methods[processElementName] = fn.Fn
 	}
-	if err := verifyValidNames("graph.AsDoFn", fn, setupName, startBundleName, processElementName, finishBundleName, teardownName); err != nil {
+	if err := verifyValidNames("graph.AsDoFn", fn, doFnNames...); err != nil {
 		return nil, err
 	}
 
@@ -360,6 +401,20 @@ func AsDoFn(fn *Fn, numMainIn mainInputs) (*DoFn, error) {
 					name, fn.Name())
 				return nil, addContext(err, fn)
 			}
+		}
+	}
+
+	// Check whether to perform SDF validation by seeing if SDF methods are present.
+	isSdf, err := validateSdfMethodsPresent(fn)
+	if err != nil {
+		return nil, addContext(err, fn)
+	}
+
+	// Perform validation on the SDF method signatures to ensure they're valid.
+	if isSdf {
+		err := validateSdfSignatures(fn, numMainIn)
+		if err != nil {
+			return nil, addContext(err, fn)
 		}
 	}
 
@@ -566,6 +621,183 @@ func validateSideInputsNumUnknown(processFnInputs []funcx.FnParam, method *funcx
 		}
 	}
 
+	return nil
+}
+
+// validateSdfMethods validates that all SDF methods are either present or
+// missing in a Fn, and then returns true if they're present and false
+// otherwise. If some are present and some are missing, it returns an error.
+func validateSdfMethodsPresent(fn *Fn) (bool, error) {
+	// Check if first sdf method is present or not, and compare all subsequent
+	// methods to that result. If there's a mismatch, then we only fail after
+	// finishing the loop so we can output all the missing methods.
+	var missing []string
+	for _, name := range sdfNames {
+		_, ok := fn.methods[name]
+		if !ok {
+			missing = append(missing, name)
+		}
+	}
+
+	switch len(missing) {
+	case 0: // All SDF methods present.
+		return true, nil
+	case len(sdfNames): // No SDF methods.
+		return false, nil
+	default: // Anything else means an invalid # of SDF methods.
+		err := errors.Errorf("not all SplittableDoFn methods are present. Missing methods: %v", missing)
+		return false, err
+	}
+}
+
+// validateSdfTypes validates that types in the SDF methods of a Fn are
+// consistent with each other (for example, element and restriction types should
+// match with each other). Returns an error if one is found, or nil if the
+// types are all valid.
+// TODO(BEAM-3301): Once SDF documentation is added to ParDo, add a comment
+// here to refer to that for specific details about what needs to be consistent.
+func validateSdfSignatures(fn *Fn, numMainIn mainInputs) error {
+	num := int(numMainIn)
+
+	// If number of main inputs is ambiguous, we check for consistency against
+	// CreateInitialRestriction.
+	if numMainIn == MainUnknown {
+		initialRestFn := fn.methods[createInitialRestrictionName]
+		paramNum := len(initialRestFn.Param)
+		switch paramNum {
+		case int(MainSingle), int(MainKv):
+			num = paramNum
+		default: // Can't infer because method has invalid # of main inputs.
+			err := errors.Errorf("invalid number of params in method %v. got: %v, want: %v or %v",
+				createInitialRestrictionName, paramNum, int(MainSingle), int(MainKv))
+			return errors.SetTopLevelMsgf(err, "Invalid number of parameters in method %v. "+
+				"Got: %v, Want: %v or %v. Check that the signature conforms to the expected signature for %v, "+
+				"and that elements in SDF method parameters match elements in %v.",
+				createInitialRestrictionName, paramNum, int(MainSingle), int(MainKv), createInitialRestrictionName, processElementName)
+		}
+	}
+
+	if err := validateSdfSigNumbers(fn, num); err != nil {
+		return err
+	}
+	if err := validateSdfSigTypes(fn, num); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSdfSigNumbers validates the number of parameters and return values
+// in each SDF method in the given Fn, and returns an error if a method has an
+// invalid/unexpected number.
+func validateSdfSigNumbers(fn *Fn, num int) error {
+	paramNums := map[string]int{
+		createInitialRestrictionName: num,
+		splitRestrictionName:         num + 1,
+		restrictionSizeName:          num + 1,
+	}
+	returnNum := 1 // TODO(BEAM-3301): Enable optional error params in SDF methods.
+
+	for _, name := range sdfNames {
+		method := fn.methods[name]
+		if len(method.Param) != paramNums[name] {
+			err := errors.Errorf("unexpected number of params in method %v. got: %v, want: %v",
+				name, len(method.Param), paramNums[name])
+			return errors.SetTopLevelMsgf(err, "Unexpected number of parameters in method %v. "+
+				"Got: %v, Want: %v. Check that the signature conforms to the expected signature for %v, "+
+				"and that elements in SDF method parameters match elements in %v.",
+				name, len(method.Param), paramNums[name], name, processElementName)
+		}
+		if len(method.Ret) != returnNum {
+			err := errors.Errorf("unexpected number of returns in method %v. got: %v, want: %v",
+				name, len(method.Ret), returnNum)
+			return errors.SetTopLevelMsgf(err, "Unexpected number of return values in method %v. "+
+				"Got: %v, Want: %v. Check that the signature conforms to the expected signature for %v.",
+				name, len(method.Ret), returnNum, name)
+		}
+	}
+	return nil
+}
+
+// validateSdfSigTypes validates the types of the parameters and return values
+// in each SDF method in the given Fn, and returns an error if a method has an
+// invalid/mismatched type. Assumes that the number of parameters and return
+// values has already been validated.
+func validateSdfSigTypes(fn *Fn, num int) error {
+	restrictionT := fn.methods[createInitialRestrictionName].Ret[0].T
+
+	for _, name := range sdfNames {
+		method := fn.methods[name]
+		switch name {
+		case createInitialRestrictionName:
+			if err := validateSdfElementT(fn, createInitialRestrictionName, method, num); err != nil {
+				return err
+			}
+		case splitRestrictionName:
+			if err := validateSdfElementT(fn, splitRestrictionName, method, num); err != nil {
+				return err
+			}
+			if method.Param[num].T != restrictionT {
+				err := errors.Errorf("mismatched restriction type in method %v, param %v. got: %v, want: %v",
+					splitRestrictionName, num, method.Param[num].T, restrictionT)
+				return errors.SetTopLevelMsgf(err, "Mismatched restriction type in method %v, "+
+					"parameter at index %v. Got: %v, Want: %v (from method %v). "+
+					"Ensure that all restrictions in an SDF are the same type.",
+					splitRestrictionName, num, method.Param[num].T, restrictionT, createInitialRestrictionName)
+			}
+			if method.Ret[0].T.Kind() != reflect.Slice ||
+				method.Ret[0].T.Elem() != restrictionT {
+				err := errors.Errorf("invalid output type in method %v, return %v. got: %v, want: %v",
+					splitRestrictionName, 0, method.Ret[0].T, reflect.SliceOf(restrictionT))
+				return errors.SetTopLevelMsgf(err, "Invalid output type in method %v, "+
+					"return value at index %v. Got: %v, Want: %v (from method %v). "+
+					"Ensure that all restrictions in an SDF are the same type, and that %v returns a slice.",
+					splitRestrictionName, 0, method.Ret[0].T, reflect.SliceOf(restrictionT), createInitialRestrictionName, splitRestrictionName)
+			}
+		case restrictionSizeName:
+			if err := validateSdfElementT(fn, restrictionSizeName, method, num); err != nil {
+				return err
+			}
+			if method.Param[num].T != restrictionT {
+				err := errors.Errorf("mismatched restriction type in method %v, param %v. got: %v, want: %v",
+					restrictionSizeName, num, method.Param[num].T, restrictionT)
+				return errors.SetTopLevelMsgf(err, "Mismatched restriction type in method %v, "+
+					"parameter at index %v. Got: %v, Want: %v (from method %v). "+
+					"Ensure that all restrictions in an SDF are the same type.",
+					restrictionSizeName, num, method.Param[num].T, restrictionT, createInitialRestrictionName)
+			}
+			if method.Ret[0].T != reflectx.Float64 {
+				err := errors.Errorf("invalid output type in method %v, return %v. got: %v, want: %v",
+					restrictionSizeName, 0, method.Ret[0].T, reflectx.Float64)
+				return errors.SetTopLevelMsgf(err, "Invalid output type in method %v, "+
+					"return value at index %v. Got: %v, Want: %v. Sizing information in SDF methods must be in float64.",
+					restrictionSizeName, 0, method.Ret[0].T, reflectx.Float64)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateSdfElementT validates that element types in an SDF method are
+// consistent with the ProcessElement method. This method assumes that the
+// first 'num' parameters to the SDF method are the elements.
+func validateSdfElementT(fn *Fn, name string, method *funcx.Fn, num int) error {
+	// ProcessElement is the most canonical source of the element type. We can
+	// processFn is valid by this point and skip unnecessary validation.
+	processFn := fn.methods[processElementName]
+	pos, _, _ := processFn.Inputs()
+
+	for i := 0; i < num; i++ {
+		if method.Param[i].T != processFn.Param[pos+i].T {
+			err := errors.Errorf("mismatched element type in method %v, param %v. got: %v, want: %v",
+				name, i, method.Param[i].T, processFn.Param[pos+i].T)
+			return errors.SetTopLevelMsgf(err, "Mismatched element type in method %v, "+
+				"parameter at index %v. Got: %v, Want: %v (from method %v). "+
+				"Ensure that element parameters in SDF methods have consistent types with element parameters in %v.",
+				name, i, method.Param[i].T, processFn.Param[pos+i].T, processElementName, processElementName)
+		}
+	}
 	return nil
 }
 

--- a/sdks/go/pkg/beam/pardo.go
+++ b/sdks/go/pkg/beam/pardo.go
@@ -53,7 +53,8 @@ func TryParDo(s Scope, dofn interface{}, col PCollection, opts ...Option) ([]PCo
 
 	var rc *coder.Coder
 	if fn.IsSplittable() {
-		rc, err = inferCoder(typex.New(*fn.RestrictionT()))
+		sdf := (*graph.SplittableDoFn)(fn)
+		rc, err = inferCoder(typex.New(sdf.RestrictionT()))
 		if err != nil {
 			return nil, addParDoCtx(err, s)
 		}


### PR DESCRIPTION
Added SDF detection and method validation when creating DoFns. This
adds all the validation except for anything to do with restriction
trackers, which will be added in a later change.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
