### PR TITLE
[BEAM-9439] Return split instead of total backlog size

### DIFF
--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisReaderTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisReaderTest.java
@@ -19,9 +19,8 @@ package org.apache.beam.sdk.io.kinesis;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -136,50 +135,50 @@ public class KinesisReaderTest {
   }
 
   @Test
-  public void getTotalBacklogBytesShouldReturnLastSeenValueWhenKinesisExceptionsOccur()
+  public void getSplitBacklogBytesShouldReturnLastSeenValueWhenKinesisExceptionsOccur()
       throws TransientKinesisException, IOException {
     reader.start();
     when(kinesisSource.getStreamName()).thenReturn("stream1");
-    doReturn(Instant.now().minus(Duration.standardMinutes(1))).when(reader).getWatermark();
+    when(shardReadersPool.getLatestRecordTimestamp())
+        .thenReturn(Instant.now().minus(Duration.standardMinutes(1)));
     when(kinesis.getBacklogBytes(eq("stream1"), any(Instant.class)))
         .thenReturn(10L)
         .thenThrow(TransientKinesisException.class)
         .thenReturn(20L);
 
-    assertThat(reader.getTotalBacklogBytes()).isEqualTo(10);
-    assertThat(reader.getTotalBacklogBytes()).isEqualTo(10);
-    assertThat(reader.getTotalBacklogBytes()).isEqualTo(20);
+    assertThat(reader.getSplitBacklogBytes()).isEqualTo(10);
+    assertThat(reader.getSplitBacklogBytes()).isEqualTo(10);
+    assertThat(reader.getSplitBacklogBytes()).isEqualTo(20);
   }
 
   @Test
-  public void getTotalBacklogBytesShouldReturnLastSeenValueWhenCalledFrequently()
+  public void getSplitBacklogBytesShouldReturnLastSeenValueWhenCalledFrequently()
       throws TransientKinesisException, IOException {
     KinesisReader backlogCachingReader = spy(createReader(Duration.standardSeconds(30)));
     backlogCachingReader.start();
-    doReturn(Instant.now().minus(Duration.standardMinutes(1)))
-        .when(backlogCachingReader)
-        .getWatermark();
+    when(shardReadersPool.getLatestRecordTimestamp())
+        .thenReturn(Instant.now().minus(Duration.standardMinutes(1)));
     when(kinesisSource.getStreamName()).thenReturn("stream1");
     when(kinesis.getBacklogBytes(eq("stream1"), any(Instant.class)))
         .thenReturn(10L)
         .thenReturn(20L);
 
-    assertThat(backlogCachingReader.getTotalBacklogBytes()).isEqualTo(10);
-    assertThat(backlogCachingReader.getTotalBacklogBytes()).isEqualTo(10);
+    assertThat(backlogCachingReader.getSplitBacklogBytes()).isEqualTo(10);
+    assertThat(backlogCachingReader.getSplitBacklogBytes()).isEqualTo(10);
   }
 
   @Test
-  public void getTotalBacklogBytesShouldReturnBacklogUnknown()
+  public void getSplitBacklogBytesShouldReturnBacklogUnknown()
       throws IOException, TransientKinesisException {
     reader.start();
     when(kinesisSource.getStreamName()).thenReturn("stream1");
-    when(reader.getWatermark())
+    when(shardReadersPool.getLatestRecordTimestamp())
         .thenReturn(BoundedWindow.TIMESTAMP_MIN_VALUE)
         .thenReturn(Instant.now().minus(Duration.standardMinutes(1)));
     when(kinesis.getBacklogBytes(eq("stream1"), any(Instant.class))).thenReturn(10L);
 
-    assertThat(reader.getTotalBacklogBytes())
+    assertThat(reader.getSplitBacklogBytes())
         .isEqualTo(UnboundedSource.UnboundedReader.BACKLOG_UNKNOWN);
-    assertThat(reader.getTotalBacklogBytes()).isEqualTo(10);
+    assertThat(reader.getSplitBacklogBytes()).isEqualTo(10);
   }
 }

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/ShardRecordsIteratorTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/ShardRecordsIteratorTest.java
@@ -20,8 +20,8 @@ package org.apache.beam.sdk.io.kinesis;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.kinesis.model.ExpiredIteratorException;
@@ -88,7 +88,7 @@ public class ShardRecordsIteratorTest {
     when(secondResult.getRecords()).thenReturn(Collections.emptyList());
     when(thirdResult.getRecords()).thenReturn(Collections.emptyList());
 
-    when(recordFilter.apply(anyListOf(KinesisRecord.class), any(ShardCheckpoint.class)))
+    when(recordFilter.apply(anyList(), any(ShardCheckpoint.class)))
         .thenAnswer(new IdentityAnswer());
 
     WatermarkPolicyFactory watermarkPolicyFactory = WatermarkPolicyFactory.withArrivalTimePolicy();
@@ -150,6 +150,30 @@ public class ShardRecordsIteratorTest {
     iterator.ackRecord(a);
     assertThat(iterator.readNextBatch()).isEqualTo(singletonList(b));
     assertThat(iterator.readNextBatch()).isEqualTo(Collections.emptyList());
+  }
+
+  @Test
+  public void tracksLatestRecordTimestamp() {
+    when(firstResult.getRecords()).thenReturn(singletonList(a));
+    when(secondResult.getRecords()).thenReturn(asList(b, c));
+    when(thirdResult.getRecords()).thenReturn(singletonList(c));
+
+    when(a.getApproximateArrivalTimestamp()).thenReturn(NOW);
+    when(b.getApproximateArrivalTimestamp()).thenReturn(NOW.plus(Duration.standardSeconds(4)));
+    when(c.getApproximateArrivalTimestamp()).thenReturn(NOW.plus(Duration.standardSeconds(2)));
+    when(d.getApproximateArrivalTimestamp()).thenReturn(NOW.plus(Duration.standardSeconds(6)));
+
+    iterator.ackRecord(a);
+    assertThat(iterator.getLatestRecordTimestamp()).isEqualTo(NOW);
+    iterator.ackRecord(b);
+    assertThat(iterator.getLatestRecordTimestamp())
+        .isEqualTo(NOW.plus(Duration.standardSeconds(4)));
+    iterator.ackRecord(c);
+    assertThat(iterator.getLatestRecordTimestamp())
+        .isEqualTo(NOW.plus(Duration.standardSeconds(4)));
+    iterator.ackRecord(d);
+    assertThat(iterator.getLatestRecordTimestamp())
+        .isEqualTo(NOW.plus(Duration.standardSeconds(6)));
   }
 
   private static class IdentityAnswer implements Answer<Object> {


### PR DESCRIPTION
This merge request changes how backlog bytes are reported by KinesisReader.

Instead of total backlog bytes, which could result in Dataflow pipelines not scaling up,
split backlog is now reported.

The split backlog size can be over-estimated as it reports the size
of the records across all shards (and also assumes that all shards
in the split have the same progress).
This can lead to unnecessary decisions to scale up the number of workers
but will never fail to scale up when this is necessary.

Also the watermark policy of the reader is user configurable and we
don't have a control over it. The calculation of backlog bytes should
always take into account the time that the record was inserted into
Kinesis as this gives accurate results which are independent of
current processing time or any other conditions that reader watermark
can be using. Therefore a separate, fixed policy is used to track
processed records for the backlog calculation.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
