### PR TITLE
[BEAM-9860] Make job_endpoint required for PortableRunner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,7 +65,7 @@
 
 ## Breaking Changes
 
-* X behavior was changed ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
+* The Python SDK now requires `--job_endpoint` to be set when using `--runner=PortableRunner` ([BEAM-9860](https://issues.apache.org/jira/browse/BEAM-9860)). Users seeking the old default behavior should set `--runner=FlinkRunner` instead.
 
 ## Deprecations
 

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1987,11 +1987,10 @@ class BeamModulePlugin implements Plugin<Project> {
       }
 
       def addPortableWordCountTask = { boolean isStreaming, String runner ->
-        def taskName = 'portableWordCount' + (runner.equals("PortableRunner") ? "" : runner) + (isStreaming ? 'Streaming' : 'Batch')
+        def taskName = 'portableWordCount' + runner + (isStreaming ? 'Streaming' : 'Batch')
         project.task(taskName) {
           dependsOn = ['installGcpTest']
           mustRunAfter = [
-            ':runners:flink:1.10:job-server-container:docker',
             ':runners:flink:1.10:job-server:shadowJar',
             ':runners:spark:job-server:shadowJar',
             ':sdks:python:container:py2:docker',
@@ -2045,8 +2044,6 @@ class BeamModulePlugin implements Plugin<Project> {
       }
       project.ext.addPortableWordCountTasks = {
         ->
-        addPortableWordCountTask(false, "PortableRunner")
-        addPortableWordCountTask(true, "PortableRunner")
         addPortableWordCountTask(false, "FlinkRunner")
         addPortableWordCountTask(true, "FlinkRunner")
         addPortableWordCountTask(false, "SparkRunner")

--- a/sdks/python/apache_beam/runners/portability/job_server.py
+++ b/sdks/python/apache_beam/runners/portability/job_server.py
@@ -22,8 +22,6 @@ from __future__ import absolute_import
 import atexit
 import shutil
 import signal
-import subprocess
-import sys
 import tempfile
 import threading
 
@@ -158,79 +156,3 @@ class JavaJarJobServer(SubprocessJobServer):
             job_port, self._artifact_port, self._expansion_port,
             artifacts_dir)),
             'localhost:%s' % job_port)
-
-
-class DockerizedJobServer(SubprocessJobServer):
-  """
-  Spins up the JobServer in a docker container for local execution.
-  """
-  def __init__(
-      self,
-      job_host="localhost",
-      job_port=None,
-      artifact_port=None,
-      expansion_port=None,
-      harness_port_range=(8100, 8200),
-      max_connection_retries=5):
-    super(DockerizedJobServer, self).__init__()
-    self.job_host = job_host
-    self.job_port = job_port
-    self.expansion_port = expansion_port
-    self.artifact_port = artifact_port
-    self.harness_port_range = harness_port_range
-    self.max_connection_retries = max_connection_retries
-
-  def subprocess_cmd_and_endpoint(self):
-    # TODO This is hardcoded to Flink at the moment but should be changed
-    job_server_image_name = "apache/beam_flink%s_job_server:latest" % (
-        pipeline_options.FlinkRunnerOptions.PUBLISHED_FLINK_VERSIONS[-1])
-    docker_path = subprocess.check_output(['which',
-                                           'docker']).strip().decode('utf-8')
-    cmd = [
-        "docker",
-        "run",
-        # We mount the docker binary and socket to be able to spin up
-        # "sibling" containers for the SDK harness.
-        "-v",
-        ':'.join([docker_path, "/bin/docker"]),
-        "-v",
-        "/var/run/docker.sock:/var/run/docker.sock"
-    ]
-
-    self.job_port, self.artifact_port, self.expansion_port = (
-        subprocess_server.pick_port(
-            self.job_port, self.artifact_port, self.expansion_port))
-
-    args = [
-        '--job-host',
-        self.job_host,
-        '--job-port',
-        str(self.job_port),
-        '--artifact-port',
-        str(self.artifact_port),
-        '--expansion-port',
-        str(self.expansion_port)
-    ]
-
-    if sys.platform == "darwin":
-      # Docker-for-Mac doesn't support host networking, so we need to explictly
-      # publish ports from the Docker container to be able to connect to it.
-      # Also, all other containers need to be aware that they run Docker-on-Mac
-      # to connect against the internal Docker-for-Mac address.
-      cmd += ["-e", "DOCKER_MAC_CONTAINER=1"]
-      cmd += ["-p", "{}:{}".format(self.job_port, self.job_port)]
-      cmd += ["-p", "{}:{}".format(self.artifact_port, self.artifact_port)]
-      cmd += ["-p", "{}:{}".format(self.expansion_port, self.expansion_port)]
-      cmd += [
-          "-p",
-          "{0}-{1}:{0}-{1}".format(
-              self.harness_port_range[0], self.harness_port_range[1])
-      ]
-    else:
-      # This shouldn't be set for MacOS because it detroys port forwardings,
-      # even though host networking is not supported on MacOS.
-      cmd.append("--network=host")
-
-    cmd.append(job_server_image_name)
-
-    return cmd + args, '%s:%s' % (self.job_host, self.job_port)

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -303,13 +303,10 @@ class PortableRunner(runner.PipelineRunner):
     return env_class.from_options(portable_options)
 
   def default_job_server(self, options):
-    # type: (PipelineOptions) -> job_server.JobServer
-    # TODO Provide a way to specify a container Docker URL
-    # https://issues.apache.org/jira/browse/BEAM-6328
-    if not self._dockerized_job_server:
-      self._dockerized_job_server = job_server.StopOnExitJobServer(
-          job_server.DockerizedJobServer())
-    return self._dockerized_job_server
+    raise NotImplementedError(
+        'You must specify a --job_endpoint when using --runner=PortableRunner. '
+        'Alternatively, you may specify which portable runner you intend to '
+        'use, such as --runner=FlinkRunner or --runner=SparkRunner.')
 
   def create_job_service_handle(self, job_service, options):
     return JobServiceHandle(job_service, options)

--- a/sdks/python/test-suites/portable/py2/build.gradle
+++ b/sdks/python/test-suites/portable/py2/build.gradle
@@ -29,53 +29,20 @@ def runScriptsDir = "${rootDir}/sdks/python/scripts"
 addPortableWordCountTasks()
 
 task preCommitPy2() {
-  dependsOn ':runners:flink:1.10:job-server-container:docker'
   dependsOn ':sdks:python:container:py2:docker'
-  dependsOn portableWordCountBatch
-  dependsOn portableWordCountStreaming
+  dependsOn ':runners:flink:1.10:job-server:shadowJar'
+  dependsOn portableWordCountFlinkRunnerBatch
+  dependsOn portableWordCountFlinkRunnerStreaming
 }
 
 task postCommitPy2() {
   dependsOn 'setupVirtualenv'
-  dependsOn ':runners:flink:1.10:job-server:shadowJar'
-  dependsOn portableWordCountFlinkRunnerBatch
-  dependsOn portableWordCountFlinkRunnerStreaming
   dependsOn 'postCommitPy2IT'
   dependsOn ':runners:spark:job-server:shadowJar'
   dependsOn portableWordCountSparkRunnerBatch
 }
 
 // TODO: Move the rest of this file into ../common.gradle.
-
-// Before running this, you need to:
-//
-// 1. Build the SDK container:
-//
-//    ./gradlew -p sdks/python/container buildAll
-//
-// 2. Either a) or b)
-//  a) If you want the Job Server to run in a Docker container:
-//
-//    ./gradlew :runners:flink:1.10:job-server-container:docker
-//
-//  b) Otherwise, start a local JobService, for example, the Portable Flink runner
-//    (in a separate shell since it continues to run):
-//
-//    ./gradlew :runners:flink:1.10:job-server:runShadow
-//
-// Then you can run this example:
-//
-//  Docker (2a):
-//
-//    ./gradlew :sdks:python:test-suites:portable:py2:portableWordCount
-//
-//  Local JobService (2b):
-//
-//    ./gradlew :sdks:python:test-suites:portable:py2:portableWordCount -PjobEndpoint=localhost:8099
-//
-task portableWordCount {
-  dependsOn project.hasProperty("streaming") ? portableWordCountStreaming : portableWordCountBatch
-}
 
 /*************************************************************************************************/
 

--- a/sdks/python/test-suites/portable/py35/build.gradle
+++ b/sdks/python/test-suites/portable/py35/build.gradle
@@ -28,17 +28,14 @@ apply from: "../common.gradle"
 addPortableWordCountTasks()
 
 task preCommitPy35() {
-    dependsOn ':runners:flink:1.10:job-server-container:docker'
     dependsOn ':sdks:python:container:py35:docker'
-    dependsOn portableWordCountBatch
-    dependsOn portableWordCountStreaming
+    dependsOn ':runners:flink:1.10:job-server:shadowJar'
+    dependsOn portableWordCountFlinkRunnerBatch
+    dependsOn portableWordCountFlinkRunnerStreaming
 }
 
 task postCommitPy35() {
     dependsOn 'setupVirtualenv'
-    dependsOn ':runners:flink:1.10:job-server:shadowJar'
-    dependsOn portableWordCountFlinkRunnerBatch
-    dependsOn portableWordCountFlinkRunnerStreaming
     dependsOn 'postCommitPy35IT'
     dependsOn ':runners:spark:job-server:shadowJar'
     dependsOn portableWordCountSparkRunnerBatch

--- a/sdks/python/test-suites/portable/py36/build.gradle
+++ b/sdks/python/test-suites/portable/py36/build.gradle
@@ -28,17 +28,14 @@ apply from: "../common.gradle"
 addPortableWordCountTasks()
 
 task preCommitPy36() {
-    dependsOn ':runners:flink:1.10:job-server-container:docker'
     dependsOn ':sdks:python:container:py36:docker'
-    dependsOn portableWordCountBatch
-    dependsOn portableWordCountStreaming
+    dependsOn ':runners:flink:1.10:job-server:shadowJar'
+    dependsOn portableWordCountFlinkRunnerBatch
+    dependsOn portableWordCountFlinkRunnerStreaming
 }
 
 task postCommitPy36() {
     dependsOn 'setupVirtualenv'
-    dependsOn ':runners:flink:1.10:job-server:shadowJar'
-    dependsOn portableWordCountFlinkRunnerBatch
-    dependsOn portableWordCountFlinkRunnerStreaming
     dependsOn 'postCommitPy36IT'
     dependsOn ':runners:spark:job-server:shadowJar'
     dependsOn portableWordCountSparkRunnerBatch

--- a/sdks/python/test-suites/portable/py37/build.gradle
+++ b/sdks/python/test-suites/portable/py37/build.gradle
@@ -28,17 +28,14 @@ apply from: "../common.gradle"
 addPortableWordCountTasks()
 
 task preCommitPy37() {
-    dependsOn ':runners:flink:1.10:job-server-container:docker'
     dependsOn ':sdks:python:container:py37:docker'
-    dependsOn portableWordCountBatch
-    dependsOn portableWordCountStreaming
+    dependsOn ':runners:flink:1.10:job-server:shadowJar'
+    dependsOn portableWordCountFlinkRunnerBatch
+    dependsOn portableWordCountFlinkRunnerStreaming
 }
 
 task postCommitPy37() {
     dependsOn 'setupVirtualenv'
-    dependsOn ':runners:flink:1.10:job-server:shadowJar'
-    dependsOn portableWordCountFlinkRunnerBatch
-    dependsOn portableWordCountFlinkRunnerStreaming
     dependsOn 'postCommitPy37IT'
     dependsOn ':runners:spark:job-server:shadowJar'
     dependsOn portableWordCountSparkRunnerBatch


### PR DESCRIPTION
Remove the default and the tests that relied on it. The only difference between the portableWordCount... and portableWordCountFlinkRunner... tests was the entry point, so we can afford to get rid of the PortableRunner tests without substantial loss in coverage. Also remove DockerizedJobServer, since it's no longer used anywhere.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
