### PR TITLE
BEAM-8924 - Update Apache Tika to 1.24

### DIFF
--- a/sdks/java/io/tika/build.gradle
+++ b/sdks/java/io/tika/build.gradle
@@ -22,7 +22,7 @@ applyJavaNature(automaticModuleName: 'org.apache.beam.sdk.io.tika')
 description = "Apache Beam :: SDKs :: Java :: IO :: Tika"
 ext.summary = "Tika Input to parse files."
 
-def tika_version = "1.23"
+def tika_version = "1.24"
 def bndlib_version = "1.43.0"
 
 dependencies {


### PR DESCRIPTION
This task is to update Tika due to multiple CVE notices (e.g. CVE-2020-1950, CVE-2020-1951)