### PR TITLE
[BEAM-9699] Add test verifying we can use ZetaSQL in Python SqlTransform

### DIFF
--- a/sdks/java/extensions/sql/expansion-service/build.gradle
+++ b/sdks/java/extensions/sql/expansion-service/build.gradle
@@ -30,6 +30,7 @@ ext.summary = """Contains code to run a SQL Expansion Service."""
 
 dependencies {
   compile project(path: ":sdks:java:extensions:sql")
+  compile project(path: ":sdks:java:extensions:sql:zetasql")
   compile project(path: ":sdks:java:expansion-service")
 }
 

--- a/sdks/java/extensions/sql/expansion-service/src/main/java/org/apache/beam/sdk/extensions/sql/expansion/ExternalSqlTransformRegistrar.java
+++ b/sdks/java/extensions/sql/expansion-service/src/main/java/org/apache/beam/sdk/extensions/sql/expansion/ExternalSqlTransformRegistrar.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.expansion;
+
+import com.google.auto.service.AutoService;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.expansion.ExternalTransformRegistrar;
+import org.apache.beam.sdk.extensions.sql.SqlTransform;
+import org.apache.beam.sdk.extensions.sql.impl.CalciteQueryPlanner;
+import org.apache.beam.sdk.extensions.sql.impl.QueryPlanner;
+import org.apache.beam.sdk.extensions.sql.zetasql.ZetaSQLQueryPlanner;
+import org.apache.beam.sdk.transforms.ExternalTransformBuilder;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PInput;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+
+@AutoService(ExternalTransformRegistrar.class)
+public class ExternalSqlTransformRegistrar implements ExternalTransformRegistrar {
+  private static final String URN = "beam:external:java:sql:v1";
+  private static final ImmutableMap<String, Class<? extends QueryPlanner>> DIALECTS =
+      ImmutableMap.<String, Class<? extends QueryPlanner>>builder()
+          .put("zetasql", ZetaSQLQueryPlanner.class)
+          .put("calcite", CalciteQueryPlanner.class)
+          .build();
+
+  @Override
+  public Map<String, Class<? extends ExternalTransformBuilder>> knownBuilders() {
+    return org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap.of(
+        URN, Builder.class);
+  }
+
+  public static class Configuration {
+    String query;
+    String dialect;
+
+    public void setQuery(String query) {
+      this.query = query;
+    }
+
+    public void setDialect(@Nullable String dialect) {
+      this.dialect = dialect;
+    }
+  }
+
+  private static class Builder
+      implements ExternalTransformBuilder<Configuration, PInput, PCollection<Row>> {
+    @Override
+    public PTransform<PInput, PCollection<Row>> buildExternal(Configuration configuration) {
+      SqlTransform transform = SqlTransform.query(configuration.query);
+      if (configuration.dialect != null) {
+        Class<? extends QueryPlanner> queryPlanner =
+            DIALECTS.get(configuration.dialect.toLowerCase());
+        if (queryPlanner == null) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Received unknown SQL Dialect '%s'. Known dialects: %s",
+                  configuration.dialect, DIALECTS.keySet()));
+        }
+        transform = transform.withQueryPlannerClass(queryPlanner);
+      }
+      return transform;
+    }
+  }
+}

--- a/sdks/java/extensions/sql/expansion-service/src/main/java/org/apache/beam/sdk/extensions/sql/expansion/package-info.java
+++ b/sdks/java/extensions/sql/expansion-service/src/main/java/org/apache/beam/sdk/extensions/sql/expansion/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** External Transform Registration for Beam SQL. */
+package org.apache.beam.sdk.extensions.sql.expansion;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SqlTransform.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SqlTransform.java
@@ -299,6 +299,7 @@ public abstract class SqlTransform extends PTransform<PInput, PCollection<Row>> 
       return builder()
           .setQueryString(configuration.query)
           .setQueryParameters(QueryParameters.ofNone())
+          .setQueryPlannerClassName(configuration.queryPlannerClassName)
           .setUdafDefinitions(Collections.emptyList())
           .setUdfDefinitions(Collections.emptyList())
           .setTableProviderMap(Collections.emptyMap())
@@ -344,9 +345,14 @@ public abstract class SqlTransform extends PTransform<PInput, PCollection<Row>> 
 
     public static class Configuration {
       String query;
+      String queryPlannerClassName;
 
       public void setQuery(String query) {
         this.query = query;
+      }
+
+      public void setQueryPlannerClassName(@Nullable String dialect) {
+        this.queryPlannerClassName = dialect;
       }
     }
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SqlTransform.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SqlTransform.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.extensions.sql;
 
-import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.expansion.ExternalTransformRegistrar;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv.BeamSqlEnvBuilder;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlPipelineOptions;
@@ -37,7 +35,6 @@ import org.apache.beam.sdk.extensions.sql.meta.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 import org.apache.beam.sdk.transforms.Combine;
-import org.apache.beam.sdk.transforms.ExternalTransformBuilder;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PCollection;
@@ -273,8 +270,7 @@ public abstract class SqlTransform extends PTransform<PInput, PCollection<Row>> 
   }
 
   @AutoValue.Builder
-  abstract static class Builder
-      implements ExternalTransformBuilder<External.Configuration, PInput, PCollection<Row>> {
+  abstract static class Builder {
     abstract Builder setQueryString(String queryString);
 
     abstract Builder setQueryParameters(QueryParameters queryParameters);
@@ -292,20 +288,6 @@ public abstract class SqlTransform extends PTransform<PInput, PCollection<Row>> 
     abstract Builder setQueryPlannerClassName(@Nullable String queryPlannerClassName);
 
     abstract SqlTransform build();
-
-    @Override
-    public PTransform<PInput, PCollection<Row>> buildExternal(
-        External.Configuration configuration) {
-      return builder()
-          .setQueryString(configuration.query)
-          .setQueryParameters(QueryParameters.ofNone())
-          .setQueryPlannerClassName(configuration.queryPlannerClassName)
-          .setUdafDefinitions(Collections.emptyList())
-          .setUdfDefinitions(Collections.emptyList())
-          .setTableProviderMap(Collections.emptyMap())
-          .setAutoUdfUdafLoad(false)
-          .build();
-    }
   }
 
   @AutoValue
@@ -329,31 +311,6 @@ public abstract class SqlTransform extends PTransform<PInput, PCollection<Row>> 
 
     static UdafDefinition of(String udafName, Combine.CombineFn combineFn) {
       return new AutoValue_SqlTransform_UdafDefinition(udafName, combineFn);
-    }
-  }
-
-  @AutoService(ExternalTransformRegistrar.class)
-  public static class External implements ExternalTransformRegistrar {
-
-    private static final String URN = "beam:external:java:sql:v1";
-
-    @Override
-    public Map<String, Class<? extends ExternalTransformBuilder>> knownBuilders() {
-      return org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap.of(
-          URN, AutoValue_SqlTransform.Builder.class);
-    }
-
-    public static class Configuration {
-      String query;
-      String queryPlannerClassName;
-
-      public void setQuery(String query) {
-        this.query = query;
-      }
-
-      public void setQueryPlannerClassName(@Nullable String dialect) {
-        this.queryPlannerClassName = dialect;
-      }
     }
   }
 }

--- a/sdks/python/apache_beam/transforms/sql.py
+++ b/sdks/python/apache_beam/transforms/sql.py
@@ -31,15 +31,9 @@ from apache_beam.transforms.external import NamedTupleBasedPayloadBuilder
 
 __all__ = ['SqlTransform']
 
-_SQL_PLANNERS = {
-    'zetasql': 'org.apache.beam.sdk.extensions.sql.zetasql.ZetaSQLQueryPlanner',
-    'calcite': 'org.apache.beam.sdk.extensions.sql.impl.CalciteQueryPlanner',
-}
-
 SqlTransformSchema = typing.NamedTuple(
-    'SqlTransformSchema',
-    [('query', unicode),
-     ('query_planner_class_name', typing.Optional[unicode])])
+    'SqlTransformSchema', [('query', unicode),
+                           ('dialect', typing.Optional[unicode])])
 
 
 class SqlTransform(ExternalTransform):
@@ -74,17 +68,9 @@ class SqlTransform(ExternalTransform):
   URN = 'beam:external:java:sql:v1'
 
   def __init__(self, query, dialect=None):
-    try:
-      query_planner = _SQL_PLANNERS[
-          dialect.lower()] if dialect is not None else None
-    except KeyError:
-      raise ValueError(
-          "Received unsupported SQL dialect \"{0}\". Supported dialects: {1}".
-          format(dialect, list(_SQL_PLANNERS.keys())))
     super(SqlTransform, self).__init__(
         self.URN,
         NamedTupleBasedPayloadBuilder(
-            SqlTransformSchema(
-                query=query, query_planner_class_name=query_planner)),
+            SqlTransformSchema(query=query, dialect=dialect)),
         BeamJarExpansionService(
             ':sdks:java:extensions:sql:expansion-service:shadowJar'))

--- a/sdks/python/apache_beam/transforms/sql.py
+++ b/sdks/python/apache_beam/transforms/sql.py
@@ -31,8 +31,15 @@ from apache_beam.transforms.external import NamedTupleBasedPayloadBuilder
 
 __all__ = ['SqlTransform']
 
+_SQL_PLANNERS = {
+    'zetasql': 'org.apache.beam.sdk.extensions.sql.zetasql.ZetaSQLQueryPlanner',
+    'calcite': 'org.apache.beam.sdk.extensions.sql.impl.CalciteQueryPlanner',
+}
+
 SqlTransformSchema = typing.NamedTuple(
-    'SqlTransformSchema', [('query', unicode)])
+    'SqlTransformSchema',
+    [('query', unicode),
+     ('query_planner_class_name', typing.Optional[unicode])])
 
 
 class SqlTransform(ExternalTransform):
@@ -66,9 +73,18 @@ class SqlTransform(ExternalTransform):
   """
   URN = 'beam:external:java:sql:v1'
 
-  def __init__(self, query):
+  def __init__(self, query, dialect=None):
+    try:
+      query_planner = _SQL_PLANNERS[
+          dialect.lower()] if dialect is not None else None
+    except KeyError:
+      raise ValueError(
+          "Received unsupported SQL dialect \"{0}\". Supported dialects: {1}".
+          format(dialect, list(_SQL_PLANNERS.keys())))
     super(SqlTransform, self).__init__(
         self.URN,
-        NamedTupleBasedPayloadBuilder(SqlTransformSchema(query=query)),
+        NamedTupleBasedPayloadBuilder(
+            SqlTransformSchema(
+                query=query, query_planner_class_name=query_planner)),
         BeamJarExpansionService(
             ':sdks:java:extensions:sql:expansion-service:shadowJar'))

--- a/sdks/python/apache_beam/transforms/sql_test.py
+++ b/sdks/python/apache_beam/transforms/sql_test.py
@@ -138,6 +138,16 @@ class SqlTransformTest(unittest.TestCase):
               ON simple.`int` = enrich.`int`"""))
       assert_that(out, equal_to([(1, "a"), (26, "z"), (1, "a")]))
 
+  def test_zetasql_generate_data(self):
+    with TestPipeline() as p:
+      out = p | SqlTransform(
+          """SELECT
+            CAST(1 AS INT64) AS `int`,
+            CAST('foo' AS STRING) AS `str`,
+            CAST(3.14  AS FLOAT64) AS `flt`""",
+          dialect="zetasql")
+      assert_that(out, equal_to([(1, "foo", 3.14)]))
+
 
 if __name__ == "__main__":
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
Adds a simple tests that sends the planner_name option through to the SQL expansion service, and verifies it worked with a ZetaSQL-specific query.

Includes changes from #11574 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
