### PR TITLE
[BEAM-7923] Emit info when capture control options are configured.

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -74,14 +74,15 @@ class Options(interactive_options.InteractiveOptions):
       _LOGGER.info(
           'Capture replay is enabled. When a PCollection is evaluated or the '
           'pipeline is executed, existing data captured from previous '
-          'computations will be replayed for consistent results. If no captured data is '
-          'available, new data from capturable sources will be captured.')
+          'computations will be replayed for consistent results. If no '
+          'captured data is available, new data from capturable sources will '
+          'be captured.')
     else:
       _LOGGER.info(
           'Capture replay is disabled. The next time a PCollection is '
           'evaluated or the pipeline is executed, new data will always be '
-          'consumed from sources in the pipeline. You will not have replayability '
-          'until re-enabling this option.')
+          'consumed from sources in the pipeline. You will not have '
+          'replayability until re-enabling this option.')
     self.capture_control._enable_capture_replay = value
 
   @property
@@ -122,8 +123,8 @@ class Options(interactive_options.InteractiveOptions):
       _ = ie.current_env()
       _LOGGER.info(
           'You have changed capture duration from %s seconds to %s seconds. '
-          'To allow new data to be captured for the updated duration, the next '
-          'time a PCollection is evaluated or the pipeline is executed, '
+          'To allow new data to be captured for the updated duration, the '
+          'next time a PCollection is evaluated or the pipeline is executed, '
           'please invoke evict_captured_data().',
           self.capture_control._capture_duration.total_seconds(),
           value.total_seconds())

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -33,6 +33,7 @@ this module in your notebook or application code.
 
 from __future__ import absolute_import
 
+import logging
 import warnings
 
 import apache_beam as beam
@@ -46,6 +47,8 @@ from apache_beam.runners.interactive.display.pcoll_visualization import visualiz
 from apache_beam.runners.interactive.options import interactive_options
 from apache_beam.runners.interactive.utils import elements_to_df
 from apache_beam.runners.interactive.utils import to_element_list
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Options(interactive_options.InteractiveOptions):
@@ -64,11 +67,33 @@ class Options(interactive_options.InteractiveOptions):
     and pipeline runs always use the same data captured; False - Disables
     capture of replayable source data so that following PCollection evaluation
     and pipeline runs always use new data from sources."""
+    # This makes sure the log handler is configured correctly in case the
+    # options are configured in an early stage.
+    _ = ie.current_env()
+    if value:
+      _LOGGER.info(
+          'Capture replay is enabled. When a PCollection is evaluated or the '
+          'pipeline is executed, existing data captured from previous '
+          'computations will be replayed for replayability. If no capture is '
+          'available, new data from capturable sources will be captured.')
+    else:
+      _LOGGER.info(
+          'You have disabled capture replay. The next time a PCollection is '
+          'evaluated or the pipeline is executed, new data will always be '
+          'captured from capturable sources. You will not have replayability '
+          'until re-enabling this option.')
     self.capture_control._enable_capture_replay = value
 
   @property
   def capturable_sources(self):
-    """Interactive Beam automatically captures data from sources in this set."""
+    """Interactive Beam automatically captures data from sources in this set.
+    """
+    _ = ie.current_env()
+    _LOGGER.info(
+        'If you alter the capturable sources, to allow new data for the '
+        'altered sources being captured the next time a PCollection is '
+        'evaluated or the pipeline is executed, please invoke '
+        'evict_captured_data().')
     return self.capture_control._capturable_sources
 
   @property
@@ -92,7 +117,17 @@ class Options(interactive_options.InteractiveOptions):
       interactive_beam.collect(some_pcoll)
     """
     assert value.total_seconds() > 0, 'Duration must be a positive value.'
-    self.capture_control._capture_duration = value
+    if self.capture_control._capture_duration.total_seconds(
+    ) != value.total_seconds():
+      _ = ie.current_env()
+      _LOGGER.info(
+          'You have changed capture duration from %s seconds to %s seconds. '
+          'To allow new data being captured for the updated duration the next '
+          'time a PCollection is evaluated or the pipeline is executed, '
+          'please invoke evict_captured_data().',
+          self.capture_control._capture_duration.total_seconds(),
+          value.total_seconds())
+      self.capture_control._capture_duration = value
 
   @property
   def capture_size_limit(self):
@@ -109,7 +144,16 @@ class Options(interactive_options.InteractiveOptions):
       # Sets the capture size limit to 1GB.
       interactive_beam.options.capture_size_limit = 1e9
     """
-    self.capture_control._capture_size_limit = value
+    if self.capture_control._capture_size_limit != value:
+      _ = ie.current_env()
+      _LOGGER.info(
+          'You have changed capture size limit from %s bytes to %s bytes. To '
+          'allow new data being captured under the updated size limit the '
+          'next time a PCollection is evaluated or the pipeline is executed, '
+          'please invoke evict_captured_data().',
+          self.capture_control._capture_size_limit,
+          value)
+      self.capture_control._capture_size_limit = value
 
   @property
   def display_timestamp_format(self):

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -74,13 +74,13 @@ class Options(interactive_options.InteractiveOptions):
       _LOGGER.info(
           'Capture replay is enabled. When a PCollection is evaluated or the '
           'pipeline is executed, existing data captured from previous '
-          'computations will be replayed for replayability. If no capture is '
+          'computations will be replayed for consistent results. If no captured data is '
           'available, new data from capturable sources will be captured.')
     else:
       _LOGGER.info(
-          'You have disabled capture replay. The next time a PCollection is '
+          'Capture replay is disabled. The next time a PCollection is '
           'evaluated or the pipeline is executed, new data will always be '
-          'captured from capturable sources. You will not have replayability '
+          'consumed from sources in the pipeline. You will not have replayability '
           'until re-enabling this option.')
     self.capture_control._enable_capture_replay = value
 
@@ -91,7 +91,7 @@ class Options(interactive_options.InteractiveOptions):
     _ = ie.current_env()
     _LOGGER.info(
         'If you alter the capturable sources, to allow new data for the '
-        'altered sources being captured the next time a PCollection is '
+        'altered sources to be captured the next time a PCollection is '
         'evaluated or the pipeline is executed, please invoke '
         'evict_captured_data().')
     return self.capture_control._capturable_sources
@@ -122,7 +122,7 @@ class Options(interactive_options.InteractiveOptions):
       _ = ie.current_env()
       _LOGGER.info(
           'You have changed capture duration from %s seconds to %s seconds. '
-          'To allow new data being captured for the updated duration the next '
+          'To allow new data to be captured for the updated duration, the next '
           'time a PCollection is evaluated or the pipeline is executed, '
           'please invoke evict_captured_data().',
           self.capture_control._capture_duration.total_seconds(),
@@ -148,7 +148,7 @@ class Options(interactive_options.InteractiveOptions):
       _ = ie.current_env()
       _LOGGER.info(
           'You have changed capture size limit from %s bytes to %s bytes. To '
-          'allow new data being captured under the updated size limit the '
+          'allow new data to be captured under the updated size limit, the '
           'next time a PCollection is evaluated or the pipeline is executed, '
           'please invoke evict_captured_data().',
           self.capture_control._capture_size_limit,

--- a/sdks/python/apache_beam/runners/interactive/options/capture_control.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_control.py
@@ -43,7 +43,7 @@ class CaptureControl(object):
     self._capturable_sources = {
         ReadFromPubSub,
     }  # yapf: disable
-    self._capture_duration = timedelta(seconds=5)
+    self._capture_duration = timedelta(seconds=60)
     self._capture_size_limit = 1e9
 
   def is_capture_size_limit_reached(self):


### PR DESCRIPTION
1. Info logging to notify users about invoking evict_captured_data on
changing capture_duration, capture_size_limit, and capturable_sources
options. The users have to explicitly evict captured data because the
process is destructive and the usage should be the same as evicting
captured data even when they don't modify options at all.
2. Info logging about behavior difference between enabling capture
replay and disabling it. This functions as a switch enabling/disabling
the replayability, thus works without the need of evicting captured
data.
3. Changed the default capture_duration from 5s to 60s.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
