### PR TITLE
[BEAM-9571] Add withMongoClientProvider to MongoDbIO

### DIFF
--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/DefaultMongoClientProvider.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/DefaultMongoClientProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.mongodb;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
+import javax.net.ssl.SSLContext;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+
+class DefaultMongoClientProvider implements SerializableFunction<Void, MongoClient> {
+  private String uri;
+  private int maxConnectionIdleTime;
+  private boolean sslEnabled;
+  private boolean sslInvalidHostNameAllowed;
+  private boolean ignoreSSLCertificate;
+
+  private DefaultMongoClientProvider(
+      String uri,
+      int maxConnectionIdleTime,
+      boolean sslEnabled,
+      boolean sslInvalidHostNameAllowed,
+      boolean ignoreSSLCertificate) {
+    this.uri = uri;
+    this.maxConnectionIdleTime = maxConnectionIdleTime;
+    this.sslEnabled = sslEnabled;
+    this.sslInvalidHostNameAllowed = sslInvalidHostNameAllowed;
+    this.ignoreSSLCertificate = ignoreSSLCertificate;
+  }
+
+  static DefaultMongoClientProvider of(
+      String uri,
+      int maxConnectionIdleTime,
+      boolean sslEnabled,
+      boolean sslInvalidHostNameAllowed,
+      boolean ignoreSSLCertificate) {
+    return new DefaultMongoClientProvider(
+        uri, maxConnectionIdleTime, sslEnabled, sslInvalidHostNameAllowed, ignoreSSLCertificate);
+  }
+
+  @Override
+  public MongoClient apply(Void input) {
+    MongoClientOptions.Builder optionsBuilder = new MongoClientOptions.Builder();
+    optionsBuilder.maxConnectionIdleTime(maxConnectionIdleTime);
+    if (sslEnabled) {
+      optionsBuilder.sslEnabled(sslEnabled).sslInvalidHostNameAllowed(sslInvalidHostNameAllowed);
+      if (ignoreSSLCertificate) {
+        SSLContext sslContext = SSLUtils.ignoreSSLCertificate();
+        optionsBuilder.sslContext(sslContext);
+        optionsBuilder.socketFactory(sslContext.getSocketFactory());
+      }
+    }
+    return new MongoClient(new MongoClientURI(uri, optionsBuilder));
+  }
+}


### PR DESCRIPTION
This introduces the option so users can configure their MongoClients at will, as discussed in #11186 PTAL
R: @alexvanboxel 