### PR TITLE
BEAM-9826 - Update Tika to 1.24.1

### DIFF
--- a/sdks/java/io/tika/build.gradle
+++ b/sdks/java/io/tika/build.gradle
@@ -22,7 +22,7 @@ applyJavaNature(automaticModuleName: 'org.apache.beam.sdk.io.tika')
 description = "Apache Beam :: SDKs :: Java :: IO :: Tika"
 ext.summary = "Tika Input to parse files."
 
-def tika_version = "1.24"
+def tika_version = "1.24.1"
 def bndlib_version = "1.43.0"
 
 dependencies {


### PR DESCRIPTION
This task is to update Tika to 1.24.1 due to:

[CVE-2020-9489] Denial of Service (DOS) Vulnerabilities in Some of Apache Tika's Parsers

https://www.openwall.com/lists/oss-security/2020/04/24/1