### PR TITLE
[BEAM-9580] Allow Flink 1.10 processing timers to finish on pipeline shutdown

### DIFF
--- a/.test-infra/jenkins/CommonTestProperties.groovy
+++ b/.test-infra/jenkins/CommonTestProperties.groovy
@@ -38,7 +38,7 @@ class CommonTestProperties {
                         DATAFLOW: ":runners:google-cloud-dataflow-java",
                         SPARK: ":runners:spark",
                         SPARK_STRUCTURED_STREAMING: ":runners:spark",
-                        FLINK: ":runners:flink:1.9",
+                        FLINK: ":runners:flink:1.10",
                         DIRECT: ":runners:direct-java"
                 ],
                 PYTHON: [

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Flink.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Flink.groovy
@@ -40,7 +40,8 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
       rootBuildScriptDir(commonJobProperties.checkoutDir)
       tasks(':sdks:java:testing:nexmark:run')
       commonJobProperties.setGradleSwitches(delegate)
-      switches('-Pnexmark.args="' +
+      switches('-Pnexmark.runner=":runners:flink:1.10"' +
+              ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
               '--runner=FlinkRunner',
               '--shutdownSourcesOnFinalWatermark=true',
@@ -56,7 +57,8 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
       rootBuildScriptDir(commonJobProperties.checkoutDir)
       tasks(':sdks:java:testing:nexmark:run')
       commonJobProperties.setGradleSwitches(delegate)
-      switches('-Pnexmark.args="' +
+      switches('-Pnexmark.runner=":runners:flink:1.10"' +
+              ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
               '--runner=FlinkRunner',
               '--shutdownSourcesOnFinalWatermark=true',
@@ -72,7 +74,8 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
       rootBuildScriptDir(commonJobProperties.checkoutDir)
       tasks(':sdks:java:testing:nexmark:run')
       commonJobProperties.setGradleSwitches(delegate)
-      switches('-Pnexmark.args="' +
+      switches('-Pnexmark.runner=":runners:flink:1.10"' +
+              ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
               '--runner=FlinkRunner',
               '--shutdownSourcesOnFinalWatermark=true',
@@ -88,7 +91,8 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
       rootBuildScriptDir(commonJobProperties.checkoutDir)
       tasks(':sdks:java:testing:nexmark:run')
       commonJobProperties.setGradleSwitches(delegate)
-      switches('-Pnexmark.args="' +
+      switches('-Pnexmark.runner=":runners:flink:1.10"' +
+              ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
               '--runner=FlinkRunner',
               '--shutdownSourcesOnFinalWatermark=true',

--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Flink.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Flink.groovy
@@ -37,7 +37,7 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Flink',
   steps {
     gradle {
       rootBuildScriptDir(commonJobProperties.checkoutDir)
-      tasks(':runners:flink:1.9:validatesRunner')
+      tasks(':runners:flink:1.10:validatesRunner')
       commonJobProperties.setGradleSwitches(delegate)
     }
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/utils/Workarounds.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/utils/Workarounds.java
@@ -18,6 +18,12 @@
 package org.apache.beam.runners.flink.translation.utils;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Field;
+import org.apache.beam.runners.core.TimerInternals;
+import org.apache.flink.runtime.state.InternalPriorityQueue;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.InternalTimerServiceImpl;
 
 /** Workarounds for dealing with limitations of Flink or its libraries. */
 public class Workarounds {
@@ -26,5 +32,24 @@ public class Workarounds {
     // Clear cache to get rid of any references to the Flink Classloader
     // See https://jira.apache.org/jira/browse/BEAM-6460
     TypeFactory.defaultInstance().clearCache();
+  }
+
+  @SuppressWarnings("all")
+  public static InternalPriorityQueue<InternalTimer<Object, TimerInternals.TimerData>>
+      retrieveInternalProcessingTimerQueue(
+          InternalTimerService<TimerInternals.TimerData> timerService) {
+    Field internalProcessingTimerQueue = null;
+    try {
+      internalProcessingTimerQueue =
+          InternalTimerServiceImpl.class.getDeclaredField("processingTimeTimersQueue");
+      internalProcessingTimerQueue.setAccessible(true);
+      return (InternalPriorityQueue) internalProcessingTimerQueue.get(timerService);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to retrieve processing timer queue.", e);
+    } finally {
+      if (internalProcessingTimerQueue != null) {
+        internalProcessingTimerQueue.setAccessible(false);
+      }
+    }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -95,6 +95,7 @@ import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.state.InternalPriorityQueue;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -508,18 +509,22 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       // there are still remaining processing-time timers. Flink will ignore pending
       // processing-time timers when upstream operators have shut down and will also
       // shut down this operator with pending processing-time timers.
-      while (this.numProcessingTimeTimers() > 0) {
-        getContainingTask().getCheckpointLock().wait(100);
+      if (numProcessingTimeTimers() > 0) {
+        timerInternals.processPendingProcessingTimeTimers();
       }
-      if (this.numProcessingTimeTimers() > 0) {
+      if (numProcessingTimeTimers() > 0) {
         throw new RuntimeException(
-            "There are still processing-time timers left, this indicates a bug");
+            "There are still "
+                + numProcessingTimeTimers()
+                + " processing-time timers left, this indicates a bug");
       }
-
       // make sure we send a +Inf watermark downstream. It can happen that we receive +Inf
       // in processWatermark*() but have holds, so we have to re-evaluate here.
       processWatermark(new Watermark(Long.MAX_VALUE));
-      invokeFinishBundle();
+      // Make sure to finish the current bundle
+      while (bundleStarted) {
+        invokeFinishBundle();
+      }
       if (currentOutputWatermark < Long.MAX_VALUE) {
         throw new RuntimeException(
             "There are still watermark holds. Watermark held at " + currentOutputWatermark);
@@ -820,23 +825,27 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
   @Override
   public void onEventTime(InternalTimer<ByteBuffer, TimerData> timer) {
     checkInvokeStartBundle();
-    fireTimer(timer);
+    fireTimerInternal(timer.getKey(), timer.getNamespace());
   }
 
   @Override
   public void onProcessingTime(InternalTimer<ByteBuffer, TimerData> timer) {
     checkInvokeStartBundle();
-    fireTimer(timer);
+    fireTimerInternal(timer.getKey(), timer.getNamespace());
+  }
+
+  // allow overriding this in ExecutableStageDoFnOperator to set the key context
+  protected void fireTimerInternal(Object key, TimerData timerData) {
+    fireTimer(timerData);
   }
 
   // allow overriding this in WindowDoFnOperator
-  protected void fireTimer(InternalTimer<ByteBuffer, TimerData> timer) {
-    TimerInternals.TimerData timerData = timer.getNamespace();
+  protected void fireTimer(TimerData timerData) {
     StateNamespace namespace = timerData.getNamespace();
     // This is a user timer, so namespace must be WindowNamespace
     checkArgument(namespace instanceof WindowNamespace);
     BoundedWindow window = ((WindowNamespace) namespace).getWindow();
-    timerInternals.onFiredOrDeletedTimer(timer.getNamespace());
+    timerInternals.onFiredOrDeletedTimer(timerData);
     pushbackDoFnRunner.onTimer(
         timerData.getTimerId(),
         timerData.getTimerFamilyId(),
@@ -1143,6 +1152,27 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
         return Long.MAX_VALUE;
       } else {
         return outputTimestampQueue.peek();
+      }
+    }
+
+    /**
+     * Processes all pending processing timers. This is intended for use during shutdown. From Flink
+     * 1.10 on, processing timer execution is stopped when the operator is closed. This leads to
+     * problems for applications which assume all pending timers will be completed. Although Flink
+     * does drain the remaining timers after close(), this is not sufficient because no new timers
+     * are allowed to be scheduled anymore. This breaks Beam pipelines which rely on all processing
+     * timers to be scheduled and executed.
+     */
+    void processPendingProcessingTimeTimers() {
+      final KeyedStateBackend<Object> keyedStateBackend = getKeyedStateBackend();
+      final InternalPriorityQueue<InternalTimer<Object, TimerData>> processingTimeTimersQueue =
+          Workarounds.retrieveInternalProcessingTimerQueue(timerService);
+
+      InternalTimer<Object, TimerData> internalTimer;
+      while ((internalTimer = processingTimeTimersQueue.poll()) != null) {
+        keyedStateBackend.setCurrentKey(internalTimer.getKey());
+        TimerData timer = internalTimer.getNamespace();
+        fireTimer(timer);
       }
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -101,7 +101,6 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateBackend;
-import org.apache.flink.streaming.api.operators.InternalTimer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.joda.time.Instant;
@@ -460,13 +459,12 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
   }
 
   @Override
-  protected void fireTimer(InternalTimer<ByteBuffer, TimerInternals.TimerData> timer) {
-    final ByteBuffer encodedKey = timer.getKey();
+  protected void fireTimerInternal(Object key, TimerInternals.TimerData timer) {
     // We have to synchronize to ensure the state backend is not concurrently accessed by the state
     // requests
     try (Locker locker = Locker.locked(stateBackendLock)) {
-      getKeyedStateBackend().setCurrentKey(encodedKey);
-      super.fireTimer(timer);
+      getKeyedStateBackend().setCurrentKey(key);
+      fireTimer(timer);
     }
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.flink.translation.wrappers.streaming;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -52,7 +51,6 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.streaming.api.operators.InternalTimer;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
@@ -158,9 +156,9 @@ public class SplittableDoFnOperator<InputT, OutputT, RestrictionT>
   }
 
   @Override
-  protected void fireTimer(InternalTimer<ByteBuffer, TimerInternals.TimerData> timer) {
-    timerInternals.onFiredOrDeletedTimer(timer.getNamespace());
-    if (timer.getNamespace().getDomain().equals(TimeDomain.EVENT_TIME)) {
+  protected void fireTimer(TimerInternals.TimerData timer) {
+    timerInternals.onFiredOrDeletedTimer(timer);
+    if (timer.getDomain().equals(TimeDomain.EVENT_TIME)) {
       // ignore this, it can only be a state cleanup timers from StatefulDoFnRunner and ProcessFn
       // does its own state cleanup and should never set event-time timers.
       return;
@@ -168,8 +166,7 @@ public class SplittableDoFnOperator<InputT, OutputT, RestrictionT>
     doFnRunner.processElement(
         WindowedValue.valueInGlobalWindow(
             KeyedWorkItems.timersWorkItem(
-                (byte[]) keyedStateInternals.getKey(),
-                Collections.singletonList(timer.getNamespace()))));
+                (byte[]) keyedStateInternals.getKey(), Collections.singletonList(timer))));
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.flink.translation.wrappers.streaming;
 
 import static org.apache.beam.runners.core.TimerInternals.TimerData;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +44,6 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.streaming.api.operators.InternalTimer;
 
 /** Flink operator for executing window {@link DoFn DoFns}. */
 public class WindowDoFnOperator<K, InputT, OutputT>
@@ -125,12 +123,11 @@ public class WindowDoFnOperator<K, InputT, OutputT>
   }
 
   @Override
-  protected void fireTimer(InternalTimer<ByteBuffer, TimerData> timer) {
-    timerInternals.onFiredOrDeletedTimer(timer.getNamespace());
+  protected void fireTimer(TimerData timer) {
+    timerInternals.onFiredOrDeletedTimer(timer);
     doFnRunner.processElement(
         WindowedValue.valueInGlobalWindow(
             KeyedWorkItems.timersWorkItem(
-                (K) keyedStateInternals.getKey(),
-                Collections.singletonList(timer.getNamespace()))));
+                (K) keyedStateInternals.getKey(), Collections.singletonList(timer))));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -3513,7 +3513,10 @@ public class ParDoTest implements Serializable {
                 fail("Should have failed due to out-of-bounds timer.");
               } catch (RuntimeException e) {
                 String message = e.getMessage();
-                List<String> expectedSubstrings = Arrays.asList("event-time timer", "expiration");
+
+                // Make sure these words are contained in error messages for
+                // both SimpleDoFnRunner and FnApiDoFnRunner (portability)
+                List<String> expectedSubstrings = Arrays.asList("timer", "expiration");
                 expectedSubstrings.forEach(
                     str ->
                         Preconditions.checkState(
@@ -3557,7 +3560,9 @@ public class ParDoTest implements Serializable {
               } catch (RuntimeException e) {
                 String message = e.getMessage();
                 List<String> expectedSubstrings =
-                    Arrays.asList("event-time timer", "output timestamp");
+                    // Make sure these words are contained in error messages for
+                    // both SimpleDoFnRunner and FnApiDoFnRunner (portability)
+                    Arrays.asList("timer", "output timestamp");
                 expectedSubstrings.forEach(
                     str ->
                         Preconditions.checkState(
@@ -3602,7 +3607,9 @@ public class ParDoTest implements Serializable {
               } catch (RuntimeException e) {
                 String message = e.getMessage();
                 List<String> expectedSubstrings =
-                    Arrays.asList("processing-time timer", "output timestamp");
+                    // Make sure these words are contained in error messages for
+                    // both SimpleDoFnRunner and FnApiDoFnRunner (portability)
+                    Arrays.asList("timer", "output timestamp");
                 expectedSubstrings.forEach(
                     str ->
                         Preconditions.checkState(


### PR DESCRIPTION
Due to the new mailbox operator architecture in Flink 1.10, processing remaining
timers during operator shutdown can't be achieved by releasing the checkpoint
lock anymore. Timers are only drained after the close() method completes.
However, at this point new timers also cannot be set anymore.

This doesn't play well with some of Beam's code (e.g. SDF) which assumes that
timers can set new timers which are guaranteed to fire at the end of the
pipeline. With the current processing model of Flink 1.10 this cannot be
guaranteed. This has manifesting in the Nexmark and ValidatesRunner tests.

While I have considered other possibilities, this was the only way to restore
the timer behavior we support with Beam and have been implementing with the
previous versions of the Flink Runner.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
