### PR TITLE
Hotfix: fix a typo in go installation link.

### DIFF
--- a/website/src/contribute/index.md
+++ b/website/src/contribute/index.md
@@ -88,7 +88,7 @@ sudo apt-get install \
    docker-ce
 ```
 
-You also need to [install Go](https://golang.org/doc/install]).
+You also need to [install Go](https://golang.org/doc/install).
 
 Once Go is installed, install goavro:
 


### PR DESCRIPTION
Fix a typo in the go installation link.
