### PR TITLE
[BEAM-9642] Create runtime invokers for SDF methods.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers.go
@@ -1,0 +1,301 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+	"reflect"
+)
+
+// This file contains invokers for SDF methods. These invokers are based off
+// exec.invoker which is used for regular DoFns. Since exec.invoker is
+// specialized for DoFns it cannot be used for SDF methods. Instead, these
+// invokers pare down the functionality to only what is essential for
+// executing SDF methods, including per-element optimizations.
+//
+// Each SDF method invoker in this file is specific to a certain method, but
+// they are all used the same way. Create an invoker with new[Method]Invoker
+// in the Up method of an exec.Unit, and then invoke it with Invoke. Finally,
+// call Reset on it when the bundle ends in FinishBundle.
+//
+// These invokers are not thread-safe.
+
+// cirInvoker is an invoker for CreateInitialRestriction.
+type cirInvoker struct {
+	fn   *funcx.Fn
+	args []interface{} // Cache to avoid allocating new slices per-element.
+	call func(elms *FullValue) (rest interface{})
+}
+
+func newCreateInitialRestrictionInvoker(fn *funcx.Fn) (*cirInvoker, error) {
+	n := &cirInvoker{
+		fn:   fn,
+		args: make([]interface{}, len(fn.Param)),
+	}
+	if err := n.initCallFn(); err != nil {
+		return nil, errors.WithContext(err, "sdf CreateInitialRestriction invoker")
+	}
+	return n, nil
+}
+
+func (n *cirInvoker) initCallFn() error {
+	// Expects a signature of the form:
+	// (key?, value) restriction
+	// TODO(BEAM-9643): Link to full documentation.
+	switch fnT := n.fn.Fn.(type) {
+	case reflectx.Func1x1:
+		n.call = func(elms *FullValue) interface{} {
+			return fnT.Call1x1(elms.Elm)
+		}
+	case reflectx.Func2x1:
+		n.call = func(elms *FullValue) interface{} {
+			return fnT.Call2x1(elms.Elm, elms.Elm2)
+		}
+	default:
+		switch len(n.fn.Param) {
+		case 1:
+			n.call = func(elms *FullValue) interface{} {
+				n.args[0] = elms.Elm
+				return n.fn.Fn.Call(n.args)[0]
+			}
+		case 2:
+			n.call = func(elms *FullValue) interface{} {
+				n.args[0] = elms.Elm
+				n.args[1] = elms.Elm2
+				return n.fn.Fn.Call(n.args)[0]
+			}
+		default:
+			return errors.Errorf("CreateInitialRestriction fn %v has unexpected number of parameters: %v",
+				n.fn.Fn.Name(), len(n.fn.Param))
+		}
+	}
+
+	return nil
+}
+
+// Invoke calls CreateInitialRestriction with the given FullValue as the element
+// and returns the resulting restriction.
+func (n *cirInvoker) Invoke(elms *FullValue) (rest interface{}) {
+	return n.call(elms)
+}
+
+// Reset zeroes argument entries in the cached slice to allow values to be
+// garbage collected after the bundle ends.
+func (n *cirInvoker) Reset() {
+	for i := range n.args {
+		n.args[i] = nil
+	}
+}
+
+// srInvoker is an invoker for SplitRestriction.
+type srInvoker struct {
+	fn   *funcx.Fn
+	args []interface{} // Cache to avoid allocating new slices per-element.
+	call func(elms *FullValue, rest interface{}) (splits interface{})
+}
+
+func newSplitRestrictionInvoker(fn *funcx.Fn) (*srInvoker, error) {
+	n := &srInvoker{
+		fn:   fn,
+		args: make([]interface{}, len(fn.Param)),
+	}
+	if err := n.initCallFn(); err != nil {
+		return nil, errors.WithContext(err, "sdf SplitRestriction invoker")
+	}
+	return n, nil
+}
+
+func (n *srInvoker) initCallFn() error {
+	// Expects a signature of the form:
+	// (key?, value, restriction) []restriction
+	// TODO(BEAM-9643): Link to full documentation.
+	switch fnT := n.fn.Fn.(type) {
+	case reflectx.Func2x1:
+		n.call = func(elms *FullValue, rest interface{}) interface{} {
+			return fnT.Call2x1(elms.Elm, rest)
+		}
+	case reflectx.Func3x1:
+		n.call = func(elms *FullValue, rest interface{}) interface{} {
+			return fnT.Call3x1(elms.Elm, elms.Elm2, rest)
+		}
+	default:
+		switch len(n.fn.Param) {
+		case 2:
+			n.call = func(elms *FullValue, rest interface{}) interface{} {
+				n.args[0] = elms.Elm
+				n.args[1] = rest
+				return n.fn.Fn.Call(n.args)[0]
+			}
+		case 3:
+			n.call = func(elms *FullValue, rest interface{}) interface{} {
+				n.args[0] = elms.Elm
+				n.args[1] = elms.Elm2
+				n.args[2] = rest
+				return n.fn.Fn.Call(n.args)[0]
+			}
+		default:
+			return errors.Errorf("SplitRestriction fn %v has unexpected number of parameters: %v",
+				n.fn.Fn.Name(), len(n.fn.Param))
+		}
+	}
+	return nil
+}
+
+// Invoke calls SplitRestriction given a FullValue containing an element and
+// the associated restriction, and returns a slice of split restrictions.
+func (n *srInvoker) Invoke(elms *FullValue, rest interface{}) (splits []interface{}) {
+	ret := n.call(elms, rest)
+
+	// Return value is an interface{}, but we need to convert it to a []interface{}.
+	val := reflect.ValueOf(ret)
+	s := make([]interface{}, 0, val.Len())
+	for i := 0; i < val.Len(); i++ {
+		s = append(s, val.Index(i).Interface())
+	}
+	return s
+}
+
+// Reset zeroes argument entries in the cached slice to allow values to be
+// garbage collected after the bundle ends.
+func (n *srInvoker) Reset() {
+	for i := range n.args {
+		n.args[i] = nil
+	}
+}
+
+// rsInvoker is an invoker for RestrictionSize.
+type rsInvoker struct {
+	fn   *funcx.Fn
+	args []interface{} // Cache to avoid allocating new slices per-element.
+	call func(elms *FullValue, rest interface{}) (size float64)
+}
+
+func newRestrictionSizeInvoker(fn *funcx.Fn) (*rsInvoker, error) {
+	n := &rsInvoker{
+		fn:   fn,
+		args: make([]interface{}, len(fn.Param)),
+	}
+	if err := n.initCallFn(); err != nil {
+		return nil, errors.WithContext(err, "sdf RestrictionSize invoker")
+	}
+	return n, nil
+}
+
+func (n *rsInvoker) initCallFn() error {
+	// Expects a signature of the form:
+	// (key?, value, restriction) float64
+	// TODO(BEAM-9643): Link to full documentation.
+	switch fnT := n.fn.Fn.(type) {
+	case reflectx.Func2x1:
+		n.call = func(elms *FullValue, rest interface{}) float64 {
+			return fnT.Call2x1(elms.Elm, rest).(float64)
+		}
+	case reflectx.Func3x1:
+		n.call = func(elms *FullValue, rest interface{}) float64 {
+			return fnT.Call3x1(elms.Elm, elms.Elm2, rest).(float64)
+		}
+	default:
+		switch len(n.fn.Param) {
+		case 2:
+			n.call = func(elms *FullValue, rest interface{}) float64 {
+				n.args[0] = elms.Elm
+				n.args[1] = rest
+				return n.fn.Fn.Call(n.args)[0].(float64)
+			}
+		case 3:
+			n.call = func(elms *FullValue, rest interface{}) float64 {
+				n.args[0] = elms.Elm
+				n.args[1] = elms.Elm2
+				n.args[2] = rest
+				return n.fn.Fn.Call(n.args)[0].(float64)
+			}
+		default:
+			return errors.Errorf("RestrictionSize fn %v has unexpected number of parameters: %v",
+				n.fn.Fn.Name(), len(n.fn.Param))
+		}
+	}
+	return nil
+}
+
+// Invoke calls RestrictionSize given a FullValue containing an element and
+// the associated restriction, and returns a size.
+func (n *rsInvoker) Invoke(elms *FullValue, rest interface{}) (size float64) {
+	return n.call(elms, rest)
+}
+
+// Reset zeroes argument entries in the cached slice to allow values to be
+// garbage collected after the bundle ends.
+func (n *rsInvoker) Reset() {
+	for i := range n.args {
+		n.args[i] = nil
+	}
+}
+
+// ctInvoker is an invoker for CreateTracker.
+type ctInvoker struct {
+	fn   *funcx.Fn
+	args []interface{} // Cache to avoid allocating new slices per-element.
+	call func(rest interface{}) sdf.RTracker
+}
+
+func newCreateTrackerInvoker(fn *funcx.Fn) (*ctInvoker, error) {
+	n := &ctInvoker{
+		fn:   fn,
+		args: make([]interface{}, len(fn.Param)),
+	}
+	if err := n.initCallFn(); err != nil {
+		return nil, errors.WithContext(err, "sdf CreateTracker invoker")
+	}
+	return n, nil
+}
+
+func (n *ctInvoker) initCallFn() error {
+	// Expects a signature of the form:
+	// (restriction) sdf.RTracker
+	// TODO(BEAM-9643): Link to full documentation.
+	switch fnT := n.fn.Fn.(type) {
+	case reflectx.Func1x1:
+		n.call = func(rest interface{}) sdf.RTracker {
+			return fnT.Call1x1(rest).(sdf.RTracker)
+		}
+	default:
+		if len(n.fn.Param) != 1 {
+			return errors.Errorf("CreateTracker fn %v has unexpected number of parameters: %v",
+				n.fn.Fn.Name(), len(n.fn.Param))
+		}
+		n.call = func(rest interface{}) sdf.RTracker {
+			n.args[0] = rest
+			return n.fn.Fn.Call(n.args)[0].(sdf.RTracker)
+		}
+	}
+	return nil
+}
+
+// Invoke calls CreateTracker given a restriction and returns an sdf.RTracker.
+func (n *ctInvoker) Invoke(rest interface{}) sdf.RTracker {
+	return n.call(rest)
+}
+
+// Reset zeroes argument entries in the cached slice to allow values to be
+// garbage collected after the bundle ends.
+func (n *ctInvoker) Reset() {
+	for i := range n.args {
+		n.args[i] = nil
+	}
+}

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
@@ -1,0 +1,279 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+// TestInvokes runs tests on each SDF method invoker, using the SDFs defined
+// in this file. Tests both single-element and KV element cases.
+func TestInvokes(t *testing.T) {
+	// Setup.
+	dfn, err := graph.NewDoFn(&Sdf{}, graph.NumMainInputs(graph.MainSingle))
+	if err != nil {
+		t.Fatalf("invalid function: %v", err)
+	}
+	sdf := (*graph.SplittableDoFn)(dfn)
+
+	dfn, err = graph.NewDoFn(&KvSdf{}, graph.NumMainInputs(graph.MainKv))
+	if err != nil {
+		t.Fatalf("invalid function: %v", err)
+	}
+	kvsdf := (*graph.SplittableDoFn)(dfn)
+
+	// Tests.
+	t.Run("createInitialRestrictionCallFn", func(t *testing.T) {
+		tests := []struct {
+			name string
+			sdf  *graph.SplittableDoFn
+			elms *FullValue
+			want Restriction
+		}{
+			{"SingleElem", sdf, &FullValue{Elm: 5}, Restriction{5}},
+			{"KvElem", kvsdf, &FullValue{Elm: 5, Elm2: 2}, Restriction{7}},
+		}
+		for _, test := range tests {
+			test := test
+			fn := test.sdf.CreateInitialRestrictionFn()
+			t.Run(test.name, func(t *testing.T) {
+				invoker, err := newCreateInitialRestrictionInvoker(fn)
+				if err != nil {
+					t.Fatalf("newCreateInitialRestrictionInvoker failed: %v", err)
+				}
+				got := invoker.Invoke(test.elms)
+				if !cmp.Equal(got, test.want) {
+					t.Errorf("Invoke(%v) has incorrect output: got: %v, want: %v",
+						test.elms, got, test.want)
+				}
+				invoker.Reset()
+				for i, arg := range invoker.args {
+					if arg != nil {
+						t.Errorf("Reset() failed to empty all args. args[%v] = %v", i, arg)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("invokeSplitRestriction", func(t *testing.T) {
+		tests := []struct {
+			name string
+			sdf  *graph.SplittableDoFn
+			elms *FullValue
+			rest Restriction
+			want []interface{}
+		}{
+			{
+				"SingleElem",
+				sdf,
+				&FullValue{Elm: 5},
+				Restriction{3},
+				[]interface{}{Restriction{8}, Restriction{9}},
+			}, {
+				"KvElem",
+				kvsdf,
+				&FullValue{Elm: 5, Elm2: 2},
+				Restriction{3},
+				[]interface{}{Restriction{8}, Restriction{5}},
+			},
+		}
+		for _, test := range tests {
+			test := test
+			fn := test.sdf.SplitRestrictionFn()
+			t.Run(test.name, func(t *testing.T) {
+				invoker, err := newSplitRestrictionInvoker(fn)
+				if err != nil {
+					t.Fatalf("newSplitRestrictionInvoker failed: %v", err)
+				}
+				got := invoker.Invoke(test.elms, test.rest)
+				if !cmp.Equal(got, test.want) {
+					t.Errorf("Invoke(%v, %v) has incorrect output: got: %v, want: %v",
+						test.elms, test.rest, got, test.want)
+				}
+				invoker.Reset()
+				for i, arg := range invoker.args {
+					if arg != nil {
+						t.Errorf("Reset() failed to empty all args. args[%v] = %v", i, arg)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("invokeRestrictionSize", func(t *testing.T) {
+		tests := []struct {
+			name string
+			sdf  *graph.SplittableDoFn
+			elms *FullValue
+			rest Restriction
+			want float64
+		}{
+			{
+				"SingleElem",
+				sdf,
+				&FullValue{Elm: 5},
+				Restriction{3},
+				8,
+			}, {
+				"KvElem",
+				kvsdf,
+				&FullValue{Elm: 5, Elm2: 2},
+				Restriction{3},
+				10,
+			},
+		}
+		for _, test := range tests {
+			test := test
+			fn := test.sdf.RestrictionSizeFn()
+			t.Run(test.name, func(t *testing.T) {
+				invoker, err := newRestrictionSizeInvoker(fn)
+				if err != nil {
+					t.Fatalf("newRestrictionSizeInvoker failed: %v", err)
+				}
+				got := invoker.Invoke(test.elms, test.rest)
+				if !cmp.Equal(got, test.want) {
+					t.Errorf("Invoke(%v, %v) has incorrect output: got: %v, want: %v",
+						test.elms, test.rest, got, test.want)
+				}
+			})
+		}
+	})
+
+	t.Run("invokeCreateTracker", func(t *testing.T) {
+		tests := []struct {
+			name string
+			sdf  *graph.SplittableDoFn
+			rest Restriction
+			want *RTracker
+		}{
+			{
+				"SingleElem",
+				sdf,
+				Restriction{3},
+				&RTracker{
+					Restriction{3},
+					1,
+				},
+			}, {
+				"KvElem",
+				kvsdf,
+				Restriction{5},
+				&RTracker{
+					Restriction{5},
+					2,
+				},
+			},
+		}
+		for _, test := range tests {
+			test := test
+			fn := test.sdf.CreateTrackerFn()
+			t.Run(test.name, func(t *testing.T) {
+				invoker, err := newCreateTrackerInvoker(fn)
+				if err != nil {
+					t.Fatalf("newCreateTrackerInvoker failed: %v", err)
+				}
+				got := invoker.Invoke(test.rest)
+				if !cmp.Equal(got, test.want) {
+					t.Errorf("Invoke(%v) has incorrect output: got: %v, want: %v",
+						test.rest, got, test.want)
+				}
+			})
+		}
+	})
+}
+
+type Restriction struct {
+	Val int
+}
+
+// RTracker's methods can all be no-ops, we just need it to implement sdf.RTracker.
+type RTracker struct {
+	Rest Restriction
+	Val  int
+}
+
+func (rt *RTracker) TryClaim(interface{}) bool                      { return false }
+func (rt *RTracker) GetError() error                                { return nil }
+func (rt *RTracker) TrySplit(fraction float64) (interface{}, error) { return nil, nil }
+func (rt *RTracker) GetProgress() float64                           { return 0 }
+func (rt *RTracker) IsDone() bool                                   { return false }
+
+// In order to test that these methods get called properly, each one has an
+// implementation that lets us confirm that each argument was passed properly.
+
+type Sdf struct {
+}
+
+// CreateInitialRestriction creates a restriction with the given value.
+func (fn *Sdf) CreateInitialRestriction(i int) Restriction {
+	return Restriction{i}
+}
+
+// SplitRestriction outputs two restrictions, the first containing the sum of i
+// and rest.Val, the second containing the same value plus 1.
+func (fn *Sdf) SplitRestriction(i int, rest Restriction) []Restriction {
+	return []Restriction{{rest.Val + i}, {rest.Val + i + 1}}
+}
+
+// RestrictionSize returns the sum of i and rest.Val as a float64.
+func (fn *Sdf) RestrictionSize(i int, rest Restriction) float64 {
+	return (float64)(i + rest.Val)
+}
+
+// CreateTracker creates an RTracker containing the given restriction and a Val
+// of 1.
+func (fn *Sdf) CreateTracker(rest Restriction) *RTracker {
+	return &RTracker{rest, 1}
+}
+
+// ProcessElement is a no-op, it's only included to pass validation.
+func (fn *Sdf) ProcessElement(*RTracker, int) int {
+	return 0
+}
+
+type KvSdf struct {
+}
+
+// CreateInitialRestriction creates a restriction with the sum of the given
+// values.
+func (fn *KvSdf) CreateInitialRestriction(i int, j int) Restriction {
+	return Restriction{i + j}
+}
+
+// SplitRestriction outputs two restrictions, the first containing the sum of i
+// and rest.Val, the second containing the sum of j and rest.Val.
+func (fn *KvSdf) SplitRestriction(i int, j int, rest Restriction) []Restriction {
+	return []Restriction{{rest.Val + i}, {rest.Val + j}}
+}
+
+// RestrictionSize returns the sum of i, j, and rest.Val as a float64.
+func (fn *KvSdf) RestrictionSize(i int, j int, rest Restriction) float64 {
+	return (float64)(i + j + rest.Val)
+}
+
+// CreateTracker creates an RTracker containing the given restriction and a Val
+// of 2.
+func (fn *KvSdf) CreateTracker(rest Restriction) *RTracker {
+	return &RTracker{rest, 2}
+}
+
+// ProcessElement is a no-op, it's only included to pass validation.
+func (fn *KvSdf) ProcessElement(*RTracker, int, int) int {
+	return 0
+}


### PR DESCRIPTION
This is just a first pass, and I now realize that I can do a bunch
more to optimize this for execution time, but that will come in a
subsequent commit probably. For now, this commit adds SDF method
invokers that have functioning unit tests. Next stage will be trying to
get it to return a function, so we can avoid a lot of the unnecessary
code that's currently getting executed once per element, like the switch
statements.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
