### PR TITLE
[BEAM-9446] Retain unknown arguments when using uber jar job server.

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -296,8 +296,12 @@ class PipelineOptions(HasDisplayData):
       while i < len(unknown_args):
         # Treat all unary flags as booleans, and all binary argument values as
         # strings.
-        if i + 1 >= len(unknown_args) or unknown_args[i + 1].startswith('--'):
-          parser.add_argument(unknown_args[i], action='store_true')
+        if i + 1 >= len(unknown_args) or unknown_args[i + 1].startswith('-'):
+          split = unknown_args[i].rsplit('=')
+          if len(split) == 1:
+            parser.add_argument(unknown_args[i], action='store_true')
+          else:
+            parser.add_argument(split[0], type=str)
           i += 1
         else:
           parser.add_argument(unknown_args[i], type=str)

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -297,7 +297,7 @@ class PipelineOptions(HasDisplayData):
         # Treat all unary flags as booleans, and all binary argument values as
         # strings.
         if i + 1 >= len(unknown_args) or unknown_args[i + 1].startswith('-'):
-          split = unknown_args[i].rsplit('=')
+          split = unknown_args[i].split('=', 1)
           if len(split) == 1:
             parser.add_argument(unknown_args[i], action='store_true')
           else:

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -256,7 +256,8 @@ class PipelineOptions(HasDisplayData):
   def get_all_options(
       self,
       drop_default=False,
-      add_extra_args_fn=None  # type: Optional[Callable[[_BeamArgumentParser], None]]
+      add_extra_args_fn=None,  # type: Optional[Callable[[_BeamArgumentParser], None]]
+      retain_unknown_options=False
   ):
     # type: (...) -> Dict[str, Any]
 
@@ -270,6 +271,9 @@ class PipelineOptions(HasDisplayData):
         values, are not returned as part of the result dictionary.
       add_extra_args_fn: Callback to populate additional arguments, can be used
         by runner to supply otherwise unknown args.
+      retain_unknown_options: If set to true, options not recognized by any
+        known pipeline options class will still be included in the result. If
+        set to false, they will be discarded.
 
     Returns:
       Dictionary of all args and values.
@@ -285,10 +289,25 @@ class PipelineOptions(HasDisplayData):
       cls._add_argparse_args(parser)  # pylint: disable=protected-access
     if add_extra_args_fn:
       add_extra_args_fn(parser)
+
     known_args, unknown_args = parser.parse_known_args(self._flags)
-    if unknown_args:
-      _LOGGER.warning("Discarding unparseable args: %s", unknown_args)
-    result = vars(known_args)
+    if retain_unknown_options:
+      i = 0
+      while i < len(unknown_args):
+        # Treat all unary flags as booleans, and all binary argument values as
+        # strings.
+        if i + 1 >= len(unknown_args) or unknown_args[i + 1].startswith('--'):
+          parser.add_argument(unknown_args[i], action='store_true')
+          i += 1
+        else:
+          parser.add_argument(unknown_args[i], type=str)
+          i += 2
+      parsed_args = parser.parse_args(self._flags)
+    else:
+      if unknown_args:
+        _LOGGER.warning("Discarding unparseable args: %s", unknown_args)
+      parsed_args = known_args
+    result = vars(parsed_args)
 
     overrides = self._all_options.copy()
     # Apply the overrides if any

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -305,15 +305,41 @@ class PipelineOptionsTest(unittest.TestCase):
     result = options.get_all_options(retain_unknown_options=True)
     self.assertEqual(result['unknown_option'], 'some_value')
 
+  def test_retain_unknown_options_binary_equals_store_string(self):
+    options = PipelineOptions(['--unknown_option=some_value'])
+    result = options.get_all_options(retain_unknown_options=True)
+    self.assertEqual(result['unknown_option'], 'some_value')
+
+  def test_retain_unknown_options_binary_multi_equals_store_string(self):
+    options = PipelineOptions(['--unknown_option=expr = "2 + 2 = 5"'])
+    result = options.get_all_options(retain_unknown_options=True)
+    self.assertEqual(result['unknown_option'], 'expr = "2 + 2 = 5"')
+
+  def test_retain_unknown_options_binary_single_dash_store_string(self):
+    options = PipelineOptions(['-i', 'some_value'])
+    result = options.get_all_options(retain_unknown_options=True)
+    self.assertEqual(result['i'], 'some_value')
+
   def test_retain_unknown_options_unary_store_true(self):
     options = PipelineOptions(['--unknown_option'])
     result = options.get_all_options(retain_unknown_options=True)
     self.assertEqual(result['unknown_option'], True)
 
+  def test_retain_unknown_options_consecutive_unary_store_true(self):
+    options = PipelineOptions(['--option_foo', '--option_bar'])
+    result = options.get_all_options(retain_unknown_options=True)
+    self.assertEqual(result['option_foo'], True)
+    self.assertEqual(result['option_bar'], True)
+
+  def test_retain_unknown_options_unary_single_dash_store_true(self):
+    options = PipelineOptions(['-i'])
+    result = options.get_all_options(retain_unknown_options=True)
+    self.assertEqual(result['i'], True)
+
   def test_retain_unknown_options_unary_missing_prefix(self):
     options = PipelineOptions(['bad_option'])
     with self.assertRaises(SystemExit):
-      result = options.get_all_options(retain_unknown_options=True)
+      options.get_all_options(retain_unknown_options=True)
 
   def test_override_options(self):
     base_flags = ['--num_workers', '5']

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -300,6 +300,21 @@ class PipelineOptionsTest(unittest.TestCase):
             'option with space'),
         ' value with space')
 
+  def test_retain_unknown_options_binary_store_string(self):
+    options = PipelineOptions(['--unknown_option', 'some_value'])
+    result = options.get_all_options(retain_unknown_options=True)
+    self.assertEqual(result['unknown_option'], 'some_value')
+
+  def test_retain_unknown_options_unary_store_true(self):
+    options = PipelineOptions(['--unknown_option'])
+    result = options.get_all_options(retain_unknown_options=True)
+    self.assertEqual(result['unknown_option'], True)
+
+  def test_retain_unknown_options_unary_missing_prefix(self):
+    options = PipelineOptions(['bad_option'])
+    with self.assertRaises(SystemExit):
+      result = options.get_all_options(retain_unknown_options=True)
+
   def test_override_options(self):
     base_flags = ['--num_workers', '5']
     options = PipelineOptions(base_flags)

--- a/sdks/python/apache_beam/runners/portability/flink_runner.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner.py
@@ -65,6 +65,13 @@ class FlinkRunner(portable_runner.PortableRunner):
     else:
       return job_server.StopOnExitJobServer(FlinkJarJobServer(options))
 
+  def create_job_service_handle(self, job_service, options):
+    return portable_runner.JobServiceHandle(
+        job_service,
+        options,
+        retain_unknown_options=options.view_as(
+            pipeline_options.FlinkRunnerOptions).flink_submit_uber_jar)
+
   @staticmethod
   def add_http_scheme(flink_master):
     """Adds a http protocol scheme if none provided."""

--- a/sdks/python/apache_beam/runners/portability/spark_runner.py
+++ b/sdks/python/apache_beam/runners/portability/spark_runner.py
@@ -64,6 +64,7 @@ class SparkRunner(portable_runner.PortableRunner):
         retain_unknown_options=options.view_as(
             pipeline_options.SparkRunnerOptions).spark_submit_uber_jar)
 
+
 class SparkJarJobServer(job_server.JavaJarJobServer):
   def __init__(self, options):
     super(SparkJarJobServer, self).__init__(options)

--- a/sdks/python/apache_beam/runners/portability/spark_runner.py
+++ b/sdks/python/apache_beam/runners/portability/spark_runner.py
@@ -57,6 +57,12 @@ class SparkRunner(portable_runner.PortableRunner):
           spark_options.spark_rest_url, options)
     return job_server.StopOnExitJobServer(SparkJarJobServer(options))
 
+  def create_job_service_handle(self, job_service, options):
+    return portable_runner.JobServiceHandle(
+        job_service,
+        options,
+        retain_unknown_options=options.view_as(
+            pipeline_options.SparkRunnerOptions).spark_submit_uber_jar)
 
 class SparkJarJobServer(job_server.JavaJarJobServer):
   def __init__(self, options):

--- a/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server_test.py
+++ b/sdks/python/apache_beam/runners/portability/spark_uber_jar_job_server_test.py
@@ -32,10 +32,13 @@ import grpc
 import requests_mock
 
 from apache_beam.options import pipeline_options
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SparkRunnerOptions
 from apache_beam.portability.api import beam_artifact_api_pb2
 from apache_beam.portability.api import beam_artifact_api_pb2_grpc
 from apache_beam.portability.api import beam_job_api_pb2
 from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.runners.portability import spark_runner
 from apache_beam.runners.portability import spark_uber_jar_job_server
 
 
@@ -213,6 +216,19 @@ class SparkUberJarJobServerTest(unittest.TestCase):
                                message_text="oops"),
                            beam_job_api_pb2.JobState.FAILED,
                        ])
+
+  def test_retain_unknown_options(self):
+    original_options = PipelineOptions(['--unknown_option_foo', 'some_value'])
+    spark_options = original_options.view_as(SparkRunnerOptions)
+    spark_options.spark_submit_uber_jar = True
+    spark_options.spark_rest_url = 'spark://localhost:6066'
+    runner = spark_runner.SparkRunner()
+
+    job_service_handle = runner.create_job_service(original_options)
+    options_proto = job_service_handle.get_pipeline_options()
+
+    self.assertEqual(
+        options_proto['beam:option:unknown_option_foo:v1'], 'some_value')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See #11052 for context.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
