### PR TITLE
[BEAM-3301] Adding restriction trackers and validation.

### DIFF
--- a/sdks/go/pkg/beam/core/funcx/fn.go
+++ b/sdks/go/pkg/beam/core/funcx/fn.go
@@ -17,6 +17,7 @@ package funcx
 
 import (
 	"fmt"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
 	"reflect"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
@@ -66,6 +67,9 @@ const (
 	FnType FnParamKind = 0x40
 	// FnWindow indicates a function input parameter that implements typex.Window.
 	FnWindow FnParamKind = 0x80
+	// FnRTracker indicates a function input parameter that implements
+	// sdf.RTracker.
+	FnRTracker FnParamKind = 0x100
 )
 
 func (k FnParamKind) String() string {
@@ -86,6 +90,8 @@ func (k FnParamKind) String() string {
 		return "Type"
 	case FnWindow:
 		return "Window"
+	case FnRTracker:
+		return "RTracker"
 	default:
 		return fmt.Sprintf("%v", int(k))
 	}
@@ -226,6 +232,16 @@ func (u *Fn) Window() (pos int, exists bool) {
 	return -1, false
 }
 
+// RTracker returns (index, true) iff the function expects an sdf.RTracker.
+func (u *Fn) RTracker() (pos int, exists bool) {
+	for i, p := range u.Param {
+		if p.Kind == FnRTracker {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
 // Error returns (index, true) iff the function returns an error.
 func (u *Fn) Error() (pos int, exists bool) {
 	for i, p := range u.Ret {
@@ -290,6 +306,8 @@ func New(fn reflectx.Func) (*Fn, error) {
 			kind = FnWindow
 		case t == reflectx.Type:
 			kind = FnType
+		case t.Implements(reflect.TypeOf((*sdf.RTracker)(nil)).Elem()):
+			kind = FnRTracker
 		case typex.IsContainer(t), typex.IsConcrete(t), typex.IsUniversal(t):
 			kind = FnValue
 		case IsEmit(t):
@@ -353,7 +371,7 @@ func SubReturns(list []ReturnParam, indices ...int) []ReturnParam {
 }
 
 // The order of present parameters and return values must be as follows:
-// func(FnContext?, FnWindow?, FnEventTime?, FnType?, (FnValue, SideInput*)?, FnEmit*) (RetEventTime?, RetOutput?, RetError?)
+// func(FnContext?, FnWindow?, FnEventTime?, FnType?, FnRTracker?, (FnValue, SideInput*)?, FnEmit*) (RetEventTime?, RetOutput?, RetError?)
 //     where ? indicates 0 or 1, and * indicates any number.
 //     and  a SideInput is one of FnValue or FnIter or FnReIter
 // Note: Fns with inputs must have at least one FnValue as the main input.
@@ -381,6 +399,7 @@ var (
 	errWindowParamPrecedence    = errors.New("may only have a single Window parameter and it must precede the EventTime and main input parameter")
 	errEventTimeParamPrecedence = errors.New("may only have a single beam.EventTime parameter and it must precede the main input parameter")
 	errReflectTypePrecedence    = errors.New("may only have a single reflect.Type parameter and it must precede the main input parameter")
+	errRTrackerPrecedence       = errors.New("may only have a single sdf.RTracker parameter and it must precede the main input parameter")
 	errInputPrecedence          = errors.New("inputs parameters must precede emit function parameters")
 )
 
@@ -394,6 +413,7 @@ const (
 	psType
 	psInput
 	psOutput
+	psRTracker
 )
 
 func nextParamState(cur paramState, transition FnParamKind) (paramState, error) {
@@ -408,6 +428,8 @@ func nextParamState(cur paramState, transition FnParamKind) (paramState, error) 
 			return psEventTime, nil
 		case FnType:
 			return psType, nil
+		case FnRTracker:
+			return psRTracker, nil
 		}
 	case psContext:
 		switch transition {
@@ -417,6 +439,8 @@ func nextParamState(cur paramState, transition FnParamKind) (paramState, error) 
 			return psEventTime, nil
 		case FnType:
 			return psType, nil
+		case FnRTracker:
+			return psRTracker, nil
 		}
 	case psWindow:
 		switch transition {
@@ -424,13 +448,22 @@ func nextParamState(cur paramState, transition FnParamKind) (paramState, error) 
 			return psEventTime, nil
 		case FnType:
 			return psType, nil
+		case FnRTracker:
+			return psRTracker, nil
 		}
 	case psEventTime:
 		switch transition {
 		case FnType:
 			return psType, nil
+		case FnRTracker:
+			return psRTracker, nil
 		}
 	case psType:
+		switch transition {
+		case FnRTracker:
+			return psRTracker, nil
+		}
+	case psRTracker:
 		// Completely handled by the default clause
 	case psInput:
 		switch transition {
@@ -453,6 +486,8 @@ func nextParamState(cur paramState, transition FnParamKind) (paramState, error) 
 		return -1, errEventTimeParamPrecedence
 	case FnType:
 		return -1, errReflectTypePrecedence
+	case FnRTracker:
+		return -1, errRTrackerPrecedence
 	case FnIter, FnReIter, FnValue:
 		return psInput, nil
 	case FnEmit:

--- a/sdks/go/pkg/beam/core/graph/fn.go
+++ b/sdks/go/pkg/beam/core/graph/fn.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
@@ -155,6 +156,7 @@ const (
 	createInitialRestrictionName = "CreateInitialRestriction"
 	splitRestrictionName         = "SplitRestriction"
 	restrictionSizeName          = "RestrictionSize"
+	createTrackerName            = "CreateTracker"
 
 	createAccumulatorName = "CreateAccumulator"
 	addInputName          = "AddInput"
@@ -174,12 +176,14 @@ var doFnNames = []string{
 	createInitialRestrictionName,
 	splitRestrictionName,
 	restrictionSizeName,
+	createTrackerName,
 }
 
 var sdfNames = []string{
 	createInitialRestrictionName,
 	splitRestrictionName,
 	restrictionSizeName,
+	createTrackerName,
 }
 
 // DoFn represents a DoFn.
@@ -235,6 +239,10 @@ func (f *SplittableDoFn) SplitRestrictionFn() *funcx.Fn {
 
 func (f *SplittableDoFn) RestrictionSizeFn() *funcx.Fn {
 	return f.methods[restrictionSizeName]
+}
+
+func (f *SplittableDoFn) CreateTrackerFn() *funcx.Fn {
+	return f.methods[createTrackerName]
 }
 
 func (f *SplittableDoFn) Name() string {
@@ -402,8 +410,8 @@ func AsDoFn(fn *Fn, numMainIn mainInputs) (*DoFn, error) {
 		}
 	}
 
-	// Check whether to perform SDF validation by seeing if SDF methods are present.
-	isSdf, err := validateSdfMethodsPresent(fn)
+	// Check whether to perform SDF validation.
+	isSdf, err := validateIsSdf(fn)
 	if err != nil {
 		return nil, addContext(err, fn)
 	}
@@ -615,13 +623,18 @@ func validateSideInputsNumUnknown(processFnInputs []funcx.FnParam, method *funcx
 	return nil
 }
 
-// validateSdfMethods validates that all SDF methods are either present or
-// missing in a Fn, and then returns true if they're present and false
-// otherwise. If some are present and some are missing, it returns an error.
-func validateSdfMethodsPresent(fn *Fn) (bool, error) {
-	// Check if first sdf method is present or not, and compare all subsequent
-	// methods to that result. If there's a mismatch, then we only fail after
-	// finishing the loop so we can output all the missing methods.
+// validateIsSdf checks whether a Fn either is or is not an SDF, and returns
+// true if it is, false if it isn't, or an error if it doesn't fulfill the
+// requirements for either case.
+//
+// For a Fn to be an SDF it must:
+//   * Implement all the SDF methods.
+//   * Include an RTracker parameter in ProcessElement.
+// For a Fn to not be an SDF, it must:
+//   * Implement none of the SDF methods.
+//   * Not include an RTracker parameter in ProcessElement.
+func validateIsSdf(fn *Fn) (bool, error) {
+	// Store missing method names so we can output them to the user if validation fails.
 	var missing []string
 	for _, name := range sdfNames {
 		_, ok := fn.methods[name]
@@ -630,18 +643,39 @@ func validateSdfMethodsPresent(fn *Fn) (bool, error) {
 		}
 	}
 
+	var isSdf bool
 	switch len(missing) {
 	case 0: // All SDF methods present.
-		return true, nil
+		isSdf = true
 	case len(sdfNames): // No SDF methods.
-		return false, nil
+		isSdf = false
 	default: // Anything else means an invalid # of SDF methods.
 		err := errors.Errorf("not all SplittableDoFn methods are present. Missing methods: %v", missing)
 		return false, err
 	}
+
+	processFn := fn.methods[processElementName]
+	if pos, ok := processFn.RTracker(); ok != isSdf {
+		if ok {
+			err := errors.Errorf("method %v has sdf.RTracker as param %v, expected none",
+				processElementName, pos)
+			return false, errors.SetTopLevelMsgf(err, "Method %v has an sdf.RTracker parameter at index %v, "+
+				"but is not part of a splittable DoFn. sdf.RTracker is invalid in %v in non-splittable DoFns.",
+				processElementName, pos, processElementName)
+		} else {
+			pos, _, ok = processFn.Inputs()
+			err := errors.Errorf("method %v missing sdf.RTracker, expected one at index %v",
+				processElementName, pos)
+			return false, errors.SetTopLevelMsgf(err, "Method %v is missing an sdf.RTracker "+
+				"parameter despite being part of a splittable DoFn. %v in splittable DoFns requires an "+
+				"sdf.RTracker parameter before main inputs (in this case, at index %v).",
+				processElementName, processElementName, pos)
+		}
+	}
+	return isSdf, nil
 }
 
-// validateSdfTypes validates that types in the SDF methods of a Fn are
+// validateSdfSignatures validates that types in the SDF methods of a Fn are
 // consistent with each other (for example, element and restriction types should
 // match with each other). Returns an error if one is found, or nil if the
 // types are all valid.
@@ -686,6 +720,7 @@ func validateSdfSigNumbers(fn *Fn, num int) error {
 		createInitialRestrictionName: num,
 		splitRestrictionName:         num + 1,
 		restrictionSizeName:          num + 1,
+		createTrackerName:            1,
 	}
 	returnNum := 1 // TODO(BEAM-3301): Enable optional error params in SDF methods.
 
@@ -716,6 +751,7 @@ func validateSdfSigNumbers(fn *Fn, num int) error {
 // values has already been validated.
 func validateSdfSigTypes(fn *Fn, num int) error {
 	restrictionT := fn.methods[createInitialRestrictionName].Ret[0].T
+	rTrackerT := reflect.TypeOf((*sdf.RTracker)(nil)).Elem()
 
 	for _, name := range sdfNames {
 		method := fn.methods[name]
@@ -763,6 +799,31 @@ func validateSdfSigTypes(fn *Fn, num int) error {
 				return errors.SetTopLevelMsgf(err, "Invalid output type in method %v, "+
 					"return value at index %v. Got: %v, Want: %v. Sizing information in SDF methods must be in float64.",
 					restrictionSizeName, 0, method.Ret[0].T, reflectx.Float64)
+			}
+		case createTrackerName:
+			if method.Param[0].T != restrictionT {
+				err := errors.Errorf("mismatched restriction type in method %v, param %v. got: %v, want: %v",
+					createTrackerName, 0, method.Param[0].T, restrictionT)
+				return errors.SetTopLevelMsgf(err, "Mismatched restriction type in method %v, "+
+					"parameter at index %v. Got: %v, Want: %v (from method %v). "+
+					"Ensure that all restrictions in an SDF are the same type.",
+					createTrackerName, 0, method.Param[0].T, restrictionT, createInitialRestrictionName)
+			}
+			if method.Ret[0].T.Implements(rTrackerT) == false {
+				err := errors.Errorf("invalid output type in method %v, return %v: %v does not implement sdf.RTracker",
+					createTrackerName, 0, method.Ret[0].T)
+				return errors.SetTopLevelMsgf(err, "Invalid output type in method %v, "+
+					"return value at index %v (type: %v). Output of method %v must implement sdf.RTracker.",
+					createTrackerName, 0, method.Ret[0].T, createTrackerName)
+			}
+			processFn := fn.methods[processElementName]
+			pos, _ := processFn.RTracker()
+			if method.Ret[0].T != processFn.Param[pos].T {
+				err := errors.Errorf("mismatched output type in method %v, return %v: got: %v, want: %v",
+					createTrackerName, 0, method.Ret[0].T, processFn.Param[pos].T)
+				return errors.SetTopLevelMsgf(err, "Mismatched output type in method %v, "+
+					"return value at index %v. Got: %v, Want: %v (from method %v).",
+					createTrackerName, 0, method.Ret[0].T, processFn.Param[pos].T, processElementName)
 			}
 		}
 	}

--- a/sdks/go/pkg/beam/core/sdf/sdf.go
+++ b/sdks/go/pkg/beam/core/sdf/sdf.go
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sdf is experimental, incomplete, and not yet meant for general usage.
+package sdf
+
+// RTracker is an interface used to interact with restrictions while processing elements in
+// SplittableDoFns. Each implementation of RTracker is expected to be used for tracking a single
+// restriction type, which is the type that should be used to create the RTracker, and output by
+// TrySplit.
+type RTracker interface {
+	// TryClaim attempts to claim the block of work in the current restriction located at a given
+	// position. This method must be used in the ProcessElement method of Splittable DoFns to claim
+	// work before performing it. If no work is claimed, the ProcessElement is not allowed to perform
+	// work or emit outputs. If the claim is successful, the DoFn must process the entire block. If
+	// the claim is unsuccessful the ProcessElement method of the DoFn must return without performing
+	// any additional work or emitting any outputs.
+	//
+	// TryClaim accepts an arbitrary value that can be interpreted as the position of a block, and
+	// returns a boolean indicating whether the claim succeeded.
+	//
+	// If the claim fails due to an error, that error can be retrieved with GetError.
+	//
+	// For SDFs to work properly, claims must always be monotonically increasing in reference to the
+	// restriction's start and end points, and every block of work in a restriction must be claimed.
+	//
+	// This pseudocode example illustrates the typical usage of TryClaim:
+	//
+	// 	pos = position of first block after restriction.start
+	// 	for TryClaim(pos) == true {
+	// 		// Do all work in the claimed block and emit outputs.
+	// 		pos = position of next block
+	// 	}
+	// 	return
+	TryClaim(pos interface{}) (ok bool)
+
+	// GetError returns the error that made this RTracker stop executing, and it returns nil if no
+	// error occurred. If IsDone fails while validating this RTracker, this method will be
+	// called to log the error.
+	GetError() error
+
+	// TrySplit splits the current restriction into a primary and residual based on a fraction of the
+	// work remaining. The split is performed along the first valid split point located after the
+	// given fraction of the remainder. This method is called by the SDK harness when receiving a
+	// split request by the runner.
+	//
+	// The current restriction is split into two by modifying the current restriction's endpoint to
+	// turn it into the primary, and returning a new restriction tracker representing the residual.
+	// If no valid split point exists, this method returns nil instead of a residual, but does not
+	// return an error. If this method is unable to split due to some error then it returns nil and
+	// an error.
+	TrySplit(fraction float64) (residual interface{}, err error)
+
+	// GetProgress returns a double representing the current progress of the restriction as a range
+	// from 0 to 1.0.
+	GetProgress() float64
+
+	// IsDone returns a boolean indicating whether all blocks inside the restriction have been
+	// claimed. This method is called by the SDK Harness to validate that a Splittable DoFn has
+	// correctly processed all work in a restriction before finishing.
+	IsDone() bool
+}


### PR DESCRIPTION
Adding RTrackers as an interface, and adding them to the SDF validation.

I think this is the last real code involved in SDF validation, assuming I'm not forgetting anything. I might do a second pass on the error messages because they seem inconsistent with the old error messages, but the next major task is going to be working on the SDF exec code and doing some testing with the Flink runner.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
