### PR TITLE
[BEAM-9573][release-2.20] Correct computing of watermark hold for timer output timestamp

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -159,7 +159,7 @@ public class SplittableDoFnOperator<InputT, OutputT, RestrictionT>
 
   @Override
   protected void fireTimer(InternalTimer<ByteBuffer, TimerInternals.TimerData> timer) {
-    timerInternals.cleanupPendingTimer(timer.getNamespace(), true);
+    timerInternals.onFiredOrDeletedTimer(timer.getNamespace());
     if (timer.getNamespace().getDomain().equals(TimeDomain.EVENT_TIME)) {
       // ignore this, it can only be a state cleanup timers from StatefulDoFnRunner and ProcessFn
       // does its own state cleanup and should never set event-time timers.

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
@@ -126,7 +126,7 @@ public class WindowDoFnOperator<K, InputT, OutputT>
 
   @Override
   protected void fireTimer(InternalTimer<ByteBuffer, TimerData> timer) {
-    timerInternals.cleanupPendingTimer(timer.getNamespace(), true);
+    timerInternals.onFiredOrDeletedTimer(timer.getNamespace());
     doFnRunner.processElement(
         WindowedValue.valueInGlobalWindow(
             KeyedWorkItems.timersWorkItem(

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -250,40 +250,57 @@ public class DoFnOperatorTest {
   public void testWatermarkContract() throws Exception {
 
     final Instant timerTimestamp = new Instant(1000);
-    final String eventTimeMessage = "Event timer fired";
+    final String eventTimeMessage = "Event timer fired: ";
     final String processingTimeMessage = "Processing timer fired";
 
     WindowingStrategy<Object, IntervalWindow> windowingStrategy =
         WindowingStrategy.of(FixedWindows.of(new Duration(10_000)));
 
+    final String eventTimerId = "eventTimer";
+    final String eventTimerId2 = "eventTimer2";
+    final String processingTimerId = "processingTimer";
     DoFn<Integer, String> fn =
         new DoFn<Integer, String>() {
-          private static final String EVENT_TIMER_ID = "eventTimer";
-          private static final String PROCESSING_TIMER_ID = "processingTimer";
 
-          @TimerId(EVENT_TIMER_ID)
+          @TimerId(eventTimerId)
           private final TimerSpec eventTimer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
 
-          @TimerId(PROCESSING_TIMER_ID)
+          @TimerId(eventTimerId2)
+          private final TimerSpec eventTimer2 = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+          @TimerId(processingTimerId)
           private final TimerSpec processingTimer = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
 
           @ProcessElement
           public void processElement(
               ProcessContext context,
-              @TimerId(EVENT_TIMER_ID) Timer eventTimer,
-              @TimerId(PROCESSING_TIMER_ID) Timer processingTimer) {
+              @TimerId(eventTimerId) Timer eventTimer,
+              @TimerId(eventTimerId2) Timer eventTimerWithOutputTimestamp,
+              @TimerId(processingTimerId) Timer processingTimer) {
             eventTimer.set(timerTimestamp);
+            eventTimerWithOutputTimestamp
+                .withOutputTimestamp(timerTimestamp.minus(1))
+                .set(timerTimestamp);
             processingTimer.offset(Duration.millis(timerTimestamp.getMillis())).setRelative();
           }
 
-          @OnTimer(EVENT_TIMER_ID)
+          @OnTimer(eventTimerId)
           public void onEventTime(OnTimerContext context) {
             assertEquals(
                 "Timer timestamp must match set timestamp.", timerTimestamp, context.timestamp());
-            context.outputWithTimestamp(eventTimeMessage, context.timestamp());
+            context.outputWithTimestamp(eventTimeMessage + eventTimerId, context.timestamp());
           }
 
-          @OnTimer(PROCESSING_TIMER_ID)
+          @OnTimer(eventTimerId2)
+          public void onEventTime2(OnTimerContext context) {
+            assertEquals(
+                "Timer timestamp must match set timestamp.",
+                timerTimestamp,
+                context.fireTimestamp());
+            context.output(eventTimeMessage + eventTimerId2);
+          }
+
+          @OnTimer(processingTimerId)
           public void onProcessingTime(OnTimerContext context) {
             assertEquals(
                 // Timestamps in processing timer context are defined to be the input watermark
@@ -346,13 +363,23 @@ public class DoFnOperatorTest {
     testHarness.setProcessingTime(timerTimestamp.getMillis());
 
     assertThat(stripStreamRecordFromWindowedValue(testHarness.getOutput()), emptyIterable());
+    assertThat(
+        doFnOperator.timerInternals.getMinOutputTimestampMs(),
+        is(timerTimestamp.minus(1).getMillis()));
 
-    // this must fire the event timer
+    // this must fire the event timers
     testHarness.processWatermark(timerTimestamp.getMillis() + 1);
 
     assertThat(
         stripStreamRecordFromWindowedValue(testHarness.getOutput()),
-        contains(WindowedValue.of(eventTimeMessage, timerTimestamp, window1, PaneInfo.NO_FIRING)));
+        containsInAnyOrder(
+            WindowedValue.of(
+                eventTimeMessage + eventTimerId, timerTimestamp, window1, PaneInfo.NO_FIRING),
+            WindowedValue.of(
+                eventTimeMessage + eventTimerId2,
+                timerTimestamp.minus(1),
+                window1,
+                PaneInfo.NO_FIRING)));
 
     testHarness.getOutput().clear();
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
@@ -153,7 +153,7 @@ public class WindowDoFnOperatorTest {
 
     assertThat(testHarness.numKeyedStateEntries(), is(6));
     assertThat(windowDoFnOperator.currentOutputWatermark, is(1L));
-    assertThat(timerInternals.getMinOutputTimestampMs(), is(99L));
+    assertThat(timerInternals.getMinOutputTimestampMs(), is(Long.MAX_VALUE));
 
     // close window
     testHarness.processWatermark(100L);
@@ -163,7 +163,7 @@ public class WindowDoFnOperatorTest {
 
     assertThat(testHarness.numKeyedStateEntries(), is(3));
     assertThat(windowDoFnOperator.currentOutputWatermark, is(100L));
-    assertThat(timerInternals.getMinOutputTimestampMs(), is(199L));
+    assertThat(timerInternals.getMinOutputTimestampMs(), is(Long.MAX_VALUE));
 
     testHarness.processWatermark(200L);
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
@@ -133,23 +133,53 @@ public class WindowDoFnOperatorTest {
     IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(100));
     IntervalWindow window2 = new IntervalWindow(new Instant(100), Duration.millis(100));
     testHarness.processWatermark(0L);
+
+    // Use two different keys to check for correct watermark hold calculation
     testHarness.processElement(
         Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
     testHarness.processElement(
         Item.builder()
-            .key(1L)
+            .key(2L)
             .timestamp(150L)
             .value(150L)
             .window(window2)
             .build()
             .toStreamRecord());
 
-    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(2));
+    testHarness.processWatermark(1);
+
+    // Note that the following is 1 because the state is key-partitioned
+    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(1));
+
+    assertThat(testHarness.numKeyedStateEntries(), is(6));
+    assertThat(windowDoFnOperator.currentOutputWatermark, is(1L));
+    assertThat(timerInternals.getMinOutputTimestampMs(), is(99L));
 
     // close window
+    testHarness.processWatermark(100L);
+
+    // Note that the following is zero because we only the first key is active
+    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(0));
+
+    assertThat(testHarness.numKeyedStateEntries(), is(3));
+    assertThat(windowDoFnOperator.currentOutputWatermark, is(100L));
+    assertThat(timerInternals.getMinOutputTimestampMs(), is(199L));
+
     testHarness.processWatermark(200L);
 
-    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(0));
+    // All the state has been cleaned up
+    assertThat(testHarness.numKeyedStateEntries(), is(0));
+
+    assertThat(
+        stripStreamRecordFromWindowedValue(testHarness.getOutput()),
+        containsInAnyOrder(
+            WindowedValue.of(
+                KV.of(1L, 100L), new Instant(99), window, PaneInfo.createPane(true, true, ON_TIME)),
+            WindowedValue.of(
+                KV.of(2L, 150L),
+                new Instant(199),
+                window2,
+                PaneInfo.createPane(true, true, ON_TIME))));
 
     // cleanup
     testHarness.close();


### PR DESCRIPTION
### Backport of #11200.
#### [BEAM-9573] Correct computing of watermark hold for timer output timestamp

With the introduction of timer output timestamps, a new watermark hold had been
added to the Flink Runner. The watermark computation works on the keyed state
backend which computes a key-scoped watermark hold and not the desired
operator-wide watermark hold.

Computation: https://github.com/apache/beam/blob/b564239081e9351c56fb0e7d263495b95dd3f8f3/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java#L1140

Key-scoped state: https://github.com/apache/beam/blob/b564239081e9351c56fb0e7d263495b95dd3f8f3/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java#L1130

The solution is to iterate over all available state backend keys.

### Backport of #11237.
#### [BEAM-9566] Mitigate performance issue for output timestamp watermark holds

Benchmarks have shown that the minimum output timestamp computation over all
timers is very expensive because we have to iterate over all keys in the state
backend. This is especially costly for RocksDB.

This change introduces a cache which stores and updates the timer output
timestamps such that the minimum can be retrieved efficiently.

Only at startup the cache is populated from the state backend. This should
give us roughly the same performance as before introducing output timestamps for
timers.

The following have been run with RocksDB:

Nexmark Query 12 before:
```
  Conf  Runtime(sec)    (Baseline)  Events(/sec)    (Baseline)       Results    (Baseline)
  0000         105.3                       950.0                        9039
  0001           2.2                      4466.3                         196
```

Nexmark query 12 with this change:
```
Performance:
  Conf  Runtime(sec)    (Baseline)  Events(/sec)    (Baseline)       Results    (Baseline)
  0000           6.0                     16730.8                        1919
  0001           0.8                     12391.6                         196
```

For more details please see BEAM-9566.



Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
