### PR TITLE
[BEAM-8292] Portable Reshuffle for Go SDK

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -57,6 +57,8 @@ func EncodeElement(c ElementEncoder, val interface{}) ([]byte, error) {
 type ElementDecoder interface {
 	// Decode deserializes a value from the given reader.
 	Decode(io.Reader) (*FullValue, error)
+	// DecodeTo deserializes a value from the given reader into the provided FullValue.
+	DecodeTo(io.Reader, *FullValue) error
 }
 
 // MakeElementEncoder returns a ElementCoder for the given coder. It panics
@@ -145,18 +147,27 @@ func (*bytesEncoder) Encode(val *FullValue, w io.Writer) error {
 
 type bytesDecoder struct{}
 
-func (*bytesDecoder) Decode(r io.Reader) (*FullValue, error) {
+func (*bytesDecoder) DecodeTo(r io.Reader, fv *FullValue) error {
 	// Encoding: size (varint) + raw data
 
 	size, err := coder.DecodeVarInt(r)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	data, err := ioutilx.ReadN(r, (int)(size))
 	if err != nil {
+		return err
+	}
+	*fv = FullValue{Elm: data}
+	return nil
+}
+
+func (d *bytesDecoder) Decode(r io.Reader) (*FullValue, error) {
+	fv := &FullValue{}
+	if err := d.DecodeTo(r, fv); err != nil {
 		return nil, err
 	}
-	return &FullValue{Elm: data}, nil
+	return fv, nil
 }
 
 type boolEncoder struct{}
@@ -177,22 +188,32 @@ func (*boolEncoder) Encode(val *FullValue, w io.Writer) error {
 
 type boolDecoder struct{}
 
-func (*boolDecoder) Decode(r io.Reader) (*FullValue, error) {
+func (*boolDecoder) DecodeTo(r io.Reader, fv *FullValue) error {
 	// Encoding: false = 0, true = 1
 	b := make([]byte, 1, 1)
 	if err := ioutilx.ReadNBufUnsafe(r, b); err != nil {
 		if err == io.EOF {
-			return nil, err
+			return err
 		}
-		return nil, fmt.Errorf("error decoding bool: %v", err)
+		return fmt.Errorf("error decoding bool: %v", err)
 	}
 	switch b[0] {
 	case 0:
-		return &FullValue{Elm: false}, nil
+		*fv = FullValue{Elm: false}
+		return nil
 	case 1:
-		return &FullValue{Elm: true}, nil
+		*fv = FullValue{Elm: true}
+		return nil
 	}
-	return nil, fmt.Errorf("error decoding bool: received invalid value %v", b)
+	return fmt.Errorf("error decoding bool: received invalid value %v", b)
+}
+
+func (d *boolDecoder) Decode(r io.Reader) (*FullValue, error) {
+	fv := &FullValue{}
+	if err := d.DecodeTo(r, fv); err != nil {
+		return nil, err
+	}
+	return fv, nil
 }
 
 type varIntEncoder struct{}
@@ -204,13 +225,22 @@ func (*varIntEncoder) Encode(val *FullValue, w io.Writer) error {
 
 type varIntDecoder struct{}
 
-func (*varIntDecoder) Decode(r io.Reader) (*FullValue, error) {
+func (*varIntDecoder) DecodeTo(r io.Reader, fv *FullValue) error {
 	// Encoding: beam varint
 	n, err := coder.DecodeVarInt(r)
 	if err != nil {
+		return err
+	}
+	*fv = FullValue{Elm: n}
+	return nil
+}
+
+func (d *varIntDecoder) Decode(r io.Reader) (*FullValue, error) {
+	fv := &FullValue{}
+	if err := d.DecodeTo(r, fv); err != nil {
 		return nil, err
 	}
-	return &FullValue{Elm: n}, nil
+	return fv, nil
 }
 
 type doubleEncoder struct{}
@@ -222,13 +252,22 @@ func (*doubleEncoder) Encode(val *FullValue, w io.Writer) error {
 
 type doubleDecoder struct{}
 
-func (*doubleDecoder) Decode(r io.Reader) (*FullValue, error) {
+func (*doubleDecoder) DecodeTo(r io.Reader, fv *FullValue) error {
 	// Encoding: beam double (big-endian 64-bit IEEE 754 double)
 	f, err := coder.DecodeDouble(r)
 	if err != nil {
+		return err
+	}
+	*fv = FullValue{Elm: f}
+	return nil
+}
+
+func (d *doubleDecoder) Decode(r io.Reader) (*FullValue, error) {
+	fv := &FullValue{}
+	if err := d.DecodeTo(r, fv); err != nil {
 		return nil, err
 	}
-	return &FullValue{Elm: f}, nil
+	return fv, nil
 }
 
 type customEncoder struct {
@@ -259,40 +298,67 @@ type customDecoder struct {
 	dec Decoder
 }
 
-func (c *customDecoder) Decode(r io.Reader) (*FullValue, error) {
+func (c *customDecoder) DecodeTo(r io.Reader, fv *FullValue) error {
 	// (1) Read length-prefixed encoded data
 
 	size, err := coder.DecodeVarInt(r)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	data, err := ioutilx.ReadN(r, (int)(size))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// (2) Call decode
 
 	val, err := c.dec.Decode(c.t, data)
 	if err != nil {
+		return err
+	}
+	*fv = FullValue{Elm: val}
+	return err
+}
+
+func (c *customDecoder) Decode(r io.Reader) (*FullValue, error) {
+	fv := &FullValue{}
+	if err := c.DecodeTo(r, fv); err != nil {
 		return nil, err
 	}
-	return &FullValue{Elm: val}, err
+	return fv, nil
 }
 
 type kvEncoder struct {
 	fst, snd ElementEncoder
+	cached   FullValue
 }
 
 func (c *kvEncoder) Encode(val *FullValue, w io.Writer) error {
-	if err := c.fst.Encode(convertIfNeeded(val.Elm), w); err != nil {
+	defer func() {
+		// clear the cached FullValue after use to avoid leaks.
+		c.cached = FullValue{}
+	}()
+	if err := c.fst.Encode(convertIfNeeded(val.Elm, &c.cached), w); err != nil {
 		return err
 	}
-	return c.snd.Encode(convertIfNeeded(val.Elm2), w)
+	return c.snd.Encode(convertIfNeeded(val.Elm2, &c.cached), w)
 }
 
 type kvDecoder struct {
 	fst, snd ElementDecoder
+}
+
+func (c *kvDecoder) DecodeTo(r io.Reader, fv *FullValue) error {
+	var key FullValue
+	if err := c.fst.DecodeTo(r, &key); err != nil {
+		return err
+	}
+	var value FullValue
+	if err := c.snd.DecodeTo(r, &value); err != nil {
+		return err
+	}
+	*fv = FullValue{Elm: elideSingleElmFV(&key), Elm2: elideSingleElmFV(&value)}
+	return nil
 }
 
 // Decode returns a *FullValue containing the contents of the decoded KV. If
@@ -302,16 +368,12 @@ type kvDecoder struct {
 //
 // Example:
 //   KV<int, KV<...>> decodes to *FullValue{Elm: int, Elm2: *FullValue{...}}
-func (c *kvDecoder) Decode(r io.Reader) (*FullValue, error) {
-	key, err := c.fst.Decode(r)
-	if err != nil {
+func (d *kvDecoder) Decode(r io.Reader) (*FullValue, error) {
+	fv := &FullValue{}
+	if err := d.DecodeTo(r, fv); err != nil {
 		return nil, err
 	}
-	value, err := c.snd.Decode(r)
-	if err != nil {
-		return nil, err
-	}
-	return &FullValue{Elm: elideSingleElmFV(key), Elm2: elideSingleElmFV(value)}, nil
+	return fv, nil
 }
 
 // elideSingleElmFV elides a FullValue if it has only one element, returning
@@ -325,6 +387,18 @@ func elideSingleElmFV(fv *FullValue) interface{} {
 		return fv.Elm
 	}
 	return fv
+}
+
+// convertIfNeeded reuses Wrapped KVs if needed, but accepts pointer
+// to a pre-allocated non-nil *FullValue for overwriting and use.
+func convertIfNeeded(v interface{}, allocated *FullValue) *FullValue {
+	if fv, ok := v.(*FullValue); ok {
+		return fv
+	} else if _, ok := v.(FullValue); ok {
+		panic("Nested FullValues must be nested as pointers.")
+	}
+	*allocated = FullValue{Elm: v}
+	return allocated
 }
 
 // WindowEncoder handles Window serialization to a byte stream. The encoder
@@ -447,6 +521,8 @@ func (*intervalWindowDecoder) Decode(r io.Reader) ([]typex.Window, error) {
 	return ret, err
 }
 
+var paneNoFiring = []byte{0xf}
+
 // EncodeWindowedValueHeader serializes a windowed value header.
 func EncodeWindowedValueHeader(enc WindowEncoder, ws []typex.Window, t typex.EventTime, w io.Writer) error {
 	// Encoding: Timestamp, Window, Pane (header) + Element
@@ -457,7 +533,7 @@ func EncodeWindowedValueHeader(enc WindowEncoder, ws []typex.Window, t typex.Eve
 	if err := enc.Encode(ws, w); err != nil {
 		return err
 	}
-	_, err := w.Write([]byte{0xf}) // NO_FIRING pane
+	_, err := w.Write(paneNoFiring)
 	return err
 }
 
@@ -478,13 +554,4 @@ func DecodeWindowedValueHeader(dec WindowDecoder, r io.Reader) ([]typex.Window, 
 		return nil, mtime.ZeroTimestamp, err
 	}
 	return ws, t, nil
-}
-
-func convertIfNeeded(v interface{}) *FullValue {
-	if fv, ok := v.(*FullValue); ok {
-		return fv
-	} else if _, ok := v.(FullValue); ok {
-		panic("Nested FullValues must be nested as pointers.")
-	}
-	return &FullValue{Elm: v}
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -317,7 +317,7 @@ func (c *customDecoder) DecodeTo(r io.Reader, fv *FullValue) error {
 		return err
 	}
 	*fv = FullValue{Elm: val}
-	return err
+	return nil
 }
 
 func (c *customDecoder) Decode(r io.Reader) (*FullValue, error) {

--- a/sdks/go/pkg/beam/core/runtime/exec/reshuffle.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/reshuffle.go
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+)
+
+// ReshuffleInput is a Node.
+type ReshuffleInput struct {
+	UID   UnitID
+	SID   StreamID
+	Coder *coder.Coder // Coder for the input PCollection.
+	Seed  int64
+	Out   Node
+
+	r    *rand.Rand
+	enc  ElementEncoder
+	wEnc WindowEncoder
+	b    bytes.Buffer
+	// ret is a cached allocations for passing to the next Unit. Units never modify the passed in FullValue.
+	ret FullValue
+}
+
+// ID returns the unit debug id.
+func (n *ReshuffleInput) ID() UnitID {
+	return n.UID
+}
+
+// Up initializes the value and window encoders, and the random source.
+func (n *ReshuffleInput) Up(ctx context.Context) error {
+	n.enc = MakeElementEncoder(coder.SkipW(n.Coder))
+	n.wEnc = MakeWindowEncoder(n.Coder.Window)
+	n.r = rand.New(rand.NewSource(n.Seed))
+	return nil
+}
+
+// StartBundle is a no-op.
+func (n *ReshuffleInput) StartBundle(ctx context.Context, id string, data DataContext) error {
+	return MultiStartBundle(ctx, id, data, n.Out)
+}
+
+func (n *ReshuffleInput) ProcessElement(ctx context.Context, value *FullValue, values ...ReStream) error {
+	n.b.Reset()
+	if err := EncodeWindowedValueHeader(n.wEnc, value.Windows, value.Timestamp, &n.b); err != nil {
+		return err
+	}
+	if err := n.enc.Encode(value, &n.b); err != nil {
+		return errors.WithContextf(err, "encoding element %v with coder %v", value, n.Coder)
+	}
+	n.ret = FullValue{Elm: n.r.Int(), Elm2: n.b.Bytes(), Timestamp: value.Timestamp}
+	if err := n.Out.ProcessElement(ctx, &n.ret); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FinishBundle propagates finish bundle, and clears cached state.
+func (n *ReshuffleInput) FinishBundle(ctx context.Context) error {
+	n.b = bytes.Buffer{}
+	n.ret = FullValue{}
+	return MultiFinishBundle(ctx, n.Out)
+}
+
+// Down is a no-op.
+func (n *ReshuffleInput) Down(ctx context.Context) error {
+	return nil
+}
+
+func (n *ReshuffleInput) String() string {
+	return fmt.Sprintf("ReshuffleInput[%v] Coder:%v", n.SID, n.Coder)
+}
+
+// ReshuffleOutput is a Node.
+type ReshuffleOutput struct {
+	UID   UnitID
+	SID   StreamID
+	Coder *coder.Coder // Coder for the receiving PCollection.
+	Out   Node
+
+	b    bytes.Buffer
+	dec  ElementDecoder
+	wDec WindowDecoder
+	ret  FullValue
+}
+
+// ID returns the unit debug id.
+func (n *ReshuffleOutput) ID() UnitID {
+	return n.UID
+}
+
+// Up initializes the value and window encoders, and the random source.
+func (n *ReshuffleOutput) Up(ctx context.Context) error {
+	n.dec = MakeElementDecoder(coder.SkipW(n.Coder))
+	n.wDec = MakeWindowDecoder(n.Coder.Window)
+	return nil
+}
+
+// StartBundle is a no-op.
+func (n *ReshuffleOutput) StartBundle(ctx context.Context, id string, data DataContext) error {
+	return MultiStartBundle(ctx, id, data, n.Out)
+}
+
+func (n *ReshuffleOutput) ProcessElement(ctx context.Context, value *FullValue, values ...ReStream) error {
+	// Marshal the pieces into a temporary buffer since they must be transmitted on FnAPI as a single
+	// unit.
+	vs, err := values[0].Open()
+	if err != nil {
+		return errors.WithContextf(err, "decoding values for %v with coder %v", value, n.Coder)
+	}
+	defer vs.Close()
+	for {
+		v, err := vs.Read()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return errors.WithContextf(err, "reading values for %v", n)
+		}
+		n.b = *bytes.NewBuffer(v.Elm.([]byte))
+		ws, ts, err := DecodeWindowedValueHeader(n.wDec, &n.b)
+		if err != nil {
+			return errors.WithContextf(err, "decoding windows for %v", n)
+		}
+		if err := n.dec.DecodeTo(&n.b, &n.ret); err != nil {
+			return errors.WithContextf(err, "decoding element for %v", n)
+		}
+		n.ret.Windows = ws
+		n.ret.Timestamp = ts
+		if err := n.Out.ProcessElement(ctx, &n.ret); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// FinishBundle propagates finish bundle to downstream nodes.
+func (n *ReshuffleOutput) FinishBundle(ctx context.Context) error {
+	n.b = bytes.Buffer{}
+	return MultiFinishBundle(ctx, n.Out)
+}
+
+// Down is a no-op.
+func (n *ReshuffleOutput) Down(ctx context.Context) error {
+	return nil
+}
+
+func (n *ReshuffleOutput) String() string {
+	return fmt.Sprintf("ReshuffleOutput[%v] Coder:%v", n.SID, n.Coder)
+}

--- a/sdks/go/pkg/beam/core/runtime/exec/reshuffle.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/reshuffle.go
@@ -69,10 +69,7 @@ func (n *ReshuffleInput) ProcessElement(ctx context.Context, value *FullValue, v
 		return errors.WithContextf(err, "encoding element %v with coder %v", value, n.Coder)
 	}
 	n.ret = FullValue{Elm: n.r.Int(), Elm2: n.b.Bytes(), Timestamp: value.Timestamp}
-	if err := n.Out.ProcessElement(ctx, &n.ret); err != nil {
-		return err
-	}
-	return nil
+	return n.Out.ProcessElement(ctx, &n.ret)
 }
 
 // FinishBundle propagates finish bundle, and clears cached state.

--- a/sdks/go/pkg/beam/core/runtime/exec/reshuffle.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/reshuffle.go
@@ -154,6 +154,7 @@ func (n *ReshuffleOutput) ProcessElement(ctx context.Context, value *FullValue, 
 // FinishBundle propagates finish bundle to downstream nodes.
 func (n *ReshuffleOutput) FinishBundle(ctx context.Context) error {
 	n.b = bytes.Buffer{}
+	n.ret = FullValue{}
 	return MultiFinishBundle(ctx, n.Out)
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -17,6 +17,7 @@ package exec
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 
@@ -495,6 +496,26 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 		for i := 0; i < len(transform.Inputs); i++ {
 			b.links[linkID{id.to, i}] = u
 		}
+
+	case graphx.URNReshuffleInput:
+		c, w, err := b.makeCoderForPCollection(from)
+		if err != nil {
+			return nil, err
+		}
+		u = &ReshuffleInput{UID: b.idgen.New(), Seed: rand.Int63(), Coder: coder.NewW(c, w), Out: out[0]}
+
+	case graphx.URNReshuffleOutput:
+		var pid string
+		// There's only one output PCollection, and iterating through the map
+		// is the only way to extract it.
+		for _, id := range transform.GetOutputs() {
+			pid = id
+		}
+		c, w, err := b.makeCoderForPCollection(pid)
+		if err != nil {
+			return nil, err
+		}
+		u = &ReshuffleOutput{UID: b.idgen.New(), Coder: coder.NewW(c, w), Out: out[0]}
 
 	case urnDataSink:
 		port, cid, err := unmarshalPort(payload)

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -38,6 +38,7 @@ const (
 	URNParDo         = "beam:transform:pardo:v1"
 	URNFlatten       = "beam:transform:flatten:v1"
 	URNGBK           = "beam:transform:group_by_key:v1"
+	URNReshuffle     = "beam:transform:reshuffle:v1"
 	URNCombinePerKey = "beam:transform:combine_per_key:v1"
 	URNWindow        = "beam:transform:window:v1"
 
@@ -58,6 +59,8 @@ const (
 	URNDoFn     = "beam:go:transform:dofn:v1"
 
 	URNIterableSideInputKey = "beam:go:transform:iterablesideinputkey:v1"
+	URNReshuffleInput       = "beam:go:transform:reshuffleinput:v1"
+	URNReshuffleOutput      = "beam:go:transform:reshuffleoutput:v1"
 
 	URNLegacyProgressReporting = "beam:protocol:progress_reporting:v0"
 	URNMultiCore               = "beam:protocol:multi_core_bundle_processing:v1"
@@ -212,8 +215,11 @@ func (m *marshaller) addMultiEdge(edge NamedEdge) []string {
 		return []string{id}
 	}
 
-	if edge.Edge.Op == graph.CoGBK && len(edge.Edge.Input) > 1 {
+	switch {
+	case edge.Edge.Op == graph.CoGBK && len(edge.Edge.Input) > 1:
 		return []string{m.expandCoGBK(edge)}
+	case edge.Edge.Op == graph.Reshuffle:
+		return []string{m.expandReshuffle(edge)}
 	}
 
 	inputs := make(map[string]string)
@@ -471,6 +477,164 @@ func (m *marshaller) addNode(n *graph.Node) string {
 	}
 	// TODO(herohde) 11/15/2017: expose UniqueName to user.
 	return m.makeNode(id, m.coders.Add(n.Coder), n)
+}
+
+// expandReshuffle translates resharding to a composite reshuffle
+// transform.
+//
+// With proper runner support, the SDK doesn't need to do anything.
+// However, we still need to provide a backup plan in terms of other
+// PTransforms in the event the runner doesn't have a native implementation.
+//
+// In particular, the "backup plan" needs to:
+//
+//  * Encode the windowed element, preserving timestamps.
+//  * Add random keys to the encoded windowed element []bytes
+//  * GroupByKey (in the global window).
+//  * Explode the resulting elements list.
+//  * Decode the windowed element []bytes.
+//
+// While a simple reshard can be written in user terms, (timestamps and windows
+// are accessible to user functions) there are some framework internal
+// optimizations that can be done if the framework is aware of the reshard, though
+// ideally this is handled on the runner side.
+//
+// User code is able to write reshards, but it's easier to access
+// the window coders framework side, which is critical for the reshard
+// to function with unbounded inputs.
+func (m *marshaller) expandReshuffle(edge NamedEdge) string {
+	id := edgeID(edge.Edge)
+	var kvCoderID, gbkCoderID string
+	{
+		kv := makeUnionCoder()
+		kvCoderID = m.coders.Add(kv)
+		gbkCoderID = m.coders.Add(coder.NewCoGBK(kv.Components))
+	}
+
+	var subtransforms []string
+
+	in := edge.Edge.Input[0]
+
+	origInput := m.addNode(in.From)
+	// We need to preserve the old windowing/triggering here
+	// for re-instatement after the GBK.
+	preservedWSId := m.pcollections[origInput].GetWindowingStrategyId()
+
+	// Get the windowing strategy from before:
+	postReify := fmt.Sprintf("%v_%v_reifyts", nodeID(in.From), id)
+	m.makeNode(postReify, kvCoderID, in.From)
+
+	// We need to replace postReify's windowing strategy with one appropriate
+	// for reshuffles.
+	{
+		wfn := window.NewGlobalWindows()
+		m.pcollections[postReify].WindowingStrategyId =
+			m.internWindowingStrategy(&pb.WindowingStrategy{
+				// Not segregated by time...
+				WindowFn: makeWindowFn(wfn),
+				// ...output after every element is received...
+				Trigger: &pb.Trigger{
+					// Should this be an Always trigger instead?
+					Trigger: &pb.Trigger_ElementCount_{
+						ElementCount: &pb.Trigger_ElementCount{
+							ElementCount: 1,
+						},
+					},
+				},
+				// ...and after outputing, discard the output elements...
+				AccumulationMode: pb.AccumulationMode_DISCARDING,
+				// ...and since every pane should have 1 element,
+				// try to preserve the timestamp.
+				OutputTime: pb.OutputTime_EARLIEST_IN_PANE,
+				// Defaults copied from marshalWindowingStrategy.
+				// TODO(BEAM-3304): migrate to user side operations once trigger support is in.
+				EnvironmentId:   m.addDefaultEnv(),
+				MergeStatus:     pb.MergeStatus_NON_MERGING,
+				WindowCoderId:   m.coders.AddWindowCoder(makeWindowCoder(wfn)),
+				ClosingBehavior: pb.ClosingBehavior_EMIT_IF_NONEMPTY,
+				AllowedLateness: 0,
+				OnTimeBehavior:  pb.OnTimeBehavior_FIRE_ALWAYS,
+			})
+	}
+
+	// Inputs (i)
+
+	inputID := fmt.Sprintf("%v_reifyts", id)
+	payload := &pb.ParDoPayload{
+		DoFn: &pb.FunctionSpec{
+			Urn: URNReshuffleInput,
+			Payload: []byte(protox.MustEncodeBase64(&v1.TransformPayload{
+				Urn: URNReshuffleInput,
+			})),
+		},
+	}
+	input := &pb.PTransform{
+		UniqueName: inputID,
+		Spec: &pb.FunctionSpec{
+			Urn:     URNParDo,
+			Payload: protox.MustEncode(payload),
+		},
+		Inputs:        map[string]string{"i0": nodeID(in.From)},
+		Outputs:       map[string]string{"i0": postReify},
+		EnvironmentId: m.addDefaultEnv(),
+	}
+	m.transforms[inputID] = input
+	subtransforms = append(subtransforms, inputID)
+
+	outNode := edge.Edge.Output[0].To
+
+	// GBK
+
+	gbkOut := fmt.Sprintf("%v_out", nodeID(outNode))
+	m.makeNode(gbkOut, gbkCoderID, outNode)
+
+	gbkID := fmt.Sprintf("%v_gbk", id)
+	gbk := &pb.PTransform{
+		UniqueName: gbkID,
+		Spec:       &pb.FunctionSpec{Urn: URNGBK},
+		Inputs:     map[string]string{"i0": postReify},
+		Outputs:    map[string]string{"i0": gbkOut},
+	}
+	m.transforms[gbkID] = gbk
+	subtransforms = append(subtransforms, gbkID)
+
+	// Expand
+
+	outPCol := m.addNode(outNode)
+	m.pcollections[outPCol].WindowingStrategyId = preservedWSId
+
+	outputID := fmt.Sprintf("%v_unreify", id)
+	outputPayload := &pb.ParDoPayload{
+		DoFn: &pb.FunctionSpec{
+			Urn: URNReshuffleOutput,
+			Payload: []byte(protox.MustEncodeBase64(&v1.TransformPayload{
+				Urn: URNReshuffleOutput,
+			})),
+		},
+	}
+	output := &pb.PTransform{
+		UniqueName: outputID,
+		Spec: &pb.FunctionSpec{
+			Urn:     URNParDo,
+			Payload: protox.MustEncode(outputPayload),
+		},
+		Inputs:        map[string]string{"i0": gbkOut},
+		Outputs:       map[string]string{"i0": nodeID(outNode)},
+		EnvironmentId: m.addDefaultEnv(),
+	}
+	m.transforms[id] = output
+	subtransforms = append(subtransforms, id)
+
+	// Add composite for visualization, or runner optimization
+	reshuffleID := fmt.Sprintf("%v_reshuffle", id)
+	m.transforms[reshuffleID] = &pb.PTransform{
+		UniqueName:    edge.Name,
+		Subtransforms: subtransforms,
+		Spec: &pb.FunctionSpec{
+			Urn: URNReshuffle,
+		},
+	}
+	return reshuffleID
 }
 
 func (m *marshaller) makeNode(id, cid string, n *graph.Node) string {

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -534,11 +534,8 @@ func (m *marshaller) expandReshuffle(edge NamedEdge) string {
 				WindowFn: makeWindowFn(wfn),
 				// ...output after every element is received...
 				Trigger: &pb.Trigger{
-					// Should this be an Always trigger instead?
-					Trigger: &pb.Trigger_ElementCount_{
-						ElementCount: &pb.Trigger_ElementCount{
-							ElementCount: 1,
-						},
+					Trigger: &pb.Trigger_Always_{
+						Always: &pb.Trigger_Always{},
 					},
 				},
 				// ...and after outputing, discard the output elements...

--- a/sdks/go/pkg/beam/gbk.go
+++ b/sdks/go/pkg/beam/gbk.go
@@ -108,23 +108,23 @@ func TryCoGroupByKey(s Scope, cols ...PCollection) (PCollection, error) {
 // parallelism, using the following pattern:
 //
 //   pc := bigHairyComputationNeedingParallelism(scope) // PCollection<string>
-//   resharded := beam.Reshard(scope, pc)                // PCollection<string>
+//   resharded := beam.Reshuffle(scope, pc)                // PCollection<string>
 //
 // Another use case is when one has a non-deterministic DoFn followed by one
-// that performs externally-visible side effects. Inserting a Reshard
+// that performs externally-visible side effects. Inserting a Reshuffle
 // between these DoFns ensures that retries of the second DoFn will always be
 // the same, which is necessary to make side effects idempotent.
 //
 // A Reshuffle will force a break in the optimized pipeline. Consequently,
 // this operation should be used sparingly, only after determining that the
-// pipeline without reshard is broken in some way and performing an extra
+// pipeline without reshuffling is broken in some way and performing an extra
 // operation is worth the cost.
 func Reshuffle(s Scope, col PCollection) PCollection {
 	return Must(TryReshuffle(s, col))
 }
 
-// TryReshuffle inserts a Reshard into the pipeline, and returns an error if
-// the pcollection's unable to be resharded.
+// TryReshuffle inserts a Reshuffle into the pipeline, and returns an error if
+// the pcollection's unable to be reshuffled.
 func TryReshuffle(s Scope, col PCollection) (PCollection, error) {
 	addContext := func(err error, s Scope) error {
 		return errors.WithContextf(err, "inserting Reshard in scope %s", s)

--- a/sdks/go/pkg/beam/gbk.go
+++ b/sdks/go/pkg/beam/gbk.go
@@ -95,3 +95,52 @@ func TryCoGroupByKey(s Scope, cols ...PCollection) (PCollection, error) {
 	ret.SetCoder(NewCoder(ret.Type()))
 	return ret, nil
 }
+
+// Reshuffle copies a PCollection of the same kind and using the same element
+// coder, and maintains the same windowing information. Importantly, it allows
+// the result PCollection to be processed with a different sharding, in a
+// different stage than the input PCollection.
+//
+// For example, if a computation needs a lot of parallelism but
+// produces only a small amount of output data, then the computation
+// producing the data can run with as much parallelism as needed,
+// while the output file is written with a smaller amount of
+// parallelism, using the following pattern:
+//
+//   pc := bigHairyComputationNeedingParallelism(scope) // PCollection<string>
+//   resharded := beam.Reshard(scope, pc)                // PCollection<string>
+//
+// Another use case is when one has a non-deterministic DoFn followed by one
+// that performs externally-visible side effects. Inserting a Reshard
+// between these DoFns ensures that retries of the second DoFn will always be
+// the same, which is necessary to make side effects idempotent.
+//
+// A Reshuffle will force a break in the optimized pipeline. Consequently,
+// this operation should be used sparingly, only after determining that the
+// pipeline without reshard is broken in some way and performing an extra
+// operation is worth the cost.
+func Reshuffle(s Scope, col PCollection) PCollection {
+	return Must(TryReshuffle(s, col))
+}
+
+// TryReshuffle inserts a Reshard into the pipeline, and returns an error if
+// the pcollection's unable to be resharded.
+func TryReshuffle(s Scope, col PCollection) (PCollection, error) {
+	addContext := func(err error, s Scope) error {
+		return errors.WithContextf(err, "inserting Reshard in scope %s", s)
+	}
+	if !s.IsValid() {
+		return PCollection{}, addContext(errors.New("invalid scope"), s)
+	}
+	if !col.IsValid() {
+		return PCollection{}, addContext(errors.New("invalid pcollection"), s)
+	}
+	edge, err := graph.NewReshuffle(s.real, s.scope, col.n)
+	if err != nil {
+		return PCollection{}, addContext(err, s)
+	}
+	col.n.WindowingStrategy()
+	ret := PCollection{edge.Output[0].To}
+	ret.SetCoder(NewCoder(ret.Type()))
+	return ret, nil
+}

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/translate.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/translate.go
@@ -209,6 +209,9 @@ func (x *translator) translateTransform(trunk string, id string) ([]*df.Step, er
 		steps[1].Properties = newMsg(prop)
 		return steps, nil
 
+	case graphx.URNReshuffle:
+		return x.translateTransforms(fmt.Sprintf("%v%v/", trunk, path.Base(t.UniqueName)), t.Subtransforms)
+
 	case graphx.URNFlatten:
 		for _, in := range t.Inputs {
 			prop.Inputs = append(prop.Inputs, x.pcollections[in])

--- a/sdks/go/pkg/beam/runners/direct/direct.go
+++ b/sdks/go/pkg/beam/runners/direct/direct.go
@@ -295,6 +295,12 @@ func (b *builder) makeLink(id linkID) (exec.Node, error) {
 
 		return b.links[id], nil
 
+	case graph.Reshuffle:
+		// Reshuffle is a no-op in the direct runner, as there's only a single bundle
+		// on a single worker. Hoist the next node up in the cache.
+		b.links[id] = out[0]
+		return b.links[id], nil
+
 	case graph.Flatten:
 		u = &exec.Flatten{UID: b.idgen.New(), N: len(edge.Input), Out: out[0]}
 

--- a/sdks/go/test/integration/driver.go
+++ b/sdks/go/test/integration/driver.go
@@ -64,6 +64,8 @@ func main() {
 		{"cogbk:cogbk", primitives.CoGBK()},
 		{"flatten:flatten", primitives.Flatten()},
 		// {"flatten:dup", primitives.FlattenDup()},
+		{"reshuffle:reshuffle", primitives.Reshuffle()},
+		{"reshuffle:reshufflekv", primitives.ReshuffleKV()},
 	}
 
 	re := regexp.MustCompile(*filter)

--- a/sdks/go/test/integration/primitives/cogbk_test.go
+++ b/sdks/go/test/integration/primitives/cogbk_test.go
@@ -26,3 +26,15 @@ func TestCoGBK(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestReshuffle(t *testing.T) {
+	if err := ptest.Run(Reshuffle()); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestReshuffleKV(t *testing.T) {
+	if err := ptest.Run(ReshuffleKV()); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
This adds a Reshuffle transform to the Go SDK.

* In particular, it configures windowing & trigggers for a GBK to allow for fusion breaks, where parallelism needs to increase, or decrease due to data bundling properties.
* Previous element window and timestamps are preserved.
* The SDK operations are wrapped with a higher level reshuffle URN so runners can optimize this step better.
* The Go Direct Runner is aware of the Reshuffle and correctly ignores it, as it's a single bundle runner. 

Note: While this should work for streaming cases, it hasn't been tested with them yet, due to the current state of streaming the Go SDK.

It further adds one small optimization for the internal Decoding interface, called the DecodeTo method to avoid extra allocations to the heap incurred by returning a *FullValue. Can't avoid extra allocations for KV types at present, but value PCollections should have lower overhead. A subsequent PR will use the DecodeTo method at a other applicable places in the decode stack.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
