### PR TITLE
[BEAM-10047] Merge the stages 'Gather and Sort' and 'Create Batches'

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -18,8 +18,6 @@
 package org.apache.beam.sdk.io.gcp.spanner;
 
 import static org.apache.beam.sdk.io.gcp.spanner.MutationUtils.isPointDelete;
-import static org.apache.beam.sdk.io.gcp.spanner.SpannerIO.WriteGrouped.decode;
-import static org.apache.beam.sdk.io.gcp.spanner.SpannerIO.WriteGrouped.encode;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,13 +39,13 @@ import com.google.cloud.spanner.TimestampBound;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -73,7 +71,6 @@ import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.BackOff;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.Sleeper;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
@@ -983,20 +980,6 @@ public class SpannerIO {
     }
   }
 
-  /**
-   * A singleton to compare encoded MutationGroups by encoded Key that wraps {@code
-   * UnsignedBytes#lexicographicalComparator} which unfortunately is not serializable.
-   */
-  private enum EncodedKvMutationGroupComparator
-      implements Comparator<KV<byte[], byte[]>>, Serializable {
-    INSTANCE {
-      @Override
-      public int compare(KV<byte[], byte[]> a, KV<byte[], byte[]> b) {
-        return UnsignedBytes.lexicographicalComparator().compare(a.getKey(), b.getKey());
-      }
-    }
-  }
-
   /** Same as {@link Write} but supports grouped mutations. */
   public static class WriteGrouped
       extends PTransform<PCollection<MutationGroup>, SpannerWriteResult> {
@@ -1078,9 +1061,9 @@ public class SpannerIO {
             filteredMutations
                 .get(BATCHABLE_MUTATIONS_TAG)
                 .apply(
-                    "Gather And Sort",
+                    "Gather Sort And Create Batches",
                     ParDo.of(
-                            new GatherBundleAndSortFn(
+                            new GatherSortCreateBatchesFn(
                                 spec.getBatchSizeBytes(),
                                 spec.getMaxNumMutations(),
                                 spec.getMaxNumRows(),
@@ -1090,15 +1073,6 @@ public class SpannerIO {
                                         input.isBounded() == IsBounded.BOUNDED
                                             ? DEFAULT_GROUPING_FACTOR
                                             : 1),
-                                schemaView))
-                        .withSideInputs(schemaView))
-                .apply(
-                    "Create Batches",
-                    ParDo.of(
-                            new BatchFn(
-                                spec.getBatchSizeBytes(),
-                                spec.getMaxNumMutations(),
-                                spec.getMaxNumRows(),
                                 schemaView))
                         .withSideInputs(schemaView));
 
@@ -1163,70 +1137,127 @@ public class SpannerIO {
    * occur, Therefore this DoFn has to be tested in isolation.
    */
   @VisibleForTesting
-  static class GatherBundleAndSortFn extends DoFn<MutationGroup, Iterable<KV<byte[], byte[]>>> {
+  static class GatherSortCreateBatchesFn extends DoFn<MutationGroup, Iterable<MutationGroup>> {
+
     private final long maxBatchSizeBytes;
-    private final long maxNumMutations;
-    private final long maxNumRows;
-
-    // total size of the current batch.
-    private long batchSizeBytes;
-    // total number of mutated cells.
-    private long batchCells;
-    // total number of rows mutated.
-    private long batchRows;
-
+    private final long maxBatchNumMutations;
+    private final long maxBatchNumRows;
+    private final long maxSortableSizeBytes;
+    private final long maxSortableNumMutations;
+    private final long maxSortableNumRows;
     private final PCollectionView<SpannerSchema> schemaView;
+    private final ArrayList<MutationGroupContainer> mutationsToSort = new ArrayList<>();
 
-    private transient ArrayList<KV<byte[], byte[]>> mutationsToSort = null;
+    // total size of MutationGroups in mutationsToSort.
+    private long sortableSizeBytes;
+    // total number of mutated cells in mutationsToSort
+    private long sortableNumCells;
+    // total number of rows mutated in mutationsToSort
+    private long sortableNumRows;
 
-    GatherBundleAndSortFn(
+    GatherSortCreateBatchesFn(
         long maxBatchSizeBytes,
         long maxNumMutations,
         long maxNumRows,
         long groupingFactor,
         PCollectionView<SpannerSchema> schemaView) {
-      this.maxBatchSizeBytes = maxBatchSizeBytes * groupingFactor;
-      this.maxNumMutations = maxNumMutations * groupingFactor;
-      this.maxNumRows = maxNumRows * groupingFactor;
+      this.maxBatchSizeBytes = maxBatchSizeBytes;
+      this.maxBatchNumMutations = maxNumMutations;
+      this.maxBatchNumRows = maxNumRows;
+
+      if (groupingFactor <= 0) {
+        groupingFactor = 1;
+      }
+
+      this.maxSortableSizeBytes = maxBatchSizeBytes * groupingFactor;
+      this.maxSortableNumMutations = maxNumMutations * groupingFactor;
+      this.maxSortableNumRows = maxNumRows * groupingFactor;
       this.schemaView = schemaView;
     }
 
     @StartBundle
     public synchronized void startBundle() throws Exception {
-      if (mutationsToSort == null) {
-        initSorter();
-      } else {
-        throw new IllegalStateException("Sorter should be null here");
-      }
+      initSorter();
     }
 
-    private void initSorter() {
-      mutationsToSort = new ArrayList<KV<byte[], byte[]>>((int) maxNumMutations);
-      batchSizeBytes = 0;
-      batchCells = 0;
-      batchRows = 0;
+    private synchronized void initSorter() {
+      mutationsToSort.clear();
+      sortableSizeBytes = 0;
+      sortableNumCells = 0;
+      sortableNumRows = 0;
     }
 
     @FinishBundle
     public synchronized void finishBundle(FinishBundleContext c) throws Exception {
-      // Only output when there is something in the batch.
-      if (mutationsToSort.isEmpty()) {
-        mutationsToSort = null;
-      } else {
-        c.output(sortAndGetList(), Instant.now(), GlobalWindow.INSTANCE);
-      }
+      sortAndOutputBatches(new OutputReceiverForFinishBundle(c));
     }
 
-    private Iterable<KV<byte[], byte[]>> sortAndGetList() throws IOException {
-      mutationsToSort.sort(EncodedKvMutationGroupComparator.INSTANCE);
-      ArrayList<KV<byte[], byte[]>> tmp = mutationsToSort;
-      // Ensure no more mutations can be added.
-      mutationsToSort = null;
-      return tmp;
+    private synchronized void sortAndOutputBatches(OutputReceiver<Iterable<MutationGroup>> out)
+        throws IOException {
+      if (mutationsToSort.isEmpty()) {
+        // nothing to output.
+        initSorter();
+        return;
+      }
+
+      if (maxSortableNumMutations == maxBatchNumMutations) {
+        // no grouping is occurring, no need to sort and make batches, just output what we have.
+        outputBatch(out, 0, mutationsToSort.size());
+        initSorter();
+        return;
+      }
+
+      // Sort then split the sorted mutations into batches.
+      mutationsToSort.sort(Comparator.naturalOrder());
+      int batchStart = 0;
+      int batchEnd = 0;
+
+      // total size of the current batch.
+      long batchSizeBytes = 0;
+      // total number of mutated cells.
+      long batchCells = 0;
+      // total number of rows mutated.
+      long batchRows = 0;
+
+      // collect and output batches.
+      while (batchEnd < mutationsToSort.size()) {
+        MutationGroupContainer mg = mutationsToSort.get(batchEnd);
+
+        if (((batchCells + mg.numCells) > maxBatchNumMutations)
+            || ((batchSizeBytes + mg.sizeBytes) > maxBatchSizeBytes
+                || (batchRows + mg.numRows > maxBatchNumRows))) {
+          // Cannot add new element, current batch is full; output.
+          outputBatch(out, batchStart, batchEnd);
+          batchStart = batchEnd;
+          batchSizeBytes = 0;
+          batchCells = 0;
+          batchRows = 0;
+        }
+
+        batchEnd++;
+        batchSizeBytes += mg.sizeBytes;
+        batchCells += mg.numCells;
+        batchRows += mg.numRows;
+      }
+
+      if (batchStart < batchEnd) {
+        // output remaining elements
+        outputBatch(out, batchStart, mutationsToSort.size());
+      }
+      initSorter();
+    }
+
+    private void outputBatch(
+        OutputReceiver<Iterable<MutationGroup>> out, int batchStart, int batchEnd) {
+      out.output(
+          mutationsToSort.subList(batchStart, batchEnd).stream()
+              .map(o -> o.mutationGroup)
+              .collect(Collectors.toList()));
     }
 
     @ProcessElement
-    public void processElement(ProcessContext c) throws Exception {
+    public synchronized void processElement(
+        ProcessContext c, OutputReceiver<Iterable<MutationGroup>> out) throws Exception {
       SpannerSchema spannerSchema = c.sideInput(schemaView);
       MutationKeyEncoder encoder = new MutationKeyEncoder(spannerSchema);
       MutationGroup mg = c.element();
@@ -1235,79 +1266,69 @@ public class SpannerIO {
       long groupRows = mg.size();
 
       synchronized (this) {
-        if (((batchCells + groupCells) > maxNumMutations)
-            || (batchSizeBytes + groupSize) > maxBatchSizeBytes
-            || (batchRows + groupRows) > maxNumRows) {
-          c.output(sortAndGetList());
-          initSorter();
+        if (((sortableNumCells + groupCells) > maxSortableNumMutations)
+            || (sortableSizeBytes + groupSize) > maxSortableSizeBytes
+            || (sortableNumRows + groupRows) > maxSortableNumRows) {
+          sortAndOutputBatches(out);
         }
 
-        mutationsToSort.add(KV.of(encoder.encodeTableNameAndKey(mg.primary()), encode(mg)));
-        batchSizeBytes += groupSize;
-        batchCells += groupCells;
-        batchRows += groupRows;
+        mutationsToSort.add(
+            new MutationGroupContainer(
+                mg, groupSize, groupCells, groupRows, encoder.encodeTableNameAndKey(mg.primary())));
+        sortableSizeBytes += groupSize;
+        sortableNumCells += groupCells;
+        sortableNumRows += groupRows;
       }
     }
-  }
 
-  /** Batches mutations together. */
-  @VisibleForTesting
-  static class BatchFn extends DoFn<Iterable<KV<byte[], byte[]>>, Iterable<MutationGroup>> {
+    // Container class to store a MutationGroup, its sortable encoded key and its statistics.
+    private static final class MutationGroupContainer
+        implements Comparable<MutationGroupContainer> {
 
-    private final long maxBatchSizeBytes;
-    private final long maxNumMutations;
-    private final long maxNumRows;
-    private final PCollectionView<SpannerSchema> schemaView;
+      final MutationGroup mutationGroup;
+      final long sizeBytes;
+      final long numCells;
+      final long numRows;
+      final byte[] encodedKey;
 
-    BatchFn(
-        long maxBatchSizeBytes,
-        long maxNumMutations,
-        long maxNumRows,
-        PCollectionView<SpannerSchema> schemaView) {
-      this.maxBatchSizeBytes = maxBatchSizeBytes;
-      this.maxNumMutations = maxNumMutations;
-      this.maxNumRows = maxNumRows;
-      this.schemaView = schemaView;
+      MutationGroupContainer(
+          MutationGroup mutationGroup,
+          long sizeBytes,
+          long numCells,
+          long numRows,
+          byte[] encodedKey) {
+        this.mutationGroup = mutationGroup;
+        this.sizeBytes = sizeBytes;
+        this.numCells = numCells;
+        this.numRows = numRows;
+        this.encodedKey = encodedKey;
+      }
+
+      @Override
+      public int compareTo(MutationGroupContainer o) {
+        return UnsignedBytes.lexicographicalComparator().compare(this.encodedKey, o.encodedKey);
+      }
     }
 
-    @ProcessElement
-    public void processElement(ProcessContext c) throws Exception {
-      SpannerSchema spannerSchema = c.sideInput(schemaView);
-      // Current batch of mutations to be written.
-      ImmutableList.Builder<MutationGroup> batch = ImmutableList.builder();
-      // total size of the current batch.
-      long batchSizeBytes = 0;
-      // total number of mutated cells.
-      long batchCells = 0;
-      // total number of rows mutated.
-      long batchRows = 0;
+    // TODO(BEAM-1287): Remove this when FinishBundle has added support for an {@link
+    // OutputReceiver}
+    private static class OutputReceiverForFinishBundle
+        implements OutputReceiver<Iterable<MutationGroup>> {
 
-      // Iterate through list, outputting whenever a batch is complete.
-      for (KV<byte[], byte[]> kv : c.element()) {
-        MutationGroup mg = decode(kv.getValue());
+      private final FinishBundleContext c;
 
-        long groupSize = MutationSizeEstimator.sizeOf(mg);
-        long groupCells = MutationCellCounter.countOf(spannerSchema, mg);
-        long groupRows = mg.size();
-
-        if (((batchCells + groupCells) > maxNumMutations)
-            || ((batchSizeBytes + groupSize) > maxBatchSizeBytes
-                || (batchRows + groupRows > maxNumRows))) {
-          // Batch is full: output and reset.
-          c.output(batch.build());
-          batch = ImmutableList.builder();
-          batchSizeBytes = 0;
-          batchCells = 0;
-          batchRows = 0;
-        }
-        batch.add(mg);
-        batchSizeBytes += groupSize;
-        batchCells += groupCells;
-        batchRows += groupRows;
+      OutputReceiverForFinishBundle(FinishBundleContext c) {
+        this.c = c;
       }
-      // End of list, output what is left.
-      if (batchCells > 0) {
-        c.output(batch.build());
+
+      @Override
+      public void output(Iterable<MutationGroup> output) {
+        outputWithTimestamp(output, Instant.now());
+      }
+
+      @Override
+      public void outputWithTimestamp(Iterable<MutationGroup> output, Instant timestamp) {
+        c.output(output, timestamp, GlobalWindow.INSTANCE);
       }
     }
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOWriteTest.java
@@ -49,24 +49,21 @@ import com.google.cloud.spanner.Type;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.coders.SerializableCoder;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.BatchFn;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.BatchableMutationFilterFn;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.FailureMode;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.GatherBundleAndSortFn;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.WriteGrouped;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.GatherSortCreateBatchesFn;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.WriteToSpannerFn;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn.FinishBundleContext;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.Sleeper;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
@@ -100,7 +97,6 @@ public class SpannerIOWriteTest implements Serializable {
   @Captor public transient ArgumentCaptor<Iterable<Mutation>> mutationBatchesCaptor;
   @Captor public transient ArgumentCaptor<Iterable<MutationGroup>> mutationGroupListCaptor;
   @Captor public transient ArgumentCaptor<MutationGroup> mutationGroupCaptor;
-  @Captor public transient ArgumentCaptor<List<KV<byte[], byte[]>>> byteArrayKvListCaptor;
 
   private FakeServiceFactory serviceFactory;
 
@@ -912,147 +908,152 @@ public class SpannerIOWriteTest implements Serializable {
   }
 
   @Test
-  public void testGatherBundleAndSortFn() throws Exception {
-    GatherBundleAndSortFn testFn = new GatherBundleAndSortFn(10000000, 10, 1000, 100, null);
+  public void testGatherSortAndBatchFn() throws Exception {
+
+    GatherSortCreateBatchesFn testFn =
+        new GatherSortCreateBatchesFn(
+            10000000, // batch bytes
+            100, // batch up to 35 mutated cells.
+            5, // batch rows
+            100, // groupingFactor
+            null);
 
     ProcessContext mockProcessContext = Mockito.mock(ProcessContext.class);
     FinishBundleContext mockFinishBundleContext = Mockito.mock(FinishBundleContext.class);
     when(mockProcessContext.sideInput(any())).thenReturn(getSchema());
 
     // Capture the outputs.
-    doNothing().when(mockProcessContext).output(byteArrayKvListCaptor.capture());
-    // Capture the outputs.
-    doNothing().when(mockFinishBundleContext).output(byteArrayKvListCaptor.capture(), any(), any());
+    doNothing()
+        .when(mockFinishBundleContext)
+        .output(mutationGroupListCaptor.capture(), any(), any());
 
     MutationGroup[] mutationGroups =
         new MutationGroup[] {
-          g(m(4L)), g(m(1L)), g(m(5L), m(6L), m(7L), m(8L), m(9L)), g(del(2L)), g(m(3L))
+          // Unsorted group of 12 mutations.
+          // each mutation is considered 7 cells,
+          // should be sorted and output as 2 lists of 5, then 1 list of 2
+          // with mutations sorted in order.
+          g(m(4L)),
+          g(m(1L)),
+          g(m(7L)),
+          g(m(12L)),
+          g(m(10L)),
+          g(m(11L)),
+          g(m(2L)),
+          g(del(8L)),
+          g(m(3L)),
+          g(m(6L)),
+          g(m(9L)),
+          g(m(5L))
         };
 
     // Process all elements as one bundle.
     testFn.startBundle();
     for (MutationGroup m : mutationGroups) {
       when(mockProcessContext.element()).thenReturn(m);
-      testFn.processElement(mockProcessContext);
+      // outputReceiver should not be called until end of bundle.
+      testFn.processElement(mockProcessContext, null);
     }
     testFn.finishBundle(mockFinishBundleContext);
 
     verify(mockProcessContext, never()).output(any());
-    verify(mockFinishBundleContext, times(1)).output(any(), any(), any());
+    verify(mockFinishBundleContext, times(3)).output(any(), any(), any());
 
-    // Verify sorted output... first decode it...
-    List<MutationGroup> sorted =
-        byteArrayKvListCaptor.getValue().stream()
-            .map(kv -> WriteGrouped.decode(kv.getValue()))
-            .collect(Collectors.toList());
+    // Verify output are 3 batches of sorted values
     assertThat(
-        sorted,
-        contains(g(m(1L)), g(del(2L)), g(m(3L)), g(m(4L)), g(m(5L), m(6L), m(7L), m(8L), m(9L))));
+        mutationGroupListCaptor.getAllValues(),
+        contains(
+            Arrays.asList(g(m(1L)), g(m(2L)), g(m(3L)), g(m(4L)), g(m(5L))),
+            Arrays.asList(g(m(6L)), g(m(7L)), g(del(8L)), g(m(9L)), g(m(10L))),
+            Arrays.asList(g(m(11L)), g(m(12L)))));
   }
 
   @Test
   public void testGatherBundleAndSortFn_flushOversizedBundle() throws Exception {
 
-    // Setup class to bundle every 3 mutations
-    GatherBundleAndSortFn testFn =
-        new GatherBundleAndSortFn(10000000, CELLS_PER_KEY, 1000, 3, null);
+    // Setup class to bundle every 6 rows and create batches of 2.
+    GatherSortCreateBatchesFn testFn =
+        new GatherSortCreateBatchesFn(
+            10000000, // batch bytes
+            100, // batch up to 14 mutated cells.
+            2, // batch rows
+            3, // groupingFactor
+            null);
 
     ProcessContext mockProcessContext = Mockito.mock(ProcessContext.class);
     FinishBundleContext mockFinishBundleContext = Mockito.mock(FinishBundleContext.class);
     when(mockProcessContext.sideInput(any())).thenReturn(getSchema());
+    OutputReceiver<Iterable<MutationGroup>> mockOutputReceiver = mock(OutputReceiver.class);
 
     // Capture the outputs.
-    doNothing().when(mockProcessContext).output(byteArrayKvListCaptor.capture());
+    doNothing().when(mockOutputReceiver).output(mutationGroupListCaptor.capture());
     // Capture the outputs.
-    doNothing().when(mockFinishBundleContext).output(byteArrayKvListCaptor.capture(), any(), any());
+    doNothing()
+        .when(mockFinishBundleContext)
+        .output(mutationGroupListCaptor.capture(), any(), any());
 
     MutationGroup[] mutationGroups =
         new MutationGroup[] {
+          // Unsorted group of 12 mutations.
+          // each mutation is considered 7 cells,
+          // should be sorted and output as 2 lists of 5, then 1 list of 2
+          // with mutations sorted in order.
           g(m(4L)),
           g(m(1L)),
-          // end group
-          g(m(5L), m(6L), m(7L), m(8L), m(9L)),
-          // end group
+          g(m(7L)),
+          g(m(9L)),
           g(m(10L)),
-          g(m(3L)),
           g(m(11L)),
-          // end group.
-          g(m(2L))
+          // end group
+          g(m(2L)),
+          g(del(8L)), // end batch
+          g(m(3L)),
+          g(m(6L)), // end batch
+          g(m(5L))
+          // end bundle, so end group and end batch.
         };
 
     // Process all elements as one bundle.
     testFn.startBundle();
     for (MutationGroup m : mutationGroups) {
       when(mockProcessContext.element()).thenReturn(m);
-      testFn.processElement(mockProcessContext);
+      testFn.processElement(mockProcessContext, mockOutputReceiver);
     }
     testFn.finishBundle(mockFinishBundleContext);
 
-    verify(mockProcessContext, times(3)).output(any());
-    verify(mockFinishBundleContext, times(1)).output(any(), any(), any());
+    // processElement ouput receiver should have been called 3 times when the 1st group was full.
+    verify(mockOutputReceiver, times(3)).output(any());
+    // finsihBundleContext output should be called 3 times when the bundle was finished.
+    verify(mockFinishBundleContext, times(3)).output(any(), any(), any());
 
-    // verify sorted output... needs decoding...
-    List<List<KV<byte[], byte[]>>> kvGroups = byteArrayKvListCaptor.getAllValues();
-    assertEquals(4, kvGroups.size());
+    List<Iterable<MutationGroup>> mgListGroups = mutationGroupListCaptor.getAllValues();
 
-    // decode list of lists of KV to a list of lists of MutationGroup.
-    List<List<MutationGroup>> mgListGroups =
-        kvGroups.stream()
-            .map(
-                l ->
-                    l.stream()
-                        .map(kv -> WriteGrouped.decode(kv.getValue()))
-                        .collect(Collectors.toList()))
-            .collect(Collectors.toList());
-
-    // verify contents of 4 sorted groups.
+    assertEquals(6, mgListGroups.size());
+    // verify contents of 6 sorted groups.
+    // first group should be 1,3,4,7,9,11
     assertThat(mgListGroups.get(0), contains(g(m(1L)), g(m(4L))));
-    assertThat(mgListGroups.get(1), contains(g(m(5L), m(6L), m(7L), m(8L), m(9L))));
-    assertThat(mgListGroups.get(2), contains(g(m(3L)), g(m(10L)), g(m(11L))));
-    assertThat(mgListGroups.get(3), contains(g(m(2L))));
+    assertThat(mgListGroups.get(1), contains(g(m(7L)), g(m(9L))));
+    assertThat(mgListGroups.get(2), contains(g(m(10L)), g(m(11L))));
+
+    // second group at finishBundle should be 2,3,5,6,8
+    assertThat(mgListGroups.get(3), contains(g(m(2L)), g(m(3L))));
+    assertThat(mgListGroups.get(4), contains(g(m(5L)), g(m(6L))));
+    assertThat(mgListGroups.get(5), contains(g(del(8L))));
   }
 
   @Test
   public void testBatchFn_cells() throws Exception {
 
-    // Setup class to bundle every 3 mutations (3xCELLS_PER_KEY cell mutations)
-    BatchFn testFn = new BatchFn(10000000, 3 * CELLS_PER_KEY, 1000, null);
+    // Setup class to batch every 3 mutations (3xCELLS_PER_KEY cell mutations)
+    GatherSortCreateBatchesFn testFn =
+        new GatherSortCreateBatchesFn(
+            10000000, // batch bytes
+            3 * CELLS_PER_KEY, // batch up to 21 mutated cells - 3 mutations.
+            100, // batch rows
+            100, // groupingFactor
+            null);
 
-    ProcessContext mockProcessContext = Mockito.mock(ProcessContext.class);
-    when(mockProcessContext.sideInput(any())).thenReturn(getSchema());
-
-    // Capture the outputs.
-    doNothing().when(mockProcessContext).output(mutationGroupListCaptor.capture());
-
-    List<MutationGroup> mutationGroups =
-        Arrays.asList(
-            g(m(1L)),
-            g(m(4L)),
-            g(m(5L), m(6L), m(7L), m(8L), m(9L)),
-            g(m(3L)),
-            g(m(10L)),
-            g(m(11L)),
-            g(m(2L)));
-
-    List<KV<byte[], byte[]>> encodedInput =
-        mutationGroups.stream()
-            .map(mg -> KV.of((byte[]) null, WriteGrouped.encode(mg)))
-            .collect(Collectors.toList());
-
-    // Process elements.
-    when(mockProcessContext.element()).thenReturn(encodedInput);
-    testFn.processElement(mockProcessContext);
-
-    verify(mockProcessContext, times(4)).output(any());
-
-    List<Iterable<MutationGroup>> batches = mutationGroupListCaptor.getAllValues();
-    assertEquals(4, batches.size());
-
-    // verify contents of 4 batches.
-    assertThat(batches.get(0), contains(g(m(1L)), g(m(4L))));
-    assertThat(batches.get(1), contains(g(m(5L), m(6L), m(7L), m(8L), m(9L))));
-    assertThat(batches.get(2), contains(g(m(3L)), g(m(10L)), g(m(11L))));
-    assertThat(batches.get(3), contains(g(m(2L))));
+    testAndVerifyBatches(testFn);
   }
 
   @Test
@@ -1061,56 +1062,41 @@ public class SpannerIOWriteTest implements Serializable {
     long mutationSize = MutationSizeEstimator.sizeOf(m(1L));
 
     // Setup class to bundle every 3 mutations by size)
-    BatchFn testFn = new BatchFn(mutationSize * 3, 1000, 1000, null);
+    GatherSortCreateBatchesFn testFn =
+        new GatherSortCreateBatchesFn(
+            mutationSize * 3, // batch bytes = 3 mutations.
+            100, // batch cells
+            100, // batch rows
+            100, // groupingFactor
+            null);
 
-    ProcessContext mockProcessContext = Mockito.mock(ProcessContext.class);
-    when(mockProcessContext.sideInput(any())).thenReturn(getSchema());
-
-    // Capture the outputs.
-    doNothing().when(mockProcessContext).output(mutationGroupListCaptor.capture());
-
-    List<MutationGroup> mutationGroups =
-        Arrays.asList(
-            g(m(1L)),
-            g(m(4L)),
-            g(m(5L), m(6L), m(7L), m(8L), m(9L)),
-            g(m(3L)),
-            g(m(10L)),
-            g(m(11L)),
-            g(m(2L)));
-
-    List<KV<byte[], byte[]>> encodedInput =
-        mutationGroups.stream()
-            .map(mg -> KV.of((byte[]) null, WriteGrouped.encode(mg)))
-            .collect(Collectors.toList());
-
-    // Process elements.
-    when(mockProcessContext.element()).thenReturn(encodedInput);
-    testFn.processElement(mockProcessContext);
-
-    verify(mockProcessContext, times(4)).output(any());
-
-    List<Iterable<MutationGroup>> batches = mutationGroupListCaptor.getAllValues();
-    assertEquals(4, batches.size());
-
-    // verify contents of 4 batches.
-    assertThat(batches.get(0), contains(g(m(1L)), g(m(4L))));
-    assertThat(batches.get(1), contains(g(m(5L), m(6L), m(7L), m(8L), m(9L))));
-    assertThat(batches.get(2), contains(g(m(3L)), g(m(10L)), g(m(11L))));
-    assertThat(batches.get(3), contains(g(m(2L))));
+    testAndVerifyBatches(testFn);
   }
 
   @Test
   public void testBatchFn_rows() throws Exception {
 
-    // Setup class to bundle every 3 mutations (3xCELLS_PER_KEY cell mutations)
-    BatchFn testFn = new BatchFn(10000000, 1000, 3, null);
+    // Setup class to bundle every 3 rows
+    GatherSortCreateBatchesFn testFn =
+        new GatherSortCreateBatchesFn(
+            10000, // batch bytes = 3 mutations.
+            100, // batch cells
+            3, // batch rows
+            100, // groupingFactor
+            null);
 
+    testAndVerifyBatches(testFn);
+  }
+
+  private void testAndVerifyBatches(GatherSortCreateBatchesFn testFn) throws Exception {
     ProcessContext mockProcessContext = Mockito.mock(ProcessContext.class);
+    FinishBundleContext mockFinishBundleContext = Mockito.mock(FinishBundleContext.class);
     when(mockProcessContext.sideInput(any())).thenReturn(getSchema());
 
-    // Capture the outputs.
-    doNothing().when(mockProcessContext).output(mutationGroupListCaptor.capture());
+    // Capture the output at finish bundle..
+    doNothing()
+        .when(mockFinishBundleContext)
+        .output(mutationGroupListCaptor.capture(), any(), any());
 
     List<MutationGroup> mutationGroups =
         Arrays.asList(
@@ -1122,25 +1108,23 @@ public class SpannerIOWriteTest implements Serializable {
             g(m(11L)),
             g(m(2L)));
 
-    List<KV<byte[], byte[]>> encodedInput =
-        mutationGroups.stream()
-            .map(mg -> KV.of((byte[]) null, WriteGrouped.encode(mg)))
-            .collect(Collectors.toList());
-
     // Process elements.
-    when(mockProcessContext.element()).thenReturn(encodedInput);
-    testFn.processElement(mockProcessContext);
+    for (MutationGroup m : mutationGroups) {
+      when(mockProcessContext.element()).thenReturn(m);
+      testFn.processElement(mockProcessContext, null);
+    }
+    testFn.finishBundle(mockFinishBundleContext);
 
-    verify(mockProcessContext, times(4)).output(any());
+    verify(mockFinishBundleContext, times(4)).output(any(), any(), any());
 
     List<Iterable<MutationGroup>> batches = mutationGroupListCaptor.getAllValues();
     assertEquals(4, batches.size());
 
     // verify contents of 4 batches.
-    assertThat(batches.get(0), contains(g(m(1L)), g(m(4L))));
-    assertThat(batches.get(1), contains(g(m(5L), m(6L), m(7L), m(8L), m(9L))));
-    assertThat(batches.get(2), contains(g(m(3L)), g(m(10L)), g(m(11L))));
-    assertThat(batches.get(3), contains(g(m(2L))));
+    assertThat(batches.get(0), contains(g(m(1L)), g(m(2L)), g(m(3L))));
+    assertThat(batches.get(1), contains(g(m(4L)))); // small batch : next mutation group is too big.
+    assertThat(batches.get(2), contains(g(m(5L), m(6L), m(7L), m(8L), m(9L))));
+    assertThat(batches.get(3), contains(g(m(10L)), g(m(11L))));
   }
 
   private static MutationGroup g(Mutation m, Mutation... other) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOWriteTest.java
@@ -948,7 +948,6 @@ public class SpannerIOWriteTest implements Serializable {
         };
 
     // Process all elements as one bundle.
-    testFn.startBundle();
     for (MutationGroup m : mutationGroups) {
       when(mockProcessContext.element()).thenReturn(m);
       // outputReceiver should not be called until end of bundle.
@@ -1014,7 +1013,6 @@ public class SpannerIOWriteTest implements Serializable {
         };
 
     // Process all elements as one bundle.
-    testFn.startBundle();
     for (MutationGroup m : mutationGroups) {
       when(mockProcessContext.element()).thenReturn(m);
       testFn.processElement(mockProcessContext, mockOutputReceiver);


### PR DESCRIPTION

There is minimal benefit in separating these 2 stages, and significant
benefity in merging them: Gather and Sort encodes incoming
MutationGroups into a List<byte[]> which would contain up to 1GB.
This is then output (copied) to the CreateBatches where it is decoded
back into MutationGroups.

Removing this encode/decode should save up to 2GB of RAM.

Note, this PR is dependent on PR #11528,  PR #11532 and PR #11529

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
