### PR TITLE
[BEAM-4374] Short IDs for the Python SDK

### DIFF
--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -39,6 +39,7 @@ from typing import Any
 from typing import Callable
 from typing import DefaultDict
 from typing import Dict
+from typing import FrozenSet
 from typing import Iterable
 from typing import Iterator
 from typing import List
@@ -50,8 +51,10 @@ from future.utils import raise_
 from future.utils import with_metaclass
 
 from apache_beam.coders import coder_impl
+from apache_beam.metrics import monitoring_infos
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
+from apache_beam.portability.api import metrics_pb2
 from apache_beam.runners.worker import bundle_processor
 from apache_beam.runners.worker import data_plane
 from apache_beam.runners.worker import statesampler
@@ -74,6 +77,50 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_LOG_LULL_TIMEOUT_NS = 5 * 60 * 1000 * 1000 * 1000
 
 DEFAULT_BUNDLE_PROCESSOR_CACHE_SHUTDOWN_THRESHOLD_S = 60
+
+
+class ShortIdCache(object):
+  """ Cache for MonitoringInfo "short ids"
+  """
+  def __init__(self):
+    self._lock = threading.Lock()
+    self._lastShortId = 0
+    self._infoKeyToShortId = {}  # type: Dict[FrozenSet, str]
+    self._shortIdToInfo = {}  # type: Dict[str, metrics_pb2.MonitoringInfo]
+
+  def getShortId(self, monitoring_info):
+    """ Returns the assigned shortId for a given MonitoringInfo, assigns one if
+    not assigned already.
+    """
+    # type: (metrics_pb2.MonitoringInfo) -> str
+    with self._lock:
+      key = monitoring_infos.to_key(monitoring_info)
+      try:
+        return self._infoKeyToShortId[key]
+      except KeyError:
+        self._lastShortId += 1
+
+        # Convert to a hex string (and drop the '0x') for some compression
+        shortId = hex(self._lastShortId)[2:]
+
+        payload_cleared = metrics_pb2.MonitoringInfo()
+        payload_cleared.CopyFrom(monitoring_info)
+        payload_cleared.ClearField('payload')
+
+        self._infoKeyToShortId[key] = shortId
+        self._shortIdToInfo[shortId] = payload_cleared
+        return shortId
+
+  def getInfos(self, short_ids):
+    """ Gets the base MonitoringInfo (with payload cleared) for each short ID.
+
+    Throws KeyError if an unassigned short ID is encountered.
+    """
+    #type: (Iterable[str]) -> List[metrics_pb2.MonitoringInfo]
+    return [self._shortIdToInfo[short_id] for short_id in short_ids]
+
+
+SHORT_ID_CACHE = ShortIdCache()
 
 
 class SdkHarness(object):
@@ -457,6 +504,10 @@ class SdkWorker(object):
                   residual_roots=delayed_applications,
                   metrics=bundle_processor.metrics(),
                   monitoring_infos=monitoring_infos,
+                  monitoring_data={
+                      SHORT_ID_CACHE.getShortId(info): info.payload
+                      for info in monitoring_infos
+                  },
                   requires_finalization=requests_finalization))
       # Don't release here if finalize is needed.
       if not requests_finalization:
@@ -517,11 +568,28 @@ class SdkWorker(object):
     processor = self.bundle_processor_cache.lookup(request.instruction_id)
     if processor:
       self._log_lull_in_bundle_processor(processor)
+
+    monitoring_infos = processor.monitoring_infos() if processor else []
     return beam_fn_api_pb2.InstructionResponse(
         instruction_id=instruction_id,
         process_bundle_progress=beam_fn_api_pb2.ProcessBundleProgressResponse(
             metrics=processor.metrics() if processor else None,
-            monitoring_infos=processor.monitoring_infos() if processor else []))
+            monitoring_infos=monitoring_infos,
+            monitoring_data={
+                SHORT_ID_CACHE.getShortId(info): info.payload
+                for info in monitoring_infos
+            }))
+
+  def process_bundle_progress_metadata_request(self,
+                                               request,  # type: beam_fn_api_pb2.ProcessBundleProgressMetadataRequest
+                                               instruction_id  # type: str
+                                              ):
+    return beam_fn_api_pb2.InstructionResponse(
+        instruction_id=instruction_id,
+        process_bundle_progress=beam_fn_api_pb2.
+        ProcessBundleProgressMetadataResponse(
+            monitoring_info=SHORT_ID_CACHE.getInfos(
+                request.monitoring_info_id)))
 
   def finalize_bundle(self,
                       request,  # type: beam_fn_api_pb2.FinalizeBundleRequest

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -89,10 +89,10 @@ class ShortIdCache(object):
     self._shortIdToInfo = {}  # type: Dict[str, metrics_pb2.MonitoringInfo]
 
   def getShortId(self, monitoring_info):
+    # type: (metrics_pb2.MonitoringInfo) -> str
     """ Returns the assigned shortId for a given MonitoringInfo, assigns one if
     not assigned already.
     """
-    # type: (metrics_pb2.MonitoringInfo) -> str
     key = monitoring_infos.to_key(monitoring_info)
     with self._lock:
       try:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -93,8 +93,8 @@ class ShortIdCache(object):
     not assigned already.
     """
     # type: (metrics_pb2.MonitoringInfo) -> str
+    key = monitoring_infos.to_key(monitoring_info)
     with self._lock:
-      key = monitoring_infos.to_key(monitoring_info)
       try:
         return self._infoKeyToShortId[key]
       except KeyError:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -90,6 +90,7 @@ class ShortIdCache(object):
 
   def getShortId(self, monitoring_info):
     # type: (metrics_pb2.MonitoringInfo) -> str
+
     """ Returns the assigned shortId for a given MonitoringInfo, assigns one if
     not assigned already.
     """

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -113,11 +113,12 @@ class ShortIdCache(object):
         return shortId
 
   def getInfos(self, short_ids):
+    #type: (Iterable[str]) -> List[metrics_pb2.MonitoringInfo]
+
     """ Gets the base MonitoringInfo (with payload cleared) for each short ID.
 
     Throws KeyError if an unassigned short ID is encountered.
     """
-    #type: (Iterable[str]) -> List[metrics_pb2.MonitoringInfo]
     return [self._shortIdToInfo[short_id] for short_id in short_ids]
 
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -27,6 +27,7 @@ import contextlib
 import logging
 import unittest
 from builtins import range
+from collections import namedtuple
 
 import grpc
 
@@ -38,7 +39,6 @@ from apache_beam.portability.api import metrics_pb2
 from apache_beam.runners.worker import sdk_worker
 from apache_beam.runners.worker import statecache
 from apache_beam.utils.thread_pool_executor import UnboundedThreadPoolExecutor
-from collections import namedtuple
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -34,9 +34,11 @@ from apache_beam.coders import VarIntCoder
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.portability.api import metrics_pb2
 from apache_beam.runners.worker import sdk_worker
 from apache_beam.runners.worker import statecache
 from apache_beam.utils.thread_pool_executor import UnboundedThreadPoolExecutor
+from collections import namedtuple
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -226,6 +228,123 @@ class CachingStateHandlerTest(unittest.TestCase):
       self.assertEqual(get_as_list(side1), [501])  # cached on side1_token2
       self.assertEqual(get_as_list(side2), [502])  # uncached
       self.assertEqual(get_as_list(side2), [502])  # cached on bundle
+
+
+class ShortIdCacheTest(unittest.TestCase):
+  def testShortIdAssignment(self):
+    TestCase = namedtuple('TestCase', ['expectedShortId', 'info'])
+    test_cases = [
+        TestCase(*args) for args in [
+            (
+                "1",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:user:distribution_int64:v1",
+                    type="beam:metrics:distribution_int64:v1")),
+            (
+                "2",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:element_count:v1",
+                    type="beam:metrics:sum_int64:v1")),
+            (
+                "3",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:ptransform_progress:completed:v1",
+                    type="beam:metrics:progress:v1")),
+            (
+                "4",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:user:distribution_double:v1",
+                    type="beam:metrics:distribution_double:v1")),
+            (
+                "5",
+                metrics_pb2.MonitoringInfo(
+                    urn="TestingSentinelUrn", type="TestingSentinelType")),
+            (
+                "6",
+                metrics_pb2.MonitoringInfo(
+                    urn=
+                    "beam:metric:pardo_execution_time:finish_bundle_msecs:v1",
+                    type="beam:metrics:sum_int64:v1")),
+            # This case and the next one validates that different labels
+            # with the same urn are in fact assigned different short ids.
+            (
+                "7",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:user:sum_int64:v1",
+                    type="beam:metrics:sum_int64:v1",
+                    labels={
+                        "PTRANSFORM": "myT",
+                        "NAMESPACE": "harness",
+                        "NAME": "metricNumber7"
+                    })),
+            (
+                "8",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:user:sum_int64:v1",
+                    type="beam:metrics:sum_int64:v1",
+                    labels={
+                        "PTRANSFORM": "myT",
+                        "NAMESPACE": "harness",
+                        "NAME": "metricNumber8"
+                    })),
+            (
+                "9",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:user:top_n_double:v1",
+                    type="beam:metrics:top_n_double:v1",
+                    labels={
+                        "PTRANSFORM": "myT",
+                        "NAMESPACE": "harness",
+                        "NAME": "metricNumber7"
+                    })),
+            (
+                "a",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:element_count:v1",
+                    type="beam:metrics:sum_int64:v1",
+                    labels={"PCOLLECTION": "myPCol"})),
+            # validate payload is ignored for shortId assignment
+            (
+                "3",
+                metrics_pb2.MonitoringInfo(
+                    urn="beam:metric:ptransform_progress:completed:v1",
+                    type="beam:metrics:progress:v1",
+                    payload=b"this is ignored!"))
+        ]
+    ]
+
+    cache = sdk_worker.ShortIdCache()
+
+    for case in test_cases:
+      self.assertEqual(
+          case.expectedShortId,
+          cache.getShortId(case.info),
+          "Got incorrect short id for monitoring info:\n%s" % case.info)
+
+    # Retrieve all of the monitoring infos by short id, and verify that the
+    # metadata (everything but the payload) matches the originals
+    actual_recovered_infos = cache.getInfos(
+        case.expectedShortId for case in test_cases)
+    for recoveredInfo, case in zip(actual_recovered_infos, test_cases):
+      self.assertEqual(
+          monitoringInfoMetadata(case.info),
+          monitoringInfoMetadata(recoveredInfo))
+
+    # Retrieve short ids one more time in reverse
+    for case in reversed(test_cases):
+      self.assertEqual(
+          case.expectedShortId,
+          cache.getShortId(case.info),
+          "Got incorrect short id on second retrieval for monitoring info:\n%s"
+          % case.info)
+
+
+def monitoringInfoMetadata(info):
+  return {
+      descriptor.name: value
+      for descriptor,
+      value in info.ListFields() if not descriptor.name == "payload"
+  }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
