### PR TITLE
[BEAM-9605] BIP-1: Rename setRowOption to setOption on Option builder

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -336,7 +336,7 @@ public class Schema implements Serializable {
     SAME,
     WEAKEN,
     IGNORE
-  };
+  }
 
   /** Returns true if two Schemas have the same fields, but possibly in different orders. */
   public boolean equivalent(Schema other) {
@@ -389,7 +389,7 @@ public class Schema implements Serializable {
     builder.append("Options:");
     builder.append(options);
     return builder.toString();
-  };
+  }
 
   @Override
   public int hashCode() {
@@ -1171,7 +1171,6 @@ public class Schema implements Serializable {
 
     /** Get the value of an option. If the option is not found null is returned. */
     @SuppressWarnings("TypeParameterUnusedInFormals")
-    @Nullable
     public <T> T getValue(String optionName) {
       Option option = options.get(optionName);
       if (option != null) {
@@ -1182,13 +1181,11 @@ public class Schema implements Serializable {
     }
 
     /** Get the value of an option. If the option is not found null is returned. */
-    @Nullable
     public <T> T getValue(String optionName, Class<T> valueClass) {
       return getValue(optionName);
     }
 
     /** Get the value of an option. If the option is not found the default value is returned. */
-    @Nullable
     public <T> T getValueOrDefault(String optionName, T defaultValue) {
       Option option = options.get(optionName);
       if (option != null) {
@@ -1198,7 +1195,6 @@ public class Schema implements Serializable {
     }
 
     /** Get the type of an option. */
-    @Nullable
     public FieldType getType(String optionName) {
       Option option = options.get(optionName);
       if (option != null) {
@@ -1212,7 +1208,7 @@ public class Schema implements Serializable {
       return Options.builder().setOption(optionName, fieldType, value);
     }
 
-    public static Options.Builder setRowOption(String optionName, Row value) {
+    public static Options.Builder setOption(String optionName, Row value) {
       return Options.builder().setRowOption(optionName, value);
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaOptionsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaOptionsTest.java
@@ -169,7 +169,7 @@ public class SchemaOptionsTest {
 
   @Test
   public void testRowOption() {
-    Schema.Options options = Schema.Options.setRowOption(OPTION_NAME, TEST_ROW).build();
+    Schema.Options options = Schema.Options.setOption(OPTION_NAME, TEST_ROW).build();
     assertEquals(TEST_ROW, options.getValue(OPTION_NAME));
     assertEquals(FieldType.row(TEST_ROW.getSchema()), options.getType(OPTION_NAME));
   }


### PR DESCRIPTION
Rename setRowOption to setOption on Option builder as setRowOption
name is too confusing.

It sets an option as a Row, not an option on a Row. Using setOption
is better and doesn't conflict with the other setOption with 3
parameters and explicit type.

This commit also removed left over @Nullable annotations.
