### PR TITLE
[BEAM-9577] Update container boot code to stage from dependencies, if present.

### DIFF
--- a/sdks/go/container/boot.go
+++ b/sdks/go/container/boot.go
@@ -94,7 +94,7 @@ func main() {
 	// are more than one artifact.
 
 	dir := filepath.Join(*semiPersistDir, "staged")
-	artifacts, err := artifact.Materialize(ctx, *artifactEndpoint, info.GetRetrievalToken(), dir)
+	artifacts, err := artifact.Materialize(ctx, *artifactEndpoint, info.GetDependencies(), info.GetRetrievalToken(), dir)
 	if err != nil {
 		log.Fatalf("Failed to retrieve staged files: %v", err)
 	}

--- a/sdks/go/pkg/beam/artifact/materialize.go
+++ b/sdks/go/pkg/beam/artifact/materialize.go
@@ -148,11 +148,7 @@ func (a artifact) retrieve(ctx context.Context, dest string) error {
 		fd.Close()
 		return errors.Wrapf(err, "failed to flush chunks for %v", filename)
 	}
-	if err := fd.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return fd.Close()
 }
 
 func writeChunks(stream pb.ArtifactRetrievalService_GetArtifactClient, w io.Writer) error {

--- a/sdks/go/pkg/beam/artifact/materialize.go
+++ b/sdks/go/pkg/beam/artifact/materialize.go
@@ -31,15 +31,148 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	"github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/errorx"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
+	"github.com/golang/protobuf/proto"
+)
+
+// TODO(lostluck): 2018/05/28 Extract these from their enum descriptors in the pipeline_v1 proto
+const (
+	URNStagingTo      = "beam:artifact:role:staging_to:v1"
+	NoArtifactsStaged = "__no_artifacts_staged__"
 )
 
 // Materialize is a convenience helper for ensuring that all artifacts are
 // present and uncorrupted. It interprets each artifact name as a relative
 // path under the dest directory. It does not retrieve valid artifacts already
 // present.
-func Materialize(ctx context.Context, endpoint string, rt string, dest string) ([]*pb.ArtifactMetadata, error) {
+// TODO(BEAM-9577): Return a mapping of filename to dependency, rather than []*pb.ArtifactMetadata.
+// TODO(BEAM-9577): Leverage richness of roles rather than magic names to understand artifacts.
+func Materialize(ctx context.Context, endpoint string, dependencies []*pipeline_v1.ArtifactInformation, rt string, dest string) ([]*pb.ArtifactMetadata, error) {
+	if len(dependencies) > 0 {
+		return newMaterialize(ctx, endpoint, dependencies, dest)
+	} else if rt == "" || rt == NoArtifactsStaged {
+		return []*pb.ArtifactMetadata{}, nil
+	} else {
+		return legacyMaterialize(ctx, endpoint, rt, dest)
+	}
+}
+
+func newMaterialize(ctx context.Context, endpoint string, dependencies []*pipeline_v1.ArtifactInformation, dest string) ([]*pb.ArtifactMetadata, error) {
+	cc, err := grpcx.Dial(ctx, endpoint, 2*time.Minute)
+	if err != nil {
+		return nil, err
+	}
+	defer cc.Close()
+
+	return newMaterializeWithClient(ctx, pb.NewArtifactRetrievalServiceClient(cc), dependencies, dest)
+}
+
+func newMaterializeWithClient(ctx context.Context, client pb.ArtifactRetrievalServiceClient, dependencies []*pipeline_v1.ArtifactInformation, dest string) ([]*pb.ArtifactMetadata, error) {
+	resolution, err := client.ResolveArtifact(ctx, &pb.ResolveArtifactRequest{Artifacts: dependencies})
+	if err != nil {
+		return nil, err
+	}
+
+	var md []*pb.ArtifactMetadata
+	var list []retrievable
+	for _, dep := range resolution.Replacements {
+		path, err := extractStagingToPath(dep)
+		if err != nil {
+			return nil, err
+		}
+		md = append(md, &pb.ArtifactMetadata{
+			Name: path,
+		})
+
+		list = append(list, &artifact{
+			client: client,
+			dep:    dep,
+		})
+	}
+
+	return md, MultiRetrieve(ctx, 10, list, dest)
+}
+
+func extractStagingToPath(artifact *pipeline_v1.ArtifactInformation) (string, error) {
+	if artifact.RoleUrn != URNStagingTo {
+		return "", errors.Errorf("Unsupported artifact role %s", artifact.RoleUrn)
+	}
+	role := pipeline_v1.ArtifactStagingToRolePayload{}
+	if err := proto.Unmarshal(artifact.RolePayload, &role); err != nil {
+		return "", err
+	}
+	return role.StagedName, nil
+}
+
+type artifact struct {
+	client pb.ArtifactRetrievalServiceClient
+	dep    *pipeline_v1.ArtifactInformation
+}
+
+func (a artifact) retrieve(ctx context.Context, dest string) error {
+	path, err := extractStagingToPath(a.dep)
+	if err != nil {
+		return err
+	}
+
+	filename := filepath.Join(dest, filepath.FromSlash(path))
+
+	_, err = os.Stat(filename)
+	if err == nil {
+		if err = os.Remove(filename); err != nil {
+			return errors.Errorf("failed to delete: %v (remove: %v)", filename, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return errors.Wrapf(err, "failed to stat %v", filename)
+	}
+
+	stream, err := a.client.GetArtifact(ctx, &pb.GetArtifactRequest{Artifact: a.dep})
+	if err != nil {
+		return err
+	}
+
+	fd, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	w := bufio.NewWriter(fd)
+
+	err = writeChunks(stream, w)
+	if err != nil {
+		fd.Close() // drop any buffered content
+		return errors.Wrapf(err, "failed to retrieve chunk for %v", filename)
+	}
+	if err := w.Flush(); err != nil {
+		fd.Close()
+		return errors.Wrapf(err, "failed to flush chunks for %v", filename)
+	}
+	if err := fd.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeChunks(stream pb.ArtifactRetrievalService_GetArtifactClient, w io.Writer) error {
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if _, err := w.Write(chunk.Data); err != nil {
+			return errors.Wrapf(err, "chunk write failed")
+		}
+	}
+	return nil
+}
+
+func legacyMaterialize(ctx context.Context, endpoint string, rt string, dest string) ([]*pb.ArtifactMetadata, error) {
 	cc, err := grpcx.Dial(ctx, endpoint, 2*time.Minute)
 	if err != nil {
 		return nil, err
@@ -52,13 +185,23 @@ func Materialize(ctx context.Context, endpoint string, rt string, dest string) (
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get manifest")
 	}
-	md := m.GetManifest().GetArtifact()
-	return md, MultiRetrieve(ctx, client, 10, md, rt, dest)
+	mds := m.GetManifest().GetArtifact()
+
+	var list []retrievable
+	for _, md := range mds {
+		list = append(list, &legacyArtifact{
+			client: client,
+			rt:     rt,
+			md:     md,
+		})
+	}
+
+	return mds, MultiRetrieve(ctx, 10, list, dest)
 }
 
 // MultiRetrieve retrieves multiple artifacts concurrently, using at most 'cpus'
 // goroutines. It retries each artifact a few times. Convenience wrapper.
-func MultiRetrieve(ctx context.Context, client pb.LegacyArtifactRetrievalServiceClient, cpus int, list []*pb.ArtifactMetadata, rt string, dest string) error {
+func MultiRetrieve(ctx context.Context, cpus int, list []retrievable, dest string) error {
 	if len(list) == 0 {
 		return nil
 	}
@@ -86,13 +229,13 @@ func MultiRetrieve(ctx context.Context, client pb.LegacyArtifactRetrievalService
 
 				var failures []string
 				for {
-					err := Retrieve(ctx, client, a, rt, dest)
+					err := a.retrieve(ctx, dest)
 					if err == nil || permErr.Error() != nil {
 						break // done or give up
 					}
 					failures = append(failures, err.Error())
 					if len(failures) > attempts {
-						permErr.TrySetError(errors.Errorf("failed to retrieve %v in %v attempts: %v", a.Name, attempts, strings.Join(failures, "; ")))
+						permErr.TrySetError(errors.Errorf("failed to retrieve %v in %v attempts: %v", dest, attempts, strings.Join(failures, "; ")))
 						break // give up
 					}
 					time.Sleep(time.Duration(rand.Intn(5)+1) * time.Second)
@@ -103,6 +246,33 @@ func MultiRetrieve(ctx context.Context, client pb.LegacyArtifactRetrievalService
 	wg.Wait()
 
 	return permErr.Error()
+}
+
+type retrievable interface {
+	retrieve(ctx context.Context, dest string) error
+}
+
+// For testing.
+func LegacyMultiRetrieve(ctx context.Context, client pb.LegacyArtifactRetrievalServiceClient, cpus int, list []*pb.ArtifactMetadata, rt string, dest string) error {
+	var rlist []retrievable
+	for _, md := range list {
+		rlist = append(rlist, &legacyArtifact{
+			client: client,
+			rt:     rt,
+			md:     md,
+		})
+	}
+	return MultiRetrieve(ctx, cpus, rlist, dest)
+}
+
+type legacyArtifact struct {
+	client pb.LegacyArtifactRetrievalServiceClient
+	rt     string
+	md     *pb.ArtifactMetadata
+}
+
+func (a legacyArtifact) retrieve(ctx context.Context, dest string) error {
+	return Retrieve(ctx, a.client, a.md, a.rt, dest)
 }
 
 // Retrieve checks whether the given artifact is already successfully
@@ -223,8 +393,8 @@ func computeSHA256(filename string) (string, error) {
 	return hex.EncodeToString(sha256W.Sum(nil)), nil
 }
 
-func slice2queue(list []*pb.ArtifactMetadata) chan *pb.ArtifactMetadata {
-	q := make(chan *pb.ArtifactMetadata, len(list))
+func slice2queue(list []retrievable) chan retrievable {
+	q := make(chan retrievable, len(list))
 	for _, elm := range list {
 		q <- elm
 	}

--- a/sdks/go/pkg/beam/artifact/materialize_test.go
+++ b/sdks/go/pkg/beam/artifact/materialize_test.go
@@ -19,14 +19,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	"github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // TestRetrieve tests that we can successfully retrieve fresh files.
@@ -68,7 +73,7 @@ func TestMultiRetrieve(t *testing.T) {
 	defer os.RemoveAll(dst)
 
 	client := pb.NewLegacyArtifactRetrievalServiceClient(cc)
-	if err := MultiRetrieve(ctx, client, 10, artifacts, rt, dst); err != nil {
+	if err := LegacyMultiRetrieve(ctx, client, 10, artifacts, rt, dst); err != nil {
 		t.Errorf("failed to retrieve: %v", err)
 	}
 
@@ -146,6 +151,156 @@ func stage(ctx context.Context, scl pb.LegacyArtifactStagingServiceClient, t *te
 		t.Fatalf("close failed: %v", err)
 	}
 	return md
+}
+
+// Test for new artifact retrieval.
+
+func TestNewRetrieveWithManyFiles(t *testing.T) {
+	expected := map[string]string{"a.txt": "a", "b.txt": "bbb", "c.txt": "cccccccc"}
+
+	client := fakeRetrievalService{
+		artifacts: expected,
+	}
+
+	dest := makeTempDir(t)
+	defer os.RemoveAll(dest)
+	ctx := grpcx.WriteWorkerID(context.Background(), "worker")
+
+	mds, err := newMaterializeWithClient(ctx, client, client.resolvedArtifacts(), dest)
+	if err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+
+	checkStagedFiles(mds, dest, expected, t)
+}
+
+func TestNewRetrieveWithResolution(t *testing.T) {
+	expected := map[string]string{"a.txt": "a", "b.txt": "bbb", "c.txt": "cccccccc"}
+
+	client := fakeRetrievalService{
+		artifacts: expected,
+	}
+
+	dest := makeTempDir(t)
+	defer os.RemoveAll(dest)
+	ctx := grpcx.WriteWorkerID(context.Background(), "worker")
+
+	mds, err := newMaterializeWithClient(ctx, client, client.unresolvedArtifacts(), dest)
+	if err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+
+	checkStagedFiles(mds, dest, expected, t)
+}
+
+func checkStagedFiles(mds []*pb.ArtifactMetadata, dest string, expected map[string]string, t *testing.T) {
+	if len(mds) != len(expected) {
+		t.Errorf("wrong number of artifacts staged %v vs %v", len(mds), len(expected))
+	}
+	for _, md := range mds {
+		filename := filepath.Join(dest, filepath.FromSlash(md.Name))
+		fd, err := os.Open(filename)
+		if err != nil {
+			t.Errorf("error opening file %v", err)
+		}
+		defer fd.Close()
+
+		data := make([]byte, 1<<20)
+		n, err := fd.Read(data)
+		if err != nil {
+			t.Errorf("error reading file %v", err)
+		}
+
+		if string(data[:n]) != expected[md.Name] {
+			t.Errorf("missmatched contents for %v: '%s' vs '%s'", md.Name, string(data[:n]), expected[md.Name])
+		}
+	}
+}
+
+type fakeRetrievalService struct {
+	artifacts map[string]string // name -> content
+}
+
+func (fake fakeRetrievalService) resolvedArtifacts() []*pipeline_v1.ArtifactInformation {
+	var artifacts []*pipeline_v1.ArtifactInformation
+	for name, contents := range fake.artifacts {
+		payload, _ := proto.Marshal(&pipeline_v1.ArtifactStagingToRolePayload{
+			StagedName: name})
+		artifacts = append(artifacts, &pipeline_v1.ArtifactInformation{
+			TypeUrn:     "resolved",
+			TypePayload: []byte(contents),
+			RoleUrn:     URNStagingTo,
+			RolePayload: payload,
+		})
+	}
+	return artifacts
+}
+
+func (fake fakeRetrievalService) unresolvedArtifacts() []*pipeline_v1.ArtifactInformation {
+	return []*pipeline_v1.ArtifactInformation{
+		&pipeline_v1.ArtifactInformation{
+			TypeUrn: "unresolved",
+		},
+	}
+}
+
+func (fake fakeRetrievalService) ResolveArtifact(ctx context.Context, request *pb.ResolveArtifactRequest, opts ...grpc.CallOption) (*pb.ResolveArtifactResponse, error) {
+	response := pb.ResolveArtifactResponse{}
+	for _, dep := range request.Artifacts {
+		if dep.TypeUrn == "unresolved" {
+			response.Replacements = append(response.Replacements, fake.resolvedArtifacts()...)
+		} else {
+			response.Replacements = append(response.Replacements, dep)
+		}
+	}
+	return &response, nil
+}
+
+func (fake fakeRetrievalService) GetArtifact(ctx context.Context, request *pb.GetArtifactRequest, opts ...grpc.CallOption) (pb.ArtifactRetrievalService_GetArtifactClient, error) {
+	var index int
+	if request.Artifact.TypeUrn == "resolved" {
+		return fakeGetArtifactResponse{data: request.Artifact.TypePayload, index: &index}, nil
+	} else {
+		return nil, errors.Errorf("Unsupported artifact %v", request.Artifact)
+	}
+}
+
+func (fake fakeGetArtifactResponse) Recv() (*pb.GetArtifactResponse, error) {
+	if *fake.index < len(fake.data) {
+		*fake.index += 1
+		return &pb.GetArtifactResponse{Data: fake.data[*fake.index-1 : *fake.index]}, nil
+	} else {
+		return nil, io.EOF
+	}
+}
+
+type fakeGetArtifactResponse struct {
+	data  []byte
+	index *int
+}
+
+func (fake fakeGetArtifactResponse) RecvMsg(interface{}) error {
+	return nil
+}
+
+func (fake fakeGetArtifactResponse) SendMsg(interface{}) error {
+	return nil
+}
+
+func (fake fakeGetArtifactResponse) Header() (metadata.MD, error) {
+	return nil, nil
+}
+
+func (fake fakeGetArtifactResponse) Trailer() metadata.MD {
+	return nil
+}
+
+func (fake fakeGetArtifactResponse) Context() context.Context {
+	return nil
+}
+
+func (fake fakeGetArtifactResponse) CloseSend() error {
+	return nil
 }
 
 func verifySHA256(t *testing.T, filename, hash string) {

--- a/sdks/go/pkg/beam/artifact/materialize_test.go
+++ b/sdks/go/pkg/beam/artifact/materialize_test.go
@@ -260,18 +260,16 @@ func (fake fakeRetrievalService) GetArtifact(ctx context.Context, request *pb.Ge
 	var index int
 	if request.Artifact.TypeUrn == "resolved" {
 		return fakeGetArtifactResponse{data: request.Artifact.TypePayload, index: &index}, nil
-	} else {
-		return nil, errors.Errorf("Unsupported artifact %v", request.Artifact)
 	}
+	return nil, errors.Errorf("Unsupported artifact %v", request.Artifact)
 }
 
 func (fake fakeGetArtifactResponse) Recv() (*pb.GetArtifactResponse, error) {
 	if *fake.index < len(fake.data) {
 		*fake.index += 1
 		return &pb.GetArtifactResponse{Data: fake.data[*fake.index-1 : *fake.index]}, nil
-	} else {
-		return nil, io.EOF
-	}
+	} 
+	return nil, io.EOF
 }
 
 type fakeGetArtifactResponse struct {

--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -99,7 +99,7 @@ func main() {
 
 	dir := filepath.Join(*semiPersistDir, "staged")
 
-	artifacts, err := artifact.Materialize(ctx, *artifactEndpoint, info.GetRetrievalToken(), dir)
+	artifacts, err := artifact.Materialize(ctx, *artifactEndpoint, info.GetDependencies(), info.GetRetrievalToken(), dir)
 	if err != nil {
 		log.Fatalf("Failed to retrieve staged files: %v", err)
 	}

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -130,7 +130,7 @@ func main() {
 	materializeArtifactsFunc := func() {
 		dir := filepath.Join(*semiPersistDir, "staged")
 
-		files, err := artifact.Materialize(ctx, *artifactEndpoint, info.GetRetrievalToken(), dir)
+		files, err := artifact.Materialize(ctx, *artifactEndpoint, info.GetDependencies(), info.GetRetrievalToken(), dir)
 		if err != nil {
 			log.Fatalf("Failed to retrieve staged files: %v", err)
 		}


### PR DESCRIPTION
Falls back to legacy staging if no dependencies are present and the
retrieval token is non-trivial.

Currently the dependencies must be of role staging_to. Future work
to handle more expressive roles.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
