### PR TITLE
Use attachValues in SQL

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlPipelineOptions.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlPipelineOptions.java
@@ -29,4 +29,10 @@ public interface BeamSqlPipelineOptions extends PipelineOptions {
   String getPlannerName();
 
   void setPlannerName(String className);
+
+  @Description("Enables extra verification of row values for debugging.")
+  @Default.Boolean(false)
+  Boolean getVerifyRowValues();
+
+  void setVerifyRowValues(Boolean verifyRowValues);
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
@@ -24,6 +24,7 @@ import static org.apache.beam.vendor.calcite.v1_20_0.com.google.common.base.Prec
 import java.io.Serializable;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.extensions.sql.impl.BeamSqlPipelineOptions;
 import org.apache.beam.sdk.extensions.sql.impl.planner.BeamCostModel;
 import org.apache.beam.sdk.extensions.sql.impl.planner.NodeStats;
 import org.apache.beam.sdk.extensions.sql.impl.transform.agg.AggregationCombineFnAdapter;
@@ -280,9 +281,13 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
         ignoreValues = true;
       }
 
+      boolean verifyRowValues =
+          pinput.getPipeline().getOptions().as(BeamSqlPipelineOptions.class).getVerifyRowValues();
       return windowedStream
           .apply(combiner)
-          .apply("mergeRecord", ParDo.of(mergeRecord(outputSchema, windowFieldIndex, ignoreValues)))
+          .apply(
+              "mergeRecord",
+              ParDo.of(mergeRecord(outputSchema, windowFieldIndex, ignoreValues, verifyRowValues)))
           .setRowSchema(outputSchema);
     }
 
@@ -324,7 +329,10 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
     }
 
     static DoFn<Row, Row> mergeRecord(
-        Schema outputSchema, int windowStartFieldIndex, boolean ignoreValues) {
+        Schema outputSchema,
+        int windowStartFieldIndex,
+        boolean ignoreValues,
+        boolean verifyRowValues) {
       return new DoFn<Row, Row>() {
         @ProcessElement
         public void processElement(
@@ -343,7 +351,11 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
             fieldValues.add(windowStartFieldIndex, ((IntervalWindow) window).start());
           }
 
-          o.output(Row.withSchema(outputSchema).attachValues(fieldValues));
+          Row row =
+              verifyRowValues
+                  ? Row.withSchema(outputSchema).addValues(fieldValues).build()
+                  : Row.withSchema(outputSchema).attachValues(fieldValues);
+          o.output(row);
         }
       };
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
@@ -343,7 +343,7 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
             fieldValues.add(windowStartFieldIndex, ((IntervalWindow) window).start());
           }
 
-          o.output(Row.withSchema(outputSchema).addValues(fieldValues).build());
+          o.output(Row.withSchema(outputSchema).attachValues(fieldValues));
         }
       };
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -166,7 +166,7 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
               new InputGetterImpl(input, upstream.getSchema()),
               null);
 
-      // Expressions.call is equivalent to: output = Row.withSchema(outputSchema)
+      // Expressions.call is equivalent to: Lists.newArrayListWithCapacity();
       Expression valueList =
           Expressions.call(
               Lists.class, "newArrayListWithCapacity", Expressions.constant(expressions.size()));
@@ -179,9 +179,10 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
         valueList = Expressions.call(value, addToList, castOutput(value, toType));
       }
 
+      // Expressions.call is equivalent to: output =
+      // Row.withSchema(outputSchema).attachValue(values);
       Expression output = Expressions.call(Row.class, "withSchema", outputSchemaParam);
       Method attachValues = Types.lookupMethod(Row.Builder.class, "attachValues", List.class);
-      // Expressions.call is equivalent to: .attachValues(<list>);
       output = Expressions.call(output, attachValues, valueList);
 
       builder.add(

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -278,7 +278,7 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
     Expression returnValue = value;
     if (value.getType() == Object.class || !(value.getType() instanceof Class)) {
       // fast copy path, just pass object through
-      return returnValue = value;
+      returnValue = value;
     } else if (CalciteUtils.isDateTimeType(toType)
         && !Types.isAssignableFrom(ReadableInstant.class, (Class) value.getType())) {
       returnValue = castOutputTime(value, toType);

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
@@ -29,6 +29,7 @@ import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.extensions.sql.impl.BeamSqlPipelineOptions;
 import org.apache.beam.sdk.extensions.sql.impl.rel.AbstractBeamCalcRel;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.extensions.sql.meta.provider.bigquery.BeamBigQuerySqlDialect;
@@ -102,13 +103,16 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
               .collect(Collectors.toList());
       final RexNode condition = getProgram().getCondition();
 
+      boolean verifyRowValues =
+          pinput.getPipeline().getOptions().as(BeamSqlPipelineOptions.class).getVerifyRowValues();
       Schema outputSchema = CalciteUtils.toSchema(getRowType());
       CalcFn calcFn =
           new CalcFn(
               projects,
               condition == null ? null : unparseRexNode(condition),
               upstream.getSchema(),
-              outputSchema);
+              outputSchema,
+              verifyRowValues);
 
       // validate prepared expressions
       calcFn.setup();
@@ -130,6 +134,7 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
     @Nullable private final String condition;
     private final Schema inputSchema;
     private final Schema outputSchema;
+    private final boolean verifyRowValues;
     private transient List<PreparedExpression> projectExps;
     @Nullable private transient PreparedExpression conditionExp;
 
@@ -137,12 +142,14 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
         List<String> projects,
         @Nullable String condition,
         Schema inputSchema,
-        Schema outputSchema) {
+        Schema outputSchema,
+        boolean verifyRowValues) {
       Preconditions.checkArgument(projects.size() == outputSchema.getFieldCount());
       this.projects = ImmutableList.copyOf(projects);
       this.condition = condition;
       this.inputSchema = inputSchema;
       this.outputSchema = outputSchema;
+      this.verifyRowValues = verifyRowValues;
     }
 
     @Setup
@@ -190,9 +197,15 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
       for (int i = 0; i < outputSchema.getFieldCount(); i++) {
         // TODO[BEAM-8630]: performance optimization by bundling the gRPC calls
         Value v = projectExps.get(i).execute(columns, params);
-        values.add(ZetaSqlUtils.zetaSqlValueToJavaObject(v, outputSchema.getField(i).getType()));
+        values.add(
+            ZetaSqlUtils.zetaSqlValueToJavaObject(
+                v, outputSchema.getField(i).getType(), verifyRowValues));
       }
-      c.output(Row.withSchema(outputSchema).attachValues(values));
+      Row outputRow =
+          verifyRowValues
+              ? Row.withSchema(outputSchema).addValues(values).build()
+              : Row.withSchema(outputSchema).attachValues(values);
+      c.output(outputRow);
     }
 
     @Teardown

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
@@ -53,6 +53,7 @@ import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.SqlNode;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 
 /**
  * BeamRelNode to replace {@code Project} and {@code Filter} node based on the {@code ZetaSQL}
@@ -186,13 +187,14 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
       }
 
       Row.Builder output = Row.withSchema(outputSchema);
+      List<Object> values = Lists.newArrayListWithExpectedSize(outputSchema.getFieldCount());
       for (int i = 0; i < outputSchema.getFieldCount(); i++) {
         // TODO[BEAM-8630]: performance optimization by bundling the gRPC calls
         Value v = projectExps.get(i).execute(columns, params);
-        output.addValue(
+        values.add(
             ZetaSqlUtils.zetaSqlValueToJavaObject(v, outputSchema.getField(i).getType()));
       }
-      c.output(output.build());
+      c.output(Row.withSchema(outputSchema).attachValues(values));
     }
 
     @Teardown

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
@@ -186,13 +186,11 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
         return;
       }
 
-      Row.Builder output = Row.withSchema(outputSchema);
       List<Object> values = Lists.newArrayListWithExpectedSize(outputSchema.getFieldCount());
       for (int i = 0; i < outputSchema.getFieldCount(); i++) {
         // TODO[BEAM-8630]: performance optimization by bundling the gRPC calls
         Value v = projectExps.get(i).execute(columns, params);
-        values.add(
-            ZetaSqlUtils.zetaSqlValueToJavaObject(v, outputSchema.getField(i).getType()));
+        values.add(ZetaSqlUtils.zetaSqlValueToJavaObject(v, outputSchema.getField(i).getType()));
       }
       c.output(Row.withSchema(outputSchema).attachValues(values));
     }

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
@@ -239,6 +239,6 @@ public final class ZetaSqlUtils {
     for (int i = 0; i < values.size(); i++) {
       objects.add(zetaSqlValueToJavaObject(values.get(i), schema.getField(i).getType()));
     }
-    return Row.withSchema(schema).addValues(objects).build();
+    return Row.withSchema(schema).attachValues(objects);
   }
 }

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
@@ -188,7 +188,8 @@ public final class ZetaSqlUtils {
     return Value.createStructValue(createZetaSqlStructTypeFromBeamSchema(schema), values);
   }
 
-  public static Object zetaSqlValueToJavaObject(Value value, FieldType fieldType) {
+  public static Object zetaSqlValueToJavaObject(
+      Value value, FieldType fieldType, boolean verifyValues) {
     if (value.isNull()) {
       return null;
     }
@@ -213,9 +214,10 @@ public final class ZetaSqlUtils {
       case BYTES:
         return value.getBytesValue().toByteArray();
       case ARRAY:
-        return zetaSqlArrayValueToJavaList(value, fieldType.getCollectionElementType());
+        return zetaSqlArrayValueToJavaList(
+            value, fieldType.getCollectionElementType(), verifyValues);
       case ROW:
-        return zetaSqlStructValueToBeamRow(value, fieldType.getRowSchema());
+        return zetaSqlStructValueToBeamRow(value, fieldType.getRowSchema(), verifyValues);
       default:
         throw new UnsupportedOperationException(
             "Unsupported Beam fieldType: " + fieldType.getTypeName());
@@ -227,18 +229,25 @@ public final class ZetaSqlUtils {
     return Instant.ofEpochMilli(millis);
   }
 
-  private static List<Object> zetaSqlArrayValueToJavaList(Value arrayValue, FieldType elementType) {
+  private static List<Object> zetaSqlArrayValueToJavaList(
+      Value arrayValue, FieldType elementType, boolean verifyValues) {
     return arrayValue.getElementList().stream()
-        .map(e -> zetaSqlValueToJavaObject(e, elementType))
+        .map(e -> zetaSqlValueToJavaObject(e, elementType, verifyValues))
         .collect(Collectors.toList());
   }
 
-  private static Row zetaSqlStructValueToBeamRow(Value structValue, Schema schema) {
+  private static Row zetaSqlStructValueToBeamRow(
+      Value structValue, Schema schema, boolean verifyValues) {
     List<Object> objects = new ArrayList<>(schema.getFieldCount());
     List<Value> values = structValue.getFieldList();
     for (int i = 0; i < values.size(); i++) {
-      objects.add(zetaSqlValueToJavaObject(values.get(i), schema.getField(i).getType()));
+      objects.add(
+          zetaSqlValueToJavaObject(values.get(i), schema.getField(i).getType(), verifyValues));
     }
-    return Row.withSchema(schema).attachValues(objects);
+    Row row =
+        verifyValues
+            ? Row.withSchema(schema).addValues(objects).build()
+            : Row.withSchema(schema).attachValues(objects);
+    return row;
   }
 }

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
@@ -4061,7 +4061,6 @@ public class ZetaSQLDialectSpecTest {
         "AVG(LONG) is not supported. You might want to use AVG(CAST(expression AS DOUBLE).");
     zetaSQLQueryPlanner.convertToBeamRel(sql);
   }
-
   @Test
   public void testReverseString() {
     String sql = "SELECT REVERSE('abc');";

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
@@ -4061,6 +4061,7 @@ public class ZetaSQLDialectSpecTest {
         "AVG(LONG) is not supported. You might want to use AVG(CAST(expression AS DOUBLE).");
     zetaSQLQueryPlanner.convertToBeamRel(sql);
   }
+
   @Test
   public void testReverseString() {
     String sql = "SELECT REVERSE('abc');";

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtilsTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtilsTest.java
@@ -127,6 +127,7 @@ public class ZetaSqlUtilsTest {
 
   @Test
   public void testZetaSqlValueToJavaObject() {
-    assertEquals(ZetaSqlUtils.zetaSqlValueToJavaObject(TEST_VALUE, TEST_FIELD_TYPE), TEST_ROW);
+    assertEquals(
+        ZetaSqlUtils.zetaSqlValueToJavaObject(TEST_VALUE, TEST_FIELD_TYPE, true), TEST_ROW);
   }
 }


### PR DESCRIPTION
Use the more efficient attachValues when building rows in SQL. addValues does a deep copy of the parameter, while addValue does not. We have also recently made API improvements that makes addValues slightly less efficient, so this allows SQL to bypass that.

We are not using attachValues on any of the IOs. This is strictly for internal rows generated by SQL.