### PR TITLE
[BEAM-9883] Refactor SDF test restrictions.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
@@ -248,6 +248,10 @@ type VetRestriction struct {
 	CreateRest, SplitRest, RestSize, CreateTracker, ProcessElm bool
 }
 
+func (r VetRestriction) copy() VetRestriction {
+	return r
+}
+
 // VetRTracker's methods can all be no-ops, we just need it to implement
 // sdf.RTracker and allow validating that it was passed to ProcessElement.
 type VetRTracker struct {
@@ -280,19 +284,14 @@ func (fn *VetSdf) CreateInitialRestriction(i int) *VetRestriction {
 // split restrictions add a suffix of the form ".#" to the ID.
 func (fn *VetSdf) SplitRestriction(i int, rest *VetRestriction) []*VetRestriction {
 	rest.SplitRest = true
-	rest1 := &VetRestriction{
-		ID:            rest.ID + ".1",
-		Val:           i,
-		CreateRest:    rest.CreateRest,
-		SplitRest:     true,
-		RestSize:      rest.RestSize,
-		CreateTracker: rest.CreateTracker,
-		ProcessElm:    rest.ProcessElm,
-	}
-	rest2 := &VetRestriction{}
-	*rest2 = *rest1
-	rest2.ID = rest.ID + ".2"
-	return []*VetRestriction{rest1, rest2}
+	rest.Val = i
+
+	rest1 := rest.copy()
+	rest1.ID += ".1"
+	rest2 := rest.copy()
+	rest2.ID += ".2"
+
+	return []*VetRestriction{&rest1, &rest2}
 }
 
 // RestrictionSize just returns i as the size, as well as flipping appropriate
@@ -311,10 +310,13 @@ func (fn *VetSdf) CreateTracker(rest *VetRestriction) *VetRTracker {
 	return &VetRTracker{rest}
 }
 
-// ProcessElement emits a copy of the restriction in the restriction tracker it
+// ProcessElement emits the restriction from the restriction tracker it
 // received, with the appropriate flags flipped to track that this was called.
-func (fn *VetSdf) ProcessElement(rt *VetRTracker, i int, emit func(VetRestriction)) {
-	rest := *rt.Rest
+// Note that emitting restrictions is discouraged in normal usage. It is only
+// done here to allow validating that ProcessElement is being executed
+// properly.
+func (fn *VetSdf) ProcessElement(rt *VetRTracker, i int, emit func(*VetRestriction)) {
+	rest := rt.Rest
 	rest.Key = nil
 	rest.Val = i
 	rest.ProcessElm = true
@@ -339,20 +341,15 @@ func (fn *VetKvSdf) CreateInitialRestriction(i, j int) *VetRestriction {
 // split restrictions add a suffix of the form ".#" to the ID.
 func (fn *VetKvSdf) SplitRestriction(i, j int, rest *VetRestriction) []*VetRestriction {
 	rest.SplitRest = true
-	rest1 := &VetRestriction{
-		ID:            rest.ID + ".1",
-		Key:           i,
-		Val:           j,
-		CreateRest:    rest.CreateRest,
-		SplitRest:     true,
-		RestSize:      rest.RestSize,
-		CreateTracker: rest.CreateTracker,
-		ProcessElm:    rest.ProcessElm,
-	}
-	rest2 := &VetRestriction{}
-	*rest2 = *rest1
-	rest2.ID = rest.ID + ".2"
-	return []*VetRestriction{rest1, rest2}
+	rest.Key = i
+	rest.Val = j
+
+	rest1 := rest.copy()
+	rest1.ID += ".1"
+	rest2 := rest.copy()
+	rest2.ID += ".2"
+
+	return []*VetRestriction{&rest1, &rest2}
 }
 
 // RestrictionSize just returns the sum of i and j as the size, as well as
@@ -371,10 +368,13 @@ func (fn *VetKvSdf) CreateTracker(rest *VetRestriction) *VetRTracker {
 	return &VetRTracker{rest}
 }
 
-// ProcessElement emits a copy of the restriction in the restriction tracker it
+// ProcessElement emits the restriction from the restriction tracker it
 // received, with the appropriate flags flipped to track that this was called.
-func (fn *VetKvSdf) ProcessElement(rt *VetRTracker, i, j int, emit func(VetRestriction)) {
-	rest := *rt.Rest
+// Note that emitting restrictions is discouraged in normal usage. It is only
+// done here to allow validating that ProcessElement is being executed
+// properly.
+func (fn *VetKvSdf) ProcessElement(rt *VetRTracker, i, j int, emit func(*VetRestriction)) {
+	rest := rt.Rest
 	rest.Key = i
 	rest.Val = j
 	rest.ProcessElm = true

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
@@ -37,11 +37,11 @@ func TestSdfNodes(t *testing.T) {
 	// have testable behavior to confirm that they got correctly invoked.
 	// Without knowing the expected behavior of these DoFns, the desired outputs
 	// in the unit tests below will not make much sense.
-	dfn, err := graph.NewDoFn(&Sdf{}, graph.NumMainInputs(graph.MainSingle))
+	dfn, err := graph.NewDoFn(&VetSdf{}, graph.NumMainInputs(graph.MainSingle))
 	if err != nil {
 		t.Fatalf("invalid function: %v", err)
 	}
-	kvdfn, err := graph.NewDoFn(&KvSdf{}, graph.NumMainInputs(graph.MainKv))
+	kvdfn, err := graph.NewDoFn(&VetKvSdf{}, graph.NumMainInputs(graph.MainKv))
 	if err != nil {
 		t.Fatalf("invalid function: %v", err)
 	}
@@ -59,19 +59,19 @@ func TestSdfNodes(t *testing.T) {
 				name: "SingleElem",
 				fn:   dfn,
 				in: FullValue{
-					Elm:       5,
+					Elm:       1,
 					Elm2:      nil,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
 				want: FullValue{
 					Elm: &FullValue{
-						Elm:       5,
+						Elm:       1,
 						Elm2:      nil,
 						Timestamp: testTimestamp,
 						Windows:   testWindows,
 					},
-					Elm2:      Restriction{5},
+					Elm2:      &VetRestriction{ID: "Sdf", CreateRest: true, Val: 1},
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
@@ -80,19 +80,19 @@ func TestSdfNodes(t *testing.T) {
 				name: "KvElem",
 				fn:   kvdfn,
 				in: FullValue{
-					Elm:       5,
+					Elm:       1,
 					Elm2:      2,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
 				want: FullValue{
 					Elm: &FullValue{
-						Elm:       5,
+						Elm:       1,
 						Elm2:      2,
 						Timestamp: testTimestamp,
 						Windows:   testWindows,
 					},
-					Elm2:      Restriction{7},
+					Elm2:      &VetRestriction{ID: "KvSdf", CreateRest: true, Key: 1, Val: 2},
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
@@ -109,8 +109,8 @@ func TestSdfNodes(t *testing.T) {
 
 				got := capt.Elements[0]
 				if !cmp.Equal(got, test.want) {
-					t.Errorf("ProcessElement(%v) has incorrect output: got: %v, want: %v",
-						test.in, got, test.want)
+					t.Errorf("PairWithRestriction(%v) has incorrect output: (-got, +want)\n%v",
+						test.in, cmp.Diff(got, test.want))
 				}
 			})
 		}
@@ -130,12 +130,12 @@ func TestSdfNodes(t *testing.T) {
 				fn:   dfn,
 				in: FullValue{
 					Elm: &FullValue{
-						Elm:       2,
+						Elm:       1,
 						Elm2:      nil,
 						Timestamp: testTimestamp,
 						Windows:   testWindows,
 					},
-					Elm2:      Restriction{5},
+					Elm2:      &VetRestriction{ID: "Sdf"},
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
@@ -143,28 +143,28 @@ func TestSdfNodes(t *testing.T) {
 					{
 						Elm: &FullValue{
 							Elm: &FullValue{
-								Elm:       2,
+								Elm:       1,
 								Elm2:      nil,
 								Timestamp: testTimestamp,
 								Windows:   testWindows,
 							},
-							Elm2: Restriction{7},
+							Elm2: &VetRestriction{ID: "Sdf.1", SplitRest: true, RestSize: true, Val: 1},
 						},
-						Elm2:      9.0,
+						Elm2:      1.0,
 						Timestamp: testTimestamp,
 						Windows:   testWindows,
 					},
 					{
 						Elm: &FullValue{
 							Elm: &FullValue{
-								Elm:       2,
+								Elm:       1,
 								Elm2:      nil,
 								Timestamp: testTimestamp,
 								Windows:   testWindows,
 							},
-							Elm2: Restriction{8},
+							Elm2: &VetRestriction{ID: "Sdf.2", SplitRest: true, RestSize: true, Val: 1},
 						},
-						Elm2:      10.0,
+						Elm2:      1.0,
 						Timestamp: testTimestamp,
 						Windows:   testWindows,
 					},
@@ -175,12 +175,12 @@ func TestSdfNodes(t *testing.T) {
 				fn:   kvdfn,
 				in: FullValue{
 					Elm: &FullValue{
-						Elm:       2,
-						Elm2:      5,
+						Elm:       1,
+						Elm2:      2,
 						Timestamp: testTimestamp,
 						Windows:   testWindows,
 					},
-					Elm2:      Restriction{3},
+					Elm2:      &VetRestriction{ID: "KvSdf"},
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
@@ -188,28 +188,28 @@ func TestSdfNodes(t *testing.T) {
 					{
 						Elm: &FullValue{
 							Elm: &FullValue{
-								Elm:       2,
-								Elm2:      5,
+								Elm:       1,
+								Elm2:      2,
 								Timestamp: testTimestamp,
 								Windows:   testWindows,
 							},
-							Elm2: Restriction{5},
+							Elm2: &VetRestriction{ID: "KvSdf.1", SplitRest: true, RestSize: true, Key: 1, Val: 2},
 						},
-						Elm2:      12.0,
+						Elm2:      3.0,
 						Timestamp: testTimestamp,
 						Windows:   testWindows,
 					},
 					{
 						Elm: &FullValue{
 							Elm: &FullValue{
-								Elm:       2,
-								Elm2:      5,
+								Elm:       1,
+								Elm2:      2,
 								Timestamp: testTimestamp,
 								Windows:   testWindows,
 							},
-							Elm2: Restriction{8},
+							Elm2: &VetRestriction{ID: "KvSdf.2", SplitRest: true, RestSize: true, Key: 1, Val: 2},
 						},
-						Elm2:      15.0,
+						Elm2:      3.0,
 						Timestamp: testTimestamp,
 						Windows:   testWindows,
 					},
@@ -227,7 +227,7 @@ func TestSdfNodes(t *testing.T) {
 
 				for i, got := range capt.Elements {
 					if !cmp.Equal(got, test.want[i]) {
-						t.Errorf("ProcessElement(%v) has incorrect output %v: got: %v, want: %v",
+						t.Errorf("SplitAndSizeRestrictions(%v) has incorrect output %v: got: %v, want: %v",
 							test.in, i, got, test.want)
 					}
 				}
@@ -249,16 +249,16 @@ func TestSdfNodes(t *testing.T) {
 				fn:   dfn,
 				in: FullValue{
 					Elm: &FullValue{
-						Elm:  3,
-						Elm2: Restriction{5},
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf"},
 					},
-					Elm2:      8.0,
+					Elm2:      1.0,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
 				want: FullValue{
-					Elm:       8,
-					Elm2:      4,
+					Elm:       VetRestriction{ID: "Sdf", CreateTracker: true, ProcessElm: true, Val: 1},
+					Elm2:      nil,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
@@ -269,20 +269,20 @@ func TestSdfNodes(t *testing.T) {
 				in: FullValue{
 					Elm: &FullValue{
 						Elm: &FullValue{
-							Elm:       3,
-							Elm2:      10,
+							Elm:       1,
+							Elm2:      2,
 							Timestamp: testTimestamp,
 							Windows:   testWindows,
 						},
-						Elm2: Restriction{5},
+						Elm2: &VetRestriction{ID: "KvSdf"},
 					},
-					Elm2:      18.0,
+					Elm2:      3.0,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
 				want: FullValue{
-					Elm:       8,
-					Elm2:      12,
+					Elm:       VetRestriction{ID: "KvSdf", CreateTracker: true, ProcessElm: true, Key: 1, Val: 2},
+					Elm2:      nil,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
@@ -300,7 +300,7 @@ func TestSdfNodes(t *testing.T) {
 
 				got := capt.Elements[0]
 				if !cmp.Equal(got, test.want) {
-					t.Errorf("ProcessElement(%v) has incorrect output: got: %v, want: %v",
+					t.Errorf("ProcessSizedElementsAndRestrictions(%v) has incorrect output: got: %v, want: %v",
 						test.in, got, test.want)
 				}
 			})

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
@@ -257,7 +257,7 @@ func TestSdfNodes(t *testing.T) {
 					Windows:   testWindows,
 				},
 				want: FullValue{
-					Elm:       VetRestriction{ID: "Sdf", CreateTracker: true, ProcessElm: true, Val: 1},
+					Elm:       &VetRestriction{ID: "Sdf", CreateTracker: true, ProcessElm: true, Val: 1},
 					Elm2:      nil,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
@@ -281,7 +281,7 @@ func TestSdfNodes(t *testing.T) {
 					Windows:   testWindows,
 				},
 				want: FullValue{
-					Elm:       VetRestriction{ID: "KvSdf", CreateTracker: true, ProcessElm: true, Key: 1, Val: 2},
+					Elm:       &VetRestriction{ID: "KvSdf", CreateTracker: true, ProcessElm: true, Key: 1, Val: 2},
 					Elm2:      nil,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,


### PR DESCRIPTION
Refactoring the restriction used for testing SDFs. Instead of having
some obtuse behavior that we can validate, it now just contains a bunch
of flags we can flip to track that it was used in each method.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
