### PR TITLE
[BEAM-7554] Add MillisInstant logical type to replace DATETIME 

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -420,7 +420,6 @@ public class Schema implements Serializable {
     FLOAT,
     DOUBLE,
     STRING, // String.
-    DATETIME, // Date and time.
     BOOLEAN, // Boolean.
     BYTES, // Byte array.
     ARRAY,
@@ -432,7 +431,6 @@ public class Schema implements Serializable {
     public static final Set<TypeName> NUMERIC_TYPES =
         ImmutableSet.of(BYTE, INT16, INT32, INT64, DECIMAL, FLOAT, DOUBLE);
     public static final Set<TypeName> STRING_TYPES = ImmutableSet.of(STRING);
-    public static final Set<TypeName> DATE_TYPES = ImmutableSet.of(DATETIME);
     public static final Set<TypeName> COLLECTION_TYPES = ImmutableSet.of(ARRAY, ITERABLE);
     public static final Set<TypeName> MAP_TYPES = ImmutableSet.of(MAP);
     public static final Set<TypeName> COMPOSITE_TYPES = ImmutableSet.of(ROW);
@@ -447,10 +445,6 @@ public class Schema implements Serializable {
 
     public boolean isStringType() {
       return STRING_TYPES.contains(this);
-    }
-
-    public boolean isDateType() {
-      return DATE_TYPES.contains(this);
     }
 
     public boolean isCollectionType() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.BiMap;
@@ -679,7 +680,7 @@ public class Schema implements Serializable {
     public static final FieldType BOOLEAN = FieldType.of(TypeName.BOOLEAN);
 
     /** The type of datetime fields. */
-    public static final FieldType DATETIME = FieldType.of(TypeName.DATETIME);
+    public static final FieldType DATETIME = FieldType.logicalType(MillisInstant.of());
 
     /** Create an array type for the given field type. */
     public static FieldType array(FieldType elementType) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoderHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoderHelpers.java
@@ -32,7 +32,6 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.DoubleCoder;
 import org.apache.beam.sdk.coders.FloatCoder;
-import org.apache.beam.sdk.coders.InstantCoder;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.MapCoder;
@@ -61,7 +60,6 @@ class SchemaCoderHelpers {
           .put(TypeName.FLOAT, FloatCoder.of())
           .put(TypeName.DOUBLE, DoubleCoder.of())
           .put(TypeName.STRING, StringUtf8Coder.of())
-          .put(TypeName.DATETIME, InstantCoder.of())
           .put(TypeName.BOOLEAN, BooleanCoder.of())
           .build();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -131,15 +131,8 @@ public class SchemaTranslation {
         }
         builder.setLogicalType(logicalTypeBuilder.build());
         break;
-        // Special-case for DATETIME and DECIMAL which are logical types in portable representation,
+        // Special-case for DECIMAL which is a logical type in portable representation,
         // but not yet in Java. (BEAM-7554)
-      case DATETIME:
-        builder.setLogicalType(
-            SchemaApi.LogicalType.newBuilder()
-                .setUrn(URN_BEAM_LOGICAL_DATETIME)
-                .setRepresentation(fieldTypeToProto(FieldType.INT64, serializeLogicalType))
-                .build());
-        break;
       case DECIMAL:
         builder.setLogicalType(
             SchemaApi.LogicalType.newBuilder()

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MillisInstant.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MillisInstant.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.logicaltypes;
+
+import org.joda.time.Instant;
+import org.joda.time.ReadableInstant;
+
+/** A timestamp represented as nanoseconds since the epoch. */
+public class MillisInstant extends MillisType<ReadableInstant> {
+  public static final String IDENTIFIER = "beam:logical_type:millis_instant:v1";
+
+  private MillisInstant() {
+    super(IDENTIFIER);
+  }
+
+  public static MillisInstant of() {
+    return new MillisInstant();
+  }
+
+  @Override
+  public Long toBaseType(ReadableInstant input) {
+    return input.getMillis();
+  }
+
+  @Override
+  public ReadableInstant toInputType(Long millis) {
+    return Instant.ofEpochMilli(millis);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MillisInstant.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MillisInstant.java
@@ -20,7 +20,7 @@ package org.apache.beam.sdk.schemas.logicaltypes;
 import org.joda.time.Instant;
 import org.joda.time.ReadableInstant;
 
-/** A timestamp represented as nanoseconds since the epoch. */
+/** A timestamp represented as milliseconds since the epoch. */
 public class MillisInstant extends MillisType<ReadableInstant> {
   public static final String IDENTIFIER = "beam:logical_type:millis_instant:v1";
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MillisType.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MillisType.java
@@ -19,7 +19,7 @@ package org.apache.beam.sdk.schemas.logicaltypes;
 
 import org.apache.beam.sdk.schemas.Schema;
 
-/** Base class for types representing timestamps or durations as nanoseconds. */
+/** Base class for types representing timestamps or durations as milliseconds. */
 abstract class MillisType<T> implements Schema.LogicalType<T, Long> {
   private final String identifier;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MillisType.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MillisType.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.logicaltypes;
+
+import org.apache.beam.sdk.schemas.Schema;
+
+/** Base class for types representing timestamps or durations as nanoseconds. */
+abstract class MillisType<T> implements Schema.LogicalType<T, Long> {
+  private final String identifier;
+
+  MillisType(String identifier) {
+    this.identifier = identifier;
+  }
+
+  @Override
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  @Override
+  public Schema.FieldType getArgumentType() {
+    return Schema.FieldType.STRING;
+  }
+
+  @Override
+  public String getArgument() {
+    return "";
+  }
+
+  @Override
+  public Schema.FieldType getBaseType() {
+    return Schema.FieldType.INT64;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -881,10 +881,6 @@ public class AvroUtils {
         LogicalType logicalType = typeWithNullability.type.getLogicalType();
         return new Conversions.DecimalConversion().toBytes(decimal, null, logicalType);
 
-      case DATETIME:
-        throw new IllegalArgumentException(
-            "DATETIME is not supported, use MillisInstant logical type instead.");
-
       case BYTES:
         return ByteBuffer.wrap((byte[]) value);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -86,6 +86,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Primitives;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ClassUtils;
+import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Instant;
 import org.joda.time.ReadableInstant;
@@ -1174,7 +1175,8 @@ public class ByteBuddyUtils {
                   .filter(ElementMatchers.named("getMillis"))
                   .getOnly()));
 
-      if (type.isSubtypeOf(TypeDescriptor.of(BaseLocal.class))) {
+      if (type.isSubtypeOf(TypeDescriptor.of(BaseLocal.class))
+          || type.equals(TypeDescriptor.of(DateTime.class))) {
         // Access DateTimeZone.UTC
         stackManipulations.add(
             FieldAccess.forField(
@@ -1183,7 +1185,7 @@ public class ByteBuddyUtils {
                         .filter(ElementMatchers.named("UTC"))
                         .getOnly())
                 .read());
-        // All subclasses of BaseLocal contain a ()(long, DateTimeZone) constructor
+        // All subclasses of BaseLocal (and DateTime) contain a ()(long, DateTimeZone) constructor
         // that takes in a millis and time zone argument. Call that constructor of the field to
         // initialize it.
         stackManipulations.add(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.ReadableInstant;
@@ -138,7 +139,8 @@ public class StaticSchemaInference {
     } else if (type.isSubtypeOf(TypeDescriptor.of(CharSequence.class))) {
       return FieldType.STRING;
     } else if (type.isSubtypeOf(TypeDescriptor.of(ReadableInstant.class))) {
-      return FieldType.DATETIME;
+      // TODO: What about java8 time instant?
+      return FieldType.logicalType(MillisInstant.of());
     } else if (type.isSubtypeOf(TypeDescriptor.of(ByteBuffer.class))) {
       return FieldType.BYTES;
     } else if (type.isSubtypeOf(TypeDescriptor.of(Iterable.class))) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
@@ -67,7 +67,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
 /**
  * Jackson serializer and deserializer for {@link Row Rows}.
  *
- * <p>Supports converting between JSON primitive types and:
+ * <p>Supports converting between JSON primitive types and the following schema primitive types:
  *
  * <ul>
  *   <li>{@link Schema.TypeName#BYTE}
@@ -78,11 +78,16 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  *   <li>{@link Schema.TypeName#DOUBLE}
  *   <li>{@link Schema.TypeName#BOOLEAN}
  *   <li>{@link Schema.TypeName#STRING}
+ *   <li>{@link Schema.TypeName#DECIMAL}
  * </ul>
+ *
+ * <p>The composite types {@link Schema.TypeName#ROW}, {@link Schema.TypeName#ARRAY}, and
+ * {@link Schema.TypeName#ITERABLE} are also supported, as well as logical types, which are
+ * represented in JSON using the representation for their base type.
  */
 @Experimental(Kind.SCHEMAS)
 public class RowJson {
-  private static final ImmutableSet<TypeName> SUPPORTED_TYPES =
+  private static final ImmutableSet<TypeName> SUPPORTED_PRIMITIVE_TYPES =
       ImmutableSet.of(BYTE, INT16, INT32, INT64, FLOAT, DOUBLE, BOOLEAN, STRING, DECIMAL);
 
   /**
@@ -97,7 +102,7 @@ public class RowJson {
               "Field type%s %s not supported when converting between JSON and Rows. Supported types are: %s",
               unsupportedFields.size() > 1 ? "s" : "",
               unsupportedFields.toString(),
-              SUPPORTED_TYPES.toString()));
+              SUPPORTED_PRIMITIVE_TYPES.toString()));
     }
   }
 
@@ -147,7 +152,7 @@ public class RowJson {
       return findUnsupportedFields(fieldType.getLogicalType().getBaseType(), fieldName);
     }
 
-    if (!SUPPORTED_TYPES.contains(fieldTypeName)) {
+    if (!SUPPORTED_PRIMITIVE_TYPES.contains(fieldTypeName)) {
       return ImmutableList.of(new UnsupportedField(fieldName, fieldTypeName));
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
@@ -81,9 +81,9 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  *   <li>{@link Schema.TypeName#DECIMAL}
  * </ul>
  *
- * <p>The composite types {@link Schema.TypeName#ROW}, {@link Schema.TypeName#ARRAY}, and
- * {@link Schema.TypeName#ITERABLE} are also supported, as well as logical types, which are
- * represented in JSON using the representation for their base type.
+ * <p>The composite types {@link Schema.TypeName#ROW}, {@link Schema.TypeName#ARRAY}, and {@link
+ * Schema.TypeName#ITERABLE} are also supported, as well as logical types, which are represented in
+ * JSON using the representation for their base type.
  */
 @Experimental(Kind.SCHEMAS)
 public class RowJson {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -202,8 +202,8 @@ public abstract class Row implements Serializable {
   }
 
   /**
-   * Get a {@link TypeName#DATETIME} value by field name, {@link IllegalStateException} is thrown if
-   * schema doesn't match.
+   * Get a {@link org.apache.beam.sdk.schemas.logicaltypes.MillisInstant} value by field name,
+   * {@link IllegalStateException} is thrown if schema doesn't match.
    */
   @Nullable
   public ReadableDateTime getDateTime(String fieldName) {
@@ -353,8 +353,8 @@ public abstract class Row implements Serializable {
   }
 
   /**
-   * Get a {@link TypeName#DATETIME} value by field index, {@link IllegalStateException} is thrown
-   * if schema doesn't match.
+   * Get a {@link org.apache.beam.sdk.schemas.logicaltypes.MillisInstant} value by field index,
+   * {@link IllegalStateException} is thrown if schema doesn't match.
    */
   @Nullable
   public ReadableDateTime getDateTime(int idx) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowUtils.java
@@ -162,9 +162,6 @@ class RowUtils {
           LogicalType logicalType = fieldType.getLogicalType();
           processedValue = cases.processLogicalType(rowPosition, logicalType, value, this);
           break;
-        case DATETIME:
-          processedValue = cases.processDateTime(rowPosition, (AbstractInstant) value, this);
-          break;
         case BYTE:
           processedValue = cases.processByte(rowPosition, (Byte) value, this);
           break;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AutoValueSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AutoValueSchemaTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.Charset;
 import org.apache.beam.sdk.schemas.AutoValueSchemaTest.SimpleAutoValueWithBuilder.Builder;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.apache.beam.sdk.schemas.utils.SchemaTestUtils;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.Row;
@@ -52,8 +53,8 @@ public class AutoValueSchemaTest {
           .addInt32Field("anInt")
           .addInt64Field("aLong")
           .addBooleanField("aBoolean")
-          .addDateTimeField("dateTime")
-          .addDateTimeField("instant")
+          .addLogicalTypeField("dateTime", MillisInstant.of())
+          .addLogicalTypeField("instant", MillisInstant.of())
           .addByteArrayField("bytes")
           .addByteArrayField("byteBuffer")
           .addDecimalField("bigDecimal")

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AutoValueSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AutoValueSchemaTest.java
@@ -40,7 +40,7 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link AutoValueSchema}. */
 @RunWith(JUnit4.class)
 public class AutoValueSchemaTest {
-  static final DateTime DATE = DateTime.parse("1979-03-14");
+  static final DateTime DATE = DateTime.parse("1979-03-14T00:00:00Z");
   static final byte[] BYTE_ARRAY = "bytearray".getBytes(Charset.defaultCharset());
   static final StringBuilder STRING_BUILDER = new StringBuilder("stringbuilder");
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
@@ -299,7 +299,7 @@ public class AvroSchemaTest {
 
   private static final byte[] BYTE_ARRAY = new byte[] {1, 2, 3, 4};
   private static final DateTime DATE_TIME =
-      new DateTime().withDate(1979, 3, 14).withTime(1, 2, 3, 4);
+      new DateTime(DateTimeZone.UTC).withDate(1979, 3, 14).withTime(1, 2, 3, 4);
   private static final LocalDate DATE = new LocalDate(1979, 3, 14);
   private static final TestAvroNested AVRO_NESTED_SPECIFIC_RECORD = new TestAvroNested(true, 42);
   private static final TestAvro AVRO_SPECIFIC_RECORD =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
@@ -453,8 +453,6 @@ public class AvroSchemaTest {
 
   @Test
   public void testRowToPojo() {
-
-    LocalDate test = new LocalDate(((Instant) ROW_FOR_POJO.getValue(8)).getMillis());
     SerializableFunction<Row, AvroPojo> fromRow =
         new AvroRecordSchema().fromRowFunction(TypeDescriptor.of(AvroPojo.class));
     assertEquals(AVRO_POJO, fromRow.apply(ROW_FOR_POJO));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AvroSchemaTest.java
@@ -34,6 +34,7 @@ import org.apache.avro.util.Utf8;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.apache.beam.sdk.schemas.transforms.Group;
 import org.apache.beam.sdk.schemas.utils.AvroUtils;
 import org.apache.beam.sdk.testing.PAssert;
@@ -50,7 +51,6 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Days;
-import org.joda.time.Instant;
 import org.joda.time.LocalDate;
 import org.junit.Rule;
 import org.junit.Test;
@@ -271,8 +271,8 @@ public class AvroSchemaTest {
           .addNullableField("string", FieldType.STRING)
           .addNullableField("bytes", FieldType.BYTES)
           .addField("fixed", FieldType.logicalType(FixedBytes.of(4)))
-          .addField("date", FieldType.DATETIME)
-          .addField("timestampMillis", FieldType.DATETIME)
+          .addField("date", FieldType.logicalType(MillisInstant.of()))
+          .addField("timestampMillis", FieldType.logicalType(MillisInstant.of()))
           .addField("testEnum", FieldType.logicalType(TEST_ENUM_TYPE))
           .addNullableField("row", SUB_TYPE)
           .addNullableField("array", FieldType.array(SUB_TYPE))
@@ -289,8 +289,8 @@ public class AvroSchemaTest {
           .addNullableField("string", FieldType.STRING)
           .addNullableField("bytes", FieldType.BYTES)
           .addField("fixed", FieldType.logicalType(FixedBytes.of(4)))
-          .addField("date", FieldType.DATETIME)
-          .addField("timestampMillis", FieldType.DATETIME)
+          .addField("date", FieldType.logicalType(MillisInstant.of()))
+          .addField("timestampMillis", FieldType.logicalType(MillisInstant.of()))
           .addField("testEnum", FieldType.logicalType(TEST_ENUM_TYPE))
           .addNullableField("row", SUB_TYPE)
           .addNullableField("array", FieldType.array(SUB_TYPE.withNullable(false)))

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
@@ -63,7 +63,7 @@ import org.junit.rules.ExpectedException;
 
 /** Tests for the {@link JavaBeanSchema} schema provider. */
 public class JavaBeanSchemaTest {
-  static final DateTime DATE = DateTime.parse("1979-03-14");
+  static final DateTime DATE = DateTime.parse("1979-03-14T00:00:00Z");
   static final byte[] BYTE_ARRAY = "bytearray".getBytes(Charset.defaultCharset());
 
   private SimpleBean createSimple(String name) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaFieldSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaFieldSchemaTest.java
@@ -72,8 +72,8 @@ import org.junit.Test;
 
 /** Tests for the {@link JavaFieldSchema} schema provider. */
 public class JavaFieldSchemaTest {
-  static final DateTime DATE = DateTime.parse("1979-03-14");
-  static final Instant INSTANT = DateTime.parse("1979-03-15").toInstant();
+  static final DateTime DATE = DateTime.parse("1979-03-14T00:00:00Z");
+  static final Instant INSTANT = DateTime.parse("1979-03-15T00:00:00Z").toInstant();
   static final byte[] BYTE_ARRAY = "bytearray".getBytes(Charset.defaultCharset());
   static final ByteBuffer BYTE_BUFFER =
       ByteBuffer.wrap("byteBuffer".getBytes(Charset.defaultCharset()));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/AvroUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/AvroUtilsTest.java
@@ -261,7 +261,10 @@ public class AvroUtilsTest {
         .addField(Field.of("string", FieldType.STRING))
         .addField(Field.of("bytes", FieldType.BYTES))
         .addField(Field.of("decimal", FieldType.DECIMAL))
-        .addField(Field.of("timestampMillis", FieldType.DATETIME))
+        .addField(
+            Field.of(
+                "timestampMillis",
+                FieldType.logicalType(org.apache.beam.sdk.schemas.logicaltypes.MillisInstant.of())))
         .addField(Field.of("row", FieldType.row(subSchema)))
         .addField(Field.of("array", FieldType.array(FieldType.row(subSchema))))
         .addField(Field.of("map", FieldType.map(FieldType.STRING, FieldType.row(subSchema))))

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
@@ -57,6 +57,10 @@ import org.junit.Test;
 
 /** Tests for the {@link JavaBeanUtils} class. */
 public class JavaBeanUtilsTest {
+
+  public static final DateTime DATETIME_03_14 = DateTime.parse("1979-03-14T00:00:00Z");
+  public static final DateTime DATETIME_03_15 = DateTime.parse("1979-03-15T00:00:00Z");
+
   @Test
   public void testNullable() {
     Schema schema =
@@ -125,8 +129,8 @@ public class JavaBeanUtilsTest {
     simpleBean.setAnInt(43);
     simpleBean.setaLong(44);
     simpleBean.setaBoolean(true);
-    simpleBean.setDateTime(DateTime.parse("1979-03-14"));
-    simpleBean.setInstant(DateTime.parse("1979-03-15").toInstant());
+    simpleBean.setDateTime(DATETIME_03_14);
+    simpleBean.setInstant(DATETIME_03_15.toInstant());
     simpleBean.setBytes("bytes1".getBytes(Charset.defaultCharset()));
     simpleBean.setByteBuffer(ByteBuffer.wrap("bytes2".getBytes(Charset.defaultCharset())));
     simpleBean.setBigDecimal(new BigDecimal(42));
@@ -147,8 +151,8 @@ public class JavaBeanUtilsTest {
     assertEquals((int) 43, getters.get(3).get(simpleBean));
     assertEquals((long) 44, getters.get(4).get(simpleBean));
     assertTrue((Boolean) getters.get(5).get(simpleBean));
-    assertEquals(DateTime.parse("1979-03-14").toInstant(), getters.get(6).get(simpleBean));
-    assertEquals(DateTime.parse("1979-03-15").toInstant(), getters.get(7).get(simpleBean));
+    assertEquals(DATETIME_03_14.toInstant().getMillis(), getters.get(6).get(simpleBean));
+    assertEquals(DATETIME_03_15.toInstant().getMillis(), getters.get(7).get(simpleBean));
     assertArrayEquals(
         "Unexpected bytes",
         "bytes1".getBytes(Charset.defaultCharset()),
@@ -178,8 +182,8 @@ public class JavaBeanUtilsTest {
     setters.get(3).set(simpleBean, (int) 43);
     setters.get(4).set(simpleBean, (long) 44);
     setters.get(5).set(simpleBean, true);
-    setters.get(6).set(simpleBean, DateTime.parse("1979-03-14").toInstant());
-    setters.get(7).set(simpleBean, DateTime.parse("1979-03-15").toInstant());
+    setters.get(6).set(simpleBean, DATETIME_03_14.toInstant().getMillis());
+    setters.get(7).set(simpleBean, DATETIME_03_15.toInstant().getMillis());
     setters.get(8).set(simpleBean, "bytes1".getBytes(Charset.defaultCharset()));
     setters.get(9).set(simpleBean, "bytes2".getBytes(Charset.defaultCharset()));
     setters.get(10).set(simpleBean, new BigDecimal(42));
@@ -191,8 +195,8 @@ public class JavaBeanUtilsTest {
     assertEquals((int) 43, simpleBean.getAnInt());
     assertEquals((long) 44, simpleBean.getaLong());
     assertTrue(simpleBean.isaBoolean());
-    assertEquals(DateTime.parse("1979-03-14"), simpleBean.getDateTime());
-    assertEquals(DateTime.parse("1979-03-15").toInstant(), simpleBean.getInstant());
+    assertEquals(DATETIME_03_14, simpleBean.getDateTime());
+    assertEquals(DATETIME_03_15.toInstant(), simpleBean.getInstant());
     assertArrayEquals(
         "Unexpected bytes", "bytes1".getBytes(Charset.defaultCharset()), simpleBean.getBytes());
     assertEquals(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
@@ -56,8 +56,8 @@ import org.junit.Test;
 
 /** Tests for the {@link POJOUtils} class. */
 public class POJOUtilsTest {
-  static final DateTime DATE = DateTime.parse("1979-03-14");
-  static final Instant INSTANT = DateTime.parse("1979-03-15").toInstant();
+  static final DateTime DATE = DateTime.parse("1979-03-14T00:00:00Z");
+  static final Instant INSTANT = DateTime.parse("1979-03-15T00:00:00Z").toInstant();
   static final byte[] BYTE_ARRAY = "byteArray".getBytes(Charset.defaultCharset());
   static final ByteBuffer BYTE_BUFFER =
       ByteBuffer.wrap("byteBuffer".getBytes(Charset.defaultCharset()));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
@@ -148,8 +148,8 @@ public class POJOUtilsTest {
     assertEquals((int) 43, getters.get(3).get(simplePojo));
     assertEquals((long) 44, getters.get(4).get(simplePojo));
     assertTrue((Boolean) getters.get(5).get(simplePojo));
-    assertEquals(DATE.toInstant(), getters.get(6).get(simplePojo));
-    assertEquals(INSTANT, getters.get(7).get(simplePojo));
+    assertEquals(DATE.toInstant().getMillis(), getters.get(6).get(simplePojo));
+    assertEquals(INSTANT.getMillis(), getters.get(7).get(simplePojo));
     assertArrayEquals("Unexpected bytes", BYTE_ARRAY, (byte[]) getters.get(8).get(simplePojo));
     assertArrayEquals(
         "Unexpected bytes", BYTE_BUFFER.array(), (byte[]) getters.get(9).get(simplePojo));
@@ -174,8 +174,8 @@ public class POJOUtilsTest {
     setters.get(3).set(simplePojo, (int) 43);
     setters.get(4).set(simplePojo, (long) 44);
     setters.get(5).set(simplePojo, true);
-    setters.get(6).set(simplePojo, DATE.toInstant());
-    setters.get(7).set(simplePojo, INSTANT);
+    setters.get(6).set(simplePojo, DATE.toInstant().getMillis());
+    setters.get(7).set(simplePojo, INSTANT.getMillis());
     setters.get(8).set(simplePojo, BYTE_ARRAY);
     setters.get(9).set(simplePojo, BYTE_BUFFER.array());
     setters.get(10).set(simplePojo, new BigDecimal(42));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
 
@@ -305,8 +306,8 @@ public class TestJavaBeans {
           .addInt32Field("anInt")
           .addInt64Field("aLong")
           .addBooleanField("aBoolean")
-          .addDateTimeField("dateTime")
-          .addDateTimeField("instant")
+          .addLogicalTypeField("dateTime", MillisInstant.of())
+          .addLogicalTypeField("instant", MillisInstant.of())
           .addByteArrayField("bytes")
           .addByteArrayField("byteBuffer")
           .addDecimalField("bigDecimal")

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
@@ -32,6 +32,7 @@ import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
 
@@ -445,8 +446,8 @@ public class TestPOJOs {
           .addInt32Field("anInt")
           .addInt64Field("aLong")
           .addBooleanField("aBoolean")
-          .addDateTimeField("dateTime")
-          .addDateTimeField("instant")
+          .addLogicalTypeField("dateTime", MillisInstant.of())
+          .addLogicalTypeField("instant", MillisInstant.of())
           .addByteArrayField("bytes")
           .addByteArrayField("byteBuffer")
           .addDecimalField("bigDecimal")
@@ -1004,8 +1005,8 @@ public class TestPOJOs {
           .addNullableField("anInt", FieldType.INT32)
           .addNullableField("aLong", FieldType.INT64)
           .addNullableField("aBoolean", FieldType.BOOLEAN)
-          .addNullableField("dateTime", FieldType.DATETIME)
-          .addNullableField("instant", FieldType.DATETIME)
+          .addNullableField("dateTime", FieldType.logicalType(MillisInstant.of()))
+          .addNullableField("instant", FieldType.logicalType(MillisInstant.of()))
           .addNullableField("bytes", FieldType.BYTES)
           .addNullableField("byteBuffer", FieldType.BYTES)
           .addNullableField("bigDecimal", FieldType.DECIMAL)

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
@@ -332,11 +332,11 @@ public class RowJsonTest {
 
     @Test
     public void testDeserializerThrowsForUnsupportedType() throws Exception {
-      Schema schema = Schema.builder().addDateTimeField("f_dateTime").build();
+      Schema schema = Schema.builder().addByteArrayField("f_bytes").build();
 
       thrown.expect(UnsupportedRowJsonException.class);
-      thrown.expectMessage("DATETIME");
-      thrown.expectMessage("f_dateTime");
+      thrown.expectMessage("BYTES");
+      thrown.expectMessage("f_bytes");
       thrown.expectMessage("not supported");
 
       RowJson.RowJsonDeserializer.forSchema(schema);
@@ -344,11 +344,11 @@ public class RowJsonTest {
 
     @Test
     public void testDeserializerThrowsForUnsupportedArrayElementType() throws Exception {
-      Schema schema = Schema.builder().addArrayField("f_dateTimeArray", FieldType.DATETIME).build();
+      Schema schema = Schema.builder().addArrayField("f_bytesArray", FieldType.BYTES).build();
 
       thrown.expect(UnsupportedRowJsonException.class);
-      thrown.expectMessage("DATETIME");
-      thrown.expectMessage("f_dateTimeArray[]");
+      thrown.expectMessage("BYTES");
+      thrown.expectMessage("f_bytesArray[]");
       thrown.expectMessage("not supported");
 
       RowJson.RowJsonDeserializer.forSchema(schema);
@@ -356,14 +356,13 @@ public class RowJsonTest {
 
     @Test
     public void testDeserializerThrowsForUnsupportedNestedFieldType() throws Exception {
-      Schema nestedSchema =
-          Schema.builder().addArrayField("f_dateTimeArray", FieldType.DATETIME).build();
+      Schema nestedSchema = Schema.builder().addArrayField("f_bytesArray", FieldType.BYTES).build();
 
       Schema schema = Schema.builder().addRowField("f_nestedRow", nestedSchema).build();
 
       thrown.expect(UnsupportedRowJsonException.class);
-      thrown.expectMessage("DATETIME");
-      thrown.expectMessage("f_nestedRow.f_dateTimeArray[]");
+      thrown.expectMessage("BYTES");
+      thrown.expectMessage("f_nestedRow.f_bytesArray[]");
       thrown.expectMessage("not supported");
 
       RowJson.RowJsonDeserializer.forSchema(schema);
@@ -374,13 +373,13 @@ public class RowJsonTest {
       Schema schema =
           Schema.builder()
               .addInt32Field("f_int32")
-              .addDateTimeField("f_dateTime")
-              .addArrayField("f_dateTimeArray", FieldType.DATETIME)
+              .addByteArrayField("f_bytes")
+              .addArrayField("f_bytesArray", FieldType.BYTES)
               .build();
 
       thrown.expect(UnsupportedRowJsonException.class);
-      thrown.expectMessage("f_dateTime=DATETIME");
-      thrown.expectMessage("f_dateTimeArray[]=DATETIME");
+      thrown.expectMessage("f_bytes=BYTES");
+      thrown.expectMessage("f_bytesArray[]=BYTES");
       thrown.expectMessage("not supported");
 
       RowJson.RowJsonDeserializer.forSchema(schema);

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -350,9 +350,8 @@ class ProtoSchemaTranslator {
               schema.createConverter(field).convertFromProtoValue(entry.getValue()));
           break;
         case MAP:
-        case DATETIME:
         default:
-          throw new IllegalStateException("These datatypes are not possible in extentions.");
+          throw new IllegalStateException("These datatypes are not possible in extensions.");
       }
     }
     return optionsBuilder;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
@@ -257,10 +257,8 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
           // Combining over a single field, so extract just that field.
           combined =
               (combined == null)
-                  ? byFields.aggregateFieldBaseValue(
-                      inputs.get(0), combineFn, fieldAggregation.outputField)
-                  : combined.aggregateFieldBaseValue(
-                      inputs.get(0), combineFn, fieldAggregation.outputField);
+                  ? byFields.aggregateField(inputs.get(0), combineFn, fieldAggregation.outputField)
+                  : combined.aggregateField(inputs.get(0), combineFn, fieldAggregation.outputField);
         }
       }
 
@@ -283,6 +281,7 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
 
       boolean verifyRowValues =
           pinput.getPipeline().getOptions().as(BeamSqlPipelineOptions.class).getVerifyRowValues();
+
       return windowedStream
           .apply(combiner)
           .apply(
@@ -342,9 +341,9 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
                   + (!ignoreValues ? kvRow.getRow(1).getFieldCount() : 0);
           List<Object> fieldValues = Lists.newArrayListWithCapacity(capacity);
 
-          fieldValues.addAll(kvRow.getRow(0).getBaseValues());
+          fieldValues.addAll(kvRow.getRow(0).getValues());
           if (!ignoreValues) {
-            fieldValues.addAll(kvRow.getRow(1).getBaseValues());
+            fieldValues.addAll(kvRow.getRow(1).getValues());
           }
 
           if (windowStartFieldIndex != -1) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -416,12 +416,7 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
 
       Expression value =
           Expressions.convert_(
-              Expressions.call(
-                  expression,
-                  "getBaseValue",
-                  Expressions.constant(index),
-                  Expressions.constant(convertTo)),
-              convertTo);
+              Expressions.call(expression, "getValue", Expressions.constant(index)), convertTo);
       return (storageType != Object.class) ? value(value, fromType) : value;
     }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -287,7 +287,7 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
     Object[] convertedColumns = new Object[schema.getFields().size()];
     int i = 0;
     for (Schema.Field field : schema.getFields()) {
-      convertedColumns[i] = fieldToAvatica(field.getType(), row.getBaseValue(i, Object.class));
+      convertedColumns[i] = fieldToAvatica(field.getType(), row.getValue(i));
       ++i;
     }
     return convertedColumns;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
@@ -85,7 +85,6 @@ public class BeamBuiltinAggregations {
       case INT16:
       case BYTE:
       case FLOAT:
-      case DATETIME:
       case DECIMAL:
       case STRING:
         return new CustMax<>();
@@ -111,7 +110,6 @@ public class BeamBuiltinAggregations {
       case BYTE:
       case INT16:
       case FLOAT:
-      case DATETIME:
       case DECIMAL:
       case STRING:
         return new CustMin();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -24,6 +24,7 @@ import java.util.stream.IntStream;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.apache.beam.sdk.schemas.logicaltypes.PassThroughLogicalType;
 import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.BiMap;
 import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableBiMap;
@@ -90,13 +91,10 @@ public class CalciteUtils {
 
   /** Returns true if the type is any of the various date time types. */
   public static boolean isDateTimeType(FieldType fieldType) {
-    if (fieldType.getTypeName() == TypeName.DATETIME) {
-      return true;
-    }
-
     if (fieldType.getTypeName().isLogicalType()) {
       String logicalId = fieldType.getLogicalType().getIdentifier();
       return logicalId.equals(DateType.IDENTIFIER)
+          || logicalId.equals(MillisInstant.IDENTIFIER)
           || logicalId.equals(TimeType.IDENTIFIER)
           || logicalId.equals(TimeWithLocalTzType.IDENTIFIER)
           || logicalId.equals(TimestampWithLocalTzType.IDENTIFIER);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
+import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.test.TestBoundedTable;
 import org.apache.beam.sdk.schemas.Schema;
@@ -379,14 +380,11 @@ public class BeamComplexTypeTest {
 
     Schema inputRowSchema =
         Schema.builder()
-            .addField("timeTypeField", FieldType.logicalType(new DummySqlTimeType()))
-            .addField("dateTypeField", FieldType.logicalType(new DummySqlDateType()))
+            .addField("timeTypeField", CalciteUtils.TIME)
+            .addField("dateTypeField", CalciteUtils.DATE)
             .build();
 
-    Row row =
-        Row.withSchema(inputRowSchema)
-            .addValues(dateTime.getMillis(), dateTime.getMillis())
-            .build();
+    Row row = Row.withSchema(inputRowSchema).addValues(dateTime, dateTime).build();
 
     Schema outputRowSchema =
         Schema.builder()
@@ -407,70 +405,6 @@ public class BeamComplexTypeTest {
     pipeline.run().waitUntilFinish(Duration.standardMinutes(2));
   }
 
-  private static class DummySqlTimeType implements Schema.LogicalType<Long, Instant> {
-    @Override
-    public String getIdentifier() {
-      return "SqlTimeType";
-    }
-
-    @Override
-    public FieldType getArgumentType() {
-      return FieldType.STRING;
-    }
-
-    @Override
-    public String getArgument() {
-      return "";
-    }
-
-    @Override
-    public Schema.FieldType getBaseType() {
-      return Schema.FieldType.DATETIME;
-    }
-
-    @Override
-    public Instant toBaseType(Long input) {
-      return new Instant((long) input);
-    }
-
-    @Override
-    public Long toInputType(Instant base) {
-      return base.getMillis();
-    }
-  }
-
-  private static class DummySqlDateType implements Schema.LogicalType<Long, Instant> {
-    @Override
-    public String getIdentifier() {
-      return "SqlDateType";
-    }
-
-    @Override
-    public FieldType getArgumentType() {
-      return FieldType.STRING;
-    }
-
-    @Override
-    public String getArgument() {
-      return "";
-    }
-
-    @Override
-    public Schema.FieldType getBaseType() {
-      return Schema.FieldType.DATETIME;
-    }
-
-    @Override
-    public Instant toBaseType(Long input) {
-      return new Instant((long) input);
-    }
-
-    @Override
-    public Long toInputType(Instant base) {
-      return base.getMillis();
-    }
-  }
-
   @Test
   public void testNullDatetimeFields() {
     Instant current = new Instant(1561671380000L); // Long value corresponds to 27/06/2019
@@ -480,17 +414,15 @@ public class BeamComplexTypeTest {
         Schema.builder()
             .addField("dateTimeField", FieldType.DATETIME)
             .addNullableField("nullableDateTimeField", FieldType.DATETIME)
-            .addField("timeTypeField", FieldType.logicalType(new DummySqlTimeType()))
-            .addNullableField(
-                "nullableTimeTypeField", FieldType.logicalType(new DummySqlTimeType()))
-            .addField("dateTypeField", FieldType.logicalType(new DummySqlDateType()))
-            .addNullableField(
-                "nullableDateTypeField", FieldType.logicalType(new DummySqlDateType()))
+            .addField("timeTypeField", CalciteUtils.TIME)
+            .addNullableField("nullableTimeTypeField", CalciteUtils.TIME)
+            .addField("dateTypeField", CalciteUtils.DATE)
+            .addNullableField("nullableDateTypeField", CalciteUtils.DATE)
             .build();
 
     Row dateTimeRow =
         Row.withSchema(dateTimeFieldSchema)
-            .addValues(current, null, date.getMillis(), null, current.getMillis(), null)
+            .addValues(current, null, date, null, current, null)
             .build();
 
     PCollection<Row> outputRow =

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
@@ -61,19 +61,19 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
   private static final double PRECISION_DOUBLE = 1e-7;
   private static final float PRECISION_FLOAT = 1e-7f;
 
-  private static final Map<Class, TypeName> JAVA_CLASS_TO_TYPENAME =
-      ImmutableMap.<Class, TypeName>builder()
-          .put(Byte.class, TypeName.BYTE)
-          .put(Short.class, TypeName.INT16)
-          .put(Integer.class, TypeName.INT32)
-          .put(Long.class, TypeName.INT64)
-          .put(Float.class, TypeName.FLOAT)
-          .put(Double.class, TypeName.DOUBLE)
-          .put(BigDecimal.class, TypeName.DECIMAL)
-          .put(String.class, TypeName.STRING)
-          .put(DateTime.class, TypeName.DATETIME)
-          .put(Boolean.class, TypeName.BOOLEAN)
-          .put(byte[].class, TypeName.BYTES)
+  private static final Map<Class, FieldType> JAVA_CLASS_TO_FIELDTYPE =
+      ImmutableMap.<Class, FieldType>builder()
+          .put(Byte.class, FieldType.BYTE)
+          .put(Short.class, FieldType.INT16)
+          .put(Integer.class, FieldType.INT32)
+          .put(Long.class, FieldType.INT64)
+          .put(Float.class, FieldType.FLOAT)
+          .put(Double.class, FieldType.DOUBLE)
+          .put(BigDecimal.class, FieldType.DECIMAL)
+          .put(String.class, FieldType.STRING)
+          .put(DateTime.class, FieldType.DATETIME)
+          .put(Boolean.class, FieldType.BOOLEAN)
+          .put(byte[].class, FieldType.BYTES)
           .build();
 
   private static final Schema ROW_TYPE =
@@ -228,15 +228,15 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
     private transient List<ExpressionTestCase> exps = new ArrayList<>();
 
     public ExpressionChecker addExpr(String expression, Object expectedValue) {
-      TypeName resultTypeName = JAVA_CLASS_TO_TYPENAME.get(expectedValue.getClass());
+      FieldType resultType = JAVA_CLASS_TO_FIELDTYPE.get(expectedValue.getClass());
       checkArgument(
-          resultTypeName != null,
+          resultType != null,
           String.format(
               "The type of the expected value '%s' is unknown in 'addExpr(String expression, "
                   + "Object expectedValue)'. Please use 'addExpr(String expr, Object expected, "
                   + "FieldType type)' instead and provide the type of the expected object",
               expectedValue));
-      addExpr(expression, expectedValue, FieldType.of(resultTypeName));
+      addExpr(expression, expectedValue, resultType);
       return this;
     }
 

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/BeamZetaSqlCalcRel.java
@@ -182,7 +182,7 @@ public class BeamZetaSqlCalcRel extends AbstractBeamCalcRel {
         columns.put(
             columnName(i),
             ZetaSqlUtils.javaObjectToZetaSqlValue(
-                row.getBaseValue(i, Object.class), inputSchema.getField(i).getType()));
+                row.getValue(i), inputSchema.getField(i).getType()));
       }
 
       // TODO[BEAM-8630]: support parameters in expression evaluation

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSqlUtils.java
@@ -187,9 +187,7 @@ public final class ZetaSqlUtils {
     List<Value> values = new ArrayList<>(row.getFieldCount());
 
     for (int i = 0; i < row.getFieldCount(); i++) {
-      values.add(
-          javaObjectToZetaSqlValue(
-              row.getBaseValue(i, Object.class), schema.getField(i).getType()));
+      values.add(javaObjectToZetaSqlValue(row.getValue(i), schema.getField(i).getType()));
     }
     return Value.createStructValue(createZetaSqlStructTypeFromBeamSchema(schema), values);
   }

--- a/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseIO.java
+++ b/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseIO.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.apache.beam.sdk.schemas.transforms.Select;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -105,8 +106,8 @@ import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
  * <tr><td>{@link TableSchema.TypeName#UINT16}</td> <td>{@link Schema.TypeName#INT32}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#UINT32}</td> <td>{@link Schema.TypeName#INT64}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#UINT64}</td> <td>{@link Schema.TypeName#INT64}</td></tr>
- * <tr><td>{@link TableSchema.TypeName#DATE}</td> <td>{@link Schema.TypeName#DATETIME}</td></tr>
- * <tr><td>{@link TableSchema.TypeName#DATETIME}</td> <td>{@link Schema.TypeName#DATETIME}</td></tr>
+ * <tr><td>{@link TableSchema.TypeName#DATE}</td> <td>{@link MillisInstant}</td></tr>
+ * <tr><td>{@link TableSchema.TypeName#DATETIME}</td> <td>{@link MillisInstant}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#ARRAY}</td> <td>{@link Schema.TypeName#ARRAY}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#ENUM8}</td> <td>{@link Schema.TypeName#STRING}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#ENUM16}</td> <td>{@link Schema.TypeName#STRING}</td></tr>

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilsTest.java
@@ -162,7 +162,7 @@ public class BigQueryUtilsTest {
               ISODateTimeFormat.dateHourMinuteSecondFraction()
                   .withZoneUTC()
                   .parseDateTime("2019-08-18T15:52:07.123"),
-              new DateTime(123456),
+              new DateTime(123456, ISOChronology.getInstanceUTC()),
               false,
               Base64.getDecoder().decode("ABCD1234"))
           .build();
@@ -174,7 +174,7 @@ public class BigQueryUtilsTest {
           .set("name", "test")
           .set("timestamp_variant1", "2019-08-16 13:52:07 UTC")
           .set("timestamp_variant2", "2019-08-17 14:52:07.123 UTC")
-          // we'll loose precession, but it's something BigQuery can output!
+          // we'll lose precession, but it's something BigQuery can output!
           .set("timestamp_variant3", "2019-08-18 15:52:07.123456 UTC")
           .set(
               "timestamp_variant4",

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/SchemaUtil.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/SchemaUtil.java
@@ -53,6 +53,7 @@ import java.util.stream.IntStream;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.logicaltypes.MillisInstant;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
@@ -79,7 +80,6 @@ class SchemaUtil {
                   .put(Schema.TypeName.BOOLEAN, ResultSet::getBoolean)
                   .put(Schema.TypeName.BYTE, ResultSet::getByte)
                   .put(Schema.TypeName.BYTES, ResultSet::getBytes)
-                  .put(Schema.TypeName.DATETIME, ResultSet::getTimestamp)
                   .put(Schema.TypeName.DECIMAL, ResultSet::getBigDecimal)
                   .put(Schema.TypeName.DOUBLE, ResultSet::getDouble)
                   .put(Schema.TypeName.FLOAT, ResultSet::getFloat)
@@ -228,8 +228,6 @@ class SchemaUtil {
         Schema.FieldType elementType = fieldType.getCollectionElementType();
         ResultSetFieldExtractor elementExtractor = createFieldExtractor(elementType);
         return createArrayExtractor(elementExtractor);
-      case DATETIME:
-        return TIMESTAMP_EXTRACTOR;
       case LOGICAL_TYPE:
         return createLogicalTypeExtractor(fieldType.getLogicalType());
       default:
@@ -263,6 +261,9 @@ class SchemaUtil {
   private static <InputT, BaseT> ResultSetFieldExtractor createLogicalTypeExtractor(
       final Schema.LogicalType<InputT, BaseT> fieldType) {
     String logicalTypeName = fieldType.getIdentifier();
+    if (logicalTypeName.equals(MillisInstant.IDENTIFIER)) {
+      return TIMESTAMP_EXTRACTOR;
+    }
     JDBCType underlyingType = JDBCType.valueOf(logicalTypeName);
     switch (underlyingType) {
       case DATE:


### PR DESCRIPTION
This PR adds a `MillisInstant` logical type, and replaces all usages of the primitive `DATETIME` type with it.

`MillisInstant` mirrors the `NanosInstant` type. It uses `org.joda.time.Instant` rather than `java.time.Instant` for consistency with `DATETIME`, and it is backed by an `INT64` representing the number of milliseconds since the epoch.

The majority of the changes in this PR are relatively trivial, but there are a few significant (and some potentially controversial) ones:
- Updates the datetime getter/setter functions generated in `ByteBuddyUtils` to produce and consume instances of `Long` rather than `Instant`. This is necessary because these functions are expected to produce/consume the base type for logical types.
- Updates all joda time literals in schema inference tests so they specify a timezone.
- Throughout the SQL module I've replaced references to `getBaseValue` with `getValue`. Previously the only logical types used in SQL were `PassThroughLogicalType` instances, where the input type and base type were the same.

Changes that are not currently included in this PR but we might consider:
- Replace all references to `DateTime` (`addDateTimeField`, `addDateTimeValue`, ..) with `Instant`, and deprecate or remove the `DateTime` references.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
