### PR TITLE
[BEAM-9747] Deprecate RedisIO.readAll() and add RedisIO.readKeyPatterns as a replacement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,7 @@
 
 * X behavior is deprecated and will be removed in X versions ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 * Remove Gearpump runner. ([BEAM-9999](https://issues.apache.org/jira/browse/BEAM-9999))
+* RedisIO.readAll() is deprecated and will be removed in 2 versions, users must use RedisIO.readKeyPatterns() as a replacement ([BEAM-9747](https://issues.apache.org/jira/browse/BEAM-9747)).
 
 ## Known Issues
 

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
@@ -80,13 +80,13 @@ import redis.clients.jedis.ScanResult;
  *
  * }</pre>
  *
- * <p>{@link #readAll()} can be used to request Redis server using input PCollection elements as key
- * pattern (as String).
+ * <p>{@link #readKeyPatterns()} can be used to request Redis server using input PCollection
+ * elements as key pattern (as String).
  *
  * <pre>{@code
  * pipeline.apply(...)
  *    // here we have a PCollection<String> with the key patterns
- *    .apply(RedisIO.readAll().withEndpoint("::1", 6379))
+ *    .apply(RedisIO.readKeyPatterns().withEndpoint("::1", 6379))
  *   // here we have a PCollection<KV<String,String>>
  *
  * }</pre>
@@ -122,9 +122,25 @@ public class RedisIO {
   /**
    * Like {@link #read()} but executes multiple instances of the Redis query substituting each
    * element of a {@link PCollection} as key pattern.
+   *
+   * @deprecated This method is not consistent with the readAll pattern of other transforms and will
+   *     be remove soon. Please update you code to use {@link #readKeyPatterns()} instead.
    */
+  @Deprecated
   public static ReadAll readAll() {
     return new AutoValue_RedisIO_ReadAll.Builder()
+        .setConnectionConfiguration(RedisConnectionConfiguration.create())
+        .setBatchSize(1000)
+        .setOutputParallelization(true)
+        .build();
+  }
+
+  /**
+   * Like {@link #read()} but executes multiple instances of the Redis query substituting each
+   * element of a {@link PCollection} as key pattern.
+   */
+  public static ReadKeyPatterns readKeyPatterns() {
+    return new AutoValue_RedisIO_ReadKeyPatterns.Builder()
         .setConnectionConfiguration(RedisConnectionConfiguration.create())
         .setBatchSize(1000)
         .setOutputParallelization(true)
@@ -229,14 +245,20 @@ public class RedisIO {
           .apply(Create.of(keyPattern()))
           .apply(ParDo.of(new ReadKeysWithPattern(connectionConfiguration())))
           .apply(
-              RedisIO.readAll()
+              RedisIO.readKeyPatterns()
                   .withConnectionConfiguration(connectionConfiguration())
                   .withBatchSize(batchSize())
                   .withOutputParallelization(outputParallelization()));
     }
   }
 
-  /** Implementation of {@link #readAll()}. */
+  /**
+   * Implementation of {@link #readAll()}.
+   *
+   * @deprecated This class will be removed soon. Please update you code to depend on {@link
+   *     ReadKeyPatterns} instead.
+   */
+  @Deprecated
   @AutoValue
   public abstract static class ReadAll
       extends PTransform<PCollection<String>, PCollection<KV<String, String>>> {
@@ -298,6 +320,85 @@ public class RedisIO {
      * default is to parallelize and should only be changed if this is known to be unnecessary.
      */
     public ReadAll withOutputParallelization(boolean outputParallelization) {
+      return toBuilder().setOutputParallelization(outputParallelization).build();
+    }
+
+    @Override
+    public PCollection<KV<String, String>> expand(PCollection<String> input) {
+      checkArgument(connectionConfiguration() != null, "withConnectionConfiguration() is required");
+      PCollection<KV<String, String>> output =
+          input
+              .apply(ParDo.of(new ReadFn(connectionConfiguration(), batchSize())))
+              .setCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+      if (outputParallelization()) {
+        output = output.apply(new Reparallelize());
+      }
+      return output;
+    }
+  }
+
+  /** Implementation of {@link #readKeyPatterns()}. */
+  @AutoValue
+  public abstract static class ReadKeyPatterns
+      extends PTransform<PCollection<String>, PCollection<KV<String, String>>> {
+
+    @Nullable
+    abstract RedisConnectionConfiguration connectionConfiguration();
+
+    abstract int batchSize();
+
+    abstract boolean outputParallelization();
+
+    abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      @Nullable
+      abstract Builder setConnectionConfiguration(RedisConnectionConfiguration connection);
+
+      abstract Builder setBatchSize(int batchSize);
+
+      abstract Builder setOutputParallelization(boolean outputParallelization);
+
+      abstract ReadKeyPatterns build();
+    }
+
+    public ReadKeyPatterns withEndpoint(String host, int port) {
+      checkArgument(host != null, "host can not be null");
+      checkArgument(port > 0, "port can not be negative or 0");
+      return toBuilder()
+          .setConnectionConfiguration(connectionConfiguration().withHost(host).withPort(port))
+          .build();
+    }
+
+    public ReadKeyPatterns withAuth(String auth) {
+      checkArgument(auth != null, "auth can not be null");
+      return toBuilder()
+          .setConnectionConfiguration(connectionConfiguration().withAuth(auth))
+          .build();
+    }
+
+    public ReadKeyPatterns withTimeout(int timeout) {
+      checkArgument(timeout >= 0, "timeout can not be negative");
+      return toBuilder()
+          .setConnectionConfiguration(connectionConfiguration().withTimeout(timeout))
+          .build();
+    }
+
+    public ReadKeyPatterns withConnectionConfiguration(RedisConnectionConfiguration connection) {
+      checkArgument(connection != null, "connection can not be null");
+      return toBuilder().setConnectionConfiguration(connection).build();
+    }
+
+    public ReadKeyPatterns withBatchSize(int batchSize) {
+      return toBuilder().setBatchSize(batchSize).build();
+    }
+
+    /**
+     * Whether to reshuffle the resulting PCollection so results are distributed to all workers. The
+     * default is to parallelize and should only be changed if this is known to be unnecessary.
+     */
+    public ReadKeyPatterns withOutputParallelization(boolean outputParallelization) {
       return toBuilder().setOutputParallelization(outputParallelization).build();
     }
 


### PR DESCRIPTION
The idea is to let this deprecation for two releases before introducing the ReadAll pattern based on Reads for RedisIO to like proposed in [BEAM-9403](https://issues.apache.org/jira/browse/BEAM-9403).

R: @aromanenko-dev 