### PR TITLE
[BEAM-9692] Replace apply_WriteToBigQuery with PTransformOverride

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -26,7 +26,6 @@ from __future__ import absolute_import
 from __future__ import division
 
 import base64
-import json
 import logging
 import os
 import subprocess
@@ -464,6 +463,9 @@ class DataflowRunner(PipelineRunner):
     # any added PTransforms.
     pipeline.replace_all(DataflowRunner._PTRANSFORM_OVERRIDES)
 
+    from apache_beam.runners.dataflow.ptransform_overrides import WriteToBigQueryPTransformOverride
+    pipeline.replace_all([WriteToBigQueryPTransformOverride(pipeline, options)])
+
     if (apiclient._use_fnapi(options) and
         not apiclient._use_unified_worker(options)):
       pipeline.replace_all(DataflowRunner._JRH_PTRANSFORM_OVERRIDES)
@@ -804,42 +806,6 @@ class DataflowRunner(PipelineRunner):
             PropertyNames.ENCODING: step.encoding,
             PropertyNames.OUTPUT_NAME: PropertyNames.OUT
         }])
-
-  def apply_WriteToBigQuery(self, transform, pcoll, options):
-    # Make sure this is the WriteToBigQuery class that we expected, and that
-    # users did not specifically request the new BQ sink by passing experiment
-    # flag.
-
-    # TODO(BEAM-6928): Remove this function for release 2.14.0.
-    experiments = options.view_as(DebugOptions).experiments or []
-    from apache_beam.runners.dataflow.internal import apiclient
-    use_fnapi = apiclient._use_fnapi(options)
-    if (not isinstance(transform, beam.io.WriteToBigQuery) or use_fnapi or
-        'use_beam_bq_sink' in experiments):
-      return self.apply_PTransform(transform, pcoll, options)
-    if transform.schema == beam.io.gcp.bigquery.SCHEMA_AUTODETECT:
-      raise RuntimeError(
-          'Schema auto-detection is not supported on the native sink')
-    standard_options = options.view_as(StandardOptions)
-    if standard_options.streaming:
-      if (transform.write_disposition ==
-          beam.io.BigQueryDisposition.WRITE_TRUNCATE):
-        raise RuntimeError('Can not use write truncation mode in streaming')
-      return self.apply_PTransform(transform, pcoll, options)
-    else:
-      from apache_beam.io.gcp.bigquery_tools import parse_table_schema_from_json
-      schema = None
-      if transform.schema:
-        schema = parse_table_schema_from_json(json.dumps(transform.schema))
-      return pcoll | 'WriteToBigQuery' >> beam.io.Write(
-          beam.io.BigQuerySink(
-              transform.table_reference.tableId,
-              transform.table_reference.datasetId,
-              transform.table_reference.projectId,
-              schema,
-              transform.create_disposition,
-              transform.write_disposition,
-              kms_key=transform.kms_key))
 
   # TODO(srohde): Remove this after internal usages have been removed.
   def apply_GroupByKey(self, transform, pcoll, options):

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -752,6 +752,9 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.assertEqual(
         gbk_step[u'properties']['output_info'], expected_output_info)
 
+  @unittest.skipIf(
+      sys.version_info.minor == 8,
+      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_write_bigquery_translation(self):
     runner = DataflowRunner()
 
@@ -802,6 +805,9 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     del step_encoding[u'component_encodings'][0][u'@type']
     self.assertEqual(expected_step, write_step)
 
+  @unittest.skipIf(
+      sys.version_info.minor == 8,
+      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_write_bigquery_failed_translation(self):
     """Tests that WriteToBigQuery cannot have any consumers if replaced."""
     runner = DataflowRunner()

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -752,6 +752,67 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.assertEqual(
         gbk_step[u'properties']['output_info'], expected_output_info)
 
+  def test_write_bigquery_translation(self):
+    runner = DataflowRunner()
+
+    with beam.Pipeline(runner=runner,
+                       options=PipelineOptions(self.default_properties)) as p:
+      # pylint: disable=expression-not-assigned
+      p | beam.Create([1]) | beam.io.WriteToBigQuery('some.table')
+
+    job_dict = json.loads(str(runner.job))
+
+    expected_step = {
+        "kind": "ParallelWrite",
+        "name": "s2",
+        "properties": {
+            "create_disposition": "CREATE_IF_NEEDED",
+            "dataset": "some",
+            "display_data": [],
+            "encoding": {
+                "@type": "kind:windowed_value",
+                "component_encodings": [{
+                    "component_encodings": [],
+                    "pipeline_proto_coder_id": "ref_Coder_RowAsDictJsonCoder_4"
+                }, {
+                    "@type": "kind:global_window"
+                }],
+                "is_wrapper": True
+            },
+            "format": "bigquery",
+            "parallel_input": {
+                "@type": "OutputReference",
+                "output_name": "out",
+                "step_name": "s1"
+            },
+            "table": "table",
+            "user_name": "WriteToBigQuery/Write/NativeWrite",
+            "write_disposition": "WRITE_APPEND"
+        }
+    }
+    job_dict = json.loads(str(runner.job))
+    write_step = [
+        s for s in job_dict[u'steps']
+        if s[u'properties'][u'user_name'].startswith('WriteToBigQuery')
+    ][0]
+
+    # Delete the @type field because in this case it is a hash which may change
+    # depending on the pickling version.
+    step_encoding = write_step[u'properties'][u'encoding']
+    del step_encoding[u'component_encodings'][0][u'@type']
+    self.assertEqual(expected_step, write_step)
+
+  def test_write_bigquery_failed_translation(self):
+    """Tests that WriteToBigQuery cannot have any consumers if replaced."""
+    runner = DataflowRunner()
+
+    with self.assertRaises(ValueError):
+      with beam.Pipeline(runner=runner,
+                         options=PipelineOptions(self.default_properties)) as p:
+        # pylint: disable=expression-not-assigned
+        out = p | beam.Create([1]) | beam.io.WriteToBigQuery('some.table')
+        out['FailedRows'] | 'MyTransform' >> beam.Map(lambda _: _)
+
 
 class CustomMergingWindowFn(window.WindowFn):
   def assign(self, assign_context):

--- a/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
+++ b/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
@@ -21,6 +21,8 @@
 
 from __future__ import absolute_import
 
+from apache_beam.options.pipeline_options import DebugOptions
+from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.pipeline import PTransformOverride
 
 
@@ -184,3 +186,137 @@ class NativeReadPTransformOverride(PTransformOverride):
     # will choose the incorrect coder for this transform.
     return Read(ptransform.source).with_output_types(
         ptransform.source.coder.to_type_hint())
+
+
+class WriteToBigQueryPTransformOverride(PTransformOverride):
+  def __init__(self, pipeline, options):
+    super(WriteToBigQueryPTransformOverride, self).__init__()
+    self.options = options
+    self.outputs = []
+
+    self._check_bq_outputs(pipeline)
+
+  def _check_bq_outputs(self, pipeline):
+    """Checks that there are no consumers if the transform will be replaced.
+
+    The WriteToBigQuery replacement is the native BigQuerySink which has an
+    output of a PDone. The original transform, however, returns a dict. The user
+    may be inadvertantly using the dict output which will have no side-effects
+    or fail pipeline construction esoterically. This checks the outputs and
+    gives a user-friendsly error.
+    """
+    # Imported here to avoid circular dependencies.
+    # pylint: disable=wrong-import-order, wrong-import-position
+    from apache_beam.pipeline import PipelineVisitor
+    from apache_beam.io import WriteToBigQuery
+
+    # First, retrieve all the outpts from all the WriteToBigQuery transforms
+    # that will be replaced. Later, we will use these to make sure no one
+    # consumes these.
+    class GetWriteToBqOutputsVisitor(PipelineVisitor):
+      def __init__(self, matches):
+        self.matches = matches
+        self.outputs = set()
+
+      def enter_composite_transform(self, transform_node):
+        # Only add outputs that are going to be replaced.
+        if self.matches(transform_node):
+          self.outputs.update(set(transform_node.outputs.values()))
+
+    outputs_visitor = GetWriteToBqOutputsVisitor(self.matches)
+    pipeline.visit(outputs_visitor)
+
+    # Finally, verify that there are no consumers to the previously found
+    # outputs.
+    class VerifyWriteToBqOutputsVisitor(PipelineVisitor):
+      def __init__(self, outputs):
+        self.outputs = outputs
+
+      def enter_composite_transform(self, transform_node):
+        self.visit_transform(transform_node)
+
+      def visit_transform(self, transform_node):
+        if [o for o in self.outputs if o in transform_node.inputs]:
+          raise ValueError(
+              'WriteToBigQuery was being replaced with the native '
+              'BigQuerySink, but the transform "{}" has an input which will be '
+              'replaced with a PDone. To fix, please remove all transforms '
+              'that read from any WriteToBigQuery transforms.'.format(
+                  transform_node.full_label))
+
+    pipeline.visit(VerifyWriteToBqOutputsVisitor(outputs_visitor.outputs))
+
+  def matches(self, applied_ptransform):
+    # Imported here to avoid circular dependencies.
+    # pylint: disable=wrong-import-order, wrong-import-position
+    from apache_beam import io
+    from apache_beam.runners.dataflow.internal import apiclient
+
+    transform = applied_ptransform.transform
+    if (not isinstance(transform, io.WriteToBigQuery) or
+        getattr(transform, 'override', False)):
+      return False
+
+    use_fnapi = apiclient._use_fnapi(self.options)
+    experiments = self.options.view_as(DebugOptions).experiments or []
+    if (use_fnapi or 'use_beam_bq_sink' in experiments):
+      return False
+
+    if transform.schema == io.gcp.bigquery.SCHEMA_AUTODETECT:
+      raise RuntimeError(
+          'Schema auto-detection is not supported on the native sink')
+
+    # The replacement is only valid for Batch.
+    standard_options = self.options.view_as(StandardOptions)
+    if standard_options.streaming:
+      if transform.write_disposition == io.BigQueryDisposition.WRITE_TRUNCATE:
+        raise RuntimeError('Can not use write truncation mode in streaming')
+      return False
+
+    self.outputs = list(applied_ptransform.outputs.keys())
+    return True
+
+  def get_replacement_transform(self, ptransform):
+    # Imported here to avoid circular dependencies.
+    # pylint: disable=wrong-import-order, wrong-import-position
+    from apache_beam import io
+
+    class WriteToBigQuery(io.WriteToBigQuery):
+      override = True
+
+      def __init__(self, transform, outputs):
+        self.transform = transform
+        self.outputs = outputs
+
+      def __getattr__(self, name):
+        """Returns the given attribute from the parent.
+
+        This allows this transform to act like a WriteToBigQuery transform
+        without having to construct a new WriteToBigQuery transform.
+        """
+        return self.transform.__getattribute__(name)
+
+      def expand(self, pcoll):
+        from apache_beam.io.gcp.bigquery_tools import parse_table_schema_from_json
+        import json
+
+        schema = None
+        if self.schema:
+          schema = parse_table_schema_from_json(json.dumps(self.schema))
+
+        out = pcoll | io.Write(
+            io.BigQuerySink(
+                self.table_reference.tableId,
+                self.table_reference.datasetId,
+                self.table_reference.projectId,
+                schema,
+                self.create_disposition,
+                self.write_disposition,
+                kms_key=self.kms_key))
+
+        # The WriteToBigQuery can have different outputs depending on if it's
+        # Batch or Streaming. This retrieved the output keys from the node and
+        # is replacing them here to be consistent.
+        return {key: out for key in self.outputs}
+
+    return WriteToBigQuery(ptransform, self.outputs)


### PR DESCRIPTION
Replace apply_WriteToBigQuery with PTransformOverride

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
