### PR TITLE
[BEAM-9639][BEAM-9608] Improvements for FnApiRunner

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -584,6 +584,23 @@ def optimize_pipeline(
       pipeline_proto, stages, known_runner_urns, partial)
 
 
+def get_all_side_inputs_and_consumers(stages):
+  # type: (Iterable[Stage]) -> Tuple[Set[str], Dict[str, List[Stage]], Dict[str, List[beam_runner_api_pb2.PTransform]]]
+  all_side_inputs = set()  # type: Set[str]
+  stage_consumers = collections.defaultdict(
+      list)  # type: DefaultDict[str, List[Stage]]
+  transform_consumers = collections.defaultdict(
+      list)  # type: DefaultDict[str, List[beam_runner_api_pb2.PTransform]]
+  for stage in stages:
+    for transform in stage.transforms:
+      for input in transform.inputs.values():
+        stage_consumers[input].append(stage)
+        transform_consumers[input].append(transform)
+    for si in stage.side_inputs():
+      all_side_inputs.add(si)
+  return all_side_inputs, stage_consumers, transform_consumers
+
+
 # Optimization stages.
 
 
@@ -604,21 +621,7 @@ def annotate_downstream_side_inputs(stages, pipeline_context):
 
   This representation is also amenable to simple recomputation on fusion.
   """
-  consumers = collections.defaultdict(
-      list)  # type: DefaultDict[str, List[Stage]]
-
-  def get_all_side_inputs():
-    # type: () -> Set[str]
-    all_side_inputs = set()  # type: Set[str]
-    for stage in stages:
-      for transform in stage.transforms:
-        for input in transform.inputs.values():
-          consumers[input].append(stage)
-      for si in stage.side_inputs():
-        all_side_inputs.add(si)
-    return all_side_inputs
-
-  all_side_inputs = frozenset(get_all_side_inputs())
+  all_side_inputs, consumers, _ = get_all_side_inputs_and_consumers(stages)
 
   downstream_side_inputs_by_stage = {}  # type: Dict[Stage, FrozenSet[str]]
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -26,6 +26,7 @@ import collections
 import functools
 import logging
 from builtins import object
+from typing import Any
 from typing import Container
 from typing import DefaultDict
 from typing import Dict
@@ -74,6 +75,9 @@ PAR_DO_URNS = frozenset([
 ])
 
 IMPULSE_BUFFER = b'impulse'
+
+# SideInputId is identified by a consumer ParDo + tag.
+SideInputId = Tuple[str, str]
 
 
 class Stage(object):
@@ -643,7 +647,7 @@ def annotate_downstream_side_inputs(stages, pipeline_context):
 
   for stage in stages:
     stage.downstream_side_inputs = compute_downstream_side_inputs(stage)
-  return stages
+  return downstream_side_inputs_by_stage
 
 
 def annotate_stateful_dofns_as_roots(stages, pipeline_context):
@@ -1032,7 +1036,7 @@ def expand_gbk(stages, pipeline_context):
                       urn=bundle_processor.DATA_OUTPUT_URN,
                       payload=grouping_buffer))
           ],
-          downstream_side_inputs=frozenset(),
+          downstream_side_inputs={},
           must_follow=stage.must_follow)
       yield gbk_write
 
@@ -1085,7 +1089,7 @@ def fix_flatten_coders(stages, pipeline_context):
                           urn=bundle_processor.IDENTITY_DOFN_URN),
                       environment_id=transform.environment_id)
               ],
-              downstream_side_inputs=frozenset(),
+              downstream_side_inputs={},
               must_follow=stage.must_follow)
           pcollections[transcoded_pcollection].CopyFrom(pcollections[pcoll_in])
           pcollections[transcoded_pcollection].unique_name = (
@@ -1123,7 +1127,7 @@ def sink_flattens(stages, pipeline_context):
                         urn=bundle_processor.DATA_OUTPUT_URN,
                         payload=buffer_id))
             ],
-            downstream_side_inputs=frozenset(),
+            downstream_side_inputs={},
             must_follow=stage.must_follow)
         flatten_writes.append(flatten_write)
         yield flatten_write

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -366,11 +366,11 @@ class PortableRunner(runner.PipelineRunner):
         proto_pipeline = translations.optimize_pipeline(
             proto_pipeline,
             phases=[
-                translations.annotate_downstream_side_inputs,
                 translations.annotate_stateful_dofns_as_roots,
                 translations.fix_side_input_pcoll_coders,
                 translations.lift_combiners,
                 translations.expand_sdf,
+                translations.annotate_downstream_side_inputs,
                 translations.fix_flatten_coders,
                 # fn_api_runner_transforms.sink_flattens,
                 translations.greedily_fuse,

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -366,11 +366,11 @@ class PortableRunner(runner.PipelineRunner):
         proto_pipeline = translations.optimize_pipeline(
             proto_pipeline,
             phases=[
+                translations.annotate_downstream_side_inputs,
                 translations.annotate_stateful_dofns_as_roots,
                 translations.fix_side_input_pcoll_coders,
                 translations.lift_combiners,
                 translations.expand_sdf,
-                translations.annotate_downstream_side_inputs,
                 translations.fix_flatten_coders,
                 # fn_api_runner_transforms.sink_flattens,
                 translations.greedily_fuse,


### PR DESCRIPTION
r: @robertwb 

These changes are mostly reshuffling of code.

Each commit is a logical unit, so each commit can be reviewed separately. The commit message explains what each commit does:

- **commit**[BEAM-9608] BundleManagers use BundleContextManager for configuration - (this commit modifies the BundleManagers to receive only a BundleContextManager with most of their configuration. It also adds a `dry_run` option for processing bundles without writing to `pcoll_buffers`)
- **commit**[BEAM-9639] Storing side inputs after producer execution, not before consumption - (this commit ensures that side inputs are stored in state right after they are computed - not before they are consumed. this will be useful in streaming so each bundle's inputs are eagerly available)
  - **commit**Ensuring downstream side inputs are calculated on fully expanded graph - (this commit is more of an accessory to the previous one. It ensures that during graph translations, downstream_side_inputs are annotated after SDFs are expanded)
- **commit**[BEAM-9639] Separate Stage and Bundle execution. Improve typing. - (this commit separates the sections of the code for executing a stage such as context creation, committing of side inputs, scheduling of all bundles until no deferred inputs vs the sections of executing a bundle for that stage such as pushing data to worker, collecting bundle deferred inputs)

---
## Notes/todos from https://github.com/apache/beam/pull/11229

- [ ] It's odd that _run_stage no longer takes as a parameter the stage to run. Perhaps bundle_context_manager (and its class?) should be named stage_context or similar?
- [ ] On this note, perhaps it makes sense to break FnApiRunner into the (mostly stateless) runner that can execute multiple pipelines and an executor (that has methods like run_stage) that might be stateful and is initialized with and tasked with running a single pipeline. Much of what is on context(s) would become state of self of this new object.
- [ ] I was bitten by the fact that it is an error to access the process_bundle_descriptor before _extract_outputs is called. This should be clearly documented (and similarly for the other lazy attributes(s) in this class). Given that that's called external to this class and can't easily be checked, makes me wonder if the boundary of encapsulation needs to be adjusted here.







------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
