### PR TITLE
[BEAM-9569] Fix BeamSqlPojoExample logRecords method to not require Row coder inference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,7 @@ conversion to beam schema options. *Remark: Schema aware is still experimental.*
 * Dataflow runner now requires the `--region` option to be set, unless a default value is set in the environment ([BEAM-9199](https://issues.apache.org/jira/browse/BEAM-9199)). See [here](https://cloud.google.com/dataflow/docs/concepts/regional-endpoints) for more details.
 * HBaseIO.ReadAll now requires a PCollection of HBaseIO.Read objects instead of HBaseQuery objects ([BEAM-9279](https://issues.apache.org/jira/browse/BEAM-9279)).
 * ProcessContext.updateWatermark has been removed in favor of using a WatermarkEstimator ([BEAM-9430](https://issues.apache.org/jira/browse/BEAM-9430)).
+* Coder inference for PCollection of Row objects has been disabled ([BEAM-9569](https://issues.apache.org/jira/browse/BEAM-9569)).
 
 ## Deprecations
 * Java SDK: Beam Schema FieldType.getMetadata is now deprecated and is replaced by the Beam

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/BeamSqlPojoExample.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/BeamSqlPojoExample.java
@@ -101,13 +101,13 @@ class BeamSqlPojoExample {
     pipeline.run().waitUntilFinish();
   }
 
-  private static MapElements<Row, Row> logRecords(String suffix) {
+  private static MapElements<Row, Void> logRecords(String suffix) {
     return MapElements.via(
-        new SimpleFunction<Row, Row>() {
+        new SimpleFunction<Row, Void>() {
           @Override
-          public Row apply(Row input) {
+          public Void apply(Row input) {
             System.out.println(input.getValues() + suffix);
-            return input;
+            return null;
           }
         });
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Customer.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Customer.java
@@ -25,8 +25,8 @@ import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 /** Describes a customer. */
 @DefaultSchema(JavaBeanSchema.class)
 public class Customer implements Serializable {
-  private String name;
   private int id;
+  private String name;
   private String countryOfResidence;
 
   public Customer(int id, String name, String countryOfResidence) {
@@ -37,24 +37,24 @@ public class Customer implements Serializable {
 
   public Customer() {}
 
-  public String getName() {
-    return name;
-  }
-
   public int getId() {
     return id;
+  }
+
+  public String getName() {
+    return name;
   }
 
   public String getCountryOfResidence() {
     return countryOfResidence;
   }
 
-  public void setName(String name) {
-    this.name = name;
-  }
-
   public void setId(int id) {
     this.id = id;
+  }
+
+  public void setName(String name) {
+    this.name = name;
   }
 
   public void setCountryOfResidence(String countryOfResidence) {
@@ -77,6 +77,20 @@ public class Customer implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, id, countryOfResidence);
+    return Objects.hash(id, name, countryOfResidence);
+  }
+
+  @Override
+  public String toString() {
+    return "Customer{"
+        + "id="
+        + id
+        + ", name='"
+        + name
+        + '\''
+        + ", countryOfResidence='"
+        + countryOfResidence
+        + '\''
+        + '}';
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Order.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Order.java
@@ -67,4 +67,9 @@ public class Order implements Serializable {
   public int hashCode() {
     return Objects.hash(id, customerId);
   }
+
+  @Override
+  public String toString() {
+    return "Order{" + "id=" + id + ", customerId=" + customerId + '}';
+  }
 }


### PR DESCRIPTION
It also adds a warning that Coder inference of Row objects is now
disabled into the release CHANGELOG.

R: @reuvenlax 
CC: @ibzib 