### PR TITLE
[BEAM-9724] Use consistent short package names for protos

### DIFF
--- a/sdks/go/cmd/beamctl/cmd/artifact.go
+++ b/sdks/go/cmd/beamctl/cmd/artifact.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/artifact"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +67,7 @@ func stageFn(cmd *cobra.Command, args []string) error {
 
 	// (2) Stage files in parallel, commit and print out token
 
-	client := pb.NewLegacyArtifactStagingServiceClient(cc)
+	client := jobpb.NewLegacyArtifactStagingServiceClient(cc)
 	list, err := artifact.MultiStage(ctx, client, 10, files, stagingToken)
 	if err != nil {
 		return err
@@ -88,8 +88,8 @@ func listFn(cmd *cobra.Command, args []string) error {
 	}
 	defer cc.Close()
 
-	client := pb.NewLegacyArtifactRetrievalServiceClient(cc)
-	md, err := client.GetManifest(ctx, &pb.GetManifestRequest{})
+	client := jobpb.NewLegacyArtifactRetrievalServiceClient(cc)
+	md, err := client.GetManifest(ctx, &jobpb.GetManifestRequest{})
 	if err != nil {
 		return err
 	}

--- a/sdks/go/cmd/beamctl/cmd/provision.go
+++ b/sdks/go/cmd/beamctl/cmd/provision.go
@@ -16,7 +16,7 @@
 package cmd
 
 import (
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cobra"
 )
@@ -46,9 +46,9 @@ func infoFn(cmd *cobra.Command, args []string) error {
 	}
 	defer cc.Close()
 
-	client := pb.NewProvisionServiceClient(cc)
+	client := fnpb.NewProvisionServiceClient(cc)
 
-	info, err := client.GetProvisionInfo(ctx, &pb.GetProvisionInfoRequest{})
+	info, err := client.GetProvisionInfo(ctx, &fnpb.GetProvisionInfoRequest{})
 	if err != nil {
 		return err
 	}

--- a/sdks/go/pkg/beam/artifact/gcsproxy/retrieval.go
+++ b/sdks/go/pkg/beam/artifact/gcsproxy/retrieval.go
@@ -20,7 +20,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/gcsx"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
@@ -30,12 +30,12 @@ import (
 // Cloud Storage (GCS). It serves a single manifest and ignores
 // the worker id. The server performs no caching or pre-fetching.
 type RetrievalServer struct {
-	md    *pb.Manifest
+	md    *jobpb.Manifest
 	blobs map[string]string
 }
 
 // ReadProxyManifest reads and parses the proxy manifest from GCS.
-func ReadProxyManifest(ctx context.Context, object string) (*pb.ProxyManifest, error) {
+func ReadProxyManifest(ctx context.Context, object string) (*jobpb.ProxyManifest, error) {
 	bucket, obj, err := gcsx.ParseObject(object)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid manifest object %v", object)
@@ -49,7 +49,7 @@ func ReadProxyManifest(ctx context.Context, object string) (*pb.ProxyManifest, e
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read manifest %v", object)
 	}
-	var md pb.ProxyManifest
+	var md jobpb.ProxyManifest
 	if err := proto.Unmarshal(content, &md); err != nil {
 		return nil, errors.Wrapf(err, "invalid manifest %v", object)
 	}
@@ -58,7 +58,7 @@ func ReadProxyManifest(ctx context.Context, object string) (*pb.ProxyManifest, e
 
 // NewRetrievalServer creates a artifact retrieval server for the
 // given manifest. It requires that the locations are in GCS.
-func NewRetrievalServer(md *pb.ProxyManifest) (*RetrievalServer, error) {
+func NewRetrievalServer(md *jobpb.ProxyManifest) (*RetrievalServer, error) {
 	if err := validate(md); err != nil {
 		return nil, err
 	}
@@ -74,12 +74,12 @@ func NewRetrievalServer(md *pb.ProxyManifest) (*RetrievalServer, error) {
 }
 
 // GetManifest returns the manifest for all artifacts.
-func (s *RetrievalServer) GetManifest(ctx context.Context, req *pb.GetManifestRequest) (*pb.GetManifestResponse, error) {
-	return &pb.GetManifestResponse{Manifest: s.md}, nil
+func (s *RetrievalServer) GetManifest(ctx context.Context, req *jobpb.GetManifestRequest) (*jobpb.GetManifestResponse, error) {
+	return &jobpb.GetManifestResponse{Manifest: s.md}, nil
 }
 
 // GetArtifact returns a given artifact.
-func (s *RetrievalServer) GetArtifact(req *pb.LegacyGetArtifactRequest, stream pb.LegacyArtifactRetrievalService_GetArtifactServer) error {
+func (s *RetrievalServer) GetArtifact(req *jobpb.LegacyGetArtifactRequest, stream jobpb.LegacyArtifactRetrievalService_GetArtifactServer) error {
 	key := req.GetName()
 	blob, ok := s.blobs[key]
 	if !ok {
@@ -105,7 +105,7 @@ func (s *RetrievalServer) GetArtifact(req *pb.LegacyGetArtifactRequest, stream p
 	for {
 		n, err := r.Read(data)
 		if n > 0 {
-			if err := stream.Send(&pb.ArtifactChunk{Data: data[:n]}); err != nil {
+			if err := stream.Send(&jobpb.ArtifactChunk{Data: data[:n]}); err != nil {
 				return errors.Wrap(err, "chunk send failed")
 			}
 		}
@@ -119,7 +119,7 @@ func (s *RetrievalServer) GetArtifact(req *pb.LegacyGetArtifactRequest, stream p
 	return nil
 }
 
-func validate(md *pb.ProxyManifest) error {
+func validate(md *jobpb.ProxyManifest) error {
 	keys := make(map[string]bool)
 	for _, a := range md.GetManifest().GetArtifact() {
 		if _, seen := keys[a.Name]; seen {

--- a/sdks/go/pkg/beam/artifact/gcsproxy/staging.go
+++ b/sdks/go/pkg/beam/artifact/gcsproxy/staging.go
@@ -26,7 +26,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/gcsx"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
@@ -64,7 +64,7 @@ func NewStagingServer(manifest string) (*StagingServer, error) {
 }
 
 // CommitManifest commits the given artifact manifest to GCS.
-func (s *StagingServer) CommitManifest(ctx context.Context, req *pb.CommitManifestRequest) (*pb.CommitManifestResponse, error) {
+func (s *StagingServer) CommitManifest(ctx context.Context, req *jobpb.CommitManifestRequest) (*jobpb.CommitManifestResponse, error) {
 	manifest := req.GetManifest()
 
 	s.mu.Lock()
@@ -75,7 +75,7 @@ func (s *StagingServer) CommitManifest(ctx context.Context, req *pb.CommitManife
 	}
 	s.mu.Unlock()
 
-	data, err := proto.Marshal(&pb.ProxyManifest{Manifest: manifest, Location: loc})
+	data, err := proto.Marshal(&jobpb.ProxyManifest{Manifest: manifest, Location: loc})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal proxy manifest")
 	}
@@ -93,13 +93,13 @@ func (s *StagingServer) CommitManifest(ctx context.Context, req *pb.CommitManife
 	// now, but would be needed for a staging server that serves multiple
 	// jobs. Such a server would also use the ID sent with each request.
 
-	return &pb.CommitManifestResponse{RetrievalToken: gcsx.MakeObject(s.bucket, s.manifest)}, nil
+	return &jobpb.CommitManifestResponse{RetrievalToken: gcsx.MakeObject(s.bucket, s.manifest)}, nil
 }
 
 // matchLocations ensures that all artifacts have been staged and have valid
 // content. It is fine for staged artifacts to not appear in the manifest.
-func matchLocations(artifacts []*pb.ArtifactMetadata, blobs map[string]staged) ([]*pb.ProxyManifest_Location, error) {
-	var loc []*pb.ProxyManifest_Location
+func matchLocations(artifacts []*jobpb.ArtifactMetadata, blobs map[string]staged) ([]*jobpb.ProxyManifest_Location, error) {
+	var loc []*jobpb.ProxyManifest_Location
 	for _, a := range artifacts {
 		info, ok := blobs[a.Name]
 		if !ok {
@@ -112,13 +112,13 @@ func matchLocations(artifacts []*pb.ArtifactMetadata, blobs map[string]staged) (
 			return nil, errors.Errorf("staged artifact for %v has invalid SHA256: %v, want %v", a.Name, info.hash, a.Sha256)
 		}
 
-		loc = append(loc, &pb.ProxyManifest_Location{Name: a.Name, Uri: info.object})
+		loc = append(loc, &jobpb.ProxyManifest_Location{Name: a.Name, Uri: info.object})
 	}
 	return loc, nil
 }
 
 // PutArtifact stores the given artifact in GCS.
-func (s *StagingServer) PutArtifact(ps pb.LegacyArtifactStagingService_PutArtifactServer) error {
+func (s *StagingServer) PutArtifact(ps jobpb.LegacyArtifactStagingService_PutArtifactServer) error {
 	// Read header
 
 	header, err := ps.Recv()
@@ -153,7 +153,7 @@ func (s *StagingServer) PutArtifact(ps pb.LegacyArtifactStagingService_PutArtifa
 	s.blobs[md.Name] = staged{object: gcsx.MakeObject(s.bucket, object), hash: hash}
 	s.mu.Unlock()
 
-	return ps.SendAndClose(&pb.PutArtifactResponse{})
+	return ps.SendAndClose(&jobpb.PutArtifactResponse{})
 }
 
 // reader is an adapter between the artifact stream and the GCS stream reader.
@@ -161,7 +161,7 @@ func (s *StagingServer) PutArtifact(ps pb.LegacyArtifactStagingService_PutArtifa
 type reader struct {
 	sha256W hash.Hash
 	buf     []byte
-	stream  pb.LegacyArtifactStagingService_PutArtifactServer
+	stream  jobpb.LegacyArtifactStagingService_PutArtifactServer
 }
 
 func (r *reader) Read(buf []byte) (int, error) {

--- a/sdks/go/pkg/beam/artifact/materialize.go
+++ b/sdks/go/pkg/beam/artifact/materialize.go
@@ -47,7 +47,7 @@ const (
 // present and uncorrupted. It interprets each artifact name as a relative
 // path under the dest directory. It does not retrieve valid artifacts already
 // present.
-// TODO(BEAM-9577): Return a mapping of filename to dependency, rather than []*pb.ArtifactMetadata.
+// TODO(BEAM-9577): Return a mapping of filename to dependency, rather than []*jobpb.ArtifactMetadata.
 // TODO(BEAM-9577): Leverage richness of roles rather than magic names to understand artifacts.
 func Materialize(ctx context.Context, endpoint string, dependencies []*pipepb.ArtifactInformation, rt string, dest string) ([]*jobpb.ArtifactMetadata, error) {
 	if len(dependencies) > 0 {
@@ -262,9 +262,9 @@ func LegacyMultiRetrieve(ctx context.Context, client jobpb.LegacyArtifactRetriev
 }
 
 type legacyArtifact struct {
-	client pb.LegacyArtifactRetrievalServiceClient
+	client jobpb.LegacyArtifactRetrievalServiceClient
 	rt     string
-	md     *pb.ArtifactMetadata
+	md     *jobpb.ArtifactMetadata
 }
 
 func (a legacyArtifact) retrieve(ctx context.Context, dest string) error {

--- a/sdks/go/pkg/beam/artifact/materialize.go
+++ b/sdks/go/pkg/beam/artifact/materialize.go
@@ -30,8 +30,8 @@ import (
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
-	ppb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/errorx"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
 	"github.com/golang/protobuf/proto"
@@ -49,40 +49,40 @@ const (
 // present.
 // TODO(BEAM-9577): Return a mapping of filename to dependency, rather than []*pb.ArtifactMetadata.
 // TODO(BEAM-9577): Leverage richness of roles rather than magic names to understand artifacts.
-func Materialize(ctx context.Context, endpoint string, dependencies []*ppb.ArtifactInformation, rt string, dest string) ([]*pb.ArtifactMetadata, error) {
+func Materialize(ctx context.Context, endpoint string, dependencies []*pipepb.ArtifactInformation, rt string, dest string) ([]*jobpb.ArtifactMetadata, error) {
 	if len(dependencies) > 0 {
 		return newMaterialize(ctx, endpoint, dependencies, dest)
 	} else if rt == "" || rt == NoArtifactsStaged {
-		return []*pb.ArtifactMetadata{}, nil
+		return []*jobpb.ArtifactMetadata{}, nil
 	} else {
 		return legacyMaterialize(ctx, endpoint, rt, dest)
 	}
 }
 
-func newMaterialize(ctx context.Context, endpoint string, dependencies []*ppb.ArtifactInformation, dest string) ([]*pb.ArtifactMetadata, error) {
+func newMaterialize(ctx context.Context, endpoint string, dependencies []*pipepb.ArtifactInformation, dest string) ([]*jobpb.ArtifactMetadata, error) {
 	cc, err := grpcx.Dial(ctx, endpoint, 2*time.Minute)
 	if err != nil {
 		return nil, err
 	}
 	defer cc.Close()
 
-	return newMaterializeWithClient(ctx, pb.NewArtifactRetrievalServiceClient(cc), dependencies, dest)
+	return newMaterializeWithClient(ctx, jobpb.NewArtifactRetrievalServiceClient(cc), dependencies, dest)
 }
 
-func newMaterializeWithClient(ctx context.Context, client pb.ArtifactRetrievalServiceClient, dependencies []*ppb.ArtifactInformation, dest string) ([]*pb.ArtifactMetadata, error) {
-	resolution, err := client.ResolveArtifacts(ctx, &pb.ResolveArtifactsRequest{Artifacts: dependencies})
+func newMaterializeWithClient(ctx context.Context, client jobpb.ArtifactRetrievalServiceClient, dependencies []*pipepb.ArtifactInformation, dest string) ([]*jobpb.ArtifactMetadata, error) {
+	resolution, err := client.ResolveArtifacts(ctx, &jobpb.ResolveArtifactsRequest{Artifacts: dependencies})
 	if err != nil {
 		return nil, err
 	}
 
-	var md []*pb.ArtifactMetadata
+	var md []*jobpb.ArtifactMetadata
 	var list []retrievable
 	for _, dep := range resolution.Replacements {
 		path, err := extractStagingToPath(dep)
 		if err != nil {
 			return nil, err
 		}
-		md = append(md, &pb.ArtifactMetadata{
+		md = append(md, &jobpb.ArtifactMetadata{
 			Name: path,
 		})
 
@@ -95,11 +95,11 @@ func newMaterializeWithClient(ctx context.Context, client pb.ArtifactRetrievalSe
 	return md, MultiRetrieve(ctx, 10, list, dest)
 }
 
-func extractStagingToPath(artifact *ppb.ArtifactInformation) (string, error) {
+func extractStagingToPath(artifact *pipepb.ArtifactInformation) (string, error) {
 	if artifact.RoleUrn != URNStagingTo {
 		return "", errors.Errorf("Unsupported artifact role %s", artifact.RoleUrn)
 	}
-	role := ppb.ArtifactStagingToRolePayload{}
+	role := pipepb.ArtifactStagingToRolePayload{}
 	if err := proto.Unmarshal(artifact.RolePayload, &role); err != nil {
 		return "", err
 	}
@@ -107,8 +107,8 @@ func extractStagingToPath(artifact *ppb.ArtifactInformation) (string, error) {
 }
 
 type artifact struct {
-	client pb.ArtifactRetrievalServiceClient
-	dep    *ppb.ArtifactInformation
+	client jobpb.ArtifactRetrievalServiceClient
+	dep    *pipepb.ArtifactInformation
 }
 
 func (a artifact) retrieve(ctx context.Context, dest string) error {
@@ -128,7 +128,7 @@ func (a artifact) retrieve(ctx context.Context, dest string) error {
 		return errors.Wrapf(err, "failed to stat %v", filename)
 	}
 
-	stream, err := a.client.GetArtifact(ctx, &pb.GetArtifactRequest{Artifact: a.dep})
+	stream, err := a.client.GetArtifact(ctx, &jobpb.GetArtifactRequest{Artifact: a.dep})
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func (a artifact) retrieve(ctx context.Context, dest string) error {
 	return fd.Close()
 }
 
-func writeChunks(stream pb.ArtifactRetrievalService_GetArtifactClient, w io.Writer) error {
+func writeChunks(stream jobpb.ArtifactRetrievalService_GetArtifactClient, w io.Writer) error {
 	for {
 		chunk, err := stream.Recv()
 		if err == io.EOF {
@@ -168,16 +168,16 @@ func writeChunks(stream pb.ArtifactRetrievalService_GetArtifactClient, w io.Writ
 	return nil
 }
 
-func legacyMaterialize(ctx context.Context, endpoint string, rt string, dest string) ([]*pb.ArtifactMetadata, error) {
+func legacyMaterialize(ctx context.Context, endpoint string, rt string, dest string) ([]*jobpb.ArtifactMetadata, error) {
 	cc, err := grpcx.Dial(ctx, endpoint, 2*time.Minute)
 	if err != nil {
 		return nil, err
 	}
 	defer cc.Close()
 
-	client := pb.NewLegacyArtifactRetrievalServiceClient(cc)
+	client := jobpb.NewLegacyArtifactRetrievalServiceClient(cc)
 
-	m, err := client.GetManifest(ctx, &pb.GetManifestRequest{RetrievalToken: rt})
+	m, err := client.GetManifest(ctx, &jobpb.GetManifestRequest{RetrievalToken: rt})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get manifest")
 	}
@@ -249,7 +249,7 @@ type retrievable interface {
 }
 
 // LegacyMultiRetrieve is exported for testing.
-func LegacyMultiRetrieve(ctx context.Context, client pb.LegacyArtifactRetrievalServiceClient, cpus int, list []*pb.ArtifactMetadata, rt string, dest string) error {
+func LegacyMultiRetrieve(ctx context.Context, client jobpb.LegacyArtifactRetrievalServiceClient, cpus int, list []*jobpb.ArtifactMetadata, rt string, dest string) error {
 	var rlist []retrievable
 	for _, md := range list {
 		rlist = append(rlist, &legacyArtifact{
@@ -275,7 +275,7 @@ func (a legacyArtifact) retrieve(ctx context.Context, dest string) error {
 // retrieved. If not, it retrieves into the dest directory. It overwrites any
 // previous retrieval attempt and may leave a corrupt/partial local file on
 // failure.
-func Retrieve(ctx context.Context, client pb.LegacyArtifactRetrievalServiceClient, a *pb.ArtifactMetadata, rt string, dest string) error {
+func Retrieve(ctx context.Context, client jobpb.LegacyArtifactRetrievalServiceClient, a *jobpb.ArtifactMetadata, rt string, dest string) error {
 	filename := filepath.Join(dest, filepath.FromSlash(a.Name))
 
 	_, err := os.Stat(filename)
@@ -310,8 +310,8 @@ func Retrieve(ctx context.Context, client pb.LegacyArtifactRetrievalServiceClien
 // It validates that the given SHA256 matches the content and fails otherwise.
 // It expects the file to not exist, but does not clean up on failure and
 // may leave a corrupt file.
-func retrieve(ctx context.Context, client pb.LegacyArtifactRetrievalServiceClient, a *pb.ArtifactMetadata, rt string, filename string) error {
-	stream, err := client.GetArtifact(ctx, &pb.LegacyGetArtifactRequest{Name: a.Name, RetrievalToken: rt})
+func retrieve(ctx context.Context, client jobpb.LegacyArtifactRetrievalServiceClient, a *jobpb.ArtifactMetadata, rt string, filename string) error {
+	stream, err := client.GetArtifact(ctx, &jobpb.LegacyGetArtifactRequest{Name: a.Name, RetrievalToken: rt})
 	if err != nil {
 		return err
 	}
@@ -342,7 +342,7 @@ func retrieve(ctx context.Context, client pb.LegacyArtifactRetrievalServiceClien
 	return nil
 }
 
-func retrieveChunks(stream pb.LegacyArtifactRetrievalService_GetArtifactClient, w io.Writer) (string, error) {
+func retrieveChunks(stream jobpb.LegacyArtifactRetrievalService_GetArtifactClient, w io.Writer) (string, error) {
 	sha256W := sha256.New()
 	for {
 		chunk, err := stream.Recv()
@@ -398,8 +398,8 @@ func slice2queue(list []retrievable) chan retrievable {
 	return q
 }
 
-func queue2slice(q chan *pb.ArtifactMetadata) []*pb.ArtifactMetadata {
-	var ret []*pb.ArtifactMetadata
+func queue2slice(q chan *jobpb.ArtifactMetadata) []*jobpb.ArtifactMetadata {
+	var ret []*jobpb.ArtifactMetadata
 	for elm := range q {
 		ret = append(ret, elm)
 	}

--- a/sdks/go/pkg/beam/artifact/materialize_test.go
+++ b/sdks/go/pkg/beam/artifact/materialize_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
 	"github.com/golang/protobuf/proto"
@@ -47,7 +47,7 @@ func TestRetrieve(t *testing.T) {
 	dst := makeTempDir(t)
 	defer os.RemoveAll(dst)
 
-	client := pb.NewLegacyArtifactRetrievalServiceClient(cc)
+	client := jobpb.NewLegacyArtifactRetrievalServiceClient(cc)
 	for _, a := range artifacts {
 		filename := makeFilename(dst, a.Name)
 		if err := Retrieve(ctx, client, a, rt, dst); err != nil {
@@ -72,7 +72,7 @@ func TestMultiRetrieve(t *testing.T) {
 	dst := makeTempDir(t)
 	defer os.RemoveAll(dst)
 
-	client := pb.NewLegacyArtifactRetrievalServiceClient(cc)
+	client := jobpb.NewLegacyArtifactRetrievalServiceClient(cc)
 	if err := LegacyMultiRetrieve(ctx, client, 10, artifacts, rt, dst); err != nil {
 		t.Errorf("failed to retrieve: %v", err)
 	}
@@ -84,10 +84,10 @@ func TestMultiRetrieve(t *testing.T) {
 
 // populate stages a set of artifacts with the given keys, each with
 // slightly different sizes and chucksizes.
-func populate(ctx context.Context, cc *grpc.ClientConn, t *testing.T, keys []string, size int, st string) (string, []*pb.ArtifactMetadata) {
-	scl := pb.NewLegacyArtifactStagingServiceClient(cc)
+func populate(ctx context.Context, cc *grpc.ClientConn, t *testing.T, keys []string, size int, st string) (string, []*jobpb.ArtifactMetadata) {
+	scl := jobpb.NewLegacyArtifactStagingServiceClient(cc)
 
-	var artifacts []*pb.ArtifactMetadata
+	var artifacts []*jobpb.ArtifactMetadata
 	for i, key := range keys {
 		a := stage(ctx, scl, t, key, size+7*i, 97+i, st)
 		artifacts = append(artifacts, a)
@@ -102,7 +102,7 @@ func populate(ctx context.Context, cc *grpc.ClientConn, t *testing.T, keys []str
 
 // stage stages an artifact with the given key, size and chuck size. The content is
 // always 'z's.
-func stage(ctx context.Context, scl pb.LegacyArtifactStagingServiceClient, t *testing.T, key string, size, chunkSize int, st string) *pb.ArtifactMetadata {
+func stage(ctx context.Context, scl jobpb.LegacyArtifactStagingServiceClient, t *testing.T, key string, size, chunkSize int, st string) *jobpb.ArtifactMetadata {
 	data := make([]byte, size)
 	for i := 0; i < size; i++ {
 		data[i] = 'z'
@@ -138,7 +138,7 @@ func stage(ctx context.Context, scl pb.LegacyArtifactStagingServiceClient, t *te
 
 		chunk := &jobpb.PutArtifactRequest{
 			Content: &jobpb.PutArtifactRequest_Data{
-				Data: &pb.ArtifactChunk{
+				Data: &jobpb.ArtifactChunk{
 					Data: data[i:end],
 				},
 			},

--- a/sdks/go/pkg/beam/artifact/server_test.go
+++ b/sdks/go/pkg/beam/artifact/server_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -42,8 +42,8 @@ func startServer(t *testing.T) *grpc.ClientConn {
 	real := &server{m: make(map[string]*manifest)}
 
 	gs := grpc.NewServer()
-	pb.RegisterLegacyArtifactStagingServiceServer(gs, real)
-	pb.RegisterLegacyArtifactRetrievalServiceServer(gs, real)
+	jobpb.RegisterLegacyArtifactStagingServiceServer(gs, real)
+	jobpb.RegisterLegacyArtifactRetrievalServiceServer(gs, real)
 	go gs.Serve(listener)
 
 	t.Logf("server listening on %v", endpoint)
@@ -56,12 +56,12 @@ func startServer(t *testing.T) *grpc.ClientConn {
 }
 
 type data struct {
-	md     *pb.ArtifactMetadata
+	md     *jobpb.ArtifactMetadata
 	chunks [][]byte
 }
 
 type manifest struct {
-	md *pb.Manifest
+	md *jobpb.Manifest
 	m  map[string]*data // key -> data
 	mu sync.Mutex
 }
@@ -72,7 +72,7 @@ type server struct {
 	mu sync.Mutex
 }
 
-func (s *server) PutArtifact(ps pb.LegacyArtifactStagingService_PutArtifactServer) error {
+func (s *server) PutArtifact(ps jobpb.LegacyArtifactStagingService_PutArtifactServer) error {
 	// Read header
 
 	header, err := ps.Recv()
@@ -118,10 +118,10 @@ func (s *server) PutArtifact(ps pb.LegacyArtifactStagingService_PutArtifactServe
 	m.m[key] = &data{chunks: chunks}
 	m.mu.Unlock()
 
-	return ps.SendAndClose(&pb.PutArtifactResponse{})
+	return ps.SendAndClose(&jobpb.PutArtifactResponse{})
 }
 
-func (s *server) CommitManifest(ctx context.Context, req *pb.CommitManifestRequest) (*pb.CommitManifestResponse, error) {
+func (s *server) CommitManifest(ctx context.Context, req *jobpb.CommitManifestRequest) (*jobpb.CommitManifestResponse, error) {
 	token := req.GetStagingSessionToken()
 	if token == "" {
 		return nil, errors.New("missing staging session token")
@@ -147,10 +147,10 @@ func (s *server) CommitManifest(ctx context.Context, req *pb.CommitManifestReque
 	}
 	m.md = req.GetManifest()
 
-	return &pb.CommitManifestResponse{RetrievalToken: token}, nil
+	return &jobpb.CommitManifestResponse{RetrievalToken: token}, nil
 }
 
-func (s *server) GetManifest(ctx context.Context, req *pb.GetManifestRequest) (*pb.GetManifestResponse, error) {
+func (s *server) GetManifest(ctx context.Context, req *jobpb.GetManifestRequest) (*jobpb.GetManifestResponse, error) {
 	token := req.GetRetrievalToken()
 	if token == "" {
 		return nil, errors.New("missing retrieval token")
@@ -163,10 +163,10 @@ func (s *server) GetManifest(ctx context.Context, req *pb.GetManifestRequest) (*
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return &pb.GetManifestResponse{Manifest: m.md}, nil
+	return &jobpb.GetManifestResponse{Manifest: m.md}, nil
 }
 
-func (s *server) GetArtifact(req *pb.LegacyGetArtifactRequest, stream pb.LegacyArtifactRetrievalService_GetArtifactServer) error {
+func (s *server) GetArtifact(req *jobpb.LegacyGetArtifactRequest, stream jobpb.LegacyArtifactRetrievalService_GetArtifactServer) error {
 	token := req.GetRetrievalToken()
 	if token == "" {
 		return errors.New("missing retrieval token")
@@ -192,7 +192,7 @@ func (s *server) GetArtifact(req *pb.LegacyGetArtifactRequest, stream pb.LegacyA
 	// Send chunks exactly as we received them.
 
 	for _, chunk := range chunks {
-		if err := stream.Send(&pb.ArtifactChunk{Data: chunk}); err != nil {
+		if err := stream.Send(&jobpb.ArtifactChunk{Data: chunk}); err != nil {
 			return err
 		}
 	}

--- a/sdks/go/pkg/beam/artifact/stage.go
+++ b/sdks/go/pkg/beam/artifact/stage.go
@@ -30,15 +30,15 @@ import (
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/errorx"
 )
 
 // Commit commits a manifest with the given staged artifacts. It returns the
 // staging token, if successful.
-func Commit(ctx context.Context, client pb.LegacyArtifactStagingServiceClient, artifacts []*pb.ArtifactMetadata, st string) (string, error) {
-	req := &pb.CommitManifestRequest{
-		Manifest: &pb.Manifest{
+func Commit(ctx context.Context, client jobpb.LegacyArtifactStagingServiceClient, artifacts []*jobpb.ArtifactMetadata, st string) (string, error) {
+	req := &jobpb.CommitManifestRequest{
+		Manifest: &jobpb.Manifest{
 			Artifact: artifacts,
 		},
 		StagingSessionToken: st,
@@ -51,7 +51,7 @@ func Commit(ctx context.Context, client pb.LegacyArtifactStagingServiceClient, a
 }
 
 // StageDir stages a local directory with relative path keys. Convenience wrapper.
-func StageDir(ctx context.Context, client pb.LegacyArtifactStagingServiceClient, src string, st string) ([]*pb.ArtifactMetadata, error) {
+func StageDir(ctx context.Context, client jobpb.LegacyArtifactStagingServiceClient, src string, st string) ([]*jobpb.ArtifactMetadata, error) {
 	list, err := scan(src)
 	if err != nil || len(list) == 0 {
 		return nil, err
@@ -62,7 +62,7 @@ func StageDir(ctx context.Context, client pb.LegacyArtifactStagingServiceClient,
 // MultiStage stages a set of local files with the given keys. It returns
 // the full artifact metadate.  It retries each artifact a few times.
 // Convenience wrapper.
-func MultiStage(ctx context.Context, client pb.LegacyArtifactStagingServiceClient, cpus int, list []KeyedFile, st string) ([]*pb.ArtifactMetadata, error) {
+func MultiStage(ctx context.Context, client jobpb.LegacyArtifactStagingServiceClient, cpus int, list []KeyedFile, st string) ([]*jobpb.ArtifactMetadata, error) {
 	if cpus < 1 {
 		cpus = 1
 	}
@@ -77,7 +77,7 @@ func MultiStage(ctx context.Context, client pb.LegacyArtifactStagingServiceClien
 	close(q)
 	var permErr errorx.GuardedError
 
-	ret := make(chan *pb.ArtifactMetadata, len(list))
+	ret := make(chan *jobpb.ArtifactMetadata, len(list))
 
 	var wg sync.WaitGroup
 	for i := 0; i < cpus; i++ {
@@ -119,7 +119,7 @@ func MultiStage(ctx context.Context, client pb.LegacyArtifactStagingServiceClien
 
 // Stage stages a local file as an artifact with the given key. It computes
 // the SHA256 and returns the full artifact metadata.
-func Stage(ctx context.Context, client pb.LegacyArtifactStagingServiceClient, key, filename, st string) (*pb.ArtifactMetadata, error) {
+func Stage(ctx context.Context, client jobpb.LegacyArtifactStagingServiceClient, key, filename, st string) (*jobpb.ArtifactMetadata, error) {
 	stat, err := os.Stat(filename)
 	if err != nil {
 		return nil, err
@@ -128,12 +128,12 @@ func Stage(ctx context.Context, client pb.LegacyArtifactStagingServiceClient, ke
 	if err != nil {
 		return nil, err
 	}
-	md := &pb.ArtifactMetadata{
+	md := &jobpb.ArtifactMetadata{
 		Name:        key,
 		Permissions: uint32(stat.Mode()),
 		Sha256:      hash,
 	}
-	pmd := &pb.PutArtifactMetadata{
+	pmd := &jobpb.PutArtifactMetadata{
 		Metadata:            md,
 		StagingSessionToken: st,
 	}
@@ -149,8 +149,8 @@ func Stage(ctx context.Context, client pb.LegacyArtifactStagingServiceClient, ke
 		return nil, err
 	}
 
-	header := &pb.PutArtifactRequest{
-		Content: &pb.PutArtifactRequest_Metadata{
+	header := &jobpb.PutArtifactRequest{
+		Content: &jobpb.PutArtifactRequest_Metadata{
 			Metadata: pmd,
 		},
 	}
@@ -172,7 +172,7 @@ func Stage(ctx context.Context, client pb.LegacyArtifactStagingServiceClient, ke
 	return md, nil
 }
 
-func stageChunks(stream pb.LegacyArtifactStagingService_PutArtifactClient, r io.Reader) (string, error) {
+func stageChunks(stream jobpb.LegacyArtifactStagingService_PutArtifactClient, r io.Reader) (string, error) {
 	sha256W := sha256.New()
 	data := make([]byte, 1<<20)
 	for {
@@ -182,9 +182,9 @@ func stageChunks(stream pb.LegacyArtifactStagingService_PutArtifactClient, r io.
 				panic(err) // cannot fail
 			}
 
-			chunk := &pb.PutArtifactRequest{
-				Content: &pb.PutArtifactRequest_Data{
-					Data: &pb.ArtifactChunk{
+			chunk := &jobpb.PutArtifactRequest{
+				Content: &jobpb.PutArtifactRequest_Data{
+					Data: &jobpb.ArtifactChunk{
 						Data: data[:n],
 					},
 				},

--- a/sdks/go/pkg/beam/artifact/stage_test.go
+++ b/sdks/go/pkg/beam/artifact/stage_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
 	"google.golang.org/grpc"
 )
@@ -30,7 +30,7 @@ import (
 func TestStage(t *testing.T) {
 	cc := startServer(t)
 	defer cc.Close()
-	client := pb.NewLegacyArtifactStagingServiceClient(cc)
+	client := jobpb.NewLegacyArtifactStagingServiceClient(cc)
 
 	ctx := grpcx.WriteWorkerID(context.Background(), "idA")
 	keys := []string{"foo", "bar", "baz/baz/baz"}
@@ -40,7 +40,7 @@ func TestStage(t *testing.T) {
 	md5s := makeTempFiles(t, src, keys, 300)
 
 	st := "whatever"
-	var artifacts []*pb.ArtifactMetadata
+	var artifacts []*jobpb.ArtifactMetadata
 	for _, key := range keys {
 		a, err := Stage(ctx, client, key, makeFilename(src, key), st)
 		if err != nil {
@@ -59,7 +59,7 @@ func TestStage(t *testing.T) {
 func TestStageDir(t *testing.T) {
 	cc := startServer(t)
 	defer cc.Close()
-	client := pb.NewLegacyArtifactStagingServiceClient(cc)
+	client := jobpb.NewLegacyArtifactStagingServiceClient(cc)
 
 	ctx := grpcx.WriteWorkerID(context.Background(), "idB")
 	keys := []string{"1", "2", "3", "4", "a/5", "a/6", "a/7", "a/8", "a/a/9", "a/a/10", "a/b/11", "a/b/12"}
@@ -81,10 +81,10 @@ func TestStageDir(t *testing.T) {
 }
 
 func validate(ctx context.Context, cc *grpc.ClientConn, t *testing.T, keys, sha256s []string, rt string) {
-	rcl := pb.NewLegacyArtifactRetrievalServiceClient(cc)
+	rcl := jobpb.NewLegacyArtifactRetrievalServiceClient(cc)
 
 	for i, key := range keys {
-		stream, err := rcl.GetArtifact(ctx, &pb.LegacyGetArtifactRequest{Name: key, RetrievalToken: rt})
+		stream, err := rcl.GetArtifact(ctx, &jobpb.LegacyGetArtifactRequest{Name: key, RetrievalToken: rt})
 		if err != nil {
 			t.Fatalf("failed to get artifact for %v: %v", key, err)
 		}

--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -31,7 +31,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/stringx"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 )
@@ -173,13 +173,13 @@ func (b *builder) makeWindowingStrategy(id string) (*window.WindowingStrategy, e
 	return w, nil
 }
 
-func unmarshalWindowFn(wfn *pb.FunctionSpec) (*window.Fn, error) {
+func unmarshalWindowFn(wfn *pipepb.FunctionSpec) (*window.Fn, error) {
 	switch urn := wfn.GetUrn(); urn {
 	case graphx.URNGlobalWindowsWindowFn:
 		return window.NewGlobalWindows(), nil
 
 	case graphx.URNFixedWindowsWindowFn:
-		var payload pb.FixedWindowsPayload
+		var payload pipepb.FixedWindowsPayload
 		if err := proto.Unmarshal(wfn.GetPayload(), &payload); err != nil {
 			return nil, err
 		}
@@ -190,7 +190,7 @@ func unmarshalWindowFn(wfn *pb.FunctionSpec) (*window.Fn, error) {
 		return window.NewFixedWindows(size), nil
 
 	case graphx.URNSlidingWindowsWindowFn:
-		var payload pb.SlidingWindowsPayload
+		var payload pipepb.SlidingWindowsPayload
 		if err := proto.Unmarshal(wfn.GetPayload(), &payload); err != nil {
 			return nil, err
 		}
@@ -205,7 +205,7 @@ func unmarshalWindowFn(wfn *pb.FunctionSpec) (*window.Fn, error) {
 		return window.NewSlidingWindows(period, size), nil
 
 	case graphx.URNSessionsWindowFn:
-		var payload pb.SessionWindowsPayload
+		var payload pipepb.SessionWindowsPayload
 		if err := proto.Unmarshal(wfn.GetPayload(), &payload); err != nil {
 			return nil, err
 		}
@@ -337,13 +337,13 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 		var data string
 		switch urn {
 		case graphx.URNParDo:
-			var pardo pb.ParDoPayload
+			var pardo pipepb.ParDoPayload
 			if err := proto.Unmarshal(payload, &pardo); err != nil {
 				return nil, errors.Wrapf(err, "invalid ParDo payload for %v", transform)
 			}
 			data = string(pardo.GetDoFn().GetPayload())
 		case urnPerKeyCombinePre, urnPerKeyCombineMerge, urnPerKeyCombineExtract, urnPerKeyCombineConvert:
-			var cmb pb.CombinePayload
+			var cmb pipepb.CombinePayload
 			if err := proto.Unmarshal(payload, &cmb); err != nil {
 				return nil, errors.Wrapf(err, "invalid CombinePayload payload for %v", transform)
 			}
@@ -493,7 +493,7 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 		}
 
 	case graphx.URNWindow:
-		var wp pb.WindowIntoPayload
+		var wp pipepb.WindowIntoPayload
 		if err := proto.Unmarshal(payload, &wp); err != nil {
 			return nil, errors.Wrapf(err, "invalid WindowInto payload for %v", transform)
 		}

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -320,7 +320,7 @@ func (m *marshaller) addMultiEdge(edge NamedEdge) []string {
 
 	case graph.Combine:
 		payload := &pipepb.ParDoPayload{
-			DoFn: &pb.FunctionSpec{
+			DoFn: &pipepb.FunctionSpec{
 				Urn:     URNJavaDoFn,
 				Payload: []byte(mustEncodeMultiEdgeBase64(edge.Edge)),
 			},
@@ -701,7 +701,7 @@ func marshalWindowingStrategy(c *CoderMarshaller, w *window.WindowingStrategy) *
 	return ws
 }
 
-func makeWindowFn(w *window.Fn) *pb.FunctionSpec {
+func makeWindowFn(w *window.Fn) *pipepb.FunctionSpec {
 	switch w.Kind {
 	case window.GlobalWindows:
 		return &pipepb.FunctionSpec{

--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 )
 
 const (
@@ -133,10 +133,10 @@ type clientID struct {
 
 // This is a reduced version of the full gRPC interface to help with testing.
 // TODO(wcn): need a compile-time assertion to make sure this stays synced with what's
-// in pb.BeamFnData_DataClient
+// in fnpb.BeamFnData_DataClient
 type dataClient interface {
-	Send(*pb.Elements) error
-	Recv() (*pb.Elements, error)
+	Send(*fnpb.Elements) error
+	Recv() (*fnpb.Elements, error)
 }
 
 // DataChannel manages a single gRPC stream over the Data API. Data from
@@ -166,7 +166,7 @@ func newDataChannel(ctx context.Context, port exec.Port) (*DataChannel, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to connect to data service at %v", port.URL)
 	}
-	client, err := pb.NewBeamFnDataClient(cc).Data(ctx)
+	client, err := fnpb.NewBeamFnDataClient(cc).Data(ctx)
 	if err != nil {
 		cc.Close()
 		return nil, errors.Wrapf(err, "failed to create data client on %v", port.URL)
@@ -391,7 +391,7 @@ type dataWriter struct {
 }
 
 // send requires the ch.mu lock to be held.
-func (w *dataWriter) send(msg *pb.Elements) error {
+func (w *dataWriter) send(msg *fnpb.Elements) error {
 	recordStreamSend(msg)
 	if err := w.ch.client.Send(msg); err != nil {
 		if err == io.EOF {
@@ -423,8 +423,8 @@ func (w *dataWriter) Close() error {
 	w.ch.mu.Lock()
 	defer w.ch.mu.Unlock()
 	delete(w.ch.writers, w.id)
-	msg := &pb.Elements{
-		Data: []*pb.Elements_Data{
+	msg := &fnpb.Elements{
+		Data: []*fnpb.Elements_Data{
 			{
 				InstructionId: string(w.id.instID),
 				TransformId:   w.id.ptransformID,
@@ -446,8 +446,8 @@ func (w *dataWriter) Flush() error {
 		return nil
 	}
 
-	msg := &pb.Elements{
-		Data: []*pb.Elements_Data{
+	msg := &fnpb.Elements{
+		Data: []*fnpb.Elements_Data{
 			{
 				InstructionId: string(w.id.instID),
 				TransformId:   w.id.ptransformID,

--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr_test.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 )
 
 const extraData = 2
@@ -40,16 +40,16 @@ type fakeDataClient struct {
 	skipFirstError bool
 }
 
-func (f *fakeDataClient) Recv() (*pb.Elements, error) {
+func (f *fakeDataClient) Recv() (*fnpb.Elements, error) {
 	f.calls++
 	data := []byte{1, 2, 3, 4}
-	elemData := pb.Elements_Data{
+	elemData := fnpb.Elements_Data{
 		InstructionId: "inst_ref",
 		Data:          data,
 		TransformId:   "ptr",
 	}
 
-	msg := pb.Elements{}
+	msg := fnpb.Elements{}
 
 	// Send extraData more than the number of elements buffered in the channel.
 	for i := 0; i < bufElements+extraData; i++ {
@@ -66,7 +66,7 @@ func (f *fakeDataClient) Recv() (*pb.Elements, error) {
 		return &msg, f.err
 	case 3:
 		elemData.Data = []byte{}
-		msg.Data = []*pb.Elements_Data{&elemData}
+		msg.Data = []*fnpb.Elements_Data{&elemData}
 		// Broadcasting done here means that this code providing messages
 		// has not been blocked by the bug blocking the dataReader
 		// from getting more messages.
@@ -77,7 +77,7 @@ func (f *fakeDataClient) Recv() (*pb.Elements, error) {
 	}
 }
 
-func (f *fakeDataClient) Send(*pb.Elements) error {
+func (f *fakeDataClient) Send(*fnpb.Elements) error {
 	// We skip errors on the first call to test that  errors can be returned
 	// on the sentinel value send in dataWriter.Close
 	// Otherwise, we return an io.EOF similar to semantics documented

--- a/sdks/go/pkg/beam/core/runtime/harness/logging_test.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/logging_test.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 )
 
 func TestLogger(t *testing.T) {
-	ch := make(chan *pb.LogEntry, 1)
+	ch := make(chan *fnpb.LogEntry, 1)
 	l := logger{out: ch}
 
 	instID := "INST"
@@ -45,7 +45,7 @@ func TestLogger(t *testing.T) {
 	if got, want := e.GetLogLocation(), "logging_test.go:34"; !strings.HasSuffix(got, want) {
 		t.Errorf("incorrect LogLocation: got %v, want suffix %v", got, want)
 	}
-	if got, want := e.GetSeverity(), pb.LogEntry_Severity_INFO; got != want {
+	if got, want := e.GetSeverity(), fnpb.LogEntry_Severity_INFO; got != want {
 		t.Errorf("incorrect Severity: got %v, want %v", got, want)
 	}
 }

--- a/sdks/go/pkg/beam/core/runtime/harness/session.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/session.go
@@ -25,7 +25,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/harness/session"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/hooks"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -73,7 +73,7 @@ func recordMessage(opcode session.Kind, pb *session.Entry) error {
 	}
 
 	eh := &session.EntryHeader{
-		Kind: pb.Kind,
+		Kind: fnpb.Kind,
 		Len:  int64(len(body.Bytes())),
 	}
 
@@ -105,7 +105,7 @@ func recordMessage(opcode session.Kind, pb *session.Entry) error {
 	return nil
 }
 
-func recordInstructionRequest(req *pb.InstructionRequest) error {
+func recordInstructionRequest(req *fnpb.InstructionRequest) error {
 	return recordMessage(session.Kind_INSTRUCTION_REQUEST,
 		&session.Entry{
 			Kind: session.Kind_INSTRUCTION_REQUEST,
@@ -115,7 +115,7 @@ func recordInstructionRequest(req *pb.InstructionRequest) error {
 		})
 }
 
-func recordInstructionResponse(resp *pb.InstructionResponse) error {
+func recordInstructionResponse(resp *fnpb.InstructionResponse) error {
 	return recordMessage(session.Kind_INSTRUCTION_RESPONSE,
 		&session.Entry{
 			Kind: session.Kind_INSTRUCTION_RESPONSE,
@@ -125,7 +125,7 @@ func recordInstructionResponse(resp *pb.InstructionResponse) error {
 		})
 }
 
-func recordStreamReceive(data *pb.Elements) error {
+func recordStreamReceive(data *fnpb.Elements) error {
 	return recordMessage(session.Kind_DATA_RECEIVED,
 		&session.Entry{
 			Kind: session.Kind_DATA_RECEIVED,
@@ -135,7 +135,7 @@ func recordStreamReceive(data *pb.Elements) error {
 		})
 }
 
-func recordStreamSend(data *pb.Elements) error {
+func recordStreamSend(data *fnpb.Elements) error {
 	return recordMessage(session.Kind_DATA_SENT,
 		&session.Entry{
 			Kind: session.Kind_DATA_SENT,
@@ -145,7 +145,7 @@ func recordStreamSend(data *pb.Elements) error {
 		})
 }
 
-func recordLogEntries(entries *pb.LogEntry_List) error {
+func recordLogEntries(entries *fnpb.LogEntry_List) error {
 	return recordMessage(session.Kind_LOG_ENTRIES,
 		&session.Entry{
 			Kind: session.Kind_LOG_ENTRIES,

--- a/sdks/go/pkg/beam/core/runtime/harness/session.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/session.go
@@ -73,7 +73,7 @@ func recordMessage(opcode session.Kind, pb *session.Entry) error {
 	}
 
 	eh := &session.EntryHeader{
-		Kind: fnpb.Kind,
+		Kind: pb.Kind,
 		Len:  int64(len(body.Bytes())),
 	}
 

--- a/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -104,7 +104,7 @@ func (s *ScopedStateReader) Close() error {
 
 type stateKeyReader struct {
 	instID instructionID
-	key    *pb.StateKey
+	key    *fnpb.StateKey
 
 	token []byte
 	buf   []byte
@@ -116,9 +116,9 @@ type stateKeyReader struct {
 }
 
 func newSideInputReader(ch *StateChannel, id exec.StreamID, sideInputID string, instID instructionID, k, w []byte) *stateKeyReader {
-	key := &pb.StateKey{
-		Type: &pb.StateKey_MultimapSideInput_{
-			MultimapSideInput: &pb.StateKey_MultimapSideInput{
+	key := &fnpb.StateKey{
+		Type: &fnpb.StateKey_MultimapSideInput_{
+			MultimapSideInput: &fnpb.StateKey_MultimapSideInput{
 				TransformId: id.PtransformID,
 				SideInputId: sideInputID,
 				Window:      w,
@@ -134,9 +134,9 @@ func newSideInputReader(ch *StateChannel, id exec.StreamID, sideInputID string, 
 }
 
 func newRunnerReader(ch *StateChannel, instID instructionID, k []byte) *stateKeyReader {
-	key := &pb.StateKey{
-		Type: &pb.StateKey_Runner_{
-			Runner: &pb.StateKey_Runner{
+	key := &fnpb.StateKey{
+		Type: &fnpb.StateKey_Runner_{
+			Runner: &fnpb.StateKey_Runner{
 				Key: k,
 			},
 		},
@@ -164,12 +164,12 @@ func (r *stateKeyReader) Read(buf []byte) (int, error) {
 		localChannel := r.ch
 		r.mu.Unlock()
 
-		req := &pb.StateRequest{
+		req := &fnpb.StateRequest{
 			// Id: set by StateChannel
 			InstructionId: string(r.instID),
 			StateKey:      r.key,
-			Request: &pb.StateRequest_Get{
-				Get: &pb.StateGetRequest{
+			Request: &fnpb.StateRequest_Get{
+				Get: &fnpb.StateGetRequest{
 					ContinuationToken: r.token,
 				},
 			},
@@ -243,8 +243,8 @@ func (m *StateChannelManager) Open(ctx context.Context, port exec.Port) (*StateC
 }
 
 type stateClient interface {
-	Send(*pb.StateRequest) error
-	Recv() (*pb.StateResponse, error)
+	Send(*fnpb.StateRequest) error
+	Recv() (*fnpb.StateResponse, error)
 }
 
 // StateChannel manages state transactions over a single gRPC connection.
@@ -254,10 +254,10 @@ type StateChannel struct {
 	id     string
 	client stateClient
 
-	requests      chan *pb.StateRequest
+	requests      chan *fnpb.StateRequest
 	nextRequestNo int32
 
-	responses map[string]chan<- *pb.StateResponse
+	responses map[string]chan<- *fnpb.StateResponse
 	mu        sync.Mutex
 
 	// a closure that forces the state manager to recreate this stream.
@@ -285,7 +285,7 @@ func newStateChannel(ctx context.Context, port exec.Port) (*StateChannel, error)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to connect to state service %v", port.URL)
 	}
-	client, err := pb.NewBeamFnStateClient(cc).State(ctx)
+	client, err := fnpb.NewBeamFnStateClient(cc).State(ctx)
 	if err != nil {
 		cc.Close()
 		return nil, errors.Wrapf(err, "failed to create state client %v", port.URL)
@@ -297,8 +297,8 @@ func makeStateChannel(ctx context.Context, cancelFn context.CancelFunc, id strin
 	ret := &StateChannel{
 		id:        id,
 		client:    client,
-		requests:  make(chan *pb.StateRequest, 10),
-		responses: make(map[string]chan<- *pb.StateResponse),
+		requests:  make(chan *fnpb.StateRequest, 10),
+		responses: make(map[string]chan<- *fnpb.StateResponse),
 		cancelFn:  cancelFn,
 		DoneCh:    ctx.Done(),
 	}
@@ -346,7 +346,7 @@ func (c *StateChannel) write(ctx context.Context) {
 	var err error
 	var id string
 	for {
-		var req *pb.StateRequest
+		var req *fnpb.StateRequest
 		select {
 		case req = <-c.requests:
 		case <-c.DoneCh: // Close the goroutine on context cancel.
@@ -380,16 +380,16 @@ func (c *StateChannel) write(ctx context.Context) {
 	c.terminateStreamOnError(err)
 
 	if ok {
-		ch <- &pb.StateResponse{Id: id, Error: fmt.Sprintf("StateChannel[%v].write failed to send: %v", c.id, err)}
+		ch <- &fnpb.StateResponse{Id: id, Error: fmt.Sprintf("StateChannel[%v].write failed to send: %v", c.id, err)}
 	}
 }
 
 // Send sends a state request and returns the response.
-func (c *StateChannel) Send(req *pb.StateRequest) (*pb.StateResponse, error) {
+func (c *StateChannel) Send(req *fnpb.StateRequest) (*fnpb.StateResponse, error) {
 	id := fmt.Sprintf("r%v", atomic.AddInt32(&c.nextRequestNo, 1))
 	req.Id = id
 
-	ch := make(chan *pb.StateResponse, 1)
+	ch := make(chan *fnpb.StateResponse, 1)
 	c.mu.Lock()
 	if c.closedErr != nil {
 		defer c.mu.Unlock()
@@ -400,7 +400,7 @@ func (c *StateChannel) Send(req *pb.StateRequest) (*pb.StateResponse, error) {
 
 	c.requests <- req
 
-	var resp *pb.StateResponse
+	var resp *fnpb.StateResponse
 	select {
 	case resp = <-ch:
 	case <-c.DoneCh:

--- a/sdks/go/pkg/beam/core/runtime/pipelinex/replace.go
+++ b/sdks/go/pkg/beam/core/runtime/pipelinex/replace.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 )
 
 // Update merges a pipeline with the given components, which may add, replace
 // or delete its values. It returns the merged pipeline. The input is not
 // modified.
-func Update(p *pb.Pipeline, values *pb.Components) (*pb.Pipeline, error) {
+func Update(p *pipepb.Pipeline, values *pipepb.Components) (*pipepb.Pipeline, error) {
 	ret := shallowClonePipeline(p)
 	reflectx.UpdateMap(ret.Components.Transforms, values.Transforms)
 	reflectx.UpdateMap(ret.Components.Pcollections, values.Pcollections)
@@ -43,7 +43,7 @@ func Update(p *pb.Pipeline, values *pb.Components) (*pb.Pipeline, error) {
 // as roots and input/output for composite transforms. It also
 // ensures that unique names are so and topologically sorts each
 // subtransform list.
-func Normalize(p *pb.Pipeline) (*pb.Pipeline, error) {
+func Normalize(p *pipepb.Pipeline) (*pipepb.Pipeline, error) {
 	if len(p.GetComponents().GetTransforms()) == 0 {
 		return nil, errors.New("empty pipeline")
 	}
@@ -56,15 +56,15 @@ func Normalize(p *pb.Pipeline) (*pb.Pipeline, error) {
 }
 
 // TrimCoders returns the transitive closure of the given coders ids.
-func TrimCoders(coders map[string]*pb.Coder, ids ...string) map[string]*pb.Coder {
-	ret := make(map[string]*pb.Coder)
+func TrimCoders(coders map[string]*pipepb.Coder, ids ...string) map[string]*pipepb.Coder {
+	ret := make(map[string]*pipepb.Coder)
 	for _, id := range ids {
 		walkCoders(coders, ret, id)
 	}
 	return ret
 }
 
-func walkCoders(coders, accum map[string]*pb.Coder, id string) {
+func walkCoders(coders, accum map[string]*pipepb.Coder, id string) {
 	if _, ok := accum[id]; ok {
 		return // already visited
 	}
@@ -77,7 +77,7 @@ func walkCoders(coders, accum map[string]*pb.Coder, id string) {
 }
 
 // computeRoots returns the root (top-level) transform IDs.
-func computeRoots(xforms map[string]*pb.PTransform) []string {
+func computeRoots(xforms map[string]*pipepb.PTransform) []string {
 	var roots []string
 	parents := makeParentMap(xforms)
 	for id := range xforms {
@@ -89,7 +89,7 @@ func computeRoots(xforms map[string]*pb.PTransform) []string {
 	return TopologicalSort(xforms, roots)
 }
 
-func makeParentMap(xforms map[string]*pb.PTransform) map[string]string {
+func makeParentMap(xforms map[string]*pipepb.PTransform) map[string]string {
 	parent := make(map[string]string)
 	for id, t := range xforms {
 		for _, key := range t.Subtransforms {
@@ -101,8 +101,8 @@ func makeParentMap(xforms map[string]*pb.PTransform) map[string]string {
 
 // computeCompositeInputOutput computes the derived input/output maps
 // for composite transforms.
-func computeCompositeInputOutput(xforms map[string]*pb.PTransform) map[string]*pb.PTransform {
-	ret := reflectx.ShallowClone(xforms).(map[string]*pb.PTransform)
+func computeCompositeInputOutput(xforms map[string]*pipepb.PTransform) map[string]*pipepb.PTransform {
+	ret := reflectx.ShallowClone(xforms).(map[string]*pipepb.PTransform)
 
 	seen := make(map[string]bool)
 	for id := range xforms {
@@ -113,7 +113,7 @@ func computeCompositeInputOutput(xforms map[string]*pb.PTransform) map[string]*p
 
 // walk traverses the structure recursively to compute the input/output
 // maps of composite transforms. Update the transform map.
-func walk(id string, ret map[string]*pb.PTransform, seen map[string]bool) {
+func walk(id string, ret map[string]*pipepb.PTransform, seen map[string]bool) {
 	t := ret[id]
 	if seen[id] || len(t.Subtransforms) == 0 {
 		return
@@ -158,7 +158,7 @@ func diff(a, b map[string]bool) map[string]string {
 }
 
 // inout adds the input and output pcollection ids to the accumulators.
-func inout(transform *pb.PTransform, in, out map[string]bool) {
+func inout(transform *pipepb.PTransform, in, out map[string]bool) {
 	for _, col := range transform.GetInputs() {
 		in[col] = true
 	}
@@ -169,8 +169,8 @@ func inout(transform *pb.PTransform, in, out map[string]bool) {
 
 // ensureUniqueNames ensures that each name is unique. Any conflict is
 // resolved by adding '1, '2, etc to the name.
-func ensureUniqueNames(xforms map[string]*pb.PTransform) map[string]*pb.PTransform {
-	ret := reflectx.ShallowClone(xforms).(map[string]*pb.PTransform)
+func ensureUniqueNames(xforms map[string]*pipepb.PTransform) map[string]*pipepb.PTransform {
+	ret := reflectx.ShallowClone(xforms).(map[string]*pipepb.PTransform)
 
 	// Sort the transforms to make to make renaming deterministic.
 	var ordering []string

--- a/sdks/go/pkg/beam/core/runtime/pipelinex/replace_test.go
+++ b/sdks/go/pkg/beam/core/runtime/pipelinex/replace_test.go
@@ -18,34 +18,34 @@ package pipelinex
 import (
 	"testing"
 
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestEnsureUniqueName(t *testing.T) {
 	tests := []struct {
-		in, exp map[string]*pb.PTransform
+		in, exp map[string]*pipepb.PTransform
 	}{
 		{
-			in: map[string]*pb.PTransform{
+			in: map[string]*pipepb.PTransform{
 				"1": {UniqueName: "a"},
 				"2": {UniqueName: "b"},
 				"3": {UniqueName: "c"},
 			},
-			exp: map[string]*pb.PTransform{
+			exp: map[string]*pipepb.PTransform{
 				"1": {UniqueName: "a"},
 				"2": {UniqueName: "b"},
 				"3": {UniqueName: "c"},
 			},
 		},
 		{
-			in: map[string]*pb.PTransform{
+			in: map[string]*pipepb.PTransform{
 				"2": {UniqueName: "a"},
 				"1": {UniqueName: "a"},
 				"3": {UniqueName: "a"},
 			},
-			exp: map[string]*pb.PTransform{
+			exp: map[string]*pipepb.PTransform{
 				"1": {UniqueName: "a"},
 				"2": {UniqueName: "a'1"},
 				"3": {UniqueName: "a'2"},
@@ -63,10 +63,10 @@ func TestEnsureUniqueName(t *testing.T) {
 
 func TestComputeInputOutput(t *testing.T) {
 	tests := []struct {
-		in, exp map[string]*pb.PTransform
+		in, exp map[string]*pipepb.PTransform
 	}{
 		{ // singleton composite
-			in: map[string]*pb.PTransform{
+			in: map[string]*pipepb.PTransform{
 				"1": {
 					UniqueName:    "a",
 					Subtransforms: []string{"2"},
@@ -77,7 +77,7 @@ func TestComputeInputOutput(t *testing.T) {
 					Outputs:    map[string]string{"i0": "p2"},
 				},
 			},
-			exp: map[string]*pb.PTransform{
+			exp: map[string]*pipepb.PTransform{
 				"1": {
 					UniqueName:    "a",
 					Subtransforms: []string{"2"},
@@ -92,7 +92,7 @@ func TestComputeInputOutput(t *testing.T) {
 			},
 		},
 		{ // closed composite
-			in: map[string]*pb.PTransform{
+			in: map[string]*pipepb.PTransform{
 				"1": {
 					UniqueName:    "a",
 					Subtransforms: []string{"2", "3"},
@@ -100,7 +100,7 @@ func TestComputeInputOutput(t *testing.T) {
 				"2": {UniqueName: "b", Outputs: map[string]string{"i0": "p1"}},
 				"3": {UniqueName: "c", Inputs: map[string]string{"i0": "p1"}},
 			},
-			exp: map[string]*pb.PTransform{
+			exp: map[string]*pipepb.PTransform{
 				"1": {
 					UniqueName:    "a",
 					Subtransforms: []string{"2", "3"},

--- a/sdks/go/pkg/beam/provision/provision.go
+++ b/sdks/go/pkg/beam/provision/provision.go
@@ -24,23 +24,23 @@ import (
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
 	"github.com/golang/protobuf/jsonpb"
-	google_protobuf "github.com/golang/protobuf/ptypes/struct"
+	google_pb "github.com/golang/protobuf/ptypes/struct"
 )
 
 // Info returns the runtime provisioning info for the worker.
-func Info(ctx context.Context, endpoint string) (*pb.ProvisionInfo, error) {
+func Info(ctx context.Context, endpoint string) (*fnpb.ProvisionInfo, error) {
 	cc, err := grpcx.Dial(ctx, endpoint, 2*time.Minute)
 	if err != nil {
 		return nil, err
 	}
 	defer cc.Close()
 
-	client := pb.NewProvisionServiceClient(cc)
+	client := fnpb.NewProvisionServiceClient(cc)
 
-	resp, err := client.GetProvisionInfo(ctx, &pb.GetProvisionInfoRequest{})
+	resp, err := client.GetProvisionInfo(ctx, &fnpb.GetProvisionInfoRequest{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get manifest")
 	}
@@ -51,7 +51,7 @@ func Info(ctx context.Context, endpoint string) (*pb.ProvisionInfo, error) {
 }
 
 // OptionsToProto converts pipeline options to a proto struct via JSON.
-func OptionsToProto(v interface{}) (*google_protobuf.Struct, error) {
+func OptionsToProto(v interface{}) (*google_pb.Struct, error) {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
@@ -60,8 +60,8 @@ func OptionsToProto(v interface{}) (*google_protobuf.Struct, error) {
 }
 
 // JSONToProto converts JSON-encoded pipeline options to a proto struct.
-func JSONToProto(data string) (*google_protobuf.Struct, error) {
-	var out google_protobuf.Struct
+func JSONToProto(data string) (*google_pb.Struct, error) {
+	var out google_pb.Struct
 	if err := jsonpb.UnmarshalString(string(data), &out); err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func JSONToProto(data string) (*google_protobuf.Struct, error) {
 }
 
 // ProtoToOptions converts pipeline options from a proto struct via JSON.
-func ProtoToOptions(opt *google_protobuf.Struct, v interface{}) error {
+func ProtoToOptions(opt *google_pb.Struct, v interface{}) error {
 	data, err := ProtoToJSON(opt)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func ProtoToOptions(opt *google_protobuf.Struct, v interface{}) error {
 }
 
 // ProtoToJSON converts pipeline options from a proto struct to JSON.
-func ProtoToJSON(opt *google_protobuf.Struct) (string, error) {
+func ProtoToJSON(opt *google_pb.Struct) (string, error) {
 	if opt == nil {
 		return "{}", nil
 	}

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/pipelinex"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"golang.org/x/oauth2/google"
 	df "google.golang.org/api/dataflow/v1b3"
 )
@@ -69,7 +69,7 @@ type JobOptions struct {
 }
 
 // Translate translates a pipeline to a Dataflow job.
-func Translate(p *pb.Pipeline, opts *JobOptions, workerURL, jarURL, modelURL string) (*df.Job, error) {
+func Translate(p *pipepb.Pipeline, opts *JobOptions, workerURL, jarURL, modelURL string) (*df.Job, error) {
 	// (1) Translate pipeline to v1b3 speak.
 
 	steps, err := translate(p)

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/translate.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/translate.go
@@ -33,7 +33,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/stringx"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	pubsub_v1 "github.com/apache/beam/sdks/go/pkg/beam/io/pubsubio/v1"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/golang/protobuf/proto"
 	df "google.golang.org/api/dataflow/v1b3"
 )
@@ -64,7 +64,7 @@ const (
 // full graph. Special steps are also inserted around GBK, for example, which
 // makes the placement of the decoration somewhat tricky. The harness will
 // also never see steps that the service executes directly, notably GBK/CoGBK.
-func translate(p *pb.Pipeline) ([]*df.Step, error) {
+func translate(p *pipepb.Pipeline) ([]*df.Step, error) {
 	// NOTE: Dataflow apparently assumes that the steps are in topological order.
 	// Otherwise, it fails with "Output out for step  was not found.". We assume
 	// the pipeline has been normalized and each subtransform list is in such order.
@@ -74,13 +74,13 @@ func translate(p *pb.Pipeline) ([]*df.Step, error) {
 }
 
 type translator struct {
-	comp          *pb.Components
+	comp          *pipepb.Components
 	pcollections  map[string]*outputReference
 	coders        *graphx.CoderUnmarshaller
 	bogusCoderRef *graphx.CoderRef
 }
 
-func newTranslator(comp *pb.Components) *translator {
+func newTranslator(comp *pipepb.Components) *translator {
 	bytesCoderRef, _ := graphx.EncodeCoderRef(coder.NewW(coder.NewBytes(), coder.NewGlobalWindow()))
 
 	return &translator{
@@ -128,7 +128,7 @@ func (x *translator) translateTransform(trunk string, id string) ([]*df.Step, er
 		return []*df.Step{x.newStep(id, impulseKind, prop)}, nil
 
 	case graphx.URNParDo:
-		var payload pb.ParDoPayload
+		var payload pipepb.ParDoPayload
 		if err := proto.Unmarshal(t.Spec.Payload, &payload); err != nil {
 			return nil, errors.Wrapf(err, "invalid ParDo payload for %v", t)
 		}
@@ -189,7 +189,7 @@ func (x *translator) translateTransform(trunk string, id string) ([]*df.Step, er
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid CombinePerKey, couldn't extract GBK from %v", t)
 		}
-		var payload pb.CombinePayload
+		var payload pipepb.CombinePayload
 		if err := proto.Unmarshal(t.Spec.Payload, &payload); err != nil {
 			return nil, errors.Wrapf(err, "invalid Combine payload for %v", t)
 		}
@@ -318,7 +318,7 @@ func (x *translator) translateOutputs(outputs map[string]string) []output {
 	return ret
 }
 
-func (x *translator) translateCoder(pcol *pb.PCollection, id string) *graphx.CoderRef {
+func (x *translator) translateCoder(pcol *pipepb.PCollection, id string) *graphx.CoderRef {
 	c, err := x.coders.Coder(id)
 	if err != nil {
 		panic(err)
@@ -326,7 +326,7 @@ func (x *translator) translateCoder(pcol *pb.PCollection, id string) *graphx.Cod
 	return x.wrapCoder(pcol, c)
 }
 
-func (x *translator) wrapCoder(pcol *pb.PCollection, c *coder.Coder) *graphx.CoderRef {
+func (x *translator) wrapCoder(pcol *pipepb.PCollection, c *coder.Coder) *graphx.CoderRef {
 	// TODO(herohde) 3/16/2018: ensure windowed values for Dataflow
 
 	ws := x.comp.WindowingStrategies[pcol.WindowingStrategyId]
@@ -343,14 +343,14 @@ func (x *translator) wrapCoder(pcol *pb.PCollection, c *coder.Coder) *graphx.Cod
 
 // extractWindowingStrategy returns a self-contained windowing strategy from
 // the given pcollection id.
-func (x *translator) extractWindowingStrategy(pid string) *pb.MessageWithComponents {
+func (x *translator) extractWindowingStrategy(pid string) *pipepb.MessageWithComponents {
 	ws := x.comp.WindowingStrategies[x.comp.Pcollections[pid].WindowingStrategyId]
 
-	msg := &pb.MessageWithComponents{
-		Components: &pb.Components{
+	msg := &pipepb.MessageWithComponents{
+		Components: &pipepb.Components{
 			Coders: pipelinex.TrimCoders(x.comp.Coders, ws.WindowCoderId),
 		},
-		Root: &pb.MessageWithComponents_WindowingStrategy{
+		Root: &pipepb.MessageWithComponents_WindowingStrategy{
 			WindowingStrategy: ws,
 		},
 	}
@@ -359,7 +359,7 @@ func (x *translator) extractWindowingStrategy(pid string) *pb.MessageWithCompone
 
 // makeOutputReferences builds a map from PCollection id to the Dataflow representation.
 // Each output is named after the generating transform.
-func makeOutputReferences(xforms map[string]*pb.PTransform) map[string]*outputReference {
+func makeOutputReferences(xforms map[string]*pipepb.PTransform) map[string]*outputReference {
 	ret := make(map[string]*outputReference)
 	for id, t := range xforms {
 		if len(t.Subtransforms) > 0 {

--- a/sdks/go/pkg/beam/runners/session/session.go
+++ b/sdks/go/pkg/beam/runners/session/session.go
@@ -34,8 +34,8 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/harness/session"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
-	fnapi_pb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
-	rapi_pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 )
@@ -56,13 +56,13 @@ var sessionFile = flag.String("session_file", "", "Session file for the runner")
 type controlServer struct {
 	filename   string
 	wg         *sync.WaitGroup // used to signal when the session is completed
-	ctrlStream fnapi_pb.BeamFnControl_ControlServer
+	ctrlStream fnpb.BeamFnControl_ControlServer
 	dataServer *grpc.Server
-	dataStream fnapi_pb.BeamFnData_DataServer
+	dataStream fnapb.BeamFnData_DataServer
 	dwg        *sync.WaitGroup
 }
 
-func (c *controlServer) Control(stream fnapi_pb.BeamFnControl_ControlServer) error {
+func (c *controlServer) Control(stream fnpb.BeamFnControl_ControlServer) error {
 	fmt.Println("Go SDK connected")
 	c.ctrlStream = stream
 	// We have a connected worker. Start reading the session file and issuing
@@ -72,6 +72,10 @@ func (c *controlServer) Control(stream fnapi_pb.BeamFnControl_ControlServer) err
 	c.wg.Done()
 	fmt.Println("session replay complete")
 	return nil
+}
+
+func (c *controlServer) GetProcessBundleDescriptor(ctx context.Context, r *fnpb.GetProcessBundleDescriptorRequest) (*fnpb.ProcessBundleDescriptor, error) {
+	return nil, nil
 }
 
 func (c *controlServer) establishDataChannel(beamPort, tcpPort string) {
@@ -87,7 +91,7 @@ func (c *controlServer) establishDataChannel(beamPort, tcpPort string) {
 	// the data server is listening on.
 
 	c.dataServer = grpc.NewServer()
-	fnapi_pb.RegisterBeamFnDataServer(c.dataServer, &dataServer{ctrl: c})
+	fnpb.RegisterBeamFnDataServer(c.dataServer, &dataServer{ctrl: c})
 	dp, err := net.Listen("tcp", tcpPort)
 	if err != nil {
 		panic(err)
@@ -97,7 +101,7 @@ func (c *controlServer) establishDataChannel(beamPort, tcpPort string) {
 	go c.dataServer.Serve(dp)
 }
 
-func (c *controlServer) registerStream(stream fnapi_pb.BeamFnData_DataServer) {
+func (c *controlServer) registerStream(stream fnpb.BeamFnData_DataServer) {
 	c.dataStream = stream
 	c.dwg.Done()
 }
@@ -194,8 +198,8 @@ func (c *controlServer) handleEntry(msg *session.Entry) {
 	}
 }
 
-func extractPortSpec(spec *rapi_pb.FunctionSpec) string {
-	var port fnapi_pb.RemoteGrpcPort
+func extractPortSpec(spec *pipepb.FunctionSpec) string {
+	var port fnpb.RemoteGrpcPort
 	if err := proto.Unmarshal(spec.GetPayload(), &port); err != nil {
 		panic(err)
 	}
@@ -213,7 +217,7 @@ type dataServer struct {
 	ctrl *controlServer
 }
 
-func (d *dataServer) Data(stream fnapi_pb.BeamFnData_DataServer) error {
+func (d *dataServer) Data(stream fnpb.BeamFnData_DataServer) error {
 	// This goroutine is only used for reading data. The stream object
 	// is passed to the control server so that all data is sent from
 	// a single goroutine to ensure proper ordering.
@@ -239,7 +243,7 @@ func (d *dataServer) Data(stream fnapi_pb.BeamFnData_DataServer) error {
 // loggingServer manages the FnAPI logging channel.
 type loggingServer struct{} // no data content
 
-func (l *loggingServer) Logging(stream fnapi_pb.BeamFnLogging_LoggingServer) error {
+func (l *loggingServer) Logging(stream fnpb.BeamFnLogging_LoggingServer) error {
 	// This stream object is only used here. The stream is used for receiving, and
 	// no sends happen on it.
 	for {
@@ -269,7 +273,7 @@ func Execute(ctx context.Context, p *beam.Pipeline) error {
 
 	// Start up the grpc logging service.
 	ls := grpc.NewServer()
-	fnapi_pb.RegisterBeamFnLoggingServer(ls, &loggingServer{})
+	fnpb.RegisterBeamFnLoggingServer(ls, &loggingServer{})
 	logPort, err := net.Listen("tcp", ":0")
 	if err != nil {
 		panic("No logging port")
@@ -282,7 +286,7 @@ func Execute(ctx context.Context, p *beam.Pipeline) error {
 	wg.Add(1)
 
 	cs := grpc.NewServer()
-	fnapi_pb.RegisterBeamFnControlServer(cs, &controlServer{
+	fnpb.RegisterBeamFnControlServer(cs, &controlServer{
 		filename: *sessionFile,
 		wg:       &wg,
 	})

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/execute.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/execute.go
@@ -23,13 +23,13 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
 	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
 )
 
 // Execute executes a pipeline on the universal runner serving the given endpoint.
 // Convenience function.
-func Execute(ctx context.Context, p *pb.Pipeline, endpoint string, opt *JobOptions, async bool) (string, error) {
+func Execute(ctx context.Context, p *pipepb.Pipeline, endpoint string, opt *JobOptions, async bool) (string, error) {
 	// (1) Prepare job to obtain artifact staging instructions.
 
 	cc, err := grpcx.Dial(ctx, endpoint, 2*time.Minute)

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/job.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/job.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
 	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/provision"
 	"github.com/golang/protobuf/proto"
 )
@@ -47,7 +47,7 @@ type JobOptions struct {
 
 // Prepare prepares a job to the given job service. It returns the preparation id
 // artifact staging endpoint, and staging token if successful.
-func Prepare(ctx context.Context, client jobpb.JobServiceClient, p *pb.Pipeline, opt *JobOptions) (id, endpoint, stagingToken string, err error) {
+func Prepare(ctx context.Context, client jobpb.JobServiceClient, p *pipepb.Pipeline, opt *JobOptions) (id, endpoint, stagingToken string, err error) {
 	hooks.SerializeHooksToOptions()
 	raw := runtime.RawOptionsWrapper{
 		Options:     beam.PipelineOptions.Export(),


### PR DESCRIPTION
I've been confused about what protos are where, since we often used simple "pb" as the short id, leaving the file to hold the context. Having a slightly more descriptive short name will help understanding of the Beam portability layer.
As such
* pipeline_v1 package will now use the short id pipepb.
* fnexecution_v1 package will now use the short id fnpb.
* jobmanagment_v1 package will now use the short id jobpb.

This also has the benefit of simplifying tooling which is less language aware.

These commits were done over the web interface, so it's possible I missed a few files. This should set the example for newer uses of the proto packages in the SDK,

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
