### PR TITLE
[BEAM-9692] Make GroupByKey into a primitive

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -849,8 +849,15 @@ class DataflowRunner(PipelineRunner):
     #
     # TODO(ccy): make Coder inference and checking less specialized and more
     # comprehensive.
+
     parent = pcoll.producer
     if parent:
+      # Skip the check because we can assume that any x-lang transform is
+      # properly formed (the onus is on the expansion service to construct
+      # transforms correctly).
+      if isinstance(parent.transform, RunnerAPIPTransformHolder):
+        return
+
       coder = parent.transform._infer_output_coder()  # pylint: disable=protected-access
     if not coder:
       coder = self._get_coder(pcoll.element_type or typehints.Any, None)

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -396,6 +396,10 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     flat = (none_str_pc, none_int_pc) | beam.Flatten()
     _ = flat | beam.GroupByKey()
 
+    # This may change if type inference changes, but we assert it here
+    # to make sure the check below is not vacuous.
+    self.assertNotIsInstance(flat.element_type, typehints.TupleConstraint)
+
     p.visit(DataflowRunner.group_by_key_input_visitor())
     p.visit(DataflowRunner.flatten_input_visitor())
 

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -50,10 +50,10 @@ from apache_beam.transforms.core import CombinePerKey
 from apache_beam.transforms.core import CombineValuesDoFn
 from apache_beam.transforms.core import DoFn
 from apache_beam.transforms.core import ParDo
-from apache_beam.transforms.core import _GroupAlsoByWindow
-from apache_beam.transforms.core import _GroupAlsoByWindowDoFn
-from apache_beam.transforms.core import _GroupByKeyOnly
 from apache_beam.transforms.ptransform import PTransform
+from apache_beam.transforms.window import WindowedValue
+from apache_beam.typehints import trivial_inference
+from apache_beam.typehints.decorators import TypeCheckError
 
 # Note that the BundleBasedDirectRunner and SwitchingDirectRunner names are
 # experimental and have no backwards compatibility guarantees.
@@ -137,6 +137,57 @@ V = typing.TypeVar('V')
 
 @typehints.with_input_types(typing.Tuple[K, V])
 @typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
+class _GroupByKeyOnly(PTransform):
+  """A group by key transform, ignoring windows."""
+  def infer_output_type(self, input_type):
+    key_type, value_type = trivial_inference.key_value_types(input_type)
+    return typehints.KV[key_type, typehints.Iterable[value_type]]
+
+  def expand(self, pcoll):
+    self._check_pcollection(pcoll)
+    return PCollection.from_(pcoll)
+
+
+@typehints.with_input_types(typing.Tuple[K, typing.Iterable[V]])
+@typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
+class _GroupAlsoByWindow(ParDo):
+  """The GroupAlsoByWindow transform."""
+  def __init__(self, windowing):
+    super(_GroupAlsoByWindow, self).__init__(_GroupAlsoByWindowDoFn(windowing))
+    self.windowing = windowing
+
+  def expand(self, pcoll):
+    self._check_pcollection(pcoll)
+    return PCollection.from_(pcoll)
+
+
+class _GroupAlsoByWindowDoFn(DoFn):
+  # TODO(robertwb): Support combiner lifting.
+
+  def __init__(self, windowing):
+    super(_GroupAlsoByWindowDoFn, self).__init__()
+    self.windowing = windowing
+
+  def infer_output_type(self, input_type):
+    key_type, windowed_value_iter_type = trivial_inference.key_value_types(
+        input_type)
+    value_type = windowed_value_iter_type.inner_type.inner_type
+    return typehints.Iterable[typehints.KV[key_type,
+                                           typehints.Iterable[value_type]]]
+
+  def start_bundle(self):
+    # pylint: disable=wrong-import-order, wrong-import-position
+    from apache_beam.transforms.trigger import create_trigger_driver
+    # pylint: enable=wrong-import-order, wrong-import-position
+    self.driver = create_trigger_driver(self.windowing, True)
+
+  def process(self, element):
+    k, vs = element
+    return self.driver.process_entire_key(k, vs)
+
+
+@typehints.with_input_types(typing.Tuple[K, V])
+@typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _StreamingGroupByKeyOnly(_GroupByKeyOnly):
   """Streaming GroupByKeyOnly placeholder for overriding in DirectRunner."""
   urn = "direct_runner:streaming_gbko:v0.1"
@@ -170,6 +221,75 @@ class _StreamingGroupAlsoByWindow(_GroupAlsoByWindow):
   def from_runner_api_parameter(unused_ptransform, payload, context):
     return _StreamingGroupAlsoByWindow(
         context.windowing_strategies.get_by_id(payload.value))
+
+
+@typehints.with_input_types(typing.Tuple[K, typing.Iterable[V]])
+@typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
+class _GroupByKey(PTransform):
+  """The DirectRunner GroupByKey implementation."""
+  class ReifyWindows(DoFn):
+    def process(
+        self, element, window=DoFn.WindowParam, timestamp=DoFn.TimestampParam):
+      try:
+        k, v = element
+      except TypeError:
+        raise TypeCheckError(
+            'Input to GroupByKey must be a PCollection with '
+            'elements compatible with KV[A, B]')
+
+      return [(k, WindowedValue(v, timestamp, [window]))]
+
+    def infer_output_type(self, input_type):
+      key_type, value_type = trivial_inference.key_value_types(input_type)
+      return typehints.Iterable[typehints.KV[
+          key_type, typehints.WindowedValue[value_type]]]  # type: ignore[misc]
+
+  def expand(self, pcoll):
+    # Imported here to avoid circular dependencies.
+    # pylint: disable=wrong-import-order, wrong-import-position
+    from apache_beam.coders import typecoders
+
+    input_type = pcoll.element_type
+    if input_type is not None:
+      # Initialize type-hints used below to enforce type-checking and to
+      # pass downstream to further PTransforms.
+      key_type, value_type = trivial_inference.key_value_types(input_type)
+      # Enforce the input to a GBK has a KV element type.
+      pcoll.element_type = typehints.typehints.coerce_to_kv_type(
+          pcoll.element_type)
+      typecoders.registry.verify_deterministic(
+          typecoders.registry.get_coder(key_type),
+          'GroupByKey operation "%s"' % self.label)
+
+      reify_output_type = typehints.KV[
+          key_type, typehints.WindowedValue[value_type]]  # type: ignore[misc]
+      gbk_input_type = (
+          typehints.
+          KV[key_type,
+             typehints.Iterable[
+                 typehints.WindowedValue[  # type: ignore[misc]
+                     value_type]]])
+      gbk_output_type = typehints.KV[key_type, typehints.Iterable[value_type]]
+
+      # pylint: disable=bad-continuation
+      return (
+          pcoll
+          | 'ReifyWindows' >>
+          (ParDo(self.ReifyWindows()).with_output_types(reify_output_type))
+          | 'GroupByKey' >> (
+              _GroupByKeyOnly().with_input_types(
+                  reify_output_type).with_output_types(gbk_input_type))
+          | (
+              'GroupByWindow' >>
+              _GroupAlsoByWindow(pcoll.windowing).with_input_types(
+                  gbk_input_type).with_output_types(gbk_output_type)))
+    else:
+      # The input_type is None, run the default
+      return (
+          pcoll
+          | 'ReifyWindows' >> ParDo(self.ReifyWindows())
+          | 'GroupByKey' >> _GroupByKeyOnly()
+          | 'GroupByWindow' >> _GroupAlsoByWindow(pcoll.windowing))
 
 
 def _get_transform_overrides(pipeline_options):
@@ -243,74 +363,10 @@ def _get_transform_overrides(pipeline_options):
       # Imported here to avoid circular dependencies.
       # pylint: disable=wrong-import-order, wrong-import-position
       from apache_beam.transforms.core import GroupByKey
-      if (isinstance(applied_ptransform.transform, GroupByKey) and
-          not getattr(applied_ptransform.transform, 'override', False)):
-        self.input_type = applied_ptransform.inputs[0].element_type
-        return True
-      return False
+      return isinstance(applied_ptransform.transform, GroupByKey)
 
     def get_replacement_transform(self, ptransform):
-      # Imported here to avoid circular dependencies.
-      # pylint: disable=wrong-import-order, wrong-import-position
-      from apache_beam.transforms.core import GroupByKey
-
-      # Subclass from GroupByKey to inherit all the proper methods.
-      class GroupByKey(GroupByKey):
-        override = True
-
-        def expand(self, pcoll):
-          # Imported here to avoid circular dependencies.
-          # pylint: disable=wrong-import-order, wrong-import-position
-          from apache_beam.coders import typecoders
-          from apache_beam.typehints import trivial_inference
-
-          input_type = pcoll.element_type
-          if input_type is not None:
-            # Initialize type-hints used below to enforce type-checking and to
-            # pass downstream to further PTransforms.
-            key_type, value_type = trivial_inference.key_value_types(input_type)
-            # Enforce the input to a GBK has a KV element type.
-            pcoll.element_type = typehints.typehints.coerce_to_kv_type(
-                pcoll.element_type)
-            typecoders.registry.verify_deterministic(
-                typecoders.registry.get_coder(key_type),
-                'GroupByKey operation "%s"' % self.label)
-
-            reify_output_type = typehints.KV[
-                key_type, typehints.WindowedValue[value_type]]  # type: ignore[misc]
-            gbk_input_type = (
-                typehints.
-                KV[key_type,
-                   typehints.Iterable[
-                       typehints.WindowedValue[  # type: ignore[misc]
-                           value_type]]])
-            gbk_output_type = typehints.KV[key_type,
-                                           typehints.Iterable[value_type]]
-
-            # pylint: disable=bad-continuation
-            return (
-                pcoll
-                | 'ReifyWindows' >> (
-                    ParDo(self.ReifyWindows()).with_output_types(
-                        reify_output_type))
-                | 'GroupByKey' >> (
-                    _GroupByKeyOnly().with_input_types(
-                        reify_output_type).with_output_types(gbk_input_type))
-                | (
-                    'GroupByWindow' >>
-                    _GroupAlsoByWindow(pcoll.windowing).with_input_types(
-                        gbk_input_type).with_output_types(gbk_output_type)))
-          else:
-            # The input_type is None, run the default
-            return (
-                pcoll
-                | 'ReifyWindows' >> ParDo(self.ReifyWindows())
-                | 'GroupByKey' >> _GroupByKeyOnly()
-                | 'GroupByWindow' >> _GroupAlsoByWindow(pcoll.windowing))
-
-      # Infer the correct type.
-      return GroupByKey().with_output_types(
-          ptransform.infer_output_type(self.input_type))
+      return _GroupByKey()
 
   overrides = [
       # This needs to be the first and the last override. Other overrides depend

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -45,6 +45,7 @@ from apache_beam.runners.common import DoFnRunner
 from apache_beam.runners.common import DoFnState
 from apache_beam.runners.dataflow.native_io.iobase import _NativeWrite  # pylint: disable=protected-access
 from apache_beam.runners.direct.direct_runner import _DirectReadFromPubSub
+from apache_beam.runners.direct.direct_runner import _GroupByKeyOnly
 from apache_beam.runners.direct.direct_runner import _StreamingGroupAlsoByWindow
 from apache_beam.runners.direct.direct_runner import _StreamingGroupByKeyOnly
 from apache_beam.runners.direct.direct_userstate import DirectUserStateContext
@@ -106,7 +107,7 @@ class TransformEvaluatorRegistry(object):
         core.Flatten: _FlattenEvaluator,
         core.Impulse: _ImpulseEvaluator,
         core.ParDo: _ParDoEvaluator,
-        core._GroupByKeyOnly: _GroupByKeyOnlyEvaluator,
+        _GroupByKeyOnly: _GroupByKeyOnlyEvaluator,
         _StreamingGroupByKeyOnly: _StreamingGroupByKeyOnlyEvaluator,
         _StreamingGroupAlsoByWindow: _StreamingGroupAlsoByWindowEvaluator,
         _NativeWrite: _NativeWriteEvaluator,
@@ -176,7 +177,7 @@ class TransformEvaluatorRegistry(object):
       True if executor should execute applied_ptransform serially.
     """
     if isinstance(applied_ptransform.transform,
-                  (core._GroupByKeyOnly,
+                  (_GroupByKeyOnly,
                    _StreamingGroupByKeyOnly,
                    _StreamingGroupAlsoByWindow,
                    _NativeWrite)):

--- a/sdks/python/apache_beam/runners/interactive/pipeline_analyzer_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_analyzer_test.py
@@ -219,7 +219,7 @@ class PipelineAnalyzerTest(unittest.TestCase):
     pipeline_proto = to_stable_runner_api(p)
 
     pipeline_info = pipeline_analyzer.PipelineInfo(pipeline_proto.components)
-    pcoll_id = 'ref_PCollection_PCollection_12'  # Output PCollection of Square
+    pcoll_id = 'ref_PCollection_PCollection_10'  # Output PCollection of Square
     cache_label1 = pipeline_info.cache_label(pcoll_id)
 
     analyzer = pipeline_analyzer.PipelineAnalyzer(

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -69,7 +69,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     _, ctx = p.to_runner_api(use_fake_coders=True, return_context=True)
     self.assertEqual(
         instr.cacheable_key(init_pcoll, instr.pcolls_to_pcoll_id(p, ctx)),
-        str(id(init_pcoll)) + '_ref_PCollection_PCollection_10')
+        str(id(init_pcoll)) + '_ref_PCollection_PCollection_8')
 
   def test_cacheable_key_with_version_map(self):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
@@ -94,8 +94,8 @@ class PipelineInstrumentTest(unittest.TestCase):
         instr.cacheable_key(
             init_pcoll_2,
             instr.pcolls_to_pcoll_id(p2, ctx),
-            {'ref_PCollection_PCollection_10': str(id(init_pcoll))}),
-        str(id(init_pcoll)) + '_ref_PCollection_PCollection_10')
+            {'ref_PCollection_PCollection_8': str(id(init_pcoll))}),
+        str(id(init_pcoll)) + '_ref_PCollection_PCollection_8')
 
   def test_cache_key(self):
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
@@ -131,19 +131,19 @@ class PipelineInstrumentTest(unittest.TestCase):
             pipeline_instrument._cacheable_key(init_pcoll): instr.Cacheable(
                 var='init_pcoll',
                 version=str(id(init_pcoll)),
-                pcoll_id='ref_PCollection_PCollection_10',
+                pcoll_id='ref_PCollection_PCollection_8',
                 producer_version=str(id(init_pcoll.producer)),
                 pcoll=init_pcoll),
             pipeline_instrument._cacheable_key(squares): instr.Cacheable(
                 var='squares',
                 version=str(id(squares)),
-                pcoll_id='ref_PCollection_PCollection_11',
+                pcoll_id='ref_PCollection_PCollection_9',
                 producer_version=str(id(squares.producer)),
                 pcoll=squares),
             pipeline_instrument._cacheable_key(cubes): instr.Cacheable(
                 var='cubes',
                 version=str(id(cubes)),
-                pcoll_id='ref_PCollection_PCollection_12',
+                pcoll_id='ref_PCollection_PCollection_10',
                 producer_version=str(id(cubes.producer)),
                 pcoll=cubes)
         })

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -1190,7 +1190,7 @@ class FnApiRunnerMetricsTest(unittest.TestCase):
 
       # postgbk monitoring infos
       labels = {
-          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_8'
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_6'
       }
       self.assert_has_counter(
           postgbk_mis, monitoring_infos.ELEMENT_COUNT_URN, labels, value=1)
@@ -1198,7 +1198,7 @@ class FnApiRunnerMetricsTest(unittest.TestCase):
           postgbk_mis, monitoring_infos.SAMPLED_BYTE_SIZE_URN, labels)
 
       labels = {
-          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_9'
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_7'
       }
       self.assert_has_counter(
           postgbk_mis, monitoring_infos.ELEMENT_COUNT_URN, labels, value=5)

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -52,7 +52,6 @@ from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.transforms import WindowInto
 from apache_beam.transforms import window
-from apache_beam.transforms.core import _GroupByKeyOnly
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display import DisplayDataItem
 from apache_beam.transforms.ptransform import PTransform
@@ -680,7 +679,7 @@ class PTransformTest(unittest.TestCase):
     with self.assertRaises(typehints.TypeCheckError) as cm:
       with TestPipeline() as pipeline:
         pcolls = pipeline | 'A' >> beam.Create(['a', 'b', 'f'])
-        pcolls | 'D' >> _GroupByKeyOnly()
+        pcolls | 'D' >> beam.GroupByKey()
 
     expected_error_prefix = (
         'Input type hint violation at D: expected '
@@ -1233,7 +1232,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         | (
             'Pair' >> beam.Map(lambda x: (x, ord(x))).with_output_types(
                 typing.Tuple[str, str]))
-        | _GroupByKeyOnly())
+        | beam.GroupByKey())
 
     # Output type should correctly be deduced.
     # GBK-only should deduce that Tuple[A, B] is turned into
@@ -1261,7 +1260,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       (
           self.p
           | beam.Create([1, 2, 3]).with_output_types(int)
-          | 'F' >> _GroupByKeyOnly())
+          | 'F' >> beam.GroupByKey())
 
     self.assertStartswith(
         e.exception.args[0],
@@ -1309,7 +1308,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
           self.p
           | 'Nums' >> beam.Create(range(5)).with_output_types(int)
           | 'ModDup' >> beam.Map(lambda x: (x % 2, x))
-          | _GroupByKeyOnly())
+          | beam.GroupByKey())
 
     self.assertEqual(
         'Pipeline type checking is enabled, however no output '
@@ -2244,7 +2243,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_gbk_type_inference(self):
     self.assertEqual(
         typehints.Tuple[str, typehints.Iterable[int]],
-        _GroupByKeyOnly().infer_output_type(typehints.KV[str, int]))
+        beam.GroupByKey().infer_output_type(typehints.KV[str, int]))
 
   def test_pipeline_inference(self):
     created = self.p | beam.Create(['a', 'b', 'c'])


### PR DESCRIPTION
This makes GBK into a primitive and moves the current implementation -- only used by the DirectRunner -- as a PTransformOverride for the DirectRunner. This leaves the apply_GroupByKey because there are some internal runners that rely on the existence of the transform. So we keep it but simply apply the GBK normally. This can be removed after an internal fix.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
