### PR TITLE
[BEAM-9731] Include more detail in passert.Equals errors.

### DIFF
--- a/sdks/go/pkg/beam/testing/passert/equals.go
+++ b/sdks/go/pkg/beam/testing/passert/equals.go
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package passert
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+)
+
+// Equals verifies the given collection has the same values as the given
+// values, under coder equality. The values can be provided as single
+// PCollection.
+func Equals(s beam.Scope, col beam.PCollection, values ...interface{}) beam.PCollection {
+	subScope := s.Scope("passert.Equals")
+	if len(values) == 0 {
+		return Empty(subScope, col)
+	}
+	if other, ok := values[0].(beam.PCollection); ok && len(values) == 1 {
+		return equals(subScope, col, other)
+	}
+
+	other := beam.Create(s, values...)
+	return equals(subScope, col, other)
+}
+
+// equals verifies that the actual values match the expected ones.
+func equals(s beam.Scope, actual, expected beam.PCollection) beam.PCollection {
+	unexpected, correct, missing := Diff(s, actual, expected)
+	beam.ParDo0(s, failIfBadEntries, beam.Impulse(s), beam.SideInput{Input: unexpected}, beam.SideInput{Input: correct}, beam.SideInput{Input: missing})
+	return actual
+}
+
+const (
+	partSeparator = "========="
+)
+
+// failIfBadEntries checks if there are any entries in the 'unexpected' or
+// 'missing' PCollections, and fails if so. The returned error message contains
+// a full list of each unexpected or missing entry.
+// If all the entries are in place, returns nil.
+func failIfBadEntries(_ []byte, unexpected, correct, missing func(*beam.T) bool) error {
+	goodCount := 0
+	var dummy beam.T
+	for correct(&dummy) {
+		goodCount++
+	}
+
+	unexpectedStrings := readToStrings(unexpected)
+	missingStrings := readToStrings(missing)
+
+	if len(unexpectedStrings)+len(missingStrings) == 0 {
+		// Hooray! No out-of-place entries; the test passes.
+		return nil
+	}
+	outStrings := []string{
+		"actual PCollection does not match expected values",
+		partSeparator,
+		fmt.Sprintf("%d correct entries (present in both)", goodCount),
+		partSeparator,
+		fmt.Sprintf("%d unexpected entries (present in actual, missing in expected)", len(unexpectedStrings)),
+	}
+	for _, entry := range unexpectedStrings {
+		outStrings = append(outStrings, "+++", entry)
+	}
+
+	outStrings = append(
+		outStrings,
+		partSeparator,
+		fmt.Sprintf("%d missing entries (missing in actual, present in expected)", len(missingStrings)),
+	)
+	for _, entry := range missingStrings {
+		outStrings = append(outStrings, "---", entry)
+	}
+	return errors.New(strings.Join(outStrings, "\n"))
+}
+
+func readToStrings(iter func(*beam.T) bool) []string {
+	out := []string{}
+	var inVal beam.T
+	for iter(&inVal) {
+		out = append(out, fmt.Sprint(inVal))
+	}
+	return out
+}

--- a/sdks/go/pkg/beam/testing/passert/equals_test.go
+++ b/sdks/go/pkg/beam/testing/passert/equals_test.go
@@ -1,0 +1,84 @@
+package passert
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+)
+
+func TestGood(t *testing.T) {
+	p, s := beam.NewPipelineWithRoot()
+	wantC := beam.Create(s, "c", "b", "a")
+	gotC := beam.Create(s, "a", "b", "c")
+
+	Equals(s, wantC, gotC)
+	if err := ptest.Run(p); err != nil {
+		t.Errorf("Pipeline failed: %v", err)
+	}
+}
+
+func TestBad(t *testing.T) {
+	tests := []struct {
+		name       string
+		actual     []string
+		expected   []string
+		errorParts []string
+	}{
+		{
+			"missing entry",
+			[]string{"a", "b"},
+			[]string{"a", "b", "MISSING"},
+			[]string{"2 correct entries", "0 unexpected entries", "1 missing entries", "MISSING"},
+		},
+		{
+			"unexpected entry",
+			[]string{"a", "b", "UNEXPECTED"},
+			[]string{"a", "b"},
+			[]string{"2 correct entries", "1 unexpected entries", "0 missing entries", "UNEXPECTED"},
+		},
+		{
+			"both kinds of problem",
+			[]string{"a", "b", "UNEXPECTED"},
+			[]string{"a", "b", "MISSING"},
+			[]string{"2 correct entries", "1 unexpected entries", "1 missing entries", "UNEXPECTED", "MISSING"},
+		},
+		{
+			"not enough",
+			[]string{"not enough"},
+			[]string{"not enough", "not enough"},
+			[]string{"1 correct entries", "0 unexpected entries", "1 missing entries", "not enough"},
+		},
+		{
+			"too many",
+			[]string{"too many", "too many"},
+			[]string{"too many"},
+			[]string{"1 correct entries", "1 unexpected entries", "0 missing entries", "too many"},
+		},
+		{
+			"both kinds of wrong count",
+			[]string{"too many", "too many", "not enough"},
+			[]string{"not enough", "too many", "not enough"},
+			[]string{"2 correct entries", "1 unexpected entries", "1 missing entries", "too many", "not enough"},
+		},
+	}
+	for _, tc := range tests {
+		p, s := beam.NewPipelineWithRoot()
+		out := Equals(s, beam.CreateList(s, tc.actual), beam.CreateList(s, tc.expected))
+		if err := ptest.Run(p); err == nil {
+			t.Errorf("%v: pipeline SUCCEEDED but should have failed; got %v", tc.name, out)
+		} else {
+			str := err.Error()
+			missing := []string{}
+			for _, part := range tc.errorParts {
+				if !strings.Contains(str, part) {
+					missing = append(missing, part)
+				}
+			}
+			if len(missing) != 0 {
+				t.Errorf("%v: pipeline failed correctly, but substrings %#v are not present in message:\n%v", tc.name, missing, str)
+			}
+		}
+	}
+}

--- a/sdks/go/pkg/beam/testing/passert/equals_test.go
+++ b/sdks/go/pkg/beam/testing/passert/equals_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package passert
 
 import (

--- a/sdks/go/pkg/beam/testing/passert/passert.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.go
@@ -32,29 +32,6 @@ import (
 //go:generate starcgen --package=passert --identifiers=diffFn,failFn,failKVFn,failGBKFn,hashFn,sumFn
 //go:generate go fmt
 
-// Equals verifies the given collection has the same values as the given
-// values, under coder equality. The values can be provided as single
-// PCollection.
-func Equals(s beam.Scope, col beam.PCollection, values ...interface{}) beam.PCollection {
-	if len(values) == 0 {
-		return Empty(s, col)
-	}
-	if other, ok := values[0].(beam.PCollection); ok && len(values) == 1 {
-		return equals(s, col, other)
-	}
-
-	other := beam.Create(s, values...)
-	return equals(s, col, other)
-}
-
-// equals verifies that the actual values match the expected ones.
-func equals(s beam.Scope, actual, expected beam.PCollection) beam.PCollection {
-	bad, _, bad2 := Diff(s, actual, expected)
-	fail(s, bad, "value %v present, but not expected")
-	fail(s, bad2, "value %v expected, but not present")
-	return actual
-}
-
 // Diff splits 2 incoming PCollections into 3: left only, both, right only. Duplicates are
 // preserved, so a value may appear multiple times and in multiple collections. Coder
 // equality is used to determine equality. Should only be used for small collections,

--- a/sdks/go/pkg/beam/testing/passert/passert.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.go
@@ -29,7 +29,7 @@ import (
 )
 
 //go:generate go install github.com/apache/beam/sdks/go/cmd/starcgen
-//go:generate starcgen --package=passert --identifiers=diffFn,failFn,failKVFn,failGBKFn,hashFn,sumFn
+//go:generate starcgen --package=passert --identifiers=diffFn,failFn,failIfBadEntries,failKVFn,failGBKFn,hashFn,sumFn
 //go:generate go fmt
 
 // Diff splits 2 incoming PCollections into 3: left only, both, right only. Duplicates are

--- a/sdks/go/pkg/beam/testing/passert/passert.shims.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.shims.go
@@ -32,6 +32,7 @@ import (
 )
 
 func init() {
+	runtime.RegisterFunction(failIfBadEntries)
 	runtime.RegisterType(reflect.TypeOf((*diffFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*failFn)(nil)).Elem())
 	runtime.RegisterType(reflect.TypeOf((*failGBKFn)(nil)).Elem())
@@ -47,6 +48,7 @@ func init() {
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int, func(*int) bool) error)(nil)).Elem(), funcMakerIntIterIntГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int, func(*string) bool) error)(nil)).Elem(), funcMakerIntIterStringГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(t typex.T), func(t typex.T), func(t typex.T)) error)(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(*typex.T) bool) error)(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X, func(*typex.Y) bool) error)(nil)).Elem(), funcMakerTypex۰XIterTypex۰YГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X, typex.Y) error)(nil)).Elem(), funcMakerTypex۰XTypex۰YГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X) error)(nil)).Elem(), funcMakerTypex۰XГError)
@@ -177,6 +179,32 @@ func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTy
 
 func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Call6x1(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) interface{} {
 	return c.fn(arg0.([]byte), arg1.(func(*typex.T) bool), arg2.(func(*typex.T) bool), arg3.(func(t typex.T)), arg4.(func(t typex.T)), arg5.(func(t typex.T)))
+}
+
+type callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError struct {
+	fn func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(*typex.T) bool) error
+}
+
+func funcMakerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError(fn interface{}) reflectx.Func {
+	f := fn.(func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(*typex.T) bool) error)
+	return &callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError{fn: f}
+}
+
+func (c *callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError) Name() string {
+	return reflectx.FunctionName(c.fn)
+}
+
+func (c *callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError) Type() reflect.Type {
+	return reflect.TypeOf(c.fn)
+}
+
+func (c *callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError) Call(args []interface{}) []interface{} {
+	out0 := c.fn(args[0].([]byte), args[1].(func(*typex.T) bool), args[2].(func(*typex.T) bool), args[3].(func(*typex.T) bool))
+	return []interface{}{out0}
+}
+
+func (c *callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError) Call4x1(arg0, arg1, arg2, arg3 interface{}) interface{} {
+	return c.fn(arg0.([]byte), arg1.(func(*typex.T) bool), arg2.(func(*typex.T) bool), arg3.(func(*typex.T) bool))
 }
 
 type callerTypex۰XIterTypex۰YГError struct {


### PR DESCRIPTION
This change reworks passert.Equals to collect all of the missing and
unexpected values in a single output string to make debugging easier.
The new Equals function uses a similar structure to Diff internally.

- Moves passert.Equals to its own file, since it got big.
- Includes string form of each out-of-place entry in error message.
- Adds summary info (number of missing/unexpected/correct entries).
- Adds tests for passert.Equals.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
 - [ ] Update `CHANGES.md` with noteworthy changes.

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
