### PR TITLE
test

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -628,46 +628,52 @@ class Pipeline(object):
     if type_options is not None and type_options.pipeline_type_check:
       transform.type_check_outputs(pvalueish_result)
 
-    for result in ptransform.get_nested_pvalues(pvalueish_result):
-      assert isinstance(result, (pvalue.PValue, pvalue.DoOutputsTuple))
+      # TODO(BEAM-9322): Set the default to True when tested to work.
+    if self._options.view_as(DebugOptions).lookup_experiment(
+        'passthrough_pcollection_output_ids', default=True):
+      for tag, result in ptransform.get_nested_pvalues(pvalueish_result):
+        assert isinstance(result, (pvalue.PValue, pvalue.DoOutputsTuple))
 
-      # Make sure we set the producer only for a leaf node in the transform DAG.
-      # This way we preserve the last transform of a composite transform as
-      # being the real producer of the result.
-      if result.producer is None:
-        result.producer = current
+        # Make sure we set the producer only for a leaf node in the transform DAG.
+        # This way we preserve the last transform of a composite transform as
+        # being the real producer of the result.
+        if result.producer is None:
+          result.producer = current
 
-      self._infer_result_type(transform, inputs, result)
+        self._infer_result_type(transform, inputs, result)
 
-      assert isinstance(result.producer.inputs, tuple)
-      # The DoOutputsTuple adds the PCollection to the outputs when accessed
-      # except for the main tag. Add the main tag here.
-      if isinstance(result, pvalue.DoOutputsTuple):
-        current.add_output(result, result._main_tag)
-        continue
+        assert isinstance(result.producer.inputs, tuple)
+        # The DoOutputsTuple adds the PCollection to the outputs when accessed
+        # except for the main tag. Add the main tag here.
+        if isinstance(result, pvalue.DoOutputsTuple):
+          current.add_output(result, result._main_tag)
+          continue
 
-      # TODO(BEAM-9322): Remove the experiment check and have this conditional
-      # be the default.
-      if self._options.view_as(DebugOptions).lookup_experiment(
-          'passthrough_pcollection_output_ids', default=False):
-        # Passthrough the PCollection output_ids from the PCollection tag.
-        # Only generate a tag if there are multiple PCollections that have a
-        # None tag. This happens when returning multiple PCollections from a
-        # composite.
-        if result.tag is None and None in current.outputs:
-          tag = len(current.outputs)
-        else:
-          tag = result.tag
         current.add_output(result, tag)
-        continue
+    else:
+      for result in ptransform.get_flattened_pvalues(pvalueish_result):
+        assert isinstance(result, (pvalue.PValue, pvalue.DoOutputsTuple))
 
-      # TODO(BEAM-9322): Find the best auto-generated tags for nested
-      # PCollections.
-      # If the user wants the old implementation of always generated
-      # PCollection output ids, then set the tag to None first, then count up
-      # from 1.
-      tag = len(current.outputs) if None in current.outputs else None
-      current.add_output(result, tag)
+        # Make sure we set the producer only for a leaf node in the transform DAG.
+        # This way we preserve the last transform of a composite transform as
+        # being the real producer of the result.
+        if result.producer is None:
+          result.producer = current
+
+        self._infer_result_type(transform, inputs, result)
+
+        assert isinstance(result.producer.inputs, tuple)
+        # The DoOutputsTuple adds the PCollection to the outputs when accessed
+        # except for the main tag. Add the main tag here.
+        if isinstance(result, pvalue.DoOutputsTuple):
+          current.add_output(result, result._main_tag)
+          continue
+
+        # If the user wants the old implementation of always generated
+        # PCollection output ids, then set the tag to None first, then count up
+        # from 1.
+        tag = len(current.outputs) if None in current.outputs else None
+        current.add_output(result, tag)
 
     if (type_options is not None and
         type_options.type_check_strictness == 'ALL_REQUIRED' and

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -592,6 +592,51 @@ class PipelineTest(unittest.TestCase):
     self.assertIs(pcoll2_unbounded.is_bounded, False)
     self.assertIs(merged.is_bounded, False)
 
+  def test_nested_pcollections_naming(self):
+    p = TestPipeline(
+        additional_pipeline_args=[
+            '--experiments=passthrough_pcollection_output_ids'
+        ])
+
+    class OutputsNestedPCollectionTuple(beam.PTransform):
+      def expand(self, pcoll):
+        partition_1 = pcoll | "partition_1" >> beam.Partition(
+            lambda _0, _1, _2: 0, 2)
+        partition_2 = pcoll | "partition_2" >> beam.Partition(
+            lambda _0, _1, _2: 0, 2)
+        return (partition_1[0], partition_2[0])
+
+    class OutputsNestedPCollectionDict(beam.PTransform):
+      def expand(self, pcoll):
+        partition_1 = pcoll | "partition_1" >> beam.Partition(
+            lambda _0, _1, _2: 0, 2)
+        partition_2 = pcoll | "partition_2" >> beam.Partition(
+            lambda _0, _1, _2: 0, 2)
+
+        print('returning')
+        return {'p_1': partition_1[0], 'p_2': partition_2}
+
+    result = p | OutputsNestedPCollectionDict()
+
+    class Visitor(PipelineVisitor):
+      def __init__(self):
+        self.output_tags = []
+
+      def enter_composite_transform(self, transform_node):
+        if isinstance(
+            transform_node.transform,
+            (OutputsNestedPCollectionTuple, OutputsNestedPCollectionDict)):
+          self.output_tags = list(transform_node.outputs.keys())
+
+      def accept(self, p):
+        p.visit(self)
+        return self.output_tags
+
+    # print('here', Visitor().accept(p))
+    self.assertListEqual(
+        Visitor().accept(p), ['p_1', 'p_2.0', 'p_2.1', 'p_2.None'])
+    # print([r.tag for r in result.values()])
+
 
 class DoFnTest(unittest.TestCase):
   def test_element(self):


### PR DESCRIPTION
Change-Id: I18a1a3c4589e1fdc90d919a223ef67465f495374

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
