### PR TITLE
[BEAM-9430] Fixes the bounds of initial watermark set to estimators instead of raising an error

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
@@ -46,6 +46,7 @@ import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.HasProgress;
 import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.NameUtils;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.KV;
@@ -537,6 +538,12 @@ public class Read {
     @NewWatermarkEstimator
     public WatermarkEstimators.Manual newWatermarkEstimator(
         @WatermarkEstimatorState Instant watermarkEstimatorState) {
+      // Making sure that the watermark is within bounds.
+      if (watermarkEstimatorState.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)) {
+        watermarkEstimatorState = BoundedWindow.TIMESTAMP_MIN_VALUE;
+      } else if (watermarkEstimatorState.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
+        watermarkEstimatorState = BoundedWindow.TIMESTAMP_MAX_VALUE;
+      }
       return new WatermarkEstimators.Manual(watermarkEstimatorState);
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimator.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.transforms.splittabledofn;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Instant;
 
 /**
@@ -45,19 +44,4 @@ public interface WatermarkEstimator<WatermarkEstimatorStateT> {
    * <p>The state returned must not be mutated.
    */
   WatermarkEstimatorStateT getState();
-
-  /**
-   * Validates that a given watermark is within timestamp min and max bounds.
-   *
-   * @param watermark watermark to validate
-   */
-  static void ensureWatermarkWithinBounds(Instant watermark) {
-    if (watermark.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)
-        || watermark.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Provided watermark %s must be within bounds [%s, %s].",
-              watermark, BoundedWindow.TIMESTAMP_MIN_VALUE, BoundedWindow.TIMESTAMP_MAX_VALUE));
-    }
-  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimator.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.transforms.splittabledofn;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Instant;
 
 /**
@@ -44,4 +45,19 @@ public interface WatermarkEstimator<WatermarkEstimatorStateT> {
    * <p>The state returned must not be mutated.
    */
   WatermarkEstimatorStateT getState();
+
+  /**
+   * Validates that a given watermark is within timestamp min and max bounds.
+   *
+   * @param watermark watermark to validate
+   */
+  static void ensureWatermarkWithinBounds(Instant watermark) {
+    if (watermark.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)
+        || watermark.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Provided watermark %s must be within bounds [%s, %s].",
+              watermark, BoundedWindow.TIMESTAMP_MIN_VALUE, BoundedWindow.TIMESTAMP_MAX_VALUE));
+    }
+  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java
@@ -37,13 +37,13 @@ public class WatermarkEstimators {
     private Instant lastReportedWatermark;
 
     public Manual(Instant watermark) {
-      BoundedWindow.validateWatermarkWithinBounds(watermark);
+      BoundedWindow.validateTimestampBounds(watermark);
       this.watermark = checkNotNull(watermark, "watermark must not be null.");
     }
 
     @Override
     public void setWatermark(Instant watermark) {
-      BoundedWindow.validateWatermarkWithinBounds(watermark);
+      BoundedWindow.validateTimestampBounds(watermark);
       this.lastReportedWatermark = watermark;
     }
 
@@ -75,7 +75,7 @@ public class WatermarkEstimators {
     private Instant watermark;
 
     public WallTime(Instant watermark) {
-      BoundedWindow.validateWatermarkWithinBounds(watermark);
+      BoundedWindow.validateTimestampBounds(watermark);
       this.watermark = checkNotNull(watermark, "watermark must not be null.");
     }
 
@@ -108,7 +108,7 @@ public class WatermarkEstimators {
     private Instant lastObservedTimestamp;
 
     public MonotonicallyIncreasing(Instant watermark) {
-      BoundedWindow.validateWatermarkWithinBounds(watermark);
+      BoundedWindow.validateTimestampBounds(watermark);
       this.watermark = checkNotNull(watermark, "timestamp must not be null.");
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java
@@ -22,7 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Instant;
 
 /**
@@ -37,18 +37,23 @@ public class WatermarkEstimators {
     private Instant lastReportedWatermark;
 
     public Manual(Instant watermark) {
+      validateWatermark(watermark);
       this.watermark = checkNotNull(watermark, "watermark must not be null.");
-      if (watermark.isBefore(GlobalWindow.TIMESTAMP_MIN_VALUE)
-          || watermark.isAfter(GlobalWindow.TIMESTAMP_MAX_VALUE)) {
+    }
+
+    private void validateWatermark(Instant watermark) {
+      if (watermark.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)
+          || watermark.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
         throw new IllegalArgumentException(
             String.format(
                 "Provided watermark %s must be within bounds [%s, %s].",
-                watermark, GlobalWindow.TIMESTAMP_MIN_VALUE, GlobalWindow.TIMESTAMP_MAX_VALUE));
+                watermark, BoundedWindow.TIMESTAMP_MIN_VALUE, BoundedWindow.TIMESTAMP_MAX_VALUE));
       }
     }
 
     @Override
     public void setWatermark(Instant watermark) {
+      validateWatermark(watermark);
       this.lastReportedWatermark = watermark;
     }
 
@@ -59,7 +64,6 @@ public class WatermarkEstimators {
       if (lastReportedWatermark != null && lastReportedWatermark.isAfter(watermark)) {
         watermark = lastReportedWatermark;
       }
-
       return watermark;
     }
 
@@ -82,12 +86,12 @@ public class WatermarkEstimators {
 
     public WallTime(Instant watermark) {
       this.watermark = checkNotNull(watermark, "watermark must not be null.");
-      if (watermark.isBefore(GlobalWindow.TIMESTAMP_MIN_VALUE)
-          || watermark.isAfter(GlobalWindow.TIMESTAMP_MAX_VALUE)) {
+      if (watermark.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)
+          || watermark.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
         throw new IllegalArgumentException(
             String.format(
                 "Provided watermark %s must be within bounds [%s, %s].",
-                watermark, GlobalWindow.TIMESTAMP_MIN_VALUE, GlobalWindow.TIMESTAMP_MAX_VALUE));
+                watermark, BoundedWindow.TIMESTAMP_MIN_VALUE, BoundedWindow.TIMESTAMP_MAX_VALUE));
       }
     }
 
@@ -121,12 +125,12 @@ public class WatermarkEstimators {
 
     public MonotonicallyIncreasing(Instant watermark) {
       this.watermark = checkNotNull(watermark, "timestamp must not be null.");
-      if (watermark.isBefore(GlobalWindow.TIMESTAMP_MIN_VALUE)
-          || watermark.isAfter(GlobalWindow.TIMESTAMP_MAX_VALUE)) {
+      if (watermark.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)
+          || watermark.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
         throw new IllegalArgumentException(
             String.format(
                 "Provided watermark %s must be within bounds [%s, %s].",
-                watermark, GlobalWindow.TIMESTAMP_MIN_VALUE, GlobalWindow.TIMESTAMP_MAX_VALUE));
+                watermark, BoundedWindow.TIMESTAMP_MIN_VALUE, BoundedWindow.TIMESTAMP_MAX_VALUE));
       }
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java
@@ -22,7 +22,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Instant;
 
 /**
@@ -37,23 +36,13 @@ public class WatermarkEstimators {
     private Instant lastReportedWatermark;
 
     public Manual(Instant watermark) {
-      validateWatermark(watermark);
+      WatermarkEstimator.ensureWatermarkWithinBounds(watermark);
       this.watermark = checkNotNull(watermark, "watermark must not be null.");
-    }
-
-    private void validateWatermark(Instant watermark) {
-      if (watermark.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)
-          || watermark.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Provided watermark %s must be within bounds [%s, %s].",
-                watermark, BoundedWindow.TIMESTAMP_MIN_VALUE, BoundedWindow.TIMESTAMP_MAX_VALUE));
-      }
     }
 
     @Override
     public void setWatermark(Instant watermark) {
-      validateWatermark(watermark);
+      WatermarkEstimator.ensureWatermarkWithinBounds(watermark);
       this.lastReportedWatermark = watermark;
     }
 
@@ -85,14 +74,8 @@ public class WatermarkEstimators {
     private Instant watermark;
 
     public WallTime(Instant watermark) {
+      WatermarkEstimator.ensureWatermarkWithinBounds(watermark);
       this.watermark = checkNotNull(watermark, "watermark must not be null.");
-      if (watermark.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)
-          || watermark.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Provided watermark %s must be within bounds [%s, %s].",
-                watermark, BoundedWindow.TIMESTAMP_MIN_VALUE, BoundedWindow.TIMESTAMP_MAX_VALUE));
-      }
     }
 
     @Override
@@ -124,14 +107,8 @@ public class WatermarkEstimators {
     private Instant lastObservedTimestamp;
 
     public MonotonicallyIncreasing(Instant watermark) {
+      WatermarkEstimator.ensureWatermarkWithinBounds(watermark);
       this.watermark = checkNotNull(watermark, "timestamp must not be null.");
-      if (watermark.isBefore(BoundedWindow.TIMESTAMP_MIN_VALUE)
-          || watermark.isAfter(BoundedWindow.TIMESTAMP_MAX_VALUE)) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Provided watermark %s must be within bounds [%s, %s].",
-                watermark, BoundedWindow.TIMESTAMP_MIN_VALUE, BoundedWindow.TIMESTAMP_MAX_VALUE));
-      }
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Instant;
 
 /**
@@ -36,13 +37,13 @@ public class WatermarkEstimators {
     private Instant lastReportedWatermark;
 
     public Manual(Instant watermark) {
-      WatermarkEstimator.ensureWatermarkWithinBounds(watermark);
+      BoundedWindow.validateWatermarkWithinBounds(watermark);
       this.watermark = checkNotNull(watermark, "watermark must not be null.");
     }
 
     @Override
     public void setWatermark(Instant watermark) {
-      WatermarkEstimator.ensureWatermarkWithinBounds(watermark);
+      BoundedWindow.validateWatermarkWithinBounds(watermark);
       this.lastReportedWatermark = watermark;
     }
 
@@ -74,7 +75,7 @@ public class WatermarkEstimators {
     private Instant watermark;
 
     public WallTime(Instant watermark) {
-      WatermarkEstimator.ensureWatermarkWithinBounds(watermark);
+      BoundedWindow.validateWatermarkWithinBounds(watermark);
       this.watermark = checkNotNull(watermark, "watermark must not be null.");
     }
 
@@ -107,7 +108,7 @@ public class WatermarkEstimators {
     private Instant lastObservedTimestamp;
 
     public MonotonicallyIncreasing(Instant watermark) {
-      WatermarkEstimator.ensureWatermarkWithinBounds(watermark);
+      BoundedWindow.validateWatermarkWithinBounds(watermark);
       this.watermark = checkNotNull(watermark, "timestamp must not be null.");
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/BoundedWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/BoundedWindow.java
@@ -83,4 +83,18 @@ public abstract class BoundedWindow {
         Long.parseLong(
             constant.getValueDescriptor().getOptions().getExtension(RunnerApi.beamConstant)));
   }
+
+  /**
+   * Validates that a given watermark is within timestamp min and max bounds.
+   *
+   * @param watermark watermark to validate
+   */
+  public static void validateWatermarkWithinBounds(Instant watermark) {
+    if (watermark.isBefore(TIMESTAMP_MIN_VALUE) || watermark.isAfter(TIMESTAMP_MAX_VALUE)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Provided watermark %s must be within bounds [%s, %s].",
+              watermark, TIMESTAMP_MIN_VALUE, TIMESTAMP_MAX_VALUE));
+    }
+  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/BoundedWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/BoundedWindow.java
@@ -85,16 +85,16 @@ public abstract class BoundedWindow {
   }
 
   /**
-   * Validates that a given watermark is within timestamp min and max bounds.
+   * Validates that a given timestamp is within min and max bounds.
    *
-   * @param watermark watermark to validate
+   * @param timestamp timestamp to validate
    */
-  public static void validateWatermarkWithinBounds(Instant watermark) {
-    if (watermark.isBefore(TIMESTAMP_MIN_VALUE) || watermark.isAfter(TIMESTAMP_MAX_VALUE)) {
+  public static void validateTimestampBounds(Instant timestamp) {
+    if (timestamp.isBefore(TIMESTAMP_MIN_VALUE) || timestamp.isAfter(TIMESTAMP_MAX_VALUE)) {
       throw new IllegalArgumentException(
           String.format(
-              "Provided watermark %s must be within bounds [%s, %s].",
-              watermark, TIMESTAMP_MIN_VALUE, TIMESTAMP_MAX_VALUE));
+              "Provided timestamp %s must be within bounds [%s, %s].",
+              timestamp, TIMESTAMP_MIN_VALUE, TIMESTAMP_MAX_VALUE));
     }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimatorsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimatorsTest.java
@@ -20,7 +20,7 @@ package org.apache.beam.sdk.transforms.splittabledofn;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.beam.sdk.testing.ResetDateTimeProvider;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -34,70 +34,70 @@ public class WatermarkEstimatorsTest {
   public @Rule ResetDateTimeProvider resetDateTimeProvider = new ResetDateTimeProvider();
 
   @Test
-  public void testManualWatermarkEstimator() throws Exception {
+  public void testManualWatermarkEstimator() {
     ManualWatermarkEstimator<Instant> watermarkEstimator =
-        new WatermarkEstimators.Manual(GlobalWindow.TIMESTAMP_MIN_VALUE);
-    assertEquals(GlobalWindow.TIMESTAMP_MIN_VALUE, watermarkEstimator.currentWatermark());
-    watermarkEstimator.setWatermark(GlobalWindow.TIMESTAMP_MIN_VALUE);
+        new WatermarkEstimators.Manual(BoundedWindow.TIMESTAMP_MIN_VALUE);
+    assertEquals(BoundedWindow.TIMESTAMP_MIN_VALUE, watermarkEstimator.currentWatermark());
+    watermarkEstimator.setWatermark(BoundedWindow.TIMESTAMP_MIN_VALUE);
     watermarkEstimator.setWatermark(
-        GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)));
+        BoundedWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)));
     assertEquals(
-        GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)),
+        BoundedWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)),
         watermarkEstimator.currentWatermark());
 
     // Make sure that even if the watermark goes backwards we report the "greatest" value we have
     // reported so far.
     watermarkEstimator.setWatermark(
-        GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(1)));
+        BoundedWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(1)));
     assertEquals(
-        GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)),
+        BoundedWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)),
         watermarkEstimator.currentWatermark());
 
-    watermarkEstimator.setWatermark(GlobalWindow.TIMESTAMP_MAX_VALUE);
-    assertEquals(GlobalWindow.TIMESTAMP_MAX_VALUE, watermarkEstimator.currentWatermark());
+    watermarkEstimator.setWatermark(BoundedWindow.TIMESTAMP_MAX_VALUE);
+    assertEquals(BoundedWindow.TIMESTAMP_MAX_VALUE, watermarkEstimator.currentWatermark());
   }
 
   @Test
-  public void testWallTimeWatermarkEstimator() throws Exception {
-    DateTimeUtils.setCurrentMillisFixed(GlobalWindow.TIMESTAMP_MIN_VALUE.getMillis());
+  public void testWallTimeWatermarkEstimator() {
+    DateTimeUtils.setCurrentMillisFixed(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis());
     WatermarkEstimator<Instant> watermarkEstimator =
         new WatermarkEstimators.WallTime(new Instant());
-    DateTimeUtils.setCurrentMillisFixed(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(1).getMillis());
-    assertEquals(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(1), watermarkEstimator.currentWatermark());
+    DateTimeUtils.setCurrentMillisFixed(BoundedWindow.TIMESTAMP_MIN_VALUE.plus(1).getMillis());
+    assertEquals(BoundedWindow.TIMESTAMP_MIN_VALUE.plus(1), watermarkEstimator.currentWatermark());
 
-    DateTimeUtils.setCurrentMillisFixed(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(2).getMillis());
+    DateTimeUtils.setCurrentMillisFixed(BoundedWindow.TIMESTAMP_MIN_VALUE.plus(2).getMillis());
     // Make sure that we don't mutate state even if the clock advanced
-    assertEquals(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(1), watermarkEstimator.getState());
-    assertEquals(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(2), watermarkEstimator.currentWatermark());
-    assertEquals(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(2), watermarkEstimator.getState());
+    assertEquals(BoundedWindow.TIMESTAMP_MIN_VALUE.plus(1), watermarkEstimator.getState());
+    assertEquals(BoundedWindow.TIMESTAMP_MIN_VALUE.plus(2), watermarkEstimator.currentWatermark());
+    assertEquals(BoundedWindow.TIMESTAMP_MIN_VALUE.plus(2), watermarkEstimator.getState());
 
     // Handle the case if the clock ever goes backwards. Could happen if we resumed processing
     // on a machine that had misconfigured clock or due to clock skew.
-    DateTimeUtils.setCurrentMillisFixed(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(1).getMillis());
-    assertEquals(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(2), watermarkEstimator.currentWatermark());
+    DateTimeUtils.setCurrentMillisFixed(BoundedWindow.TIMESTAMP_MIN_VALUE.plus(1).getMillis());
+    assertEquals(BoundedWindow.TIMESTAMP_MIN_VALUE.plus(2), watermarkEstimator.currentWatermark());
   }
 
   @Test
-  public void testMonotonicallyIncreasingWatermarkEstimator() throws Exception {
+  public void testMonotonicallyIncreasingWatermarkEstimator() {
     TimestampObservingWatermarkEstimator<Instant> watermarkEstimator =
-        new WatermarkEstimators.MonotonicallyIncreasing(GlobalWindow.TIMESTAMP_MIN_VALUE);
-    assertEquals(GlobalWindow.TIMESTAMP_MIN_VALUE, watermarkEstimator.currentWatermark());
-    watermarkEstimator.observeTimestamp(GlobalWindow.TIMESTAMP_MIN_VALUE);
+        new WatermarkEstimators.MonotonicallyIncreasing(BoundedWindow.TIMESTAMP_MIN_VALUE);
+    assertEquals(BoundedWindow.TIMESTAMP_MIN_VALUE, watermarkEstimator.currentWatermark());
+    watermarkEstimator.observeTimestamp(BoundedWindow.TIMESTAMP_MIN_VALUE);
     watermarkEstimator.observeTimestamp(
-        GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)));
+        BoundedWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)));
     assertEquals(
-        GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)),
+        BoundedWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)),
         watermarkEstimator.currentWatermark());
 
     // Make sure that even if the watermark goes backwards we report the "greatest" value we have
     // reported so far.
     watermarkEstimator.observeTimestamp(
-        GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(1)));
+        BoundedWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(1)));
     assertEquals(
-        GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)),
+        BoundedWindow.TIMESTAMP_MIN_VALUE.plus(Duration.standardHours(2)),
         watermarkEstimator.currentWatermark());
 
-    watermarkEstimator.observeTimestamp(GlobalWindow.TIMESTAMP_MAX_VALUE);
-    assertEquals(GlobalWindow.TIMESTAMP_MAX_VALUE, watermarkEstimator.currentWatermark());
+    watermarkEstimator.observeTimestamp(BoundedWindow.TIMESTAMP_MAX_VALUE);
+    assertEquals(BoundedWindow.TIMESTAMP_MAX_VALUE, watermarkEstimator.currentWatermark());
   }
 }


### PR DESCRIPTION
Fixes the bounds of initial watermark set to estimators instead of raising an error.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
