### PR TITLE
[BEAM-9733][release-2.21.0] Improve watermark and timer handling

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -111,7 +111,10 @@ spotless {
 
 test {
   systemProperty "log4j.configuration", "log4j-test.properties"
-  //systemProperty "org.slf4j.simpleLogger.defaultLogLevel", "debug"
+  // Change log level to debug:
+  // systemProperty "org.slf4j.simpleLogger.defaultLogLevel", "debug"
+  // Change log level to debug only for the package and nested packages:
+  // systemProperty "org.slf4j.simpleLogger.log.org.apache.beam.runners.flink.translation.wrappers.streaming", "debug"
   jvmArgs "-XX:-UseGCOverheadLimit"
   if (System.getProperty("beamSurefireArgline")) {
     jvmArgs System.getProperty("beamSurefireArgline")

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -116,6 +116,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.OutputTag;
 import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Flink operator for executing {@link DoFn DoFns}.
@@ -123,10 +125,14 @@ import org.joda.time.Instant;
  * @param <InputT> the input type of the {@link DoFn}
  * @param <OutputT> the output type of the {@link DoFn}
  */
+// We use Flink's lifecycle methods to initialize transient fields
+@SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
 public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<WindowedValue<OutputT>>
     implements OneInputStreamOperator<WindowedValue<InputT>, WindowedValue<OutputT>>,
         TwoInputStreamOperator<WindowedValue<InputT>, RawUnionValue, WindowedValue<OutputT>>,
         Triggerable<ByteBuffer, TimerData> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DoFnOperator.class);
 
   protected DoFn<InputT, OutputT> doFn;
 
@@ -206,14 +212,16 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
   private transient volatile long elementCount;
   /** Time that the last bundle was finished (to set the timer). */
   private transient volatile long lastFinishBundleTime;
+  /** Callback to be executed before the current bundle is started. */
+  private transient volatile Runnable preBundleCallback;
   /** Callback to be executed after the current bundle was finished. */
   private transient volatile Runnable bundleFinishedCallback;
 
   // Watermark state.
   // Volatile because these can be set in two mutually exclusive threads (see above).
-  protected transient volatile long currentInputWatermark;
-  protected transient volatile long currentSideInputWatermark;
-  protected transient volatile long currentOutputWatermark;
+  private transient volatile long currentInputWatermark;
+  private transient volatile long currentSideInputWatermark;
+  private transient volatile long currentOutputWatermark;
   private transient volatile long pushedBackWatermark;
 
   /** Constructor for DoFnOperator. */
@@ -353,9 +361,9 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       pushedBackElementsHandler = NonKeyedPushedBackElementsHandler.create(listState);
     }
 
-    setCurrentInputWatermark(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis());
-    setCurrentSideInputWatermark(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis());
-    setCurrentOutputWatermark(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis());
+    currentInputWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis();
+    currentSideInputWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis();
+    currentOutputWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis();
 
     sideInputReader = NullSideInputReader.of(sideInputs);
 
@@ -371,9 +379,9 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       Stream<WindowedValue<InputT>> pushedBack = pushedBackElementsHandler.getElements();
       long min =
           pushedBack.map(v -> v.getTimestamp().getMillis()).reduce(Long.MAX_VALUE, Math::min);
-      setPushedBackWatermark(min);
+      pushedBackWatermark = min;
     } else {
-      setPushedBackWatermark(Long.MAX_VALUE);
+      pushedBackWatermark = Long.MAX_VALUE;
     }
 
     // StatefulPardo or WindowDoFn
@@ -549,15 +557,20 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
     }
   }
 
-  protected long getPushbackWatermarkHold() {
-    return pushedBackWatermark;
+  public long getEffectiveInputWatermark() {
+    // hold back by the pushed back values waiting for side inputs
+    return Math.min(pushedBackWatermark, currentInputWatermark);
   }
 
-  protected void setPushedBackWatermark(long watermark) {
-    pushedBackWatermark = watermark;
+  public long getCurrentOutputWatermark() {
+    return currentOutputWatermark;
   }
 
-  protected void setBundleFinishedCallback(Runnable callback) {
+  protected final void setPreBundleCallback(Runnable callback) {
+    this.preBundleCallback = callback;
+  }
+
+  protected final void setBundleFinishedCallback(Runnable callback) {
     this.bundleFinishedCallback = callback;
   }
 
@@ -581,7 +594,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       min = Math.min(min, pushedBackValue.getTimestamp().getMillis());
       pushedBackElementsHandler.pushBack(pushedBackValue);
     }
-    setPushedBackWatermark(min);
+    pushedBackWatermark = min;
 
     checkInvokeFinishBundleByCount();
   }
@@ -635,7 +648,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       min = Math.min(min, pushedBackValue.getTimestamp().getMillis());
       pushedBackElementsHandler.pushBack(pushedBackValue);
     }
-    setPushedBackWatermark(min);
+    pushedBackWatermark = min;
 
     checkInvokeFinishBundleByCount();
 
@@ -644,12 +657,12 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
   }
 
   @Override
-  public void processWatermark(Watermark mark) throws Exception {
+  public final void processWatermark(Watermark mark) throws Exception {
     processWatermark1(mark);
   }
 
   @Override
-  public void processWatermark1(Watermark mark) throws Exception {
+  public final void processWatermark1(Watermark mark) throws Exception {
     // We do the check here because we are guaranteed to at least get the +Inf watermark on the
     // main input when the job finishes.
     if (currentSideInputWatermark >= BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
@@ -659,46 +672,69 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       emitAllPushedBackData();
     }
 
-    setCurrentInputWatermark(mark.getTimestamp());
+    currentInputWatermark = mark.getTimestamp();
 
-    if (keyCoder == null) {
-      long potentialOutputWatermark = Math.min(getPushbackWatermarkHold(), currentInputWatermark);
-      if (potentialOutputWatermark > currentOutputWatermark) {
-        setCurrentOutputWatermark(potentialOutputWatermark);
-        emitWatermark(currentOutputWatermark);
-      }
-    } else {
-      // hold back by the pushed back values waiting for side inputs
-      long pushedBackInputWatermark = Math.min(getPushbackWatermarkHold(), mark.getTimestamp());
-
-      timeServiceManager.advanceWatermark(new Watermark(pushedBackInputWatermark));
-
-      Instant watermarkHold = keyedStateInternals.watermarkHold();
-
-      long combinedWatermarkHold = Math.min(watermarkHold.getMillis(), getPushbackWatermarkHold());
-      combinedWatermarkHold =
-          Math.min(combinedWatermarkHold, timerInternals.getMinOutputTimestampMs());
-      long potentialOutputWatermark = Math.min(pushedBackInputWatermark, combinedWatermarkHold);
-
-      if (potentialOutputWatermark > currentOutputWatermark) {
-        setCurrentOutputWatermark(potentialOutputWatermark);
-        emitWatermark(currentOutputWatermark);
-      }
+    long inputWatermarkHold = applyInputWatermarkHold(getEffectiveInputWatermark());
+    if (keyCoder != null) {
+      timeServiceManager.advanceWatermark(new Watermark(inputWatermarkHold));
     }
+
+    long potentialOutputWatermark =
+        applyOutputWatermarkHold(
+            currentOutputWatermark, computeOutputWatermark(inputWatermarkHold));
+    maybeEmitWatermark(potentialOutputWatermark);
   }
 
-  private void emitWatermark(long watermark) {
-    // Must invoke finishBatch before emit the +Inf watermark otherwise there are some late events.
-    if (watermark >= BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
-      invokeFinishBundle();
+  /**
+   * Allows to apply a hold to the input watermark. By default, just passes the input watermark
+   * through.
+   */
+  public long applyInputWatermarkHold(long inputWatermark) {
+    return inputWatermark;
+  }
+
+  /**
+   * Allows to apply a hold to the output watermark before it is send out. By default, just passes
+   * the potential output watermark through which will make it the new output watermark.
+   *
+   * @param currentOutputWatermark the current output watermark
+   * @param potentialOutputWatermark The potential new output watermark which can be adjusted, if
+   *     needed. The input watermark hold has already been applied.
+   * @return The new output watermark which will be emitted.
+   */
+  public long applyOutputWatermarkHold(long currentOutputWatermark, long potentialOutputWatermark) {
+    return potentialOutputWatermark;
+  }
+
+  private long computeOutputWatermark(long inputWatermarkHold) {
+    final long potentialOutputWatermark;
+    if (keyCoder == null) {
+      potentialOutputWatermark = inputWatermarkHold;
+    } else {
+      Instant watermarkHold = keyedStateInternals.watermarkHold();
+      long combinedWatermarkHold = Math.min(watermarkHold.getMillis(), inputWatermarkHold);
+      potentialOutputWatermark =
+          Math.min(combinedWatermarkHold, timerInternals.getMinOutputTimestampMs());
     }
-    output.emitWatermark(new Watermark(watermark));
+    return potentialOutputWatermark;
+  }
+
+  private void maybeEmitWatermark(long watermark) {
+    if (watermark > currentOutputWatermark) {
+      // Must invoke finishBatch before emit the +Inf watermark otherwise there are some late
+      // events.
+      if (watermark >= BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
+        invokeFinishBundle();
+      }
+      LOG.debug("Emitting watermark {}", watermark);
+      currentOutputWatermark = watermark;
+      output.emitWatermark(new Watermark(watermark));
+    }
   }
 
   @Override
-  public void processWatermark2(Watermark mark) throws Exception {
-
-    setCurrentSideInputWatermark(mark.getTimestamp());
+  public final void processWatermark2(Watermark mark) throws Exception {
+    currentSideInputWatermark = mark.getTimestamp();
     if (mark.getTimestamp() >= BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
       // this means we will never see any more side input
       emitAllPushedBackData();
@@ -727,8 +763,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
     }
 
     pushedBackElementsHandler.clear();
-
-    setPushedBackWatermark(Long.MAX_VALUE);
+    pushedBackWatermark = Long.MAX_VALUE;
   }
 
   /**
@@ -743,7 +778,11 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
    */
   private void checkInvokeStartBundle() {
     if (!bundleStarted) {
+      LOG.debug("Starting bundle.");
       outputManager.flushBuffer();
+      if (preBundleCallback != null) {
+        preBundleCallback.run();
+      }
       pushbackDoFnRunner.startBundle();
       bundleStarted = true;
     }
@@ -773,15 +812,17 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
 
   protected final void invokeFinishBundle() {
     if (bundleStarted) {
+      LOG.debug("Finishing bundle.");
       pushbackDoFnRunner.finishBundle();
+      LOG.debug("Finished bundle. Element count: {}", elementCount);
       elementCount = 0L;
       lastFinishBundleTime = getProcessingTimeService().getCurrentProcessingTime();
       bundleStarted = false;
       // callback only after current bundle was fully finalized
       // it could start a new bundle, for example resulting from timer processing
       if (bundleFinishedCallback != null) {
+        LOG.debug("Invoking bundle finish callback.");
         bundleFinishedCallback.run();
-        bundleFinishedCallback = null;
       }
     }
   }
@@ -843,6 +884,11 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
 
   // allow overriding this in WindowDoFnOperator
   protected void fireTimer(TimerData timerData) {
+    LOG.debug(
+        "Firing timer: {} at {} with output time {}",
+        timerData.getTimerId(),
+        timerData.getTimestamp().getMillis(),
+        timerData.getOutputTimestamp().getMillis());
     StateNamespace namespace = timerData.getNamespace();
     // This is a user timer, so namespace must be WindowNamespace
     checkArgument(namespace instanceof WindowNamespace);
@@ -855,18 +901,6 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
         timerData.getTimestamp(),
         timerData.getOutputTimestamp(),
         timerData.getDomain());
-  }
-
-  private void setCurrentInputWatermark(long currentInputWatermark) {
-    this.currentInputWatermark = currentInputWatermark;
-  }
-
-  private void setCurrentSideInputWatermark(long currentInputWatermark) {
-    this.currentSideInputWatermark = currentInputWatermark;
-  }
-
-  private void setCurrentOutputWatermark(long currentOutputWatermark) {
-    this.currentOutputWatermark = currentOutputWatermark;
   }
 
   @SuppressWarnings("unchecked")
@@ -1259,6 +1293,11 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
     @Override
     public void setTimer(TimerData timer) {
       try {
+        LOG.debug(
+            "Setting timer: {} at {} with output time {}",
+            timer.getTimerId(),
+            timer.getTimestamp().getMillis(),
+            timer.getOutputTimestamp().getMillis());
         String contextTimerId = getContextTimerId(timer.getTimerId(), timer.getNamespace());
         // Only one timer can exist at a time for a given timer id and context.
         // If a timer gets set twice in the same context, the second must
@@ -1367,7 +1406,7 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
 
     @Override
     public Instant currentInputWatermarkTime() {
-      return new Instant(Math.min(currentInputWatermark, getPushbackWatermarkHold()));
+      return new Instant(getEffectiveInputWatermark());
     }
 
     @Nullable
@@ -1376,30 +1415,44 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
       return new Instant(currentOutputWatermark);
     }
 
+    /**
+     * Check whether event time timers lower or equal to the given timestamp exist. Caution: This is
+     * scoped by the current key.
+     */
+    public boolean hasPendingEventTimeTimers(long maxTimestamp) throws Exception {
+      for (TimerData timer : pendingTimersById.values()) {
+        if (timer.getDomain() == TimeDomain.EVENT_TIME
+            && timer.getTimestamp().getMillis() <= maxTimestamp) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     /** Unique contextual id of a timer. Used to look up any existing timers in a context. */
     private String getContextTimerId(String timerId, StateNamespace namespace) {
       return timerId + namespace.stringKey();
     }
+  }
 
-    /**
-     * In Beam, a timer with timestamp {@code T} is only illegible for firing when the time has
-     * moved past this time stamp, i.e. {@code T < current_time}. In the case of event time,
-     * current_time is the watermark, in the case of processing time it is the system time.
-     *
-     * <p>Flink's TimerService has different semantics because it only ensures {@code T <=
-     * current_time}.
-     *
-     * <p>To make up for this, we need to add one millisecond to Flink's internal timer timestamp.
-     * Note that we do not modify Beam's timestamp and we are not exposing Flink's timestamp.
-     *
-     * <p>See also https://jira.apache.org/jira/browse/BEAM-3863
-     */
-    private long adjustTimestampForFlink(long beamTimerTimestamp) {
-      if (beamTimerTimestamp == Long.MAX_VALUE) {
-        // We would overflow, do not adjust timestamp
-        return Long.MAX_VALUE;
-      }
-      return beamTimerTimestamp + 1;
+  /**
+   * In Beam, a timer with timestamp {@code T} is only illegible for firing when the time has moved
+   * past this time stamp, i.e. {@code T < current_time}. In the case of event time, current_time is
+   * the watermark, in the case of processing time it is the system time.
+   *
+   * <p>Flink's TimerService has different semantics because it only ensures {@code T <=
+   * current_time}.
+   *
+   * <p>To make up for this, we need to add one millisecond to Flink's internal timer timestamp.
+   * Note that we do not modify Beam's timestamp and we are not exposing Flink's timestamp.
+   *
+   * <p>See also https://jira.apache.org/jira/browse/BEAM-3863
+   */
+  static long adjustTimestampForFlink(long beamTimerTimestamp) {
+    if (beamTimerTimestamp == Long.MAX_VALUE) {
+      // We would overflow, do not adjust timestamp
+      return Long.MAX_VALUE;
     }
+    return beamTimerTimestamp + 1;
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -53,6 +53,8 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Flink operator for executing splittable {@link DoFn DoFns}. Specifically, for executing the
@@ -60,6 +62,8 @@ import org.joda.time.Instant;
  */
 public class SplittableDoFnOperator<InputT, OutputT, RestrictionT>
     extends DoFnOperator<KeyedWorkItem<byte[], KV<InputT, RestrictionT>>, OutputT> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SplittableDoFnOperator.class);
 
   private transient ScheduledExecutorService executorService;
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSavepointTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSavepointTest.java
@@ -66,7 +66,7 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsIterableContaining;
-import org.joda.time.Duration;
+import org.joda.time.Instant;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -291,8 +291,9 @@ public class FlinkSavepointTest implements Serializable {
     if (isPortablePipeline) {
       key =
           pipeline
-              .apply(Impulse.create())
+              .apply("ImpulseStage", Impulse.create())
               .apply(
+                  "KvMapperStage",
                   MapElements.via(
                       new InferableFunction<byte[], KV<String, Void>>() {
                         @Override
@@ -304,6 +305,7 @@ public class FlinkSavepointTest implements Serializable {
                         }
                       }))
               .apply(
+                  "TimerStage",
                   ParDo.of(
                       new DoFn<KV<String, Void>, KV<String, Long>>() {
                         @StateId("nextInteger")
@@ -311,14 +313,12 @@ public class FlinkSavepointTest implements Serializable {
                             StateSpecs.value();
 
                         @TimerId("timer")
-                        private final TimerSpec timer =
-                            TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+                        private final TimerSpec timer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
 
                         @ProcessElement
                         public void processElement(
                             ProcessContext context, @TimerId("timer") Timer timer) {
-
-                          timer.offset(Duration.ZERO).setRelative();
+                          timer.set(new Instant(0));
                         }
 
                         @OnTimer("timer")
@@ -327,20 +327,20 @@ public class FlinkSavepointTest implements Serializable {
                             @StateId("nextInteger") ValueState<Long> nextInteger,
                             @TimerId("timer") Timer timer) {
                           Long current = nextInteger.read();
-                          if (current == null) {
-                            current = -1L;
-                          }
-                          long next = current + 1;
-                          nextInteger.write(next);
-                          context.output(KV.of("key", next));
-                          timer.offset(Duration.millis(100)).setRelative();
+                          current = current != null ? current : 0L;
+                          context.output(KV.of("key", current));
+                          LOG.debug("triggering timer {}", current);
+                          nextInteger.write(current + 1);
+                          // Trigger timer again and continue to hold back the watermark
+                          timer.withOutputTimestamp(new Instant(0)).set(context.fireTimestamp());
                         }
                       }));
     } else {
       key =
           pipeline
-              .apply(GenerateSequence.from(0))
+              .apply("IdGeneratorStage", GenerateSequence.from(0))
               .apply(
+                  "KvMapperStage",
                   ParDo.of(
                       new DoFn<Long, KV<String, Long>>() {
                         @ProcessElement
@@ -351,6 +351,7 @@ public class FlinkSavepointTest implements Serializable {
     }
     if (restored) {
       return key.apply(
+          "VerificationStage",
           ParDo.of(
               new DoFn<KV<String, Long>, String>() {
 
@@ -372,6 +373,7 @@ public class FlinkSavepointTest implements Serializable {
               }));
     } else {
       return key.apply(
+          "VerificationStage",
           ParDo.of(
               new DoFn<KV<String, Long>, String>() {
 
@@ -386,12 +388,14 @@ public class FlinkSavepointTest implements Serializable {
                     ProcessContext context,
                     @StateId("valueState") ValueState<Integer> intValueState,
                     @StateId("bagState") BagState<Integer> intBagState) {
-                  Long value = Objects.requireNonNull(context.element().getValue());
+                  long value = Objects.requireNonNull(context.element().getValue());
+                  LOG.debug("value: {} timestamp: {}", value, context.timestamp().getMillis());
                   if (value == 0L) {
                     intValueState.write(42);
                     intBagState.add(40);
                     intBagState.add(1);
                     intBagState.add(1);
+                  } else if (value >= 1) {
                     oneShotLatch.countDown();
                   }
                 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/ImpulseSourceFunctionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/ImpulseSourceFunctionTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -75,8 +76,9 @@ public class ImpulseSourceFunctionTest {
     source.run(sourceContext);
     // 2) Should use checkpoint lock
     verify(sourceContext).getCheckpointLock();
-    // 3) Should emit impulse element
+    // 3) Should emit impulse element and the final watermark
     verify(sourceContext).collect(argThat(elementMatcher));
+    verify(sourceContext).emitWatermark(Watermark.MAX_WATERMARK);
     verifyNoMoreInteractions(sourceContext);
     // 4) Should modify checkpoint state
     verify(mockListState).get();
@@ -93,11 +95,13 @@ public class ImpulseSourceFunctionTest {
 
     // 1) Should finish
     source.run(sourceContext);
-    // 2) Should _not_ emit impulse element
-    verifyNoMoreInteractions(sourceContext);
-    // 3) Should keep checkpoint state
+    // 2) Should keep checkpoint state
     verify(mockListState).get();
     verifyNoMoreInteractions(mockListState);
+    // 3) Should always emit the final watermark
+    verify(sourceContext).emitWatermark(Watermark.MAX_WATERMARK);
+    // 4) Should _not_ emit impulse element
+    verifyNoMoreInteractions(sourceContext);
   }
 
   @Test(timeout = 10_000)
@@ -128,6 +132,7 @@ public class ImpulseSourceFunctionTest {
       sourceThread.join();
     }
     verify(sourceContext).collect(argThat(elementMatcher));
+    verify(sourceContext).emitWatermark(Watermark.MAX_WATERMARK);
     verify(mockListState).add(true);
     verify(mockListState).get();
     verifyNoMoreInteractions(mockListState);
@@ -162,7 +167,9 @@ public class ImpulseSourceFunctionTest {
     sourceThread.interrupt();
     sourceThread.join();
 
-    // nothing should have been emitted because the impulse was emitted before restore
+    // Should always emit the final watermark
+    verify(sourceContext).emitWatermark(Watermark.MAX_WATERMARK);
+    // no element should have been emitted because the impulse was emitted before restore
     verifyNoMoreInteractions(sourceContext);
   }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -250,6 +250,7 @@ public class DoFnOperatorTest {
   public void testWatermarkContract() throws Exception {
 
     final Instant timerTimestamp = new Instant(1000);
+    final Instant timerOutputTimestamp = timerTimestamp.minus(1);
     final String eventTimeMessage = "Event timer fired: ";
     final String processingTimeMessage = "Processing timer fired";
 
@@ -279,7 +280,7 @@ public class DoFnOperatorTest {
               @TimerId(processingTimerId) Timer processingTimer) {
             eventTimer.set(timerTimestamp);
             eventTimerWithOutputTimestamp
-                .withOutputTimestamp(timerTimestamp.minus(1))
+                .withOutputTimestamp(timerOutputTimestamp)
                 .set(timerTimestamp);
             processingTimer.offset(Duration.millis(timerTimestamp.getMillis())).setRelative();
           }
@@ -365,7 +366,7 @@ public class DoFnOperatorTest {
     assertThat(stripStreamRecordFromWindowedValue(testHarness.getOutput()), emptyIterable());
     assertThat(
         doFnOperator.timerInternals.getMinOutputTimestampMs(),
-        is(timerTimestamp.minus(1).getMillis()));
+        is(timerOutputTimestamp.getMillis()));
 
     // this must fire the event timers
     testHarness.processWatermark(timerTimestamp.getMillis() + 1);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.flink.translation.wrappers.streaming;
 
 import static org.apache.beam.runners.core.construction.PTransformTranslation.PAR_DO_TRANSFORM_URN;
+import static org.apache.beam.runners.flink.translation.wrappers.streaming.StreamRecordStripper.stripStreamRecordFromWindowedValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -25,10 +26,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -47,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
@@ -88,6 +88,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
@@ -377,10 +378,7 @@ public class ExecutableStageDoFnOperatorTest {
 
     testHarness.close(); // triggers finish bundle
 
-    assertThat(
-        testHarness.getOutput(),
-        contains(
-            new StreamRecord<>(three), new Watermark(watermark), new Watermark(Long.MAX_VALUE)));
+    assertThat(stripStreamRecordFromWindowedValue(testHarness.getOutput()), contains(three));
 
     assertThat(
         testHarness.getSideOutput(tagsToOutputTags.get(additionalOutput1)),
@@ -389,6 +387,139 @@ public class ExecutableStageDoFnOperatorTest {
     assertThat(
         testHarness.getSideOutput(tagsToOutputTags.get(additionalOutput2)),
         contains(new StreamRecord<>(five)));
+  }
+
+  @Test
+  public void testWatermarkHandling() throws Exception {
+    TupleTag<Integer> mainOutput = new TupleTag<>("main-output");
+    DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
+        new DoFnOperator.MultiOutputOutputManagerFactory(mainOutput, VoidCoder.of());
+    ExecutableStageDoFnOperator<KV<String, Integer>, Integer> operator =
+        getOperator(
+            mainOutput,
+            Collections.emptyList(),
+            outputManagerFactory,
+            WindowingStrategy.of(FixedWindows.of(Duration.millis(10))),
+            StringUtf8Coder.of(),
+            WindowedValue.getFullCoder(
+                KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()), IntervalWindow.getCoder()));
+
+    KeyedOneInputStreamOperatorTestHarness<
+            String, WindowedValue<KV<String, Integer>>, WindowedValue<Integer>>
+        testHarness =
+            new KeyedOneInputStreamOperatorTestHarness<>(
+                operator,
+                val -> val.getValue().getKey(),
+                new CoderTypeInformation<>(StringUtf8Coder.of()));
+    RemoteBundle bundle = Mockito.mock(RemoteBundle.class);
+    when(bundle.getInputReceivers())
+        .thenReturn(
+            ImmutableMap.<String, FnDataReceiver<WindowedValue>>builder()
+                .put("input", Mockito.mock(FnDataReceiver.class))
+                .build());
+    when(bundle.getTimerReceivers())
+        .thenReturn(
+            ImmutableMap.<KV<String, String>, FnDataReceiver<WindowedValue>>builder()
+                .put(KV.of("transform", "timer"), Mockito.mock(FnDataReceiver.class))
+                .put(KV.of("transform", "timer2"), Mockito.mock(FnDataReceiver.class))
+                .put(KV.of("transform", "timer3"), Mockito.mock(FnDataReceiver.class))
+                .build());
+    when(stageBundleFactory.getBundle(any(), any(), any(), any())).thenReturn(bundle);
+
+    testHarness.open();
+    assertThat(
+        operator.getCurrentOutputWatermark(), is(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis()));
+
+    // No bundle has been started, watermark can be freely advanced
+    testHarness.processWatermark(0);
+    assertThat(operator.getCurrentOutputWatermark(), is(0L));
+
+    // Trigger a new bundle
+    IntervalWindow intervalWindow = new IntervalWindow(new Instant(0), new Instant(9));
+    WindowedValue<KV<String, Integer>> windowedValue =
+        WindowedValue.of(KV.of("one", 1), Instant.now(), intervalWindow, PaneInfo.NO_FIRING);
+    testHarness.processElement(new StreamRecord<>(windowedValue));
+
+    // The output watermark should be held back during the bundle
+    testHarness.processWatermark(1);
+    assertThat(operator.getEffectiveInputWatermark(), is(1L));
+    assertThat(operator.getCurrentOutputWatermark(), is(0L));
+
+    // After the bundle has been finished, the watermark should be advanced
+    operator.invokeFinishBundle();
+    assertThat(operator.getCurrentOutputWatermark(), is(1L));
+
+    // Bundle finished, watermark can be freely advanced
+    testHarness.processWatermark(2);
+    assertThat(operator.getEffectiveInputWatermark(), is(2L));
+    assertThat(operator.getCurrentOutputWatermark(), is(2L));
+
+    // Trigger a new bundle
+    testHarness.processElement(new StreamRecord<>(windowedValue));
+    assertThat(testHarness.numEventTimeTimers(), is(1)); // cleanup timer
+
+    // Set at timer
+    Instant timerTarget = new Instant(5);
+    Instant timerTarget2 = new Instant(6);
+    operator.getLockToAcquireForStateAccessDuringBundles().lock();
+
+    BiConsumer<String, Instant> timerConsumer =
+        (timerId, timestamp) ->
+            operator.setTimer(
+                Timer.of(
+                    windowedValue.getValue().getKey(),
+                    "",
+                    windowedValue.getWindows(),
+                    timestamp,
+                    timestamp,
+                    PaneInfo.NO_FIRING),
+                TimerInternals.TimerData.of(
+                    TimerReceiverFactory.encodeToTimerDataTimerId("transform", timerId),
+                    "",
+                    StateNamespaces.window(IntervalWindow.getCoder(), intervalWindow),
+                    timestamp,
+                    timestamp,
+                    TimeDomain.EVENT_TIME));
+
+    timerConsumer.accept("timer", timerTarget);
+    timerConsumer.accept("timer2", timerTarget2);
+    assertThat(testHarness.numEventTimeTimers(), is(3));
+
+    // Advance input watermark past the timer
+    // Check the output watermark is held back
+    long targetWatermark = timerTarget.getMillis() + 100;
+    testHarness.processWatermark(targetWatermark);
+    // Do not yet advance the output watermark because we are still processing a bundle
+    assertThat(testHarness.numEventTimeTimers(), is(3));
+    assertThat(operator.getCurrentOutputWatermark(), is(2L));
+
+    // Check that the timers are fired but the output watermark is advanced no further than
+    // the minimum timer timestamp of the previous bundle because we are still processing a
+    // bundle which might contain more timers.
+    // Timers can create loops if they keep rescheduling themselves when firing
+    // Thus, we advance the watermark asynchronously to allow for checkpointing to run
+    operator.invokeFinishBundle();
+    assertThat(testHarness.numEventTimeTimers(), is(3));
+    testHarness.setProcessingTime(testHarness.getProcessingTime() + 1);
+    assertThat(testHarness.numEventTimeTimers(), is(0));
+    assertThat(operator.getCurrentOutputWatermark(), is(5L));
+
+    // Output watermark is advanced synchronously when the bundle finishes,
+    // no more timers are scheduled
+    operator.invokeFinishBundle();
+    assertThat(operator.getCurrentOutputWatermark(), is(targetWatermark));
+    assertThat(testHarness.numEventTimeTimers(), is(0));
+
+    // Watermark is advanced in a blocking fashion on close, not via a timers
+    // Create a bundle with a pending timer to simulate that
+    testHarness.processElement(new StreamRecord<>(windowedValue));
+    timerConsumer.accept("timer3", new Instant(targetWatermark));
+    assertThat(testHarness.numEventTimeTimers(), is(1));
+
+    // This should be blocking until the watermark reaches Long.MAX_VALUE.
+    testHarness.close();
+    assertThat(testHarness.numEventTimeTimers(), is(0));
+    assertThat(operator.getCurrentOutputWatermark(), is(Long.MAX_VALUE));
   }
 
   @Test
@@ -492,7 +623,7 @@ public class ExecutableStageDoFnOperatorTest {
   }
 
   @Test
-  public void testEnsureStateCleanupWithKeyedInputStateCleaner() {
+  public void testEnsureStateCleanupWithKeyedInputStateCleaner() throws Exception {
     GlobalWindow.Coder windowCoder = GlobalWindow.Coder.INSTANCE;
     InMemoryStateInternals<String> stateInternals = InMemoryStateInternals.forKey("key");
     List<String> userStateNames = ImmutableList.of("state1", "state2");
@@ -514,13 +645,13 @@ public class ExecutableStageDoFnOperatorTest {
     // Test that state is cleaned up correctly
     ExecutableStageDoFnOperator.StateCleaner stateCleaner =
         new ExecutableStageDoFnOperator.StateCleaner(
-            userStateNames, windowCoder, () -> key.getValue());
+            userStateNames, windowCoder, key::getValue, ts -> false, null);
     for (BagState<String> bagState : bagStates) {
       assertThat(Iterables.size(bagState.read()), is(1));
     }
 
     stateCleaner.clearForWindow(GlobalWindow.INSTANCE);
-    stateCleaner.cleanupState(stateInternals, (k) -> key.setValue(k));
+    stateCleaner.cleanupState(stateInternals, key::setValue);
 
     for (BagState<String> bagState : bagStates) {
       assertThat(Iterables.size(bagState.read()), is(0));
@@ -530,6 +661,10 @@ public class ExecutableStageDoFnOperatorTest {
   @Test
   public void testEnsureDeferredStateCleanupTimerFiring() throws Exception {
     testEnsureDeferredStateCleanupTimerFiring(false);
+  }
+
+  @Test
+  public void testEnsureDeferredStateCleanupTimerFiringWithCheckpointing() throws Exception {
     testEnsureDeferredStateCleanupTimerFiring(true);
   }
 
@@ -561,7 +696,7 @@ public class ExecutableStageDoFnOperatorTest {
     AtomicBoolean timerInputReceived = new AtomicBoolean();
     IntervalWindow window = new IntervalWindow(new Instant(0), new Instant(1000));
     IntervalWindow.IntervalWindowCoder windowCoder = IntervalWindow.IntervalWindowCoder.of();
-    WindowedValue<KV<String, Integer>> one =
+    WindowedValue<KV<String, Integer>> windowedValue =
         WindowedValue.of(
             KV.of("one", 1), window.maxTimestamp(), ImmutableList.of(window), PaneInfo.NO_FIRING);
 
@@ -579,36 +714,37 @@ public class ExecutableStageDoFnOperatorTest {
     when(bundle.getTimerReceivers()).thenReturn(ImmutableMap.of(timerInputKey, timerReceiver));
 
     KeyedOneInputStreamOperatorTestHarness<
-            String, WindowedValue<KV<String, Integer>>, WindowedValue<KV<String, Integer>>>
+            ByteBuffer, WindowedValue<KV<String, Integer>>, WindowedValue<Integer>>
         testHarness =
             new KeyedOneInputStreamOperatorTestHarness(
-                operator, val -> val, new CoderTypeInformation<>(keyCoder));
+                operator,
+                operator.keySelector,
+                new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
 
     testHarness.open();
 
-    Lock stateBackendLock = (Lock) Whitebox.getInternalState(operator, "stateBackendLock");
+    Lock stateBackendLock = Whitebox.getInternalState(operator, "stateBackendLock");
     stateBackendLock.lock();
 
     KeyedStateBackend<ByteBuffer> keyedStateBackend = operator.getKeyedStateBackend();
-    ByteBuffer key = FlinkKeyUtils.encodeKey(one.getValue().getKey(), keyCoder);
+    ByteBuffer key = FlinkKeyUtils.encodeKey(windowedValue.getValue().getKey(), keyCoder);
     keyedStateBackend.setCurrentKey(key);
 
     DoFnOperator.FlinkTimerInternals timerInternals =
-        (DoFnOperator.FlinkTimerInternals) Whitebox.getInternalState(operator, "timerInternals");
+        Whitebox.getInternalState(operator, "timerInternals");
 
     Object doFnRunner = Whitebox.getInternalState(operator, "doFnRunner");
     Object delegate = Whitebox.getInternalState(doFnRunner, "delegate");
     Object stateCleaner = Whitebox.getInternalState(delegate, "stateCleaner");
-    Collection<?> cleanupTimers =
-        (Collection) Whitebox.getInternalState(stateCleaner, "cleanupQueue");
+    Collection<?> cleanupQueue = Whitebox.getInternalState(stateCleaner, "cleanupQueue");
 
     // create some state which can be cleaned up
     assertThat(testHarness.numKeyedStateEntries(), is(0));
     StateNamespace stateNamespace = StateNamespaces.window(windowCoder, window);
-    BagState<String> state =
+    BagState<ByteString> state = // State from the SDK Harness is stored as ByteStrings
         operator.keyedStateInternals.state(
-            stateNamespace, StateTags.bag(stateId, StringUtf8Coder.of()));
-    state.add("testUserState");
+            stateNamespace, StateTags.bag(stateId, ByteStringCoder.of()));
+    state.add(ByteString.copyFrom("userstate".getBytes(Charsets.UTF_8)));
     assertThat(testHarness.numKeyedStateEntries(), is(1));
 
     // user timer that fires after the end of the window and after state cleanup
@@ -617,51 +753,84 @@ public class ExecutableStageDoFnOperatorTest {
             TimerReceiverFactory.encodeToTimerDataTimerId(
                 timerInputKey.getKey(), timerInputKey.getValue()),
             stateNamespace,
-            window.maxTimestamp().plus(1),
+            window.maxTimestamp(),
             TimeDomain.EVENT_TIME);
     timerInternals.setTimer(userTimer);
 
     // start of bundle
-    testHarness.processElement(new StreamRecord<>(one));
-    verify(receiver).accept(one);
+    testHarness.processElement(new StreamRecord<>(windowedValue));
+    verify(receiver).accept(windowedValue);
 
-    // move watermark past cleanup and user timer while bundle in progress
-    operator.processWatermark(new Watermark(window.maxTimestamp().plus(2).getMillis()));
+    // move watermark past user timer while bundle is in progress
+    testHarness.processWatermark(new Watermark(window.maxTimestamp().plus(1).getMillis()));
 
-    // due to watermark hold the timers won't fire at this point
-    assertFalse("Watermark must be held back until bundle is complete.", timerInputReceived.get());
-    assertThat(cleanupTimers, hasSize(0));
+    // Output watermark is held back and timers do not yet fire (they can still be changed!)
+    assertThat(timerInputReceived.get(), is(false));
+    assertThat(
+        operator.getCurrentOutputWatermark(), is(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis()));
+    // The timer fires on bundle finish
+    operator.invokeFinishBundle();
+    assertThat(timerInputReceived.getAndSet(false), is(true));
+
+    // Move watermark past the cleanup timer
+    testHarness.processWatermark(new Watermark(window.maxTimestamp().plus(2).getMillis()));
+    operator.invokeFinishBundle();
+
+    // Cleanup timer has fired and cleanup queue is prepared for bundle finish
+    assertThat(testHarness.numEventTimeTimers(), is(0));
+    assertThat(testHarness.numKeyedStateEntries(), is(1));
+    assertThat(cleanupQueue, hasSize(1));
+
+    // Cleanup timer are rescheduled if a new timer is created during the bundle
+    TimerInternals.TimerData userTimer2 =
+        TimerInternals.TimerData.of(
+            TimerReceiverFactory.encodeToTimerDataTimerId(
+                timerInputKey.getKey(), timerInputKey.getValue()),
+            stateNamespace,
+            window.maxTimestamp(),
+            TimeDomain.EVENT_TIME);
+    operator.setTimer(
+        Timer.of(
+            windowedValue.getValue().getKey(),
+            "",
+            windowedValue.getWindows(),
+            window.maxTimestamp(),
+            window.maxTimestamp(),
+            PaneInfo.NO_FIRING),
+        userTimer2);
+    assertThat(testHarness.numEventTimeTimers(), is(1));
 
     if (withCheckpointing) {
-      // Upon checkpointing, the bundle is finished and the watermark advances;
-      // timers can fire. Note: The bundle is ensured to be finished.
+      // Upon checkpointing, the bundle will be finished.
       testHarness.snapshot(0, 0);
-
-      // The user timer was scheduled to fire after cleanup, but executes first
-      assertTrue("Timer should have been triggered.", timerInputReceived.get());
-      // Cleanup will be executed after the bundle is complete
-      assertThat(cleanupTimers, hasSize(0));
-      verifyNoMoreInteractions(receiver);
     } else {
-      // Upon finishing a bundle, the watermark advances; timers can fire.
-      // Note that this will finish the current bundle, but will also start a new one
-      // when timers fire as part of advancing the watermark
       operator.invokeFinishBundle();
-
-      // The user timer was scheduled to fire after cleanup, but executes first
-      assertTrue("Timer should have been triggered.", timerInputReceived.get());
-      // Cleanup will be executed after the bundle is complete
-      assertThat(cleanupTimers, hasSize(1));
-      verifyNoMoreInteractions(receiver);
-
-      // Finish bundle which has been started by finishing the bundle
-      operator.invokeFinishBundle();
-      assertThat(cleanupTimers, hasSize(0));
     }
 
+    // Cleanup queue has been processed and cleanup timer has been re-added due to pending timers
+    // for the window.
+    assertThat(cleanupQueue, hasSize(0));
+    verifyNoMoreInteractions(receiver);
+    assertThat(testHarness.numKeyedStateEntries(), is(2));
+    assertThat(testHarness.numEventTimeTimers(), is(2));
+
+    // No timer has been fired but bundle should be ended
+    assertThat(timerInputReceived.get(), is(false));
+    assertThat(Whitebox.getInternalState(operator, "bundleStarted"), is(false));
+
+    // Allow user timer and cleanup timer to fire by triggering watermark advancement
+    testHarness.setProcessingTime(testHarness.getProcessingTime() + 1);
+    assertThat(timerInputReceived.getAndSet(false), is(true));
+    assertThat(cleanupQueue, hasSize(1));
+
+    // Cleanup will be executed after the bundle is complete because there are no more pending
+    // timers for the window
+    operator.invokeFinishBundle();
+    assertThat(cleanupQueue, hasSize(0));
     assertThat(testHarness.numKeyedStateEntries(), is(0));
 
     testHarness.close();
+    verifyNoMoreInteractions(receiver);
   }
 
   @Test
@@ -851,7 +1020,8 @@ public class ExecutableStageDoFnOperatorTest {
    * #runtimeContext}. The context factory is mocked to return {@link #stageContext} every time. The
    * behavior of the stage context itself is unchanged.
    */
-  private ExecutableStageDoFnOperator<Integer, Integer> getOperator(
+  @SuppressWarnings("rawtypes")
+  private ExecutableStageDoFnOperator getOperator(
       TupleTag<Integer> mainOutput,
       List<TupleTag<?>> additionalOutputs,
       DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory) {
@@ -864,7 +1034,8 @@ public class ExecutableStageDoFnOperatorTest {
         WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE));
   }
 
-  private ExecutableStageDoFnOperator<Integer, Integer> getOperator(
+  @SuppressWarnings("rawtypes")
+  private ExecutableStageDoFnOperator getOperator(
       TupleTag<Integer> mainOutput,
       List<TupleTag<?>> additionalOutputs,
       DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory,

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
@@ -152,7 +152,7 @@ public class WindowDoFnOperatorTest {
     assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(1));
 
     assertThat(testHarness.numKeyedStateEntries(), is(6));
-    assertThat(windowDoFnOperator.currentOutputWatermark, is(1L));
+    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(1L));
     assertThat(timerInternals.getMinOutputTimestampMs(), is(Long.MAX_VALUE));
 
     // close window
@@ -162,7 +162,7 @@ public class WindowDoFnOperatorTest {
     assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(0));
 
     assertThat(testHarness.numKeyedStateEntries(), is(3));
-    assertThat(windowDoFnOperator.currentOutputWatermark, is(100L));
+    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(100L));
     assertThat(timerInternals.getMinOutputTimestampMs(), is(Long.MAX_VALUE));
 
     testHarness.processWatermark(200L);


### PR DESCRIPTION
Backport of #11362 / 643945a8e4

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
