### PR TITLE
[BEAM-9642] Adding Go SDF fallback for unexpanded SDFs.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -46,7 +46,7 @@ func (n *PairWithRestriction) Up(ctx context.Context) error {
 	fn := (*graph.SplittableDoFn)(n.Fn).CreateInitialRestrictionFn()
 	var err error
 	if n.inv, err = newCreateInitialRestrictionInvoker(fn); err != nil {
-		return errors.WithContextf(err, "PairWithRestriction transform with UID %v", n.ID())
+		return errors.WithContextf(err, "%v", n)
 	}
 	return nil
 }
@@ -80,7 +80,7 @@ func (n *PairWithRestriction) ProcessElement(ctx context.Context, elm *FullValue
 	return n.Out.ProcessElement(ctx, &output, values...)
 }
 
-// FinishBundle does some teardown for the end of the bundle.
+// FinishBundle resets the invokers.
 func (n *PairWithRestriction) FinishBundle(ctx context.Context) error {
 	n.inv.Reset()
 	return n.Out.FinishBundle(ctx)
@@ -93,7 +93,7 @@ func (n *PairWithRestriction) Down(ctx context.Context) error {
 
 // String outputs a human-readable description of this transform.
 func (n *PairWithRestriction) String() string {
-	return fmt.Sprintf("SDF.PairWithRestriction[%v] Out:%v", path.Base(n.Fn.Name()), IDs(n.Out))
+	return fmt.Sprintf("SDF.PairWithRestriction[%v] UID:%v Out:%v", path.Base(n.Fn.Name()), n.UID, IDs(n.Out))
 }
 
 // SplitAndSizeRestrictions is an executor for the expanded SDF step of the
@@ -120,12 +120,12 @@ func (n *SplitAndSizeRestrictions) Up(ctx context.Context) error {
 	fn := (*graph.SplittableDoFn)(n.Fn).SplitRestrictionFn()
 	var err error
 	if n.splitInv, err = newSplitRestrictionInvoker(fn); err != nil {
-		return errors.WithContextf(err, "SplitAndSizeRestrictions transform with UID %v", n.ID())
+		return errors.WithContextf(err, "%v", n)
 	}
 
 	fn = (*graph.SplittableDoFn)(n.Fn).RestrictionSizeFn()
 	if n.sizeInv, err = newRestrictionSizeInvoker(fn); err != nil {
-		return errors.WithContextf(err, "SplitAndSizeRestrictions transform with UID %v", n.ID())
+		return errors.WithContextf(err, "%v", n)
 	}
 
 	return nil
@@ -171,7 +171,7 @@ func (n *SplitAndSizeRestrictions) ProcessElement(ctx context.Context, elm *Full
 	splitRests := n.splitInv.Invoke(mainElm, rest)
 	if len(splitRests) == 0 {
 		err := errors.Errorf("initial splitting returned 0 restrictions.")
-		return errors.WithContextf(err, "SplitAndSizeRestrictions transform with UID %v", n.ID())
+		return errors.WithContextf(err, "%v", n)
 	}
 
 	for _, splitRest := range splitRests {
@@ -191,7 +191,7 @@ func (n *SplitAndSizeRestrictions) ProcessElement(ctx context.Context, elm *Full
 	return nil
 }
 
-// FinishBundle does some teardown for the end of the bundle.
+// FinishBundle resets the invokers.
 func (n *SplitAndSizeRestrictions) FinishBundle(ctx context.Context) error {
 	n.splitInv.Reset()
 	n.sizeInv.Reset()
@@ -205,7 +205,7 @@ func (n *SplitAndSizeRestrictions) Down(ctx context.Context) error {
 
 // String outputs a human-readable description of this transform.
 func (n *SplitAndSizeRestrictions) String() string {
-	return fmt.Sprintf("SDF.SplitAndSizeRestrictions[%v] Out:%v", path.Base(n.Fn.Name()), IDs(n.Out))
+	return fmt.Sprintf("SDF.SplitAndSizeRestrictions[%v] UID:%v Out:%v", path.Base(n.Fn.Name()), n.UID, IDs(n.Out))
 }
 
 // ProcessSizedElementsAndRestrictions is an executor for the expanded SDF step
@@ -219,22 +219,22 @@ type ProcessSizedElementsAndRestrictions struct {
 	inv *ctInvoker
 }
 
-// ID just defers to the ParDo's ID method.
+// ID calls the ParDo's ID method.
 func (n *ProcessSizedElementsAndRestrictions) ID() UnitID {
 	return n.PDo.ID()
 }
 
-// Up performs some one-time setup and then defers to the ParDo's Up method.
+// Up performs some one-time setup and then calls the ParDo's Up method.
 func (n *ProcessSizedElementsAndRestrictions) Up(ctx context.Context) error {
 	fn := (*graph.SplittableDoFn)(n.PDo.Fn).CreateTrackerFn()
 	var err error
 	if n.inv, err = newCreateTrackerInvoker(fn); err != nil {
-		return errors.WithContextf(err, "ProcessSizedElementsAndRestrictions transform with UID %v", n.ID())
+		return errors.WithContextf(err, "%v", n)
 	}
 	return n.PDo.Up(ctx)
 }
 
-// StartBundle just defers to the ParDo's StartBundle method.
+// StartBundle calls the ParDo's StartBundle method.
 func (n *ProcessSizedElementsAndRestrictions) StartBundle(ctx context.Context, id string, data DataContext) error {
 	return n.PDo.StartBundle(ctx, id, data)
 }
@@ -263,7 +263,8 @@ func (n *ProcessSizedElementsAndRestrictions) StartBundle(ctx context.Context, i
 // but currently ignored. Output is forwarded to the underlying ParDo's outputs.
 func (n *ProcessSizedElementsAndRestrictions) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	if n.PDo.status != Active {
-		return errors.Errorf("invalid status for ParDo %v: %v, want Active", n.PDo.UID, n.PDo.status)
+		err := errors.Errorf("invalid status %v, want Active", n.PDo.status)
+		return errors.WithContextf(err, "%v", n)
 	}
 
 	rest := elm.Elm.(*FullValue).Elm2
@@ -297,19 +298,109 @@ func (n *ProcessSizedElementsAndRestrictions) ProcessElement(ctx context.Context
 	return n.PDo.processMainInput(mainIn)
 }
 
-// FinishBundle does some teardown for the end of the bundle and then defers to
-// the ParDo's FinishBundle method.
+// FinishBundle resets the invokers and then calls the ParDo's FinishBundle method.
 func (n *ProcessSizedElementsAndRestrictions) FinishBundle(ctx context.Context) error {
 	n.inv.Reset()
 	return n.PDo.FinishBundle(ctx)
 }
 
-// Down just defers to the ParDo's Down method.
+// Down calls the ParDo's Down method.
 func (n *ProcessSizedElementsAndRestrictions) Down(ctx context.Context) error {
 	return n.PDo.Down(ctx)
 }
 
 // String outputs a human-readable description of this transform.
 func (n *ProcessSizedElementsAndRestrictions) String() string {
-	return fmt.Sprintf("SDF.ProcessSizedElementsAndRestrictions[%v] Out:%v", path.Base(n.PDo.Fn.Name()), IDs(n.PDo.Out...))
+	return fmt.Sprintf("SDF.ProcessSizedElementsAndRestrictions[%v] UID:%v Out:%v", path.Base(n.PDo.Fn.Name()), n.PDo.ID(), IDs(n.PDo.Out...))
+}
+
+// SdfFallback is an executor used when an SDF isn't expanded into steps by the
+// runner, indicating that the runner doesn't support splitting. It executes all
+// the SDF steps together in one unit.
+type SdfFallback struct {
+	PDo *ParDo
+
+	initRestInv *cirInvoker
+	splitInv    *srInvoker
+	trackerInv  *ctInvoker
+}
+
+// ID calls the ParDo's ID method.
+func (n *SdfFallback) ID() UnitID {
+	return n.PDo.UID
+}
+
+// Up performs some one-time setup and then calls the ParDo's Up method.
+func (n *SdfFallback) Up(ctx context.Context) error {
+	sdf := (*graph.SplittableDoFn)(n.PDo.Fn)
+	addContext := func(err error) error {
+		return errors.WithContextf(err, "%v", n)
+	}
+	var err error
+	if n.initRestInv, err = newCreateInitialRestrictionInvoker(sdf.CreateInitialRestrictionFn()); err != nil {
+		return addContext(err)
+	}
+	if n.splitInv, err = newSplitRestrictionInvoker(sdf.SplitRestrictionFn()); err != nil {
+		return addContext(err)
+	}
+	if n.trackerInv, err = newCreateTrackerInvoker(sdf.CreateTrackerFn()); err != nil {
+		return addContext(err)
+	}
+	return n.PDo.Up(ctx)
+}
+
+// StartBundle calls the ParDo's StartBundle method.
+func (n *SdfFallback) StartBundle(ctx context.Context, id string, data DataContext) error {
+	return n.PDo.StartBundle(ctx, id, data)
+}
+
+// ProcessElement performs all the work from the steps above in one transform.
+// This means creating initial restrictions, performing initial splits on those
+// restrictions, and then creating restriction trackers and processing each
+// restriction with the underlying ParDo. This executor skips the sizing step
+// because sizing information is unnecessary for unexpanded SDFs.
+func (n *SdfFallback) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
+	if n.PDo.status != Active {
+		err := errors.Errorf("invalid status %v, want Active", n.PDo.status)
+		return errors.WithContextf(err, "%v", n)
+	}
+
+	rest := n.initRestInv.Invoke(elm)
+	splitRests := n.splitInv.Invoke(elm, rest)
+	if len(splitRests) == 0 {
+		err := errors.Errorf("initial splitting returned 0 restrictions.")
+		return errors.WithContextf(err, "%v", n)
+	}
+
+	for _, splitRest := range splitRests {
+		rt := n.trackerInv.Invoke(splitRest)
+		mainIn := &MainInput{
+			Key:      *elm,
+			Values:   values,
+			RTracker: rt,
+		}
+		if err := n.PDo.processMainInput(mainIn); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FinishBundle resets the invokers and then calls the ParDo's FinishBundle method.
+func (n *SdfFallback) FinishBundle(ctx context.Context) error {
+	n.initRestInv.Reset()
+	n.splitInv.Reset()
+	n.trackerInv.Reset()
+	return n.PDo.FinishBundle(ctx)
+}
+
+// Down calls the ParDo's Down method.
+func (n *SdfFallback) Down(ctx context.Context) error {
+	return n.PDo.Down(ctx)
+}
+
+// String outputs a human-readable description of this transform.
+func (n *SdfFallback) String() string {
+	return fmt.Sprintf("SDF.SdfFallback[%v] UID:%v Out:%v", path.Base(n.PDo.Fn.Name()), n.PDo.ID(), IDs(n.PDo.Out...))
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -420,6 +420,8 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 					u = n
 					if urn == urnProcessSizedElementsAndRestrictions {
 						u = &ProcessSizedElementsAndRestrictions{PDo: n}
+					} else if dofn.IsSplittable() {
+						u = &SdfFallback{PDo: n}
 					}
 				}
 

--- a/sdks/go/pkg/beam/runners/direct/direct.go
+++ b/sdks/go/pkg/beam/runners/direct/direct.go
@@ -239,17 +239,20 @@ func (b *builder) makeLink(id linkID) (exec.Node, error) {
 			Out:     out,
 			PID:     path.Base(edge.DoFn.Name()),
 		}
+		u = pardo
+		if edge.DoFn.IsSplittable() {
+			u = &exec.SdfFallback{PDo: pardo}
+		}
 		if len(edge.Input) == 1 {
-			u = pardo
 			break
 		}
 
 		// ParDo w/ side input. We need to insert buffering and wait. We also need to
 		// ensure that we return the correct link node.
 
-		b.units = append(b.units, pardo)
+		b.units = append(b.units, u)
 
-		w := &wait{UID: b.idgen.New(), need: len(edge.Input) - 1, next: pardo}
+		w := &wait{UID: b.idgen.New(), need: len(edge.Input) - 1, next: u}
 		b.units = append(b.units, w)
 		b.links[linkID{edge.ID(), 0}] = w
 


### PR DESCRIPTION
This allows the go direct runner and other runners that don't know how to
expand SDFs to still have the SDK harness run them.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
