### PR TITLE
[BEAM-9642] Add SDF execution units.

### DIFF
--- a/sdks/go/pkg/beam/core/funcx/fn.go
+++ b/sdks/go/pkg/beam/core/funcx/fn.go
@@ -112,12 +112,15 @@ const (
 	RetEventTime ReturnKind = 0x1
 	RetValue     ReturnKind = 0x2
 	RetError     ReturnKind = 0x4
+	RetRTracker  ReturnKind = 0x8
 )
 
 func (k ReturnKind) String() string {
 	switch k {
 	case RetError:
 		return "Error"
+	case RetRTracker:
+		return "RTracker"
 	case RetEventTime:
 		return "EventTime"
 	case RetValue:
@@ -331,6 +334,8 @@ func New(fn reflectx.Func) (*Fn, error) {
 		switch {
 		case t == reflectx.Error:
 			kind = RetError
+		case t.Implements(reflect.TypeOf((*sdf.RTracker)(nil)).Elem()):
+			kind = RetRTracker
 		case t == typex.EventTimeType:
 			kind = RetEventTime
 		case typex.IsContainer(t), typex.IsConcrete(t), typex.IsUniversal(t):
@@ -528,7 +533,7 @@ func nextRetState(cur retState, transition ReturnKind) (retState, error) {
 	switch transition {
 	case RetEventTime:
 		return -1, errEventTimeRetPrecedence
-	case RetValue:
+	case RetValue, RetRTracker:
 		return rsOutput, nil
 	case RetError:
 		return rsError, nil

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo.go
@@ -121,10 +121,14 @@ func (n *ParDo) ProcessElement(ctx context.Context, elm *FullValue, values ...Re
 		return errors.Errorf("invalid status for pardo %v: %v, want Active", n.UID, n.status)
 	}
 
-	return n.ProcessMainInput(&MainInput{Key: *elm, Values: values})
+	return n.processMainInput(&MainInput{Key: *elm, Values: values})
 }
 
-func (n *ParDo) ProcessMainInput(mainIn *MainInput) error {
+// processMainInput processes an element that has been converted into a
+// MainInput. Splitting this away from ProcessElement allows other nodes to wrap
+// a ParDo's ProcessElement functionality with their own construction of
+// MainInputs.
+func (n *ParDo) processMainInput(mainIn *MainInput) error {
 	elm := &mainIn.Key
 
 	// If the function observes windows, we must invoke it for each window. The expected fast path

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo.go
@@ -76,9 +76,9 @@ func (n *ParDo) Up(ctx context.Context) error {
 	n.inv = newInvoker(n.Fn.ProcessElementFn())
 
 	// We can't cache the context during Setup since it runs only once per bundle.
-	// Subsequent bundles might run this same node, and the context here would be 
+	// Subsequent bundles might run this same node, and the context here would be
 	// incorrectly refering to the older bundleId.
-	setupCtx :=  metrics.SetPTransformID(ctx, n.PID)
+	setupCtx := metrics.SetPTransformID(ctx, n.PID)
 	if _, err := InvokeWithoutEventTime(setupCtx, n.Fn.SetupFn(), nil); err != nil {
 		return n.fail(err)
 	}
@@ -120,11 +120,17 @@ func (n *ParDo) ProcessElement(ctx context.Context, elm *FullValue, values ...Re
 	if n.status != Active {
 		return errors.Errorf("invalid status for pardo %v: %v, want Active", n.UID, n.status)
 	}
+
+	return n.ProcessMainInput(&MainInput{Key: *elm, Values: values})
+}
+
+func (n *ParDo) ProcessMainInput(mainIn *MainInput) error {
+	elm := &mainIn.Key
+
 	// If the function observes windows, we must invoke it for each window. The expected fast path
 	// is that either there is a single window or the function doesn't observes windows.
-
 	if !mustExplodeWindows(n.inv.fn, elm, len(n.Side) > 0) {
-		val, err := n.invokeProcessFn(n.ctx, elm.Windows, elm.Timestamp, &MainInput{Key: *elm, Values: values})
+		val, err := n.invokeProcessFn(n.ctx, elm.Windows, elm.Timestamp, mainIn)
 		if err != nil {
 			return n.fail(err)
 		}
@@ -137,7 +143,8 @@ func (n *ParDo) ProcessElement(ctx context.Context, elm *FullValue, values ...Re
 		for _, w := range elm.Windows {
 			wElm := FullValue{Elm: elm.Elm, Elm2: elm.Elm2, Timestamp: elm.Timestamp, Windows: []typex.Window{w}}
 
-			val, err := n.invokeProcessFn(n.ctx, wElm.Windows, wElm.Timestamp, &MainInput{Key: wElm, Values: values})
+			val, err := n.invokeProcessFn(n.ctx, wElm.Windows, wElm.Timestamp,
+				&MainInput{Key: wElm, Values: mainIn.Values, RTracker: mainIn.RTracker})
 			if err != nil {
 				return n.fail(err)
 			}

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -1,0 +1,297 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"fmt"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
+	"path"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+)
+
+// PairWithRestriction is an executor for the expanded SDF step of the same
+// name. This is the first step of an expanded SDF. It pairs each main input
+// element with a restriction via the SDF's associated sdf.RestrictionProvider.
+// This step is followed by SplitAndSizeRestrictions.
+type PairWithRestriction struct {
+	UID UnitID
+	Fn  *graph.DoFn
+	Out []Node
+
+	inv *cirInvoker
+}
+
+// ID returns the UnitID for this unit.
+func (n *PairWithRestriction) ID() UnitID {
+	return n.UID
+}
+
+// Up performs one-time setup for this executor.
+func (n *PairWithRestriction) Up(ctx context.Context) error {
+	fn := (*graph.SplittableDoFn)(n.Fn).CreateInitialRestrictionFn()
+	var err error
+	if n.inv, err = newCreateInitialRestrictionInvoker(fn); err != nil {
+		return errors.WithContextf(err, "PairWithRestriction transform with UID %v", n.ID())
+	}
+	return nil
+}
+
+// StartBundle currently does nothing.
+func (n *PairWithRestriction) StartBundle(ctx context.Context, id string, data DataContext) error {
+	return n.Out[0].StartBundle(ctx, id, data)
+}
+
+// ProcessElement expects elm to be the main input to the ParDo. See
+// exec.FullValue for more details on the expected input.
+//
+// ProcessElement creates an initial restriction representing the entire input.
+// The output is in the structure <elem, restriction>, where elem is the main
+// input originally passed in (i.e. the parameter elm). Windows and Timestamp
+// are copied to the outer *FullValue. They still remain within the original
+// element as well, but will no longer be used.
+//
+// Output Diagram:
+//
+//   *FullValue {
+//     Elm: *FullValue (original input)
+//     Elm2: Restriction
+//     Windows
+//     Timestamps
+//   }
+func (n *PairWithRestriction) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
+	rest := n.inv.Invoke(elm)
+	output := FullValue{Elm: elm, Elm2: rest, Timestamp: elm.Timestamp, Windows: elm.Windows}
+
+	return n.Out[0].ProcessElement(ctx, &output, values...)
+}
+
+// FinishBundle does some teardown for the end of the bundle.
+func (n *PairWithRestriction) FinishBundle(ctx context.Context) error {
+	n.inv.Reset()
+	return n.Out[0].FinishBundle(ctx)
+}
+
+// Down currently does nothing.
+func (n *PairWithRestriction) Down(ctx context.Context) error {
+	return nil
+}
+
+// String outputs a human-readable description of this transform.
+func (n *PairWithRestriction) String() string {
+	return fmt.Sprintf("SDF.PairWithRestriction[%v] Out:%v", path.Base(n.Fn.Name()), IDs(n.Out...))
+}
+
+// SplitAndSizeRestrictions is an executor for the expanded SDF step of the
+// same name. It is the second step of the expanded SDF, occuring after
+// CreateInitialRestriction. It performs initial splits on the initial restrictions
+// and adds sizing information, producing one or more output elements per input
+// element. This step is followed by ProcessSizedElementsAndRestrictions.
+type SplitAndSizeRestrictions struct {
+	UID UnitID
+	Fn  *graph.DoFn
+	Out []Node
+
+	splitInv *srInvoker
+	sizeInv  *rsInvoker
+}
+
+// ID returns the UnitID for this unit.
+func (n *SplitAndSizeRestrictions) ID() UnitID {
+	return n.ID()
+}
+
+// Up performs one-time setup for this executor.
+func (n *SplitAndSizeRestrictions) Up(ctx context.Context) error {
+	fn := (*graph.SplittableDoFn)(n.Fn).SplitRestrictionFn()
+	var err error
+	if n.splitInv, err = newSplitRestrictionInvoker(fn); err != nil {
+		return errors.WithContextf(err, "SplitAndSizeRestrictions transform with UID %v", n.ID())
+	}
+
+	fn = (*graph.SplittableDoFn)(n.Fn).RestrictionSizeFn()
+	if n.sizeInv, err = newRestrictionSizeInvoker(fn); err != nil {
+		return errors.WithContextf(err, "SplitAndSizeRestrictions transform with UID %v", n.ID())
+	}
+
+	return nil
+}
+
+// StartBundle currently does nothing.
+func (n *SplitAndSizeRestrictions) StartBundle(ctx context.Context, id string, data DataContext) error {
+	return n.Out[0].StartBundle(ctx, id, data)
+}
+
+// ProcessElement expects elm.Elm to hold the original input while elm.Elm2
+// contains the restriction.
+//
+// Input Diagram:
+//
+//   *FullValue {
+//     Elm: *FullValue (original input)
+//     Elm2: Restriction
+//     Windows
+//     Timestamps
+//   }
+//
+// ProcessElement splits the given restriction into one or more restrictions and
+// then sizes each. The outputs are in the structure <<elem, restriction>, size>
+// where elem is the original main input to the unexpanded SDF. Windows and
+// Timestamps are copied to each split output.
+//
+// Output Diagram:
+//
+//   *FullValue {
+//     Elm: *FullValue {
+//       Elm:  *FullValue (original input)
+//       Elm2: Restriction
+//     }
+//     Elm2: float64 (size)
+//     Windows
+//     Timestamps
+//   }
+func (n *SplitAndSizeRestrictions) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
+	rest := elm.Elm2
+	mainElm := elm.Elm.(*FullValue)
+
+	splitRests := n.splitInv.Invoke(mainElm, rest)
+	if len(splitRests) == 0 {
+		err := errors.Errorf("initial splitting returned 0 restrictions.")
+		return errors.WithContextf(err, "SplitAndSizeRestrictions transform with UID %v", n.ID())
+	}
+
+	for _, splitRest := range splitRests {
+		size := n.sizeInv.Invoke(mainElm, splitRest)
+		output := &FullValue{}
+
+		output.Timestamp = elm.Timestamp
+		output.Windows = elm.Windows
+		output.Elm = &FullValue{Elm: mainElm, Elm2: splitRest}
+		output.Elm2 = size
+
+		if err := n.Out[0].ProcessElement(ctx, output, values...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FinishBundle does some teardown for the end of the bundle.
+func (n *SplitAndSizeRestrictions) FinishBundle(ctx context.Context) error {
+	n.splitInv.Reset()
+	n.sizeInv.Reset()
+	return n.Out[0].FinishBundle(ctx)
+}
+
+// Down currently does nothing.
+func (n *SplitAndSizeRestrictions) Down(ctx context.Context) error {
+	return nil
+}
+
+// String outputs a human-readable description of this transform.
+func (n *SplitAndSizeRestrictions) String() string {
+	return fmt.Sprintf("SDF.SplitAndSizeRestrictions[%v] Out:%v", path.Base(n.Fn.Name()), IDs(n.Out...))
+}
+
+// ProcessSizedElementsAndRestrictions is an executor for the expanded SDF step
+// of the same name. It is the final step of the expanded SDF. It sets up and
+// invokes the user's SDF methods, similar to exec.ParDo but with slight
+// changes to support the SDF's method signatures and the expected structure
+// of the FullValue being received.
+type ProcessSizedElementsAndRestrictions struct {
+	PDo *ParDo
+
+	inv *ctInvoker
+}
+
+// ID just defers to the ParDo's ID method.
+func (n *ProcessSizedElementsAndRestrictions) ID() UnitID {
+	return n.PDo.ID()
+}
+
+// Up performs some one-time setup and then defers to the ParDo's Up method.
+func (n *ProcessSizedElementsAndRestrictions) Up(ctx context.Context) error {
+	fn := (*graph.SplittableDoFn)(n.PDo.Fn).CreateTrackerFn()
+	var err error
+	if n.inv, err = newCreateTrackerInvoker(fn); err != nil {
+		return errors.WithContextf(err, "ProcessSizedElementsAndRestrictions transform with UID %v", n.ID())
+	}
+	return n.PDo.Up(ctx)
+}
+
+// StartBundle just defers to the ParDo's StartBundle method.
+func (n *ProcessSizedElementsAndRestrictions) StartBundle(ctx context.Context, id string, data DataContext) error {
+	return n.PDo.StartBundle(ctx, id, data)
+}
+
+// ProcessElement expects the same structure as the output of
+// SplitAndSizeRestrictions, approximately <<elem, restriction>, size>
+//
+// Input Diagram:
+//
+//   *FullValue {
+//     Elm: *FullValue {
+//       Elm:  *FullValue (original input)
+//       Elm2: Restriction
+//     }
+//     Elm2: float64 (size)
+//     Windows
+//     Timestamps
+//   }
+//
+// ProcessElement then creates a restriction tracker from the stored restriction
+// and processes each element using the underlying ParDo and adding the
+// restriction tracker to the normal invocation. Sizing information is present
+// but currently ignored. Output is forwarded to the underlying ParDo's outputs.
+func (n *ProcessSizedElementsAndRestrictions) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
+	if n.PDo.status != Active {
+		return errors.Errorf("invalid status for ParDo %v: %v, want Active", n.PDo.UID, n.PDo.status)
+	}
+
+	userElm := elm.Elm.(*FullValue).Elm.(*FullValue)
+	rest := elm.Elm.(*FullValue).Elm2
+	rt := n.inv.Invoke(rest)
+
+	return n.PDo.ProcessMainInput(&MainInput{
+		Key: FullValue{ // User userElm's values but the top-level windows and timestamp.
+			Elm:       userElm.Elm,
+			Elm2:      userElm.Elm2,
+			Timestamp: elm.Timestamp,
+			Windows:   elm.Windows,
+		},
+		Values:   values,
+		RTracker: rt,
+	})
+}
+
+// FinishBundle does some teardown for the end of the bundle and then defers to
+// the ParDo's FinishBundle method.
+func (n *ProcessSizedElementsAndRestrictions) FinishBundle(ctx context.Context) error {
+	n.inv.Reset()
+	return n.PDo.FinishBundle(ctx)
+}
+
+// Down just defers to the ParDo's Down method.
+func (n *ProcessSizedElementsAndRestrictions) Down(ctx context.Context) error {
+	return n.PDo.Down(ctx)
+}
+
+// String outputs a human-readable description of this transform.
+func (n *ProcessSizedElementsAndRestrictions) String() string {
+	return fmt.Sprintf("SDF.ProcessSizedElementsAndRestrictions[%v] Out:%v", path.Base(n.PDo.Fn.Name()), IDs(n.PDo.Out...))
+}

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
@@ -258,7 +258,6 @@ func (fn *Sdf) CreateTracker(rest Restriction) *RTracker {
 // RTracker.Rest.Val. The second is the input + RTracker.Val.
 func (fn *Sdf) ProcessElement(rt *RTracker, i int, emit func(int, int)) {
 	emit(i+rt.Rest.Val, i+rt.Val)
-	return
 }
 
 type KvSdf struct {
@@ -291,5 +290,4 @@ func (fn *KvSdf) CreateTracker(rest Restriction) *RTracker {
 // RTracker.Rest.Val. The second is the second input (value) + RTracker.Val.
 func (fn *KvSdf) ProcessElement(rt *RTracker, i1 int, i2 int, emit func(int, int)) {
 	emit(i1+rt.Rest.Val, i2+rt.Val)
-	return
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
@@ -38,7 +38,7 @@ func TestInvokes(t *testing.T) {
 	kvsdf := (*graph.SplittableDoFn)(dfn)
 
 	// Tests.
-	t.Run("createInitialRestrictionCallFn", func(t *testing.T) {
+	t.Run("CreateInitialRestriction Invoker (cirInvoker)", func(t *testing.T) {
 		tests := []struct {
 			name string
 			sdf  *graph.SplittableDoFn
@@ -71,7 +71,7 @@ func TestInvokes(t *testing.T) {
 		}
 	})
 
-	t.Run("invokeSplitRestriction", func(t *testing.T) {
+	t.Run("SplitRestriction Invoker (srInvoker)", func(t *testing.T) {
 		tests := []struct {
 			name string
 			sdf  *graph.SplittableDoFn
@@ -116,7 +116,7 @@ func TestInvokes(t *testing.T) {
 		}
 	})
 
-	t.Run("invokeRestrictionSize", func(t *testing.T) {
+	t.Run("RestrictionSize Invoker (rsInvoker)", func(t *testing.T) {
 		tests := []struct {
 			name string
 			sdf  *graph.SplittableDoFn
@@ -151,11 +151,17 @@ func TestInvokes(t *testing.T) {
 					t.Errorf("Invoke(%v, %v) has incorrect output: got: %v, want: %v",
 						test.elms, test.rest, got, test.want)
 				}
+				invoker.Reset()
+				for i, arg := range invoker.args {
+					if arg != nil {
+						t.Errorf("Reset() failed to empty all args. args[%v] = %v", i, arg)
+					}
+				}
 			})
 		}
 	})
 
-	t.Run("invokeCreateTracker", func(t *testing.T) {
+	t.Run("CreateTracker Invoker (ctInvoker)", func(t *testing.T) {
 		tests := []struct {
 			name string
 			sdf  *graph.SplittableDoFn
@@ -192,6 +198,12 @@ func TestInvokes(t *testing.T) {
 				if !cmp.Equal(got, test.want) {
 					t.Errorf("Invoke(%v) has incorrect output: got: %v, want: %v",
 						test.rest, got, test.want)
+				}
+				invoker.Reset()
+				for i, arg := range invoker.args {
+					if arg != nil {
+						t.Errorf("Reset() failed to empty all args. args[%v] = %v", i, arg)
+					}
 				}
 			})
 		}
@@ -242,9 +254,11 @@ func (fn *Sdf) CreateTracker(rest Restriction) *RTracker {
 	return &RTracker{rest, 1}
 }
 
-// ProcessElement is a no-op, it's only included to pass validation.
-func (fn *Sdf) ProcessElement(*RTracker, int) int {
-	return 0
+// ProcessElement emits a pair of ints. The first is the input +
+// RTracker.Rest.Val. The second is the input + RTracker.Val.
+func (fn *Sdf) ProcessElement(rt *RTracker, i int, emit func(int, int)) {
+	emit(i+rt.Rest.Val, i+rt.Val)
+	return
 }
 
 type KvSdf struct {
@@ -273,7 +287,9 @@ func (fn *KvSdf) CreateTracker(rest Restriction) *RTracker {
 	return &RTracker{rest, 2}
 }
 
-// ProcessElement is a no-op, it's only included to pass validation.
-func (fn *KvSdf) ProcessElement(*RTracker, int, int) int {
-	return 0
+// ProcessElement emits two ints. The first is the first input (key) +
+// RTracker.Rest.Val. The second is the second input (value) + RTracker.Val.
+func (fn *KvSdf) ProcessElement(rt *RTracker, i1 int, i2 int, emit func(int, int)) {
+	emit(i1+rt.Rest.Val, i2+rt.Val)
+	return
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
@@ -16,7 +16,6 @@
 package exec
 
 import (
-	"context"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/window"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
@@ -53,19 +52,19 @@ func TestSdfNodes(t *testing.T) {
 		tests := []struct {
 			name string
 			fn   *graph.DoFn
-			in   *FullValue
-			want *FullValue
+			in   FullValue
+			want FullValue
 		}{
 			{
 				name: "SingleElem",
 				fn:   dfn,
-				in: &FullValue{
+				in: FullValue{
 					Elm:       5,
 					Elm2:      nil,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
-				want: &FullValue{
+				want: FullValue{
 					Elm: &FullValue{
 						Elm:       5,
 						Elm2:      nil,
@@ -80,13 +79,13 @@ func TestSdfNodes(t *testing.T) {
 			{
 				name: "KvElem",
 				fn:   kvdfn,
-				in: &FullValue{
+				in: FullValue{
 					Elm:       5,
 					Elm2:      2,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
-				want: &FullValue{
+				want: FullValue{
 					Elm: &FullValue{
 						Elm:       5,
 						Elm2:      2,
@@ -102,13 +101,13 @@ func TestSdfNodes(t *testing.T) {
 		for _, test := range tests {
 			test := test
 			t.Run(test.name, func(t *testing.T) {
-				fake := &FakeNode{UID: 2}
-				node := &PairWithRestriction{UID: 1, Fn: test.fn, Out: fake}
-				root := &FixedRoot{UID: 0, Elements: []MainInput{{Key: *test.in}}, Out: node}
-				units := []Unit{root, node, fake}
+				capt := &CaptureNode{UID: 2}
+				node := &PairWithRestriction{UID: 1, Fn: test.fn, Out: capt}
+				root := &FixedRoot{UID: 0, Elements: []MainInput{{Key: test.in}}, Out: node}
+				units := []Unit{root, node, capt}
 				constructAndExecutePlan(t, units)
 
-				got := fake.Vals[0]
+				got := capt.Elements[0]
 				if !cmp.Equal(got, test.want) {
 					t.Errorf("ProcessElement(%v) has incorrect output: got: %v, want: %v",
 						test.in, got, test.want)
@@ -123,13 +122,13 @@ func TestSdfNodes(t *testing.T) {
 		tests := []struct {
 			name string
 			fn   *graph.DoFn
-			in   *FullValue
-			want []*FullValue
+			in   FullValue
+			want []FullValue
 		}{
 			{
 				name: "SingleElem",
 				fn:   dfn,
-				in: &FullValue{
+				in: FullValue{
 					Elm: &FullValue{
 						Elm:       2,
 						Elm2:      nil,
@@ -140,7 +139,7 @@ func TestSdfNodes(t *testing.T) {
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
-				want: []*FullValue{
+				want: []FullValue{
 					{
 						Elm: &FullValue{
 							Elm: &FullValue{
@@ -174,7 +173,7 @@ func TestSdfNodes(t *testing.T) {
 			{
 				name: "KvElem",
 				fn:   kvdfn,
-				in: &FullValue{
+				in: FullValue{
 					Elm: &FullValue{
 						Elm:       2,
 						Elm2:      5,
@@ -185,7 +184,7 @@ func TestSdfNodes(t *testing.T) {
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
-				want: []*FullValue{
+				want: []FullValue{
 					{
 						Elm: &FullValue{
 							Elm: &FullValue{
@@ -220,13 +219,13 @@ func TestSdfNodes(t *testing.T) {
 		for _, test := range tests {
 			test := test
 			t.Run(test.name, func(t *testing.T) {
-				fake := &FakeNode{UID: 2}
-				node := &SplitAndSizeRestrictions{UID: 1, Fn: test.fn, Out: fake}
-				root := &FixedRoot{UID: 0, Elements: []MainInput{{Key: *test.in}}, Out: node}
-				units := []Unit{root, node, fake}
+				capt := &CaptureNode{UID: 2}
+				node := &SplitAndSizeRestrictions{UID: 1, Fn: test.fn, Out: capt}
+				root := &FixedRoot{UID: 0, Elements: []MainInput{{Key: test.in}}, Out: node}
+				units := []Unit{root, node, capt}
 				constructAndExecutePlan(t, units)
 
-				for i, got := range fake.Vals {
+				for i, got := range capt.Elements {
 					if !cmp.Equal(got, test.want[i]) {
 						t.Errorf("ProcessElement(%v) has incorrect output %v: got: %v, want: %v",
 							test.in, i, got, test.want)
@@ -242,13 +241,13 @@ func TestSdfNodes(t *testing.T) {
 		tests := []struct {
 			name string
 			fn   *graph.DoFn
-			in   *FullValue
-			want *FullValue
+			in   FullValue
+			want FullValue
 		}{
 			{
 				name: "SingleElem",
 				fn:   dfn,
-				in: &FullValue{
+				in: FullValue{
 					Elm: &FullValue{
 						Elm: &FullValue{
 							Elm:       3,
@@ -262,7 +261,7 @@ func TestSdfNodes(t *testing.T) {
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
-				want: &FullValue{
+				want: FullValue{
 					Elm:       8,
 					Elm2:      4,
 					Timestamp: testTimestamp,
@@ -272,7 +271,7 @@ func TestSdfNodes(t *testing.T) {
 			{
 				name: "KvElem",
 				fn:   kvdfn,
-				in: &FullValue{
+				in: FullValue{
 					Elm: &FullValue{
 						Elm: &FullValue{
 							Elm:       3,
@@ -286,7 +285,7 @@ func TestSdfNodes(t *testing.T) {
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
-				want: &FullValue{
+				want: FullValue{
 					Elm:       8,
 					Elm2:      12,
 					Timestamp: testTimestamp,
@@ -297,14 +296,14 @@ func TestSdfNodes(t *testing.T) {
 		for _, test := range tests {
 			test := test
 			t.Run(test.name, func(t *testing.T) {
-				fake := &FakeNode{UID: 2}
-				n := &ParDo{UID: 1, Fn: test.fn, Out: []Node{fake}}
+				capt := &CaptureNode{UID: 2}
+				n := &ParDo{UID: 1, Fn: test.fn, Out: []Node{capt}}
 				node := &ProcessSizedElementsAndRestrictions{PDo: n}
-				root := &FixedRoot{UID: 0, Elements: []MainInput{{Key: *test.in}}, Out: node}
-				units := []Unit{root, node, fake}
+				root := &FixedRoot{UID: 0, Elements: []MainInput{{Key: test.in}}, Out: node}
+				units := []Unit{root, node, capt}
 				constructAndExecutePlan(t, units)
 
-				got := fake.Vals[0]
+				got := capt.Elements[0]
 				if !cmp.Equal(got, test.want) {
 					t.Errorf("ProcessElement(%v) has incorrect output: got: %v, want: %v",
 						test.in, got, test.want)
@@ -312,56 +311,4 @@ func TestSdfNodes(t *testing.T) {
 			})
 		}
 	})
-}
-
-// TestSplitAndSizeRestrictions verifies that the SplitAndSizeRestrictions node
-// both fulfills its contract and successfully invokes the accompanying SDF's
-// SplitRestriction and RestrictionSize methods to do so.
-func TestSplitAndSizeRestrictions(t *testing.T) {
-}
-
-// TestProcessSizedElementsAndRestrictions verifies that the
-// ProcessSizedElementsAndRestrictions node both fulfills its contract and
-// successfully invokes the accompanying SDF's CreateTracker and ProcessElement
-// methods to do so.
-func TestProcessSizedElementsAndRestrictions(t *testing.T) {
-}
-
-// FakeNode is used to capture the outputs of the node being tested by
-// TestSdfNodes. FakeNode appends each element that it receives in its
-// ProcessElement method to its Vals struct, which can then be read by the test.
-type FakeNode struct {
-	UID  UnitID
-	Vals []*FullValue
-}
-
-// ID is a no-op.
-func (n *FakeNode) ID() UnitID {
-	return n.UID
-}
-
-// Up is a no-op.
-func (*FakeNode) Up(ctx context.Context) error {
-	return nil
-}
-
-// StartBundle is a no-op.
-func (*FakeNode) StartBundle(ctx context.Context, id string, data DataContext) error {
-	return nil
-}
-
-// ProcessElement appends elm to this FakeNode's slice of elements received.
-func (n *FakeNode) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
-	n.Vals = append(n.Vals, elm)
-	return nil
-}
-
-// FinishBundle is a no-op.
-func (*FakeNode) FinishBundle(ctx context.Context) error {
-	return nil
-}
-
-// Down is a no-op.
-func (*FakeNode) Down(ctx context.Context) error {
-	return nil
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
@@ -1,0 +1,408 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+// testTimestamp is a constant used to check that timestamps are retained.
+const testTimestamp = 15
+
+// testWindow is a constant used to check that windows are retained
+var testWindows = []typex.Window{window.IntervalWindow{Start: 10, End: 20}}
+
+// TestSdfNodes verifies that the various SDF nodes fulfill each of their
+// described contracts, that they each successfully invoke any SDF methods
+// needed, and that they preserve timestamps and windows correctly.
+func TestSdfNodes(t *testing.T) {
+	// Setup. The DoFns created below are defined in sdf_invokers_test.go and
+	// have testable behavior to confirm that they got correctly invoked.
+	// Without knowing the expected behavior of these DoFns, the desired outputs
+	// in the unit tests below will not make much sense.
+	dfn, err := graph.NewDoFn(&Sdf{}, graph.NumMainInputs(graph.MainSingle))
+	if err != nil {
+		t.Fatalf("invalid function: %v", err)
+	}
+	kvdfn, err := graph.NewDoFn(&KvSdf{}, graph.NumMainInputs(graph.MainKv))
+	if err != nil {
+		t.Fatalf("invalid function: %v", err)
+	}
+
+	// Validate PairWithRestriction matches its contract and properly invokes
+	// SDF method CreateInitialRestriction.
+	t.Run("PairWithRestriction", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   *graph.DoFn
+			in   *FullValue
+			want *FullValue
+		}{
+			{
+				name: "SingleElem",
+				fn:   dfn,
+				in: &FullValue{
+					Elm:       5,
+					Elm2:      nil,
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+				want: &FullValue{
+					Elm: &FullValue{
+						Elm:       5,
+						Elm2:      nil,
+						Timestamp: testTimestamp,
+						Windows:   testWindows,
+					},
+					Elm2:      Restriction{5},
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+			},
+			{
+				name: "KvElem",
+				fn:   kvdfn,
+				in: &FullValue{
+					Elm:       5,
+					Elm2:      2,
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+				want: &FullValue{
+					Elm: &FullValue{
+						Elm:       5,
+						Elm2:      2,
+						Timestamp: testTimestamp,
+						Windows:   testWindows,
+					},
+					Elm2:      Restriction{7},
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+			},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(test.name, func(t *testing.T) {
+				ctx := context.Background()
+				fake := &FakeNode{}
+				node := PairWithRestriction{UID: 0, Fn: test.fn, Out: []Node{fake}}
+
+				if err := node.Up(ctx); err != nil {
+					t.Fatalf("Up failed: %v", err)
+				}
+				if err := node.StartBundle(ctx, "bundle_id", DataContext{}); err != nil {
+					t.Fatalf("StartBundle failed: %v", err)
+				}
+
+				if err := node.ProcessElement(ctx, test.in); err != nil {
+					t.Fatalf("ProcessElement failed: %v", err)
+				}
+				got := fake.Vals[0]
+				if !cmp.Equal(got, test.want) {
+					t.Errorf("ProcessElement(%v) has incorrect output: got: %v, want: %v",
+						test.in, got, test.want)
+				}
+				if err := node.FinishBundle(ctx); err != nil {
+					t.Fatalf("FinishBundle failed: %v", err)
+				}
+				if err := node.Down(ctx); err != nil {
+					t.Fatalf("Down failed: %v", err)
+				}
+			})
+		}
+	})
+
+	// Validate SplitAndSizeRestrictions matches its contract and properly
+	// invokes SDF methods SplitRestriction and RestrictionSize.
+	t.Run("SplitAndSizeRestrictions", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   *graph.DoFn
+			in   *FullValue
+			want []*FullValue
+		}{
+			{
+				name: "SingleElem",
+				fn:   dfn,
+				in: &FullValue{
+					Elm: &FullValue{
+						Elm:       2,
+						Elm2:      nil,
+						Timestamp: testTimestamp,
+						Windows:   testWindows,
+					},
+					Elm2:      Restriction{5},
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+				want: []*FullValue{
+					{
+						Elm: &FullValue{
+							Elm: &FullValue{
+								Elm:       2,
+								Elm2:      nil,
+								Timestamp: testTimestamp,
+								Windows:   testWindows,
+							},
+							Elm2: Restriction{7},
+						},
+						Elm2:      9.0,
+						Timestamp: testTimestamp,
+						Windows:   testWindows,
+					},
+					{
+						Elm: &FullValue{
+							Elm: &FullValue{
+								Elm:       2,
+								Elm2:      nil,
+								Timestamp: testTimestamp,
+								Windows:   testWindows,
+							},
+							Elm2: Restriction{8},
+						},
+						Elm2:      10.0,
+						Timestamp: testTimestamp,
+						Windows:   testWindows,
+					},
+				},
+			},
+			{
+				name: "KvElem",
+				fn:   kvdfn,
+				in: &FullValue{
+					Elm: &FullValue{
+						Elm:       2,
+						Elm2:      5,
+						Timestamp: testTimestamp,
+						Windows:   testWindows,
+					},
+					Elm2:      Restriction{3},
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+				want: []*FullValue{
+					{
+						Elm: &FullValue{
+							Elm: &FullValue{
+								Elm:       2,
+								Elm2:      5,
+								Timestamp: testTimestamp,
+								Windows:   testWindows,
+							},
+							Elm2: Restriction{5},
+						},
+						Elm2:      12.0,
+						Timestamp: testTimestamp,
+						Windows:   testWindows,
+					},
+					{
+						Elm: &FullValue{
+							Elm: &FullValue{
+								Elm:       2,
+								Elm2:      5,
+								Timestamp: testTimestamp,
+								Windows:   testWindows,
+							},
+							Elm2: Restriction{8},
+						},
+						Elm2:      15.0,
+						Timestamp: testTimestamp,
+						Windows:   testWindows,
+					},
+				},
+			},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(test.name, func(t *testing.T) {
+				ctx := context.Background()
+				fake := &FakeNode{}
+				node := SplitAndSizeRestrictions{UID: 0, Fn: test.fn, Out: []Node{fake}}
+
+				if err := node.Up(ctx); err != nil {
+					t.Fatalf("Up failed: %v", err)
+				}
+				if err := node.StartBundle(ctx, "bundle_id", DataContext{}); err != nil {
+					t.Fatalf("StartBundle failed: %v", err)
+				}
+
+				if err := node.ProcessElement(ctx, test.in); err != nil {
+					t.Fatalf("ProcessElement failed: %v", err)
+				}
+				for i, got := range fake.Vals {
+					if !cmp.Equal(got, test.want[i]) {
+						t.Errorf("ProcessElement(%v) has incorrect output %v: got: %v, want: %v",
+							test.in, i, got, test.want)
+					}
+				}
+				if err := node.FinishBundle(ctx); err != nil {
+					t.Fatalf("FinishBundle failed: %v", err)
+				}
+				if err := node.Down(ctx); err != nil {
+					t.Fatalf("Down failed: %v", err)
+				}
+			})
+		}
+	})
+
+	// Validate ProcessSizedElementsAndRestrictions matches its contract and
+	// properly invokes SDF methods CreateTracker and ProcessElement.
+	t.Run("ProcessSizedElementsAndRestrictions", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   *graph.DoFn
+			in   *FullValue
+			want *FullValue
+		}{
+			{
+				name: "SingleElem",
+				fn:   dfn,
+				in: &FullValue{
+					Elm: &FullValue{
+						Elm: &FullValue{
+							Elm:       3,
+							Elm2:      nil,
+							Timestamp: testTimestamp,
+							Windows:   testWindows,
+						},
+						Elm2: Restriction{5},
+					},
+					Elm2:      8.0,
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+				want: &FullValue{
+					Elm:       8,
+					Elm2:      4,
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+			},
+			{
+				name: "KvElem",
+				fn:   kvdfn,
+				in: &FullValue{
+					Elm: &FullValue{
+						Elm: &FullValue{
+							Elm:       3,
+							Elm2:      10,
+							Timestamp: testTimestamp,
+							Windows:   testWindows,
+						},
+						Elm2: Restriction{5},
+					},
+					Elm2:      18.0,
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+				want: &FullValue{
+					Elm:       8,
+					Elm2:      12,
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
+				},
+			},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(test.name, func(t *testing.T) {
+				ctx := context.Background()
+				fake := &FakeNode{}
+				n := &ParDo{UID: 0, Fn: test.fn, Out: []Node{fake}}
+				node := ProcessSizedElementsAndRestrictions{PDo: n}
+
+				if err := node.Up(ctx); err != nil {
+					t.Fatalf("Up failed: %v", err)
+				}
+				if err := node.StartBundle(ctx, "bundle_id", DataContext{}); err != nil {
+					t.Fatalf("StartBundle failed: %v", err)
+				}
+
+				if err := node.ProcessElement(ctx, test.in); err != nil {
+					t.Fatalf("ProcessElement failed: %v", err)
+				}
+				got := fake.Vals[0]
+				if !cmp.Equal(got, test.want) {
+					t.Errorf("ProcessElement(%v) has incorrect output: got: %v, want: %v",
+						test.in, got, test.want)
+				}
+				if err := node.FinishBundle(ctx); err != nil {
+					t.Fatalf("FinishBundle failed: %v", err)
+				}
+				if err := node.Down(ctx); err != nil {
+					t.Fatalf("Down failed: %v", err)
+				}
+			})
+		}
+	})
+}
+
+// TestSplitAndSizeRestrictions verifies that the SplitAndSizeRestrictions node
+// both fulfills its contract and successfully invokes the accompanying SDF's
+// SplitRestriction and RestrictionSize methods to do so.
+func TestSplitAndSizeRestrictions(t *testing.T) {
+}
+
+// TestProcessSizedElementsAndRestrictions verifies that the
+// ProcessSizedElementsAndRestrictions node both fulfills its contract and
+// successfully invokes the accompanying SDF's CreateTracker and ProcessElement
+// methods to do so.
+func TestProcessSizedElementsAndRestrictions(t *testing.T) {
+}
+
+// FakeNode is used to capture the outputs of the node being tested by
+// TestSdfNodes. FakeNode appends each element that it receives in its
+// ProcessElement method to its Vals struct, which can then be read by the test.
+type FakeNode struct {
+	Vals []*FullValue
+}
+
+// ID is a no-op.
+func (*FakeNode) ID() UnitID {
+	return 0
+}
+
+// Up is a no-op.
+func (*FakeNode) Up(ctx context.Context) error {
+	return nil
+}
+
+// StartBundle is a no-op.
+func (*FakeNode) StartBundle(ctx context.Context, id string, data DataContext) error {
+	return nil
+}
+
+// ProcessElement appends elm to this FakeNode's slice of elements received.
+func (n *FakeNode) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
+	n.Vals = append(n.Vals, elm)
+	return nil
+}
+
+// FinishBundle is a no-op.
+func (*FakeNode) FinishBundle(ctx context.Context) error {
+	return nil
+}
+
+// Down is a no-op.
+func (*FakeNode) Down(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
Adds the three units needed to execute expanded SDF transforms. Note
that this is still missing a unit to execute unexpanded SDF transforms,
and that these units are not currently created in graph translation,
so this does not actually enable SDFs to be used just yet.

Actual testing of SDFs needs to be done before enabling the graph
translation changes, but those will be coming next once any bugs
that might pop up are ironed out.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
