### PR TITLE
[BEAM-9931] Support custom Avro DatumReaders in AvroIO

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
@@ -137,6 +137,15 @@ public class AvroSource<T> extends BlockBasedSource<T> {
   // The default sync interval is 64k.
   private static final long DEFAULT_MIN_BUNDLE_SIZE = 2L * DataFileConstants.DEFAULT_SYNC_INTERVAL;
 
+  @FunctionalInterface
+  public interface DatumReaderFactory<T> extends Serializable {
+    DatumReader<T> apply(Schema writer, Schema reader);
+  }
+
+  private static final DatumReaderFactory<?> GENERIC_DATUM_READER_FACTORY = GenericDatumReader::new;
+
+  private static final DatumReaderFactory<?> REFLECT_DATUM_READER_FACTORY = ReflectDatumReader::new;
+
   // Use cases of AvroSource are:
   // 1) AvroSource<GenericRecord> Reading GenericRecord records with a specified schema.
   // 2) AvroSource<Foo> Reading records of a generated Avro class Foo.
@@ -147,6 +156,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
   // readerSchemaString  |    non-null   |   non-null  |     null      |
   // parseFn             |      null     |     null    |   non-null    |
   // outputCoder         |      null     |     null    |   non-null    |
+  // readerFactory       |     either    |    either   |    either     |
   private static class Mode<T> implements Serializable {
     private final Class<?> type;
 
@@ -157,15 +167,19 @@ public class AvroSource<T> extends BlockBasedSource<T> {
 
     @Nullable private final Coder<T> outputCoder;
 
+    @Nullable private final DatumReaderFactory<?> readerFactory;
+
     private Mode(
         Class<?> type,
         @Nullable String readerSchemaString,
         @Nullable SerializableFunction<GenericRecord, T> parseFn,
-        @Nullable Coder<T> outputCoder) {
+        @Nullable Coder<T> outputCoder,
+        @Nullable DatumReaderFactory<?> readerFactory) {
       this.type = type;
       this.readerSchemaString = internSchemaString(readerSchemaString);
       this.parseFn = parseFn;
       this.outputCoder = outputCoder;
+      this.readerFactory = readerFactory;
     }
 
     private void readObject(ObjectInputStream is) throws IOException, ClassNotFoundException {
@@ -188,19 +202,38 @@ public class AvroSource<T> extends BlockBasedSource<T> {
             "schema must be specified using withSchema() when not using a parse fn");
       }
     }
+
+    private Mode<T> withReaderFactory(DatumReaderFactory<?> factory) {
+      return new Mode<>(type, readerSchemaString, parseFn, outputCoder, factory);
+    }
+
+    private DatumReader<?> createReader(Schema writerSchema, Schema readerSchema) {
+      DatumReaderFactory<?> factory = this.readerFactory;
+      if (factory == null) {
+        factory =
+            (type == GenericRecord.class)
+                ? GENERIC_DATUM_READER_FACTORY
+                : REFLECT_DATUM_READER_FACTORY;
+      }
+      return factory.apply(writerSchema, readerSchema);
+    }
   }
 
-  private static Mode<GenericRecord> readGenericRecordsWithSchema(String schema) {
-    return new Mode<>(GenericRecord.class, schema, null, null);
+  private static Mode<GenericRecord> readGenericRecordsWithSchema(
+      String schema, @Nullable DatumReaderFactory<?> factory) {
+    return new Mode<>(GenericRecord.class, schema, null, null, factory);
   }
 
-  private static <T> Mode<T> readGeneratedClasses(Class<T> clazz) {
-    return new Mode<>(clazz, ReflectData.get().getSchema(clazz).toString(), null, null);
+  private static <T> Mode<T> readGeneratedClasses(
+      Class<T> clazz, @Nullable DatumReaderFactory<?> factory) {
+    return new Mode<>(clazz, ReflectData.get().getSchema(clazz).toString(), null, null, factory);
   }
 
   private static <T> Mode<T> parseGenericRecords(
-      SerializableFunction<GenericRecord, T> parseFn, Coder<T> outputCoder) {
-    return new Mode<>(GenericRecord.class, null, parseFn, outputCoder);
+      SerializableFunction<GenericRecord, T> parseFn,
+      Coder<T> outputCoder,
+      @Nullable DatumReaderFactory<?> factory) {
+    return new Mode<>(GenericRecord.class, null, parseFn, outputCoder, factory);
   }
 
   private final Mode<T> mode;
@@ -214,7 +247,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
         fileNameOrPattern,
         EmptyMatchTreatment.DISALLOW,
         DEFAULT_MIN_BUNDLE_SIZE,
-        readGenericRecordsWithSchema(null /* will need to be specified in withSchema */));
+        readGenericRecordsWithSchema(null /* will need to be specified in withSchema */, null));
   }
 
   public static AvroSource<GenericRecord> from(Metadata metadata) {
@@ -223,7 +256,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
         DEFAULT_MIN_BUNDLE_SIZE,
         0,
         metadata.sizeBytes(),
-        readGenericRecordsWithSchema(null /* will need to be specified in withSchema */));
+        readGenericRecordsWithSchema(null /* will need to be specified in withSchema */, null));
   }
 
   /** Like {@link #from(ValueProvider)}. */
@@ -243,7 +276,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
         getFileOrPatternSpecProvider(),
         getEmptyMatchTreatment(),
         getMinBundleSize(),
-        readGenericRecordsWithSchema(schema));
+        readGenericRecordsWithSchema(schema, mode.readerFactory));
   }
 
   /** Like {@link #withSchema(String)}. */
@@ -261,13 +294,13 @@ public class AvroSource<T> extends BlockBasedSource<T> {
           getMinBundleSize(),
           getStartOffset(),
           getEndOffset(),
-          readGeneratedClasses(clazz));
+          readGeneratedClasses(clazz, mode.readerFactory));
     }
     return new AvroSource<>(
         getFileOrPatternSpecProvider(),
         getEmptyMatchTreatment(),
         getMinBundleSize(),
-        readGeneratedClasses(clazz));
+        readGeneratedClasses(clazz, mode.readerFactory));
   }
 
   /**
@@ -284,13 +317,13 @@ public class AvroSource<T> extends BlockBasedSource<T> {
           getMinBundleSize(),
           getStartOffset(),
           getEndOffset(),
-          parseGenericRecords(parseFn, coder));
+          parseGenericRecords(parseFn, coder, mode.readerFactory));
     }
     return new AvroSource<>(
         getFileOrPatternSpecProvider(),
         getEmptyMatchTreatment(),
         getMinBundleSize(),
-        parseGenericRecords(parseFn, coder));
+        parseGenericRecords(parseFn, coder, mode.readerFactory));
   }
 
   /**
@@ -304,6 +337,16 @@ public class AvroSource<T> extends BlockBasedSource<T> {
     }
     return new AvroSource<>(
         getFileOrPatternSpecProvider(), getEmptyMatchTreatment(), minBundleSize, mode);
+  }
+
+  public AvroSource<T> withDatumReaderFactory(DatumReaderFactory<?> factory) {
+    Mode<T> newMode = mode.withReaderFactory(factory);
+    if (getMode() == SINGLE_FILE_OR_SUBRANGE) {
+      return new AvroSource<>(
+          getSingleFileMetadata(), getMinBundleSize(), getStartOffset(), getEndOffset(), newMode);
+    }
+    return new AvroSource<>(
+        getFileOrPatternSpecProvider(), getEmptyMatchTreatment(), getMinBundleSize(), newMode);
   }
 
   /** Constructor for FILEPATTERN mode. */
@@ -576,11 +619,16 @@ public class AvroSource<T> extends BlockBasedSource<T> {
       Schema readerSchema =
           internOrParseSchemaString(
               MoreObjects.firstNonNull(mode.readerSchemaString, writerSchemaString));
-      this.reader =
-          (mode.type == GenericRecord.class)
-              ? new GenericDatumReader<T>(writerSchema, readerSchema)
-              : new ReflectDatumReader<T>(writerSchema, readerSchema);
-      this.decoder = DecoderFactory.get().binaryDecoder(decodeAsInputStream(data, codec), null);
+
+      this.reader = mode.createReader(writerSchema, readerSchema);
+
+      if (codec.equals(DataFileConstants.NULL_CODEC)) {
+        // Avro can read from a byte[] using a more efficient implementation.  If the input is not
+        // compressed, pass the data in directly.
+        this.decoder = DecoderFactory.get().binaryDecoder(data, null);
+      } else {
+        this.decoder = DecoderFactory.get().binaryDecoder(decodeAsInputStream(data, codec), null);
+      }
     }
 
     @Override


### PR DESCRIPTION
Similar to PR #11479, it would be useful to be able to explicitly pass a DatumReader factory to AvroIO, and have it use that instead of GenericDatumReader or SpecificDatumReader.

This PR adds `withDatumReaderFactory` to AvroIO and plumbs it through into AvroSource.

R: @iemejia 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
