### PR TITLE
[BEAM-9775] Adding Go SDF example, adjusting GetProgress signature.

### DIFF
--- a/sdks/go/examples/stringsplit/offsetrange/offsetrange.go
+++ b/sdks/go/examples/stringsplit/offsetrange/offsetrange.go
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package offsetrange
 
 import (

--- a/sdks/go/examples/stringsplit/offsetrange/offsetrange.go
+++ b/sdks/go/examples/stringsplit/offsetrange/offsetrange.go
@@ -1,0 +1,107 @@
+package offsetrange
+
+import (
+	"errors"
+	"math"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+)
+
+func init() {
+	beam.RegisterType(reflect.TypeOf((*Tracker)(nil)))
+	beam.RegisterType(reflect.TypeOf((*Restriction)(nil)))
+}
+
+type Restriction struct {
+	Start, End int64 // Half-closed interval with boundaries [start, end).
+}
+
+// Tracker tracks a restriction  that can be represented as a range of integer values,
+// for example for byte offsets in a file, or indices in an array. Note that this tracker makes
+// no assumptions about the positions of blocks within the range, so users must handle validation
+// of block positions if needed.
+type Tracker struct {
+	Rest    Restriction
+	Claimed int64 // Tracks the last claimed position.
+	Stopped bool  // Tracks whether TryClaim has already indicated to stop processing elements for
+	// any reason.
+	Err error
+}
+
+// NewTracker is a constructor for an Tracker given a start and end range.
+func NewTracker(rest Restriction) *Tracker {
+	return &Tracker{
+		Rest:    rest,
+		Claimed: rest.Start - 1,
+		Stopped: false,
+		Err:     nil,
+	}
+}
+
+// TryClaim accepts an int64 position and successfully claims it if that position is greater than
+// the previously claimed position and less than the end of the restriction. Note that the
+// Tracker is not considered done until a position >= tracker.end tries to be claimed,
+// at which point this method signals to end processing.
+func (tracker *Tracker) TryClaim(rawPos interface{}) bool {
+	if tracker.Stopped == true {
+		tracker.Err = errors.New("cannot claim work after restriction tracker returns false")
+		return false
+	}
+
+	pos := rawPos.(int64)
+
+	if pos < tracker.Rest.Start {
+		tracker.Stopped = true
+		tracker.Err = errors.New("position claimed is out of bounds of the restriction")
+		return false
+	}
+	if pos <= tracker.Claimed {
+		tracker.Stopped = true
+		tracker.Err = errors.New("cannot claim a position lower than the previously claimed position")
+		return false
+	}
+
+	tracker.Claimed = pos
+	if pos >= tracker.Rest.End {
+		tracker.Stopped = true
+		return false
+	}
+	return true
+}
+
+// IsDone returns true if the most recent claimed element is past the end of the restriction.
+func (tracker *Tracker) GetError() error {
+	return tracker.Err
+}
+
+// TrySplit splits at the nearest integer greater than the given fraction of the remainder.
+func (tracker *Tracker) TrySplit(fraction float64) (interface{}, error) {
+	if tracker.Stopped || tracker.IsDone() {
+		return nil, nil
+	}
+	if fraction < 0 || fraction > 1 {
+		return nil, errors.New("fraction must be in range [0, 1]")
+	}
+
+	splitPt := tracker.Rest.Start + int64(fraction*float64(tracker.Rest.End-tracker.Rest.Start))
+	if splitPt == tracker.Rest.End {
+		return nil, nil
+	}
+	residual := Restriction{splitPt, tracker.Rest.End}
+	tracker.Rest.End = splitPt
+	return residual, nil
+}
+
+// GetProgress reports progress as the claimed fraction of the restriction.
+func (tracker *Tracker) GetProgress() float64 {
+	fraction := float64(tracker.Claimed-tracker.Rest.Start) /
+		float64(tracker.Rest.End-tracker.Rest.Start)
+
+	return math.Min(fraction, 1.0)
+}
+
+// IsDone returns true if the most recent claimed element is past the end of the restriction.
+func (tracker *Tracker) IsDone() bool {
+	return tracker.Claimed >= tracker.Rest.End
+}

--- a/sdks/go/examples/stringsplit/offsetrange/offsetrange.go
+++ b/sdks/go/examples/stringsplit/offsetrange/offsetrange.go
@@ -16,7 +16,6 @@ package offsetrange
 
 import (
 	"errors"
-	"math"
 	"reflect"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
@@ -107,12 +106,11 @@ func (tracker *Tracker) TrySplit(fraction float64) (interface{}, error) {
 	return residual, nil
 }
 
-// GetProgress reports progress as the claimed fraction of the restriction.
-func (tracker *Tracker) GetProgress() float64 {
-	fraction := float64(tracker.Claimed-tracker.Rest.Start) /
-		float64(tracker.Rest.End-tracker.Rest.Start)
-
-	return math.Min(fraction, 1.0)
+// GetProgress reports progress based on the claimed size and unclaimed sizes of the restriction.
+func (tracker *Tracker) GetProgress() (done, remaining float64) {
+	done = float64(tracker.Claimed - tracker.Rest.Start)
+	remaining = float64(tracker.Rest.End - tracker.Claimed)
+	return
 }
 
 // IsDone returns true if the most recent claimed element is past the end of the restriction.

--- a/sdks/go/examples/stringsplit/stringsplit.go
+++ b/sdks/go/examples/stringsplit/stringsplit.go
@@ -129,10 +129,7 @@ func (fn *StringSplitFn) ProcessElement(rt *offsetrange.Tracker, elem string, em
 		i += fn.BufSize
 	}
 	// TODO(BEAM-9799): Remove this check once error checking is automatic.
-	if err := rt.GetError(); err != nil {
-		return err
-	}
-	return nil
+	return rt.GetError()
 }
 
 // LogFn is a DoFn to log our split output.

--- a/sdks/go/examples/stringsplit/stringsplit.go
+++ b/sdks/go/examples/stringsplit/stringsplit.go
@@ -1,0 +1,230 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An example of using a Splittable DoFn in the Go SDK with a portable runner.
+//
+// The following instructions describe how to execute this example in the
+// Flink local runner.
+//
+// 1. From a command line, navigate to the top-level beam/ directory and run
+// the Flink job server:
+//    ./gradlew :runners:flink:1.10:job-server:runShadow -Djob-host=localhost -Dflink-master=local
+//
+// 2. The job server is ready to receive jobs once it outputs a log like the
+// following: `JobService started on localhost:8099`. Take note of the endpoint
+// in that log message.
+//
+// 3. While the job server is running in one command line window, create a
+// second one in the same directory and run this example with the following
+// command, using the endpoint you noted from step 2:
+//    go run sdks/go/examples/stringsplit/stringsplit.go --runner=universal --endpoint=localhost:8099
+//
+// 4. Once the pipeline is complete, the job server can be closed with ctrl+C.
+// To check the output of the pipeline, search the job server logs for the
+// phrase "StringSplit Output".
+package main
+
+import (
+	"context"
+	"flag"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/examples/stringsplit/offsetrange"
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
+)
+
+func init() {
+	beam.RegisterType(reflect.TypeOf((*StringSplitFn)(nil)).Elem())
+}
+
+// StringSplitFn is a Splittable DoFn that splits strings into substrings of the
+// specified size (for example, to be able to fit them in a small buffer).
+// See ProcessElement for more details.
+type StringSplitFn struct {
+	BufSize int64
+}
+
+// CreateInitialRestriction creates an offset range restriction for each element
+// with the size of the restriction corresponding to the length of the string.
+func (fn *StringSplitFn) CreateInitialRestriction(s string) offsetrange.Restriction {
+	return offsetrange.Restriction{Start: 0, End: int64(len(s))}
+}
+
+// SplitRestriction performs initial splits so that each restriction is split
+// into 5.
+func (fn *StringSplitFn) SplitRestriction(s string, rest offsetrange.Restriction) []offsetrange.Restriction {
+	size := rest.End - rest.Start
+	splitPts := []int64{
+		rest.Start,
+		rest.Start + (size / 5),
+		rest.Start + (size * 2 / 5),
+		rest.Start + (size * 3 / 5),
+		rest.Start + (size * 4 / 5),
+		rest.End,
+	}
+	var splits []offsetrange.Restriction
+	for i := 0; i < len(splitPts)-1; i++ {
+		splits = append(splits, offsetrange.Restriction{Start: splitPts[i], End: splitPts[i+1]})
+	}
+	return splits
+}
+
+// RestrictionSize returns the size as the difference between the restriction's
+// start and end.
+func (fn *StringSplitFn) RestrictionSize(s string, rest offsetrange.Restriction) float64 {
+	return float64(rest.End - rest.Start)
+}
+
+// CreateTracker creates an offset range restriction tracker out of the offset
+// range restriction.
+func (fn *StringSplitFn) CreateTracker(rest offsetrange.Restriction) *offsetrange.Tracker {
+	return offsetrange.NewTracker(rest)
+}
+
+// ProcessElement splits a string into substrings of a specified size (set in
+// StringSplitFn.BufSize).
+//
+// Note that the substring blocks are not guaranteed to line up with the
+// restriction boundaries. ProcessElement is expected to emit any substring
+// block that begins in its restriction, even if it extends past the end of the
+// restriction.
+//
+// Example: If BufSize is 100, then a restriction of 75 to 325 should emit the
+// following substrings: [100, 200], [200, 300], [300, 400]
+func (fn *StringSplitFn) ProcessElement(rt *offsetrange.Tracker, elem string, emit func(string)) error {
+	i := rt.Rest.Start
+	if rem := i % fn.BufSize; rem != 0 {
+		i += fn.BufSize - rem // Skip to next multiple of BufSize.
+	}
+	strEnd := int64(len(elem))
+
+	for ok := rt.TryClaim(i); ok == true; ok = rt.TryClaim(i) {
+		if i+fn.BufSize > strEnd {
+			emit(elem[i:])
+		} else {
+			emit(elem[i : i+fn.BufSize])
+		}
+		i += fn.BufSize
+	}
+	// TODO(BEAM-9799): Remove this check once error checking is automatic.
+	if err := rt.GetError(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Use our StringSplitFn to split Shakespeare monologues into substrings and
+// output them.
+func main() {
+	flag.Parse()
+	beam.Init()
+
+	ctx := context.Background()
+
+	p := beam.NewPipeline()
+	s := p.Root()
+
+	monologues := beam.Create(s, macbeth, juliet, helena)
+	split := beam.ParDo(s, &StringSplitFn{50}, monologues)
+	beam.ParDo0(s, func(ctx context.Context, in string) {
+		log.Infof(ctx, "[StringSplit Output]: %v", in)
+	}, split)
+
+	if err := beamx.Run(ctx, p); err != nil {
+		log.Fatalf(ctx, "Failed to execute job: %v", err)
+	}
+}
+
+var macbeth = `Is this a dagger which I see before me,
+The handle toward my hand? Come, let me clutch thee.
+I have thee not, and yet I see thee still.
+Art thou not, fatal vision, sensible
+To feeling as to sight? or art thou but
+A dagger of the mind, a false creation,
+Proceeding from the heat-oppressed brain?
+I see thee yet, in form as palpable
+As this which now I draw.
+Thou marshall'st me the way that I was going;
+And such an instrument I was to use.
+Mine eyes are made the fools o' the other senses,
+Or else worth all the rest; I see thee still,
+And on thy blade and dudgeon gouts of blood,
+Which was not so before. There's no such thing:
+It is the bloody business which informs
+Thus to mine eyes. Now o'er the one halfworld
+Nature seems dead, and wicked dreams abuse
+The curtain'd sleep; witchcraft celebrates
+Pale Hecate's offerings, and wither'd murder,
+Alarum'd by his sentinel, the wolf,
+Whose howl's his watch, thus with his stealthy pace.
+With Tarquin's ravishing strides, towards his design
+Moves like a ghost. Thou sure and firm-set earth,
+Hear not my steps, which way they walk, for fear
+Thy very stones prate of my whereabout,
+And take the present horror from the time,
+Which now suits with it. Whiles I threat, he lives:
+Words to the heat of deeds too cold breath gives.
+[A bell rings]
+I go, and it is done; the bell invites me.
+Hear it not, Duncan; for it is a knell
+That summons thee to heaven or to hell.`
+
+var juliet = `O Romeo, Romeo! wherefore art thou Romeo?
+Deny thy father and refuse thy name;
+Or, if thou wilt not, be but sworn my love,
+And I'll no longer be a Capulet.
+'Tis but thy name that is my enemy;
+Thou art thyself, though not a Montague.
+What's Montague? it is nor hand, nor foot,
+Nor arm, nor face, nor any other part
+Belonging to a man. O, be some other name!
+What's in a name? that which we call a rose
+By any other name would smell as sweet;
+So Romeo would, were he not Romeo call'd,
+Retain that dear perfection which he owes
+Without that title. Romeo, doff thy name,
+And for that name which is no part of thee
+Take all myself.`
+
+var helena = `Lo, she is one of this confederacy!
+Now I perceive they have conjoin'd all three
+To fashion this false sport, in spite of me.
+Injurious Hermia! most ungrateful maid!
+Have you conspired, have you with these contrived
+To bait me with this foul derision?
+Is all the counsel that we two have shared,
+The sisters' vows, the hours that we have spent,
+When we have chid the hasty-footed time
+For parting us,--O, is it all forgot?
+All school-days' friendship, childhood innocence?
+We, Hermia, like two artificial gods,
+Have with our needles created both one flower,
+Both on one sampler, sitting on one cushion,
+Both warbling of one song, both in one key,
+As if our hands, our sides, voices and minds,
+Had been incorporate. So we grow together,
+Like to a double cherry, seeming parted,
+But yet an union in partition;
+Two lovely berries moulded on one stem;
+So, with two seeming bodies, but one heart;
+Two of the first, like coats in heraldry,
+Due but to one and crowned with one crest.
+And will you rent our ancient love asunder,
+To join with men in scorning your poor friend?
+It is not friendly, 'tis not maidenly:
+Our sex, as well as I, may chide you for it,
+Though I alone do feel the injury.`

--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -572,8 +572,8 @@ func (rt *RTrackerT) GetError() error {
 func (rt *RTrackerT) TrySplit(fraction float64) (interface{}, error) {
 	return nil, nil
 }
-func (rt *RTrackerT) GetProgress() float64 {
-	return 0
+func (rt *RTrackerT) GetProgress() (float64, float64) {
+	return 0, 0
 }
 func (rt *RTrackerT) IsDone() bool {
 	return true

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
@@ -223,7 +223,7 @@ type RTracker struct {
 func (rt *RTracker) TryClaim(interface{}) bool                      { return false }
 func (rt *RTracker) GetError() error                                { return nil }
 func (rt *RTracker) TrySplit(fraction float64) (interface{}, error) { return nil, nil }
-func (rt *RTracker) GetProgress() float64                           { return 0 }
+func (rt *RTracker) GetProgress() (float64, float64)                { return 0, 0 }
 func (rt *RTracker) IsDone() bool                                   { return false }
 
 // In order to test that these methods get called properly, each one has an

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
@@ -185,7 +185,7 @@ type testRT struct {
 func (rt *testRT) TryClaim(interface{}) bool                      { return false }
 func (rt *testRT) GetError() error                                { return nil }
 func (rt *testRT) TrySplit(fraction float64) (interface{}, error) { return nil, nil }
-func (rt *testRT) GetProgress() float64                           { return 0 }
+func (rt *testRT) GetProgress() (float64, float64)                { return 0, 0 }
 func (rt *testRT) IsDone() bool                                   { return false }
 
 // splitPickFn is used for the SDF test, and just needs to fulfill SDF method

--- a/sdks/go/pkg/beam/core/sdf/sdf.go
+++ b/sdks/go/pkg/beam/core/sdf/sdf.go
@@ -63,9 +63,10 @@ type RTracker interface {
 	// an error.
 	TrySplit(fraction float64) (residual interface{}, err error)
 
-	// GetProgress returns a double representing the current progress of the restriction as a range
-	// from 0 to 1.0.
-	GetProgress() float64
+	// GetProgress returns two abstract scalars representing the amount of done and remaining work.
+	// These values have no specific units, but are used to estimate work in relation to each other
+	// and should be self-consistent.
+	GetProgress() (done float64, remaining float64)
 
 	// IsDone returns a boolean indicating whether all blocks inside the restriction have been
 	// claimed. This method is called by the SDK Harness to validate that a Splittable DoFn has


### PR DESCRIPTION
Added an SDF example.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
