### PR TITLE
[BEAM-9794] Reduce state cells needed for BufferingDoFnRunner

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -242,6 +242,10 @@ public class FlinkExecutionEnvironments {
       }
       boolean failOnCheckpointingErrors = options.getFailOnCheckpointingErrors();
       flinkStreamEnv.getCheckpointConfig().setFailOnCheckpointingErrors(failOnCheckpointingErrors);
+
+      flinkStreamEnv
+          .getCheckpointConfig()
+          .setMaxConcurrentCheckpoints(options.getNumConcurrentCheckpoints());
     }
 
     applyLatencyTrackingInterval(flinkStreamEnv.getConfig(), options);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -111,6 +111,13 @@ public interface FlinkPipelineOptions
   void setMinPauseBetweenCheckpoints(Long minPauseInterval);
 
   @Description(
+      "The maximum number of concurrent checkpoints. Defaults to 1 (=no concurrent checkpoints).")
+  @Default.Integer(1)
+  int getNumConcurrentCheckpoints();
+
+  void setNumConcurrentCheckpoints(int maxConcurrentCheckpoints);
+
+  @Description(
       "Sets the expected behaviour for tasks in case that they encounter an error in their "
           + "checkpointing procedure. If this is set to true, the task will fail on checkpointing error. "
           + "If this is set to false, the task will only decline a the checkpoint and continue running. ")

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -438,7 +438,8 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
                   windowedInputCoder,
                   windowingStrategy.getWindowFn().windowCoder(),
                   getOperatorStateBackend(),
-                  getKeyedStateBackend());
+                  getKeyedStateBackend(),
+                  options.getNumConcurrentCheckpoints());
     }
     doFnRunner = createWrappingDoFnRunner(doFnRunner, stepContext);
     earlyBindStateIfNeeded();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunner.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.DoFnRunner;
 import org.apache.beam.runners.flink.translation.types.CoderTypeSerializer;
@@ -30,6 +29,8 @@ import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.runtime.state.KeyedStateBackend;
@@ -52,7 +53,8 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
       org.apache.beam.sdk.coders.Coder windowedInputCoder,
       org.apache.beam.sdk.coders.Coder windowCoder,
       OperatorStateBackend operatorStateBackend,
-      @Nullable KeyedStateBackend<Object> keyedStateBackend)
+      @Nullable KeyedStateBackend<Object> keyedStateBackend,
+      int maxConcurrentCheckpoints)
       throws Exception {
     return new BufferingDoFnRunner<>(
         doFnRunner,
@@ -60,18 +62,20 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
         windowedInputCoder,
         windowCoder,
         operatorStateBackend,
-        keyedStateBackend);
+        keyedStateBackend,
+        maxConcurrentCheckpoints);
   }
 
   /** The underlying DoFnRunner that any buffered data will be handed over to eventually. */
   private final DoFnRunner<InputT, OutputT> underlying;
   /** A union list state which contains all to-be-acknowledged snapshot ids. */
-  private final ListState<CheckpointElement> notYetAcknowledgedSnapshots;
+  private final ListState<CheckpointIdentifier> notYetAcknowledgedSnapshots;
   /** A factory for constructing new BufferingElementsHandler scoped by an internal id. */
   private final BufferingElementsHandlerFactory bufferingElementsHandlerFactory;
-
-  /** The current active state id which is later linked to a checkpoint id. */
-  private String currentStateId;
+  /** The maximum number of buffers for data of not yet acknowledged checkpoints. */
+  final int numCheckpointBuffers;
+  /** The current active state id which, on checkpoint, is linked to a checkpoint id. */
+  int currentStateIndex;
   /** The current handler used for buffering. */
   private BufferingElementsHandler currentBufferingElementsHandler;
 
@@ -81,13 +85,18 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
       org.apache.beam.sdk.coders.Coder inputCoder,
       org.apache.beam.sdk.coders.Coder windowCoder,
       OperatorStateBackend operatorStateBackend,
-      @Nullable KeyedStateBackend keyedStateBackend)
+      @Nullable KeyedStateBackend keyedStateBackend,
+      int maxConcurrentCheckpoints)
       throws Exception {
+    Preconditions.checkArgument(
+        maxConcurrentCheckpoints > 0 && maxConcurrentCheckpoints < Short.MAX_VALUE,
+        "Maximum number of concurrent checkpoints not within the bounds of 0 and %s",
+        Short.MAX_VALUE);
 
     this.underlying = underlying;
     this.notYetAcknowledgedSnapshots =
         operatorStateBackend.getUnionListState(
-            new ListStateDescriptor<>("notYetAcknowledgedSnapshots", CheckpointElement.class));
+            new ListStateDescriptor<>("notYetAcknowledgedSnapshots", CheckpointIdentifier.class));
     this.bufferingElementsHandlerFactory =
         (stateId) -> {
           ListStateDescriptor<BufferedElement> stateDescriptor =
@@ -101,8 +110,30 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
                 operatorStateBackend.getListState(stateDescriptor));
           }
         };
-    this.currentStateId = generateNewId();
-    this.currentBufferingElementsHandler = bufferingElementsHandlerFactory.get(currentStateId);
+    this.numCheckpointBuffers = initializeState(maxConcurrentCheckpoints);
+    this.currentBufferingElementsHandler =
+        bufferingElementsHandlerFactory.get(rotateAndGetStateIndex());
+  }
+
+  /**
+   * Initialize the state index and the max checkpoint buffers based on previous not yet
+   * acknowledged checkpoints.
+   */
+  private int initializeState(int maxConcurrentCheckpoints) throws Exception {
+    List<CheckpointIdentifier> pendingSnapshots = new ArrayList<>();
+    Iterables.addAll(pendingSnapshots, notYetAcknowledgedSnapshots.get());
+    int lastUsedIndex = -1;
+    int maxIndex = 0;
+    if (!pendingSnapshots.isEmpty()) {
+      for (CheckpointIdentifier checkpointIdentifier : pendingSnapshots) {
+        maxIndex = Math.max(maxIndex, checkpointIdentifier.internalId);
+      }
+      lastUsedIndex = pendingSnapshots.get(pendingSnapshots.size() - 1).internalId;
+    }
+    this.currentStateIndex = lastUsedIndex;
+    // If a previous run had a higher number of concurrent checkpoints we need to use this number to
+    // not break the buffering/flushing logic.
+    return Math.max(maxConcurrentCheckpoints, maxIndex) + 1;
   }
 
   @Override
@@ -143,15 +174,15 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
     // We are about to get checkpointed. The elements buffered thus far
     // have to be added to the global CheckpointElement state which will
     // be used to emit elements later when this checkpoint is acknowledged.
-    addToBeAcknowledgedCheckpoint(checkpointId, currentStateId);
-    currentStateId = generateNewId();
-    currentBufferingElementsHandler = bufferingElementsHandlerFactory.get(currentStateId);
+    addToBeAcknowledgedCheckpoint(checkpointId, getStateIndex());
+    int newStateIndex = rotateAndGetStateIndex();
+    currentBufferingElementsHandler = bufferingElementsHandlerFactory.get(newStateIndex);
   }
 
   /** Should be called when a checkpoint is completed. */
   public void checkpointCompleted(long checkpointId) throws Exception {
-    List<CheckpointElement> toAck = removeToBeAcknowledgedCheckpoints(checkpointId);
-    for (CheckpointElement toBeAcked : toAck) {
+    List<CheckpointIdentifier> allToAck = gatherToBeAcknowledgedCheckpoints(checkpointId);
+    for (CheckpointIdentifier toBeAcked : allToAck) {
       BufferingElementsHandler bufferingElementsHandler =
           bufferingElementsHandlerFactory.get(toBeAcked.internalId);
       Iterator<BufferedElement> iterator = bufferingElementsHandler.getElements().iterator();
@@ -170,44 +201,48 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
     }
   }
 
-  private void addToBeAcknowledgedCheckpoint(long checkpointId, String internalId)
-      throws Exception {
+  private void addToBeAcknowledgedCheckpoint(long checkpointId, int internalId) throws Exception {
     notYetAcknowledgedSnapshots.addAll(
-        Collections.singletonList(new CheckpointElement(internalId, checkpointId)));
+        Collections.singletonList(new CheckpointIdentifier(internalId, checkpointId)));
   }
 
-  private List<CheckpointElement> removeToBeAcknowledgedCheckpoints(long checkpointId)
+  private List<CheckpointIdentifier> gatherToBeAcknowledgedCheckpoints(long checkpointId)
       throws Exception {
-    List<CheckpointElement> toBeAcknowledged = new ArrayList<>();
-    List<CheckpointElement> checkpoints = new ArrayList<>();
-    for (CheckpointElement element : notYetAcknowledgedSnapshots.get()) {
+    List<CheckpointIdentifier> toBeAcknowledged = new ArrayList<>();
+    List<CheckpointIdentifier> remaining = new ArrayList<>();
+    for (CheckpointIdentifier element : notYetAcknowledgedSnapshots.get()) {
       if (element.checkpointId <= checkpointId) {
         toBeAcknowledged.add(element);
       } else {
-        checkpoints.add(element);
+        remaining.add(element);
       }
     }
-    notYetAcknowledgedSnapshots.update(checkpoints);
+    notYetAcknowledgedSnapshots.update(remaining);
     // Sort by checkpoint id to preserve order
     toBeAcknowledged.sort(Comparator.comparingLong(o -> o.checkpointId));
     return toBeAcknowledged;
   }
 
-  private static String generateNewId() {
-    return UUID.randomUUID().toString();
+  private int rotateAndGetStateIndex() {
+    currentStateIndex = (currentStateIndex + 1) % numCheckpointBuffers;
+    return currentStateIndex;
+  }
+
+  private int getStateIndex() {
+    return currentStateIndex;
   }
 
   /** Constructs a new instance of BufferingElementsHandler with a provided state namespace. */
   private interface BufferingElementsHandlerFactory {
-    BufferingElementsHandler get(String stateId) throws Exception;
+    BufferingElementsHandler get(int stateIndex) throws Exception;
   }
 
-  private static class CheckpointElement {
+  static class CheckpointIdentifier {
 
-    final String internalId;
+    final int internalId;
     final long checkpointId;
 
-    CheckpointElement(String internalId, long checkpointId) {
+    CheckpointIdentifier(int internalId, long checkpointId) {
       this.internalId = internalId;
       this.checkpointId = checkpointId;
     }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
@@ -81,6 +81,7 @@ public class FlinkPipelineOptionsTest {
     assertThat(options.getMinPauseBetweenCheckpoints(), is(-1L));
     assertThat(options.getCheckpointingInterval(), is(-1L));
     assertThat(options.getCheckpointTimeoutMillis(), is(-1L));
+    assertThat(options.getNumConcurrentCheckpoints(), is(1));
     assertThat(options.getFailOnCheckpointingErrors(), is(true));
     assertThat(options.getNumberOfExecutionRetries(), is(-1));
     assertThat(options.getExecutionRetryDelay(), is(-1L));

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunnerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunnerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.runners.core.DoFnRunner;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests for {@link BufferingDoFnRunner}.
+ *
+ * <p>For more tests see:
+ *
+ * <p>- {@link org.apache.beam.runners.flink.FlinkRequiresStableInputTest}
+ *
+ * <p>-{@link org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperatorTest}
+ *
+ * <p>- {@link BufferedElementsTest}
+ */
+public class BufferingDoFnRunnerTest {
+
+  @Test
+  public void testRestoreWithoutConcurrentCheckpoints() throws Exception {
+    BufferingDoFnRunner bufferingDoFnRunner = createBufferingDoFnRunner(1, Collections.emptyList());
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(0));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(2));
+  }
+
+  @Test
+  public void testRestoreWithoutConcurrentCheckpointsWithPendingCheckpoint() throws Exception {
+    BufferingDoFnRunner bufferingDoFnRunner;
+
+    bufferingDoFnRunner =
+        createBufferingDoFnRunner(
+            1, Collections.singletonList(new BufferingDoFnRunner.CheckpointIdentifier(0, 1000)));
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(1));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(2));
+
+    bufferingDoFnRunner =
+        createBufferingDoFnRunner(
+            1, Collections.singletonList(new BufferingDoFnRunner.CheckpointIdentifier(1, 1000)));
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(0));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(2));
+  }
+
+  @Test
+  public void
+      testRestoreWithoutConcurrentCheckpointsWithPendingCheckpointFromConcurrentCheckpointing()
+          throws Exception {
+    BufferingDoFnRunner bufferingDoFnRunner =
+        createBufferingDoFnRunner(
+            1, Collections.singletonList(new BufferingDoFnRunner.CheckpointIdentifier(5, 42)));
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(0));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(6));
+  }
+
+  @Test
+  public void testRestoreWithConcurrentCheckpoints() throws Exception {
+    BufferingDoFnRunner bufferingDoFnRunner = createBufferingDoFnRunner(2, Collections.emptyList());
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(0));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(3));
+  }
+
+  @Test
+  public void testRestoreWithConcurrentCheckpointsFromPendingCheckpoint() throws Exception {
+    BufferingDoFnRunner bufferingDoFnRunner;
+
+    bufferingDoFnRunner =
+        createBufferingDoFnRunner(
+            2, Collections.singletonList(new BufferingDoFnRunner.CheckpointIdentifier(0, 1000)));
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(1));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(3));
+
+    bufferingDoFnRunner =
+        createBufferingDoFnRunner(
+            2, Collections.singletonList(new BufferingDoFnRunner.CheckpointIdentifier(2, 1000)));
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(0));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(3));
+  }
+
+  @Test
+  public void testRestoreWithConcurrentCheckpointsFromPendingCheckpoints() throws Exception {
+    BufferingDoFnRunner bufferingDoFnRunner;
+
+    bufferingDoFnRunner =
+        createBufferingDoFnRunner(
+            3,
+            ImmutableList.of(
+                new BufferingDoFnRunner.CheckpointIdentifier(0, 42),
+                new BufferingDoFnRunner.CheckpointIdentifier(1, 43)));
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(2));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(4));
+
+    bufferingDoFnRunner =
+        createBufferingDoFnRunner(
+            3,
+            ImmutableList.of(
+                new BufferingDoFnRunner.CheckpointIdentifier(2, 42),
+                new BufferingDoFnRunner.CheckpointIdentifier(3, 43)));
+    assertThat(bufferingDoFnRunner.currentStateIndex, is(0));
+    assertThat(bufferingDoFnRunner.numCheckpointBuffers, is(4));
+  }
+
+  @Test
+  public void testRejectConcurrentCheckpointingBoundaries() {
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          createBufferingDoFnRunner(0, Collections.emptyList());
+        });
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          createBufferingDoFnRunner(Short.MAX_VALUE, Collections.emptyList());
+        });
+  }
+
+  private static BufferingDoFnRunner createBufferingDoFnRunner(
+      int concurrentCheckpoints,
+      List<BufferingDoFnRunner.CheckpointIdentifier> notYetAcknowledgeCheckpoints)
+      throws Exception {
+    DoFnRunner doFnRunner = Mockito.mock(DoFnRunner.class);
+    OperatorStateBackend operatorStateBackend = Mockito.mock(OperatorStateBackend.class);
+
+    // Setup not yet acknowledged checkpoint union list state
+    ListState unionListState = Mockito.mock(ListState.class);
+    Mockito.when(operatorStateBackend.getUnionListState(Mockito.any())).thenReturn(unionListState);
+    Mockito.when(unionListState.get()).thenReturn(notYetAcknowledgeCheckpoints);
+
+    // Setup buffer list state
+    Mockito.when(operatorStateBackend.getListState(Mockito.any()))
+        .thenReturn(Mockito.mock(ListState.class));
+
+    return BufferingDoFnRunner.create(
+        doFnRunner,
+        "stable-input",
+        StringUtf8Coder.of(),
+        WindowedValue.getFullCoder(VarIntCoder.of(), GlobalWindow.Coder.INSTANCE),
+        operatorStateBackend,
+        null,
+        concurrentCheckpoints);
+  }
+}

--- a/website/src/_includes/flink_java_pipeline_options.html
+++ b/website/src/_includes/flink_java_pipeline_options.html
@@ -108,6 +108,11 @@ which should be called before running the tests.
   <td>Default: <code>-1</code></td>
 </tr>
 <tr>
+  <td><code>numConcurrentCheckpoints</code></td>
+  <td>The maximum number of concurrent checkpoints. Defaults to 1 (=no concurrent checkpoints).</td>
+  <td>Default: <code>1</code></td>
+</tr>
+<tr>
   <td><code>numberOfExecutionRetries</code></td>
   <td>Sets the number of times that failed tasks are re-executed. A value of zero effectively disables fault tolerance. A value of -1 indicates that the system default value (as defined in the configuration) should be used.</td>
   <td>Default: <code>-1</code></td>

--- a/website/src/_includes/flink_python_pipeline_options.html
+++ b/website/src/_includes/flink_python_pipeline_options.html
@@ -108,6 +108,11 @@ which should be called before running the tests.
   <td>Default: <code>-1</code></td>
 </tr>
 <tr>
+  <td><code>num_concurrent_checkpoints</code></td>
+  <td>The maximum number of concurrent checkpoints. Defaults to 1 (=no concurrent checkpoints).</td>
+  <td>Default: <code>1</code></td>
+</tr>
+<tr>
   <td><code>number_of_execution_retries</code></td>
   <td>Sets the number of times that failed tasks are re-executed. A value of zero effectively disables fault tolerance. A value of -1 indicates that the system default value (as defined in the configuration) should be used.</td>
   <td>Default: <code>-1</code></td>


### PR DESCRIPTION
The BufferingDoFnRunner create a new state cell for buffering data during each
checkpoint. This led to the number of state cells to reach Short.MAX_VALUE, the
maximum of supported Flink states.

This change keeps a fixed number of state cells depending on the maximum
configured parallelism for checkpoints. The state cells are reused after the
checkpoint has been acknowledged.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
