### PR TITLE
Allow accessing window parameters in finishBundle

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -152,7 +152,8 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
               @Override
               public OutputReceiver<OutputT> outputReceiver(DoFn<InputT, OutputT> doFn) {
-                return DoFnOutputReceivers.windowedReceiver(processContext, null);
+                return DoFnOutputReceivers.windowedReceiver(
+                    DoFnOutputReceivers.fromWindowedContext(processContext), null);
               }
 
               @Override
@@ -162,7 +163,8 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
               @Override
               public MultiOutputReceiver taggedOutputReceiver(DoFn<InputT, OutputT> doFn) {
-                return DoFnOutputReceivers.windowedMultiReceiver(processContext, null);
+                return DoFnOutputReceivers.windowedMultiReceiver(
+                    DoFnOutputReceivers.fromWindowedContext(processContext), null);
               }
 
               @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -112,10 +112,7 @@ public class AvroUtils {
         // {"name": "foo", "type": ["null", "something"]}
 
         // don't need recursion because nested unions aren't supported in AVRO
-        List<org.apache.avro.Schema> nonNullTypes =
-            types.stream()
-                .filter(x -> x.getType() != org.apache.avro.Schema.Type.NULL)
-                .collect(Collectors.toList());
+        List<org.apache.avro.Schema> nonNullTypes = types.stream().collect(Collectors.toList());
 
         if (nonNullTypes.size() == types.size() || nonNullTypes.isEmpty()) {
           // union without `null` or all 'null' union, keep as is.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -277,12 +277,14 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
 
             @Override
             public OutputReceiver<OutputT> outputReceiver(DoFn<InputT, OutputT> doFn) {
-              return DoFnOutputReceivers.windowedReceiver(processContext, null);
+              return DoFnOutputReceivers.windowedReceiver(
+                  DoFnOutputReceivers.fromWindowedContext(processContext), null);
             }
 
             @Override
             public MultiOutputReceiver taggedOutputReceiver(DoFn<InputT, OutputT> doFn) {
-              return DoFnOutputReceivers.windowedMultiReceiver(processContext, null);
+              return DoFnOutputReceivers.windowedMultiReceiver(
+                  DoFnOutputReceivers.fromWindowedContext(processContext), null);
             }
 
             @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -150,6 +150,9 @@ public class DoFnSignatures {
       ImmutableList.of(
           Parameter.PipelineOptionsParameter.class,
           Parameter.FinishBundleContextParameter.class,
+          Parameter.OutputReceiverParameter.class,
+          Parameter.TaggedOutputReceiverParameter.class,
+          Parameter.WindowParameter.class,
           Parameter.BundleFinalizerParameter.class);
 
   private static final ImmutableList<Class<? extends Parameter>> ALLOWED_ON_TIMER_PARAMETERS =


### PR DESCRIPTION
A bundle in Beam today can contain many windows. This often makes using finishBundle correctly tricky. Users are sometimes seen keeping maps in their DoFn of windows seen in a bundle so they can properly process them in finishBundle. We also don't support injecting an OutputReceiver in finishBundle, as there's no good way to associate a window to the output.

This PR allows injecting a BoundedWindow or OutputReceiver to the finishBundle function. In this case, the finishBundle will be invoked once per window seen in the bundle. If there is no such parameter, then the previous behavior of invoking finishBundle once is preserved.