### PR TITLE
[BEAM-9951] Creating a synthetic source for the Go SDK.

### DIFF
--- a/sdks/go/examples/stringsplit/stringsplit.go
+++ b/sdks/go/examples/stringsplit/stringsplit.go
@@ -42,8 +42,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/apache/beam/sdks/go/examples/stringsplit/offsetrange"
 	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 )
@@ -112,15 +112,15 @@ func (fn *StringSplitFn) CreateTracker(rest offsetrange.Restriction) *offsetrang
 //
 // Example: If BufSize is 100, then a restriction of 75 to 325 should emit the
 // following substrings: [100, 200], [200, 300], [300, 400]
-func (fn *StringSplitFn) ProcessElement(rt *offsetrange.Tracker, elem string, emit func(string)) {
-	log.Debugf(context.Background(), "StringSplit ProcessElement: Tracker = %v", rt)
+func (fn *StringSplitFn) ProcessElement(ctx context.Context, rt *offsetrange.Tracker, elem string, emit func(string)) {
+	log.Debugf(ctx, "StringSplit ProcessElement: Tracker = %v", rt)
 	i := rt.Rest.Start
 	if rem := i % fn.BufSize; rem != 0 {
 		i += fn.BufSize - rem // Skip to next multiple of BufSize.
 	}
 	strEnd := int64(len(elem))
 
-	for ok := rt.TryClaim(i); ok == true; ok = rt.TryClaim(i) {
+	for rt.TryClaim(i) == true {
 		if i+fn.BufSize > strEnd {
 			emit(elem[i:])
 		} else {

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -12,6 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package offsetrange defines a restriction and restriction tracker for offset
+// ranges. An offset range is just a range, with a start and end, that can
+// begin at an offset, and is commonly used to represent byte ranges for files
+// or indices for iterable containers.
 package offsetrange
 
 import (

--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package synthetic contains transforms for creating synthetic pipelines.
+// Synthetic pipelines are pipelines that simulate the behavior of possible
+// pipelines in order to test performance, splitting, liquid sharding, and
+// various other infrastructure used for running pipelines. This category of
+// tests is not concerned with the correctness of the elements themselves, but
+// needs to simulate transforms that output many elements throughout varying
+// pipeline shapes.
+package synthetic
+
+import (
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
+	"math/rand"
+	"time"
+)
+
+// Source creates a synthetic source transform that emits randomly
+// generated KV<[]byte, []byte> elements.
+//
+// This transform accepts a PCollection of SourceConfig, where each SourceConfig
+// determines the synthetic source's behavior for that element and outputs the
+// randomly generated elements.
+//
+// SourceConfigs are recommended to be created via the DefaultSourceConfig and
+// then sent to a beam.Create transform once modified. Example:
+//
+//    cfg1 := synthetic.DefaultSourceConfig()
+//    cfg1.NumElements = 1000
+//    cfg2 := synthetic.DefaultSourceConfig()
+//    cfg2.NumElements = 5000
+//    cfg2.InitialSplits = 2
+//    cfgs := beam.Create(s, cfg1, cfg2)
+//    src := synthetic.Source(s, cfgs)
+func Source(s beam.Scope, col beam.PCollection) beam.PCollection {
+	s = s.Scope("synthetic.Source")
+
+	return beam.ParDo(s, &sourceFn{}, col)
+}
+
+// sourceFn is a splittable DoFn implementing behavior for synthetic sources.
+// For usage information, see `Source`.
+//
+// The sourceFn is expected to receive elements of type sourceConfig and follow
+// that config to determine its behavior when splitting and emitting elements.
+type sourceFn struct {
+	rng *rand.Rand
+}
+
+// CreateInitialRestriction creates an offset range restriction representing
+// the number of elements to emit.
+func (fn *sourceFn) CreateInitialRestriction(config SourceConfig) offsetrange.Restriction {
+	return offsetrange.Restriction{
+		Start: 0,
+		End:   int64(config.NumElements),
+	}
+}
+
+// SplitRestriction splits restrictions equally according to the number of
+// initial splits specified in SourceConfig. Each restriction output by this
+// method will contain at least one element, so the number of splits will not
+// exceed the number of elements.
+func (fn *sourceFn) SplitRestriction(config SourceConfig, rest offsetrange.Restriction) (splits []offsetrange.Restriction) {
+	if config.InitialSplits <= 1 {
+		// Don't split, just return original restriction.
+		splits = append(splits, rest)
+		return splits
+	}
+
+	// TODO(BEAM-9978) Move this implementation of the offset range restriction
+	// splitting to the restriction itself, and add testing.
+	num := int64(config.InitialSplits)
+	offset := rest.Start
+	size := rest.End - rest.Start
+	for i := int64(0); i < num; i++ {
+		split := offsetrange.Restriction{
+			Start: offset + (i * size / num),
+			End:   offset + ((i + 1) * size / num),
+		}
+		// Skip restrictions that end up empty.
+		if split.End-split.Start <= 0 {
+			continue
+		}
+		splits = append(splits, split)
+	}
+	return splits
+}
+
+// RestrictionSize outputs the size of the restriction as the number of elements
+// that restriction will output.
+func (fn *sourceFn) RestrictionSize(config SourceConfig, rest offsetrange.Restriction) float64 {
+	// TODO(BEAM-9978) Move this size implementation to the offset range restriction itself.
+	return float64(rest.End - rest.Start)
+}
+
+// CreateTracker just creates an offset range restriction tracker for the
+// restriction.
+func (fn *sourceFn) CreateTracker(rest offsetrange.Restriction) *offsetrange.Tracker {
+	return offsetrange.NewTracker(rest)
+}
+
+// Setup sets up the random number generator.
+func (fn *sourceFn) Setup() {
+	fn.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// ProcessElement creates a number of random elements based on the restriction
+// tracker received. Each element is a random byte slice key and value, in the
+// form of KV<[]byte, []byte>.
+func (fn *sourceFn) ProcessElement(rt *offsetrange.Tracker, config SourceConfig, emit func([]byte, []byte)) error {
+	for i := rt.Rest.Start; rt.TryClaim(i) == true; i++ {
+		key := make([]byte, 8)
+		val := make([]byte, 8)
+		if _, err := fn.rng.Read(key); err != nil {
+			return err
+		}
+		if _, err := fn.rng.Read(val); err != nil {
+			return err
+		}
+		emit(key, val)
+	}
+	return nil
+}
+
+// DefaultSourceConfig creates a SourceConfig with intended defaults for its
+// fields. SourceConfigs should be initialized with this method.
+func DefaultSourceConfig() SourceConfig {
+	return SourceConfig{
+		NumElements:   1, // Defaults to 1 so at least an element is output.
+		InitialSplits: 1, // Defaults to 1, i.e. no initial splitting.
+	}
+}
+
+// SourceConfig is a struct containing all the configuration options for a
+// synthetic source.
+type SourceConfig struct {
+	// NumElements is the number of elements for the source to generate and
+	// emit.
+	NumElements int
+
+	// InitialSplits determines the number of initial splits to perform in the
+	// source's SplitRestriction method. Note that in some edge cases, the
+	// number of splits performed might differ from this config value. Each
+	// restriction will always have one element in it, and at least one
+	// restriction will always be output, so the number of splits will be in
+	// the range of [1, N] where N is the size of the original restriction.
+	InitialSplits int
+}

--- a/sdks/go/pkg/beam/io/synthetic/source_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/source_test.go
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetic
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestSourceConfig_NumElements tests that setting the number of produced
+// elements for a synthetic source works correctly.
+func TestSourceConfig_NumElements(t *testing.T) {
+	tests := []struct {
+		elms int
+		want int
+	}{
+		{elms: 0, want: 0},
+		{elms: -1, want: 0},
+		{elms: 42, want: 42},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("(elm = %v)", test.elms), func(t *testing.T) {
+			dfn := sourceFn{}
+			cfg := DefaultSourceConfig()
+			cfg.NumElements = test.elms
+
+			keys, _, err := simulateSourceFn(&dfn, cfg)
+			if err != nil {
+				t.Errorf("Failure processing sourceFn: %v", err)
+			}
+			if got := len(keys); got != test.want {
+				t.Errorf("SourceFn emitted wrong number of outputs: got: %v, want: %v",
+					got, test.want)
+			}
+		})
+	}
+}
+
+func TestSourceConfig_InitialSplits(t *testing.T) {
+	// Test that SplitRestriction creates the expected number of restrictions.
+	t.Run("NumSplits", func(t *testing.T) {
+		tests := []struct {
+			elms   int
+			splits int
+			want   int
+		}{
+			{elms: 42, splits: 10, want: 10},
+			{elms: 4, splits: 10, want: 4},
+			{elms: 42, splits: 0, want: 1},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(fmt.Sprintf("(elm = %v, splits = %v)", test.elms, test.splits), func(t *testing.T) {
+				dfn := sourceFn{}
+				cfg := DefaultSourceConfig()
+				cfg.NumElements = test.elms
+				cfg.InitialSplits = test.splits
+
+				rest := dfn.CreateInitialRestriction(cfg)
+				splits := dfn.SplitRestriction(cfg, rest)
+				if got := len(splits); got != test.want {
+					t.Errorf("SplitRestriction output the wrong number of splits: got: %v, want: %v",
+						got, test.want)
+				}
+			})
+		}
+	})
+
+	// Tests correctness of the splitting. In this case, that means that even
+	// after splitting, the same amount of elements are output.
+	t.Run("Correctness", func(t *testing.T) {
+		tests := []struct {
+			elms   int
+			want   int
+			splits int
+		}{
+			{elms: 42, want: 42, splits: 10},
+			{elms: 4, want: 4, splits: 10},
+			{elms: -1, want: 0, splits: 10},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(fmt.Sprintf("(elm = %v)", test.elms), func(t *testing.T) {
+				dfn := sourceFn{}
+				cfg := DefaultSourceConfig()
+				cfg.NumElements = test.elms
+				cfg.InitialSplits = test.splits
+
+				keys, _, err := simulateSourceFn(&dfn, cfg)
+				if err != nil {
+					t.Errorf("Failure processing sourceFn: %v", err)
+				}
+				if got := len(keys); got != test.want {
+					t.Errorf("SourceFn emitted wrong number of outputs: got: %v, want: %v",
+						got, test.want)
+				}
+			})
+		}
+	})
+}
+
+// simulateSourceFn calls CreateInitialRestriction, SplitRestriction,
+// CreateTracker, and ProcessElement on the given sourceFn with the given
+// SourceConfig, and outputs the resulting output elements. This method isn't
+// expected to accurately reflect how SDFs are executed in practice (that
+// should be done via integration tests), but to validate the implementations of
+// those methods.
+func simulateSourceFn(dfn *sourceFn, cfg SourceConfig) (keys [][]byte, vals [][]byte, err error) {
+	emitFn := func(key []byte, val []byte) {
+		keys = append(keys, key)
+		vals = append(vals, key)
+	}
+
+	rest := dfn.CreateInitialRestriction(cfg)
+	splits := dfn.SplitRestriction(cfg, rest)
+	dfn.Setup()
+	for _, split := range splits {
+		rt := dfn.CreateTracker(split)
+		if err := dfn.ProcessElement(rt, cfg, emitFn); err != nil {
+			return nil, nil, err
+		}
+	}
+	return keys, vals, nil
+}


### PR DESCRIPTION
This is just a starting point, and there's a lot more that can be added
on to this class, but this'll do for now. As part of this change, I
generalized the offset range tracker code so it could also be used in
the synthetic source.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
