### PR TITLE
[BEAM-9496] Add to_dataframe and to_pcollection APIs.

### DIFF
--- a/sdks/python/apache_beam/dataframe/convert.py
+++ b/sdks/python/apache_beam/dataframe/convert.py
@@ -30,6 +30,7 @@ def to_dataframe(
     proxy,  # type: pandas.core.generic.NDFrame
 ):
   # type: (...) -> frame_base.DeferredFrame
+
   """Convers a PCollection to a deferred dataframe-like object, which can
   manipulated with pandas methods like `filter` and `groupby`.
 
@@ -51,6 +52,7 @@ def to_pcollection(
     *dataframes,  # type: Tuple[frame_base.DeferredFrame]
     **kwargs):
   # type: (...) -> Union[pvalue.PCollection, Tuple[pvalue.PCollection]]
+
   """Converts one or more deferred dataframe-like objects back to a PCollection.
 
   This method creates and applies the actual Beam operations that compute

--- a/sdks/python/apache_beam/dataframe/convert.py
+++ b/sdks/python/apache_beam/dataframe/convert.py
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import inspect
+
+from apache_beam import pvalue
+from apache_beam.dataframe import expressions
+from apache_beam.dataframe import frame_base
+from apache_beam.dataframe import transforms
+
+
+def to_dataframe(pc):
+  pass
+
+
+# TODO: Or should this be called as_dataframe?
+def to_dataframe(pcoll, proxy):
+  return frame_base.DeferredFrame.wrap(
+      expressions.PlaceholderExpression(proxy, pcoll))
+
+
+# TODO: Or should this be called from_dataframe?
+def to_pcollection(*dataframes, **kwargs):
+  label = kwargs.pop('label', None)
+  assert not kwargs  # TODO(Py3): Use PEP 3102
+  if label is None:
+    # Attempt to come up with a reasonable, stable label.
+    previous_frame = inspect.currentframe().f_back
+
+    def name(obj):
+      for key, value in previous_frame.f_locals.items():
+        if obj is value:
+          return key
+      for key, value in previous_frame.f_globals.items():
+        if obj is value:
+          return key
+      else:
+        return '...'
+
+    label = 'ToDataframe(%s)' % ', '.join(name(e) for e in dataframes)
+
+  def extract_input(placeholder):
+    if not isinstance(placeholder._reference, pvalue.PCollection):
+      raise TypeError(
+          'Expression roots must have been created with to_dataframe.')
+    return placeholder._reference
+
+  placeholders = frozenset.union(
+      frozenset(), *[df._expr.placeholders() for df in dataframes])
+  results = {p: extract_input(p)
+             for p in placeholders
+             } | label >> transforms.DataframeExpressionsTransform(
+                 dict((ix, df._expr) for ix, df in enumerate(dataframes)))
+  if len(results) == 1:
+    return results[0]
+  else:
+    return tuple(value for key, value in sorted(results.items()))

--- a/sdks/python/apache_beam/dataframe/convert.py
+++ b/sdks/python/apache_beam/dataframe/convert.py
@@ -49,8 +49,7 @@ def to_pcollection(*dataframes, **kwargs):
       for key, value in previous_frame.f_globals.items():
         if obj is value:
           return key
-      else:
-        return '...'
+      return '...'
 
     label = 'ToDataframe(%s)' % ', '.join(name(e) for e in dataframes)
 

--- a/sdks/python/apache_beam/dataframe/convert_test.py
+++ b/sdks/python/apache_beam/dataframe/convert_test.py
@@ -58,3 +58,7 @@ class ConverTest(unittest.TestCase):
       assert_that(pc_2a, equal_to_unordered_series(2 * a), label='Check2a')
       assert_that(pc_3a, equal_to_unordered_series(3 * a), label='Check3a')
       assert_that(pc_ab, equal_to_unordered_series(a * b), label='Checkab')
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/dataframe/convert_test.py
+++ b/sdks/python/apache_beam/dataframe/convert_test.py
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import unittest
+
+import pandas as pd
+
+import apache_beam as beam
+from apache_beam.dataframe import convert
+from apache_beam.testing.util import assert_that
+
+
+class ConverTest(unittest.TestCase):
+  def test_convert(self):
+    def equal_to_unordered_series(expected):
+      def check(actual):
+        actual = pd.concat(actual)
+        if sorted(expected) != sorted(actual):
+          raise AssertionError(
+              'Series not equal: \n%s\n%s\n' % (expected, actual))
+
+      return check
+
+    with beam.Pipeline() as p:
+      a = pd.Series([1, 2, 3])
+      b = pd.Series([100, 200, 300])
+
+      pc_a = p | 'A' >> beam.Create([a])
+      pc_b = p | 'B' >> beam.Create([b])
+
+      df_a = convert.to_dataframe(pc_a, proxy=a[:0])
+      df_b = convert.to_dataframe(pc_b, proxy=b[:0])
+
+      df_2a = 2 * df_a
+      df_3a = 3 * df_a
+      df_ab = df_a * df_b
+
+      # Converting multiple results at a time can be more efficient.
+      pc_2a, pc_ab = convert.to_pcollection(df_2a, df_ab)
+      # But separate conversions can be done as well.
+      pc_3a = convert.to_pcollection(df_3a)
+
+      assert_that(pc_2a, equal_to_unordered_series(2 * a), label='Check2a')
+      assert_that(pc_3a, equal_to_unordered_series(3 * a), label='Check3a')
+      assert_that(pc_ab, equal_to_unordered_series(a * b), label='Checkab')

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -20,6 +20,7 @@ import pandas as pd
 
 import apache_beam as beam
 from apache_beam import transforms
+from apache_beam.dataframe import convert
 from apache_beam.dataframe import expressions
 from apache_beam.dataframe import frame_base
 from apache_beam.dataframe import frames  # pylint: disable=unused-import
@@ -42,61 +43,35 @@ class DataframeTransform(transforms.PTransform):
     self._proxy = proxy
 
   def expand(self, input_pcolls):
-    def wrap_as_dict(values):
-      if isinstance(values, dict):
-        return values
-      elif isinstance(values, tuple):
-        return dict(enumerate(values))
-      else:
-        return {None: values}
+    # Convert inputs to a flat dict.
+    input_dict = _flatten(input_pcolls)  # type: Dict[Any, PCollection]
+    proxies = _flatten(self._proxy)
+    input_frames = {
+        k: convert.to_dataframe(pc, proxies[k])
+        for k, pc in input_dict.items()
+    }  # type: Dict[Any, DeferredFrame]
 
-    # TODO: Infer the proxy from the input schema.
-    def proxy(key):
-      if key is None:
-        return self._proxy
-      else:
-        return self._proxy[key]
-
-    # The input can be a dictionary, tuple, or plain PCollection.
-    # Wrap as a dict for homogeneity.
-    # TODO: Possibly inject batching here.
-    input_dict = wrap_as_dict(input_pcolls)
-    placeholders = {
-        key: frame_base.DeferredFrame.wrap(
-            expressions.PlaceholderExpression(proxy(key)))
-        for key in input_dict.keys()
-    }
-
-    # The calling convention of the user-supplied func varies according to the
-    # type of the input.
-    if isinstance(input_pcolls, dict):
-      result_frames = self._func(**placeholders)
-    elif isinstance(input_pcolls, tuple):
-      result_frames = self._func(
-          *(value for _, value in sorted(placeholders.items())))
+    # Apply the function.
+    frames_input = _substitute(input_pcolls, input_frames)
+    if isinstance(frames_input, dict):
+      result_frames = self._func(**frames_input)
+    elif isinstance(frames_input, tuple):
+      result_frames = self._func(*frames_input)
     else:
-      result_frames = self._func(placeholders[None])
+      result_frames = self._func(frames_input)
 
-    # Likewise the output may be a dict, tuple, or raw (deferred) Dataframe.
-    result_dict = wrap_as_dict(result_frames)
+    # Compute results as a tuple.
+    result_frames_dict = _flatten(result_frames)
+    keys, result_frames_tuple = list(zip(*result_frames_dict.items()))
+    result_pcolls_tuple = convert.to_pcollection(
+        *result_frames_tuple, label='Eval', always_return_tuple=True)
 
-    result_pcolls = {
-        placeholders[key]._expr: pcoll
-        for key, pcoll in input_dict.items()
-    } | 'Eval' >> DataframeExpressionsTransform(
-        {key: df._expr
-         for key, df in result_dict.items()})
-
-    # Convert the result back into a set of PCollections.
-    if isinstance(result_frames, dict):
-      return result_pcolls
-    elif isinstance(result_frames, tuple):
-      return tuple((value for _, value in sorted(result_pcolls.items())))
-    else:
-      return result_pcolls[None]
+    # Convert back to the structure returned by self._func.
+    result_pcolls_dict = dict(zip(keys, result_pcolls_tuple))
+    return _substitute(result_frames, result_pcolls_dict)
 
 
-class DataframeExpressionsTransform(transforms.PTransform):
+class _DataframeExpressionsTransform(transforms.PTransform):
   def __init__(self, outputs):
     self._outputs = outputs
 
@@ -262,3 +237,53 @@ def memoize(f):
     return cache[args]
 
   return wrapper
+
+
+def _dict_union(dicts):
+  result = {}
+  for d in dicts:
+    result.update(d)
+  return result
+
+
+def _flatten(valueish, root=()):
+  """Given a nested structure of dicts, tuples, and lists, return a flat
+  dictionary where the values are the leafs and the keys are the "paths" to
+  these leaves.
+
+  For example `{a: x, b: (y, z)}` becomes `{(a,): x, (b, 0): y, (b, 1): c}`.
+  """
+  if isinstance(valueish, dict):
+    return _dict_union(_flatten(v, root + (k, )) for k, v in valueish.items())
+  elif isinstance(valueish, (tuple, list)):
+    return _dict_union(
+        _flatten(v, root + (ix, )) for ix, v in enumerate(valueish))
+  else:
+    return {root: valueish}
+
+
+def _substitute(valueish, replacements, root=()):
+  """Substitutes the values in valueish with those in replacements where the
+  keys are as in _flatten.
+
+  For example,
+
+  ```
+  _substitute(
+      {a: x, b: (y, z)},
+      {(a,): X, (b, 0): Y, (b, 1): Z})
+  ```
+
+  returns `{a: X, b: (Y, Z)}`.
+  """
+  if isinstance(valueish, dict):
+    return type(valueish)({
+        k: _substitute(v, replacements, root + (k, ))
+        for (k, v) in valueish.items()
+    })
+  elif isinstance(valueish, (tuple, list)):
+    return type(valueish)((
+        _substitute(v, replacements, root + (ix, ))
+        for (ix, v) in enumerate(valueish)))
+  else:
+    return replacements[root]

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 import apache_beam as beam
 from apache_beam import transforms
-from apache_beam.dataframe import convert
 from apache_beam.dataframe import expressions
 from apache_beam.dataframe import frames  # pylint: disable=unused-import
 
@@ -42,6 +41,9 @@ class DataframeTransform(transforms.PTransform):
     self._proxy = proxy
 
   def expand(self, input_pcolls):
+    # Avoid circular import.
+    from apache_beam.dataframe import convert
+
     # Convert inputs to a flat dict.
     input_dict = _flatten(input_pcolls)  # type: Dict[Any, PCollection]
     proxies = _flatten(self._proxy)
@@ -61,7 +63,8 @@ class DataframeTransform(transforms.PTransform):
 
     # Compute results as a tuple.
     result_frames_dict = _flatten(result_frames)
-    keys, result_frames_tuple = list(zip(*result_frames_dict.items()))
+    keys = list(result_frames_dict.keys())
+    result_frames_tuple = tuple(result_frames_dict[key] for key in keys)
     result_pcolls_tuple = convert.to_pcollection(
         *result_frames_tuple, label='Eval', always_return_tuple=True)
 

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -22,7 +22,6 @@ import apache_beam as beam
 from apache_beam import transforms
 from apache_beam.dataframe import convert
 from apache_beam.dataframe import expressions
-from apache_beam.dataframe import frame_base
 from apache_beam.dataframe import frames  # pylint: disable=unused-import
 
 


### PR DESCRIPTION
This may be a more natural interface for mixing pandas-style code with Beam.
    
It does have the downside of being inefficient if dataframes are converted back to PCollections one at a time.

Builds on https://github.com/apache/beam/pull/10760

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
