### PR TITLE
[BEAM-9601] Skip the streaming wordcount test because it uses a Python3.5.3+ feature

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
 import unittest
 from datetime import timedelta
 
@@ -40,6 +41,7 @@ from apache_beam.runners.interactive import interactive_runner
 from apache_beam.runners.interactive.testing.mock_ipython import mock_get_ipython
 from apache_beam.testing.test_stream import TestStream
 from apache_beam.transforms.window import GlobalWindow
+from apache_beam.transforms.window import IntervalWindow
 from apache_beam.utils.timestamp import Timestamp
 from apache_beam.utils.windowed_value import PaneInfo
 from apache_beam.utils.windowed_value import PaneInfoTiming
@@ -150,9 +152,10 @@ class InteractiveRunnerTest(unittest.TestCase):
     ]
     self.assertEqual(actual_reified, expected_reified)
 
+  @unittest.skipIf(
+      sys.version_info < (3, 5, 3),
+      'The tests require at least Python 3.6 to work.')
   def test_streaming_wordcount(self):
-    self.skipTest('[BEAM-9601] Test is breaking PreCommits')
-
     class WordExtractingDoFn(beam.DoFn):
       def process(self, element):
         text_line = element.strip()
@@ -196,20 +199,17 @@ class InteractiveRunnerTest(unittest.TestCase):
     # This tests that the data was correctly cached.
     pane_info = PaneInfo(True, True, PaneInfoTiming.UNKNOWN, 0, 0)
     expected_data_df = pd.DataFrame([
-        ('to', 0, [beam.window.IntervalWindow(0, 10)], pane_info),
-        ('be', 0, [beam.window.IntervalWindow(0, 10)], pane_info),
-        ('or', 0, [beam.window.IntervalWindow(0, 10)], pane_info),
-        ('not', 0, [beam.window.IntervalWindow(0, 10)], pane_info),
-        ('to', 0, [beam.window.IntervalWindow(0, 10)], pane_info),
-        ('be', 0, [beam.window.IntervalWindow(0, 10)], pane_info),
-        ('that', 20000000, [beam.window.IntervalWindow(20, 30)], pane_info),
-        ('is', 20000000, [beam.window.IntervalWindow(20, 30)], pane_info),
-        ('the', 20000000, [beam.window.IntervalWindow(20, 30)], pane_info),
-        ('question', 20000000, [beam.window.IntervalWindow(20, 30)], pane_info)
-    ],
-                                    columns=[
-                                        0, 'event_time', 'windows', 'pane_info'
-                                    ])
+        ('to', 0, [IntervalWindow(0, 10)], pane_info),
+        ('be', 0, [IntervalWindow(0, 10)], pane_info),
+        ('or', 0, [IntervalWindow(0, 10)], pane_info),
+        ('not', 0, [IntervalWindow(0, 10)], pane_info),
+        ('to', 0, [IntervalWindow(0, 10)], pane_info),
+        ('be', 0, [IntervalWindow(0, 10)], pane_info),
+        ('that', 20000000, [IntervalWindow(20, 30)], pane_info),
+        ('is', 20000000, [IntervalWindow(20, 30)], pane_info),
+        ('the', 20000000, [IntervalWindow(20, 30)], pane_info),
+        ('question', 20000000, [IntervalWindow(20, 30)], pane_info)
+    ], columns=[0, 'event_time', 'windows', 'pane_info']) # yapf: disable
 
     data_df = ib.collect(data, include_window_info=True)
     pd.testing.assert_frame_equal(expected_data_df, data_df)
@@ -217,23 +217,25 @@ class InteractiveRunnerTest(unittest.TestCase):
     # This tests that the windowing was passed correctly so that all the data
     # is aggregated also correctly.
     pane_info = PaneInfo(True, False, PaneInfoTiming.ON_TIME, 0, 0)
-    expected_counts_df = pd.DataFrame(
-        [('to', 2, 9999999, [beam.window.IntervalWindow(0, 10)], pane_info),
-         ('be', 2, 9999999, [beam.window.IntervalWindow(0, 10)], pane_info),
-         ('or', 1, 9999999, [beam.window.IntervalWindow(0, 10)], pane_info),
-         ('not', 1, 9999999, [beam.window.IntervalWindow(0, 10)], pane_info),
-         ('that', 1, 29999999, [beam.window.IntervalWindow(20, 30)], pane_info),
-         ('is', 1, 29999999, [beam.window.IntervalWindow(20, 30)], pane_info),
-         ('the', 1, 29999999, [beam.window.IntervalWindow(20, 30)], pane_info),
-         (
-             'question',
-             1,
-             29999999, [beam.window.IntervalWindow(20, 30)],
-             pane_info)],
-        columns=[0, 1, 'event_time', 'windows', 'pane_info'])
+    expected_counts_df = pd.DataFrame([
+        ('be', 2, 9999999, [IntervalWindow(0, 10)], pane_info),
+        ('not', 1, 9999999, [IntervalWindow(0, 10)], pane_info),
+        ('or', 1, 9999999, [IntervalWindow(0, 10)], pane_info),
+        ('to', 2, 9999999, [IntervalWindow(0, 10)], pane_info),
+        ('is', 1, 29999999, [IntervalWindow(20, 30)], pane_info),
+        ('question', 1, 29999999, [IntervalWindow(20, 30)], pane_info),
+        ('that', 1, 29999999, [IntervalWindow(20, 30)], pane_info),
+        ('the', 1, 29999999, [IntervalWindow(20, 30)], pane_info),
+    ], columns=[0, 1, 'event_time', 'windows', 'pane_info']) # yapf: disable
 
     counts_df = ib.collect(counts, include_window_info=True)
-    pd.testing.assert_frame_equal(expected_counts_df, counts_df)
+
+    # The group by key has no guarantee of order. So we post-process the DF by
+    # sorting so we can test equality.
+    sorted_counts_df = (counts_df
+                        .sort_values(['event_time', 0], ascending=True)
+                        .reset_index(drop=True)) # yapf: disable
+    pd.testing.assert_frame_equal(expected_counts_df, sorted_counts_df)
 
   def test_session(self):
     class MockPipelineRunner(object):


### PR DESCRIPTION
Change-Id: I9caaf395fd0fc58565e54a8458e8289af761815f

The InteractiveRunner requires Python3.5.3+. We have a pattern in which we disable the tests that fail on Python2.7.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
