### PR TITLE
[BEAM-9748] Refactor Reparallelize as an alternative Reshuffle implementation

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Reshuffle.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Reshuffle.java
@@ -140,7 +140,7 @@ public class Reshuffle<K, V> extends PTransform<PCollection<KV<K, V>>, PCollecti
         // and ensures that data to be shuffled can be generated in parallel, while reshuffling
         // provides perfect parallelism.
         // In most cases where a "fusion break" is needed, a simple reshuffle would be sufficient.
-        // The current approach is necessary only to support the particular case of JdbcIO where
+        // The current approach is necessary to support use cases such as JdbcIO where
         // a single query may produce many gigabytes of query results.
         PCollectionView<Iterable<T>> empty =
             input


### PR DESCRIPTION
Some DoFn based IOs like JdbcIO and RedisIO rely on the Reparallelize transform, a combination of a an empty PCollectionView and Reshuffle to force the materialization and reparallelize a PCollection. The idea of this issue is to extract this transform and expose it as part of the internal Reshuffle transform to avoid repeating the code for transforms (notably IOs) that require to reparallelize its output.

R: @lukecwik 