### PR TITLE
[BEAM-9946] | added new api

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 
@@ -45,6 +46,22 @@ import org.apache.beam.sdk.values.TupleTagList;
  *         }}))
  * for (int i = 0; i < 10; i++) {
  *   PCollection<Student> partition = studentsByPercentile.get(i);
+ *   ...
+ * }
+ * }</pre>
+ *
+ * <pre>{@code
+ * PCollection<Student> students = ...;
+ * // Split students up into 2 partitions, by percentile based on sideView
+ * PCollectionList<Integer> studentsByGrades =
+ *         pipeline.apply(studentsPercentage)
+ *             .apply(Partition.of(2, ((elem, numPartitions, ctx) -> {
+ *               Integer grades = ctx.sideInput(gradesView);
+ *               return elem < grades ? 0 : 1;
+ *             }),Requirements.requiresSideInputs(gradesView)));
+ *
+ *   PCollection<Student> below = studentsByPercentile.get(0); // all students who are below 50
+ *   PCollection<Student> above = studentsByPercentile.get(1); // all students who are 50 or above
  *   ...
  * }
  * }</pre>
@@ -77,6 +94,45 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
   }
 
   /**
+   * A function object that chooses an output partition for an element.
+   *
+   * @param <T> the type of the elements being partitioned
+   */
+  public interface PartitionWithSideInputsFn<T> extends Serializable {
+    /**
+     * Chooses the partition into which to put the given element.
+     *
+     * @param elem the element to be partitioned
+     * @param numPartitions the total number of partitions ({@code >= 1})
+     * @param c the {@link Contextful.Fn.Context} needed to access sideInputs.
+     * @return index of the selected partition (in the range {@code [0..numPartitions-1]})
+     */
+    int partitionFor(T elem, int numPartitions, Contextful.Fn.Context c);
+  }
+
+  /**
+   * Returns a new {@code Partition} {@code PTransform} that divides its input {@code PCollection}
+   * into the given number of partitions, using the given partitioning function.
+   *
+   * @param numPartitions the number of partitions to divide the input {@code PCollection} into
+   * @param partitionFn the function to invoke on each element to choose its output partition
+   * @param requirements the {@link Requirements} needed to run it.
+   * @throws IllegalArgumentException if {@code numPartitions <= 0}
+   */
+  public static <T> Partition<T> of(
+      int numPartitions,
+      PartitionWithSideInputsFn<? super T> partitionFn,
+      Requirements requirements) {
+    Contextful ctfFn =
+        Contextful.fn(
+            (T element, Contextful.Fn.Context c) ->
+                partitionFn.partitionFor(element, numPartitions, c),
+            requirements);
+    Object aClass = partitionFn;
+    return new Partition<>(new PartitionDoFn<T>(numPartitions, ctfFn, aClass));
+  }
+
+  /**
    * Returns a new {@code Partition} {@code PTransform} that divides its input {@code PCollection}
    * into the given number of partitions, using the given partitioning function.
    *
@@ -85,7 +141,14 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
    * @throws IllegalArgumentException if {@code numPartitions <= 0}
    */
   public static <T> Partition<T> of(int numPartitions, PartitionFn<? super T> partitionFn) {
-    return new Partition<>(new PartitionDoFn<T>(numPartitions, partitionFn));
+
+    Contextful ctfFn =
+        Contextful.fn(
+            (T element, Contextful.Fn.Context c) ->
+                partitionFn.partitionFor(element, numPartitions),
+            Requirements.empty());
+    Object aClass = partitionFn;
+    return new Partition<>(new PartitionDoFn<T>(numPartitions, ctfFn, aClass));
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -95,7 +158,10 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
     final TupleTagList outputTags = partitionDoFn.getOutputTags();
 
     PCollectionTuple outputs =
-        in.apply(ParDo.of(partitionDoFn).withOutputTags(new TupleTag<Void>() {}, outputTags));
+        in.apply(
+            ParDo.of(partitionDoFn)
+                .withOutputTags(new TupleTag<Void>() {}, outputTags)
+                .withSideInputs(partitionDoFn.getSideInputs()));
 
     PCollectionList<T> pcs = PCollectionList.empty(in.getPipeline());
     Coder<T> coder = in.getCoder();
@@ -124,21 +190,26 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
 
   private static class PartitionDoFn<X> extends DoFn<X, Void> {
     private final int numPartitions;
-    private final PartitionFn<? super X> partitionFn;
     private final TupleTagList outputTags;
+    private Contextful<Contextful.Fn<X, Integer>> ctxFn;
+    private Object originalFnForDisplayData;
 
     /**
      * Constructs a PartitionDoFn.
      *
      * @throws IllegalArgumentException if {@code numPartitions <= 0}
      */
-    public PartitionDoFn(int numPartitions, PartitionFn<? super X> partitionFn) {
+    public PartitionDoFn(
+        int numPartitions,
+        Contextful<Contextful.Fn<X, Integer>> ctxFn,
+        Object originalFnForDisplayData) {
+      this.ctxFn = ctxFn;
+      this.originalFnForDisplayData = originalFnForDisplayData;
       if (numPartitions <= 0) {
         throw new IllegalArgumentException("numPartitions must be > 0");
       }
 
       this.numPartitions = numPartitions;
-      this.partitionFn = partitionFn;
 
       TupleTagList buildOutputTags = TupleTagList.empty();
       for (int partition = 0; partition < numPartitions; partition++) {
@@ -152,12 +223,13 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
     }
 
     @ProcessElement
-    public void processElement(@Element X input, MultiOutputReceiver r) {
-      int partition = partitionFn.partitionFor(input, numPartitions);
+    public void processElement(ProcessContext c) throws Exception {
+      X input = c.element();
+      int partition = ctxFn.getClosure().apply(input, Contextful.Fn.Context.wrapProcessContext(c));
       if (0 <= partition && partition < numPartitions) {
         @SuppressWarnings("unchecked")
         TupleTag<X> typedTag = (TupleTag<X>) outputTags.get(partition);
-        r.get(typedTag).output(input);
+        c.output(typedTag, input);
       } else {
         throw new IndexOutOfBoundsException(
             "Partition function returned out of bounds index: "
@@ -174,8 +246,12 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
       builder
           .add(DisplayData.item("numPartitions", numPartitions).withLabel("Partition Count"))
           .add(
-              DisplayData.item("partitionFn", partitionFn.getClass())
+              DisplayData.item("partitionFn", originalFnForDisplayData.getClass())
                   .withLabel("Partition Function"));
+    }
+
+    public Iterable<? extends PCollectionView<?>> getSideInputs() {
+      return ctxFn.getRequirements().getSideInputs();
     }
   }
 }


### PR DESCRIPTION
Currently `Partition` transform can partition a collection into n collections based on only element value in PartitionFn to decide on which partition a particular element belongs to.

Introduce new API with additional sideInputs provided to partition function. User will be able to write logic to use both element value and sideInputs to decide on which partition a particular element belongs to.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
