### PR TITLE
[BEAM-9651] Prevent StreamPool and stream initialization livelock

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/ForwardingClientResponseObserver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/ForwardingClientResponseObserver.java
@@ -60,7 +60,7 @@ final class ForwardingClientResponseObserver<ReqT, RespT>
   }
 
   @Override
-  public void beforeStart(ClientCallStreamObserver<RespT> stream) {
-    stream.setOnReadyHandler(onReadyHandler);
+  public void beforeStart(ClientCallStreamObserver<RespT> requestStream) {
+    requestStream.setOnReadyHandler(onReadyHandler);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillServerStub.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillServerStub.java
@@ -20,20 +20,22 @@ package org.apache.beam.runners.dataflow.worker.windmill;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.runners.dataflow.worker.status.StatusDataProvider;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.CommitStatus;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataResponse;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Supplier;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Suppliers;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.net.HostAndPort;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -154,65 +156,113 @@ public abstract class WindmillServerStub implements StatusDataProvider {
   public static class StreamPool<S extends WindmillStream> {
 
     private final Duration streamTimeout;
+    private final Supplier<S> supplier;
 
     private final class StreamData {
-      final S stream = supplier.get();
-      int holds = 1;
+      final Supplier<S> lazyStream = Suppliers.memoize(supplier);
+      Instant streamCreated = Instant.now();
+      AtomicInteger holds = new AtomicInteger(1);
     };
 
     private final List<StreamData> streams;
-    private final Supplier<S> supplier;
-    private final HashMap<S, StreamData> holds;
+    private final ConcurrentHashMap<S, StreamData> holds;
 
     public StreamPool(int numStreams, Duration streamTimeout, Supplier<S> supplier) {
+      this.streamTimeout = streamTimeout;
+      this.supplier = supplier;
       this.streams = new ArrayList<>(numStreams);
       for (int i = 0; i < numStreams; i++) {
         streams.add(null);
       }
-      this.streamTimeout = streamTimeout;
-      this.supplier = supplier;
-      this.holds = new HashMap<>();
+      this.holds = new ConcurrentHashMap<>();
     }
 
     // Returns a stream for use that may be cached from a previous call.  Each call of getStream
     // must be matched with a call of releaseStream.
     public S getStream() {
       int index = ThreadLocalRandom.current().nextInt(streams.size());
-      S result;
-      S closeStream = null;
+      Instant timeoutThreshold = Instant.now().minus(streamTimeout);
+      StreamData streamData = null;
+      StreamData closeStream = null;
       synchronized (this) {
-        StreamData streamData = streams.get(index);
-        if (streamData == null
-            || streamData.stream.startTime().isBefore(Instant.now().minus(streamTimeout))) {
-          if (streamData != null && --streamData.holds == 0) {
-            holds.remove(streamData.stream);
-            closeStream = streamData.stream;
+        streamData = streams.get(index);
+        if (streamData != null) {
+          if (streamData.streamCreated.isBefore(timeoutThreshold)) {
+            if (streamData.holds.decrementAndGet() <= 0) {
+              closeStream = streamData;
+            }
+            streamData = null; // Fall through to create a new stream
           }
+        }
+        if (streamData == null) {
           streamData = new StreamData();
           streams.set(index, streamData);
-          holds.put(streamData.stream, streamData);
         }
-        streamData.holds++;
-        result = streamData.stream;
+        // The hold is decremented by releaseStream.
+        streamData.holds.incrementAndGet();
       }
+      // Close the previous stream if it was retired and there were no other holds.
       if (closeStream != null) {
-        closeStream.close();
-      }
-      return result;
-    }
-
-    // Releases a stream that was obtained with getStream.
-    public void releaseStream(S stream) {
-      boolean closeStream = false;
-      synchronized (this) {
-        if (--holds.get(stream).holds == 0) {
-          closeStream = true;
-          holds.remove(stream);
-        }
-      }
-      if (closeStream) {
+        assert (closeStream.holds.intValue() == 0);
+        S stream = closeStream.lazyStream.get();
+        StreamData removed = holds.remove(stream);
+        assert (removed == closeStream);
         stream.close();
       }
+      // Initialize the stream outside the synchronized section so that slow initialization does
+      // not block other streams.
+      S stream = streamData.lazyStream.get();
+      holds.put(stream, streamData);
+      return stream;
+    }
+
+    // Releases a stream that was obtained with getStream. If the stream was retired and this was
+    // the final hold it is closed.
+    public void releaseStream(S stream) {
+      StreamData streamData = holds.get(stream);
+      if (streamData.holds.decrementAndGet() <= 0) {
+        StreamData removed = holds.remove(stream);
+        assert (removed == streamData);
+        stream.close();
+      }
+    }
+
+    // Closes and awaits termination for all streams that do not have an active external hold,
+    // returning true if all streams were closed.
+    public boolean closeIdle(int duration, TimeUnit unit) throws InterruptedException {
+      boolean removedAll = true;
+      ArrayList<StreamData> streamsCopy = null;
+      synchronized (this) {
+        streamsCopy = new ArrayList<>(streams.size());
+        for (int i = 0; i < streams.size(); ++i) {
+          StreamData streamData = streams.get(i);
+          streams.set(i, null);
+          streamsCopy.add(streamData);
+        }
+      }
+      for (int i = 0; i < streamsCopy.size(); ++i) {
+        StreamData streamData = streamsCopy.get(i);
+        if (streamData == null) {
+          continue;
+        }
+
+        if (streamData.holds.decrementAndGet() <= 0) {
+          S stream = streamData.lazyStream.get();
+          StreamData removed = holds.remove(stream);
+          assert (removed == streamData);
+          stream.close();
+        } else {
+          removedAll = false;
+          streamsCopy.set(i, null);
+        }
+      }
+      for (StreamData streamData : streamsCopy) {
+        if (streamData == null) {
+          continue;
+        }
+        streamData.lazyStream.get().awaitTermination(duration, unit);
+      }
+      return removedAll;
     }
   }
 


### PR DESCRIPTION
Reduce StreamPool synchronized block section to not include stream
creation which includes sending initial messages. Additionally remove it from being
required to release holds. Some pipelines were observing stuck get and
release methods on synchronization.  This was due to a stuck stream
creation waiting for the onReady callback. This could possibly have
been due to the callback being queued behind other callbacks on
blocked grpc threads. This was addressed in the DirectStreamObserver
used for the fn api so we reuse it here.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
