### PR TITLE
[BEAM-9945] Ensure that the read index represents the number of fully processed elements including at the end of the channel or after splitting.

### DIFF
--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
@@ -525,7 +525,7 @@ public class BeamFnDataReadRunnerTest {
             null /* bundleFinalizer */);
   }
 
-  private static final MonitoringInfo createReadIndexMonitoringInfoAt(int index) {
+  private static MonitoringInfo createReadIndexMonitoringInfoAt(int index) {
     return new SimpleMonitoringInfoBuilder()
         .setUrn(MonitoringInfoConstants.Urns.DATA_CHANNEL_READ_INDEX)
         .setLabel(MonitoringInfoConstants.Labels.PTRANSFORM, INPUT_TRANSFORM_ID)

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
@@ -54,11 +54,14 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleSplitRequest.
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleSplitResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleSplitResponse.ChannelSplit;
 import org.apache.beam.model.pipeline.v1.Endpoints;
+import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.MessageWithComponents;
 import org.apache.beam.runners.core.construction.CoderTranslation;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
+import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
+import org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.fn.data.CompletableFutureInboundDataClient;
@@ -216,6 +219,7 @@ public class BeamFnDataReadRunnerTest {
     List<WindowedValue<String>> values = new ArrayList<>();
     FnDataReceiver<WindowedValue<String>> consumers = values::add;
     AtomicReference<String> bundleId = new AtomicReference<>("0");
+    List<PTransformRunnerFactory.ProgressRequestCallback> progressCallbacks = new ArrayList<>();
     BeamFnDataReadRunner<String> readRunner =
         new BeamFnDataReadRunner<>(
             INPUT_TRANSFORM_ID,
@@ -223,11 +227,17 @@ public class BeamFnDataReadRunnerTest {
             bundleId::get,
             COMPONENTS.getCodersMap(),
             mockBeamFnDataClient,
-            (PTransformRunnerFactory.ProgressRequestCallback callback) -> {},
+            (PTransformRunnerFactory.ProgressRequestCallback callback) -> {
+              progressCallbacks.add(callback);
+            },
             consumers);
 
     // Process for bundle id 0
     readRunner.registerInputLocation();
+
+    assertEquals(
+        createReadIndexMonitoringInfoAt(-1),
+        Iterables.getOnlyElement(Iterables.getOnlyElement(progressCallbacks).getMonitoringInfos()));
 
     verify(mockBeamFnDataClient)
         .receive(
@@ -243,7 +253,15 @@ public class BeamFnDataReadRunnerTest {
               Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
               try {
                 consumerCaptor.getValue().accept(valueInGlobalWindow("ABC"));
+                assertEquals(
+                    createReadIndexMonitoringInfoAt(0),
+                    Iterables.getOnlyElement(
+                        Iterables.getOnlyElement(progressCallbacks).getMonitoringInfos()));
                 consumerCaptor.getValue().accept(valueInGlobalWindow("DEF"));
+                assertEquals(
+                    createReadIndexMonitoringInfoAt(1),
+                    Iterables.getOnlyElement(
+                        Iterables.getOnlyElement(progressCallbacks).getMonitoringInfos()));
               } catch (Exception e) {
                 bundle1Future.fail(e);
               } finally {
@@ -253,12 +271,19 @@ public class BeamFnDataReadRunnerTest {
 
     readRunner.blockTillReadFinishes();
     future.get();
+    assertEquals(
+        createReadIndexMonitoringInfoAt(2),
+        Iterables.getOnlyElement(Iterables.getOnlyElement(progressCallbacks).getMonitoringInfos()));
     assertThat(values, contains(valueInGlobalWindow("ABC"), valueInGlobalWindow("DEF")));
 
     // Process for bundle id 1
     bundleId.set("1");
     values.clear();
     readRunner.registerInputLocation();
+    // Ensure that when we reuse the BeamFnDataReadRunner the read index is reset to -1
+    assertEquals(
+        createReadIndexMonitoringInfoAt(-1),
+        Iterables.getOnlyElement(Iterables.getOnlyElement(progressCallbacks).getMonitoringInfos()));
 
     verify(mockBeamFnDataClient)
         .receive(
@@ -274,7 +299,15 @@ public class BeamFnDataReadRunnerTest {
               Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
               try {
                 consumerCaptor.getValue().accept(valueInGlobalWindow("GHI"));
+                assertEquals(
+                    createReadIndexMonitoringInfoAt(0),
+                    Iterables.getOnlyElement(
+                        Iterables.getOnlyElement(progressCallbacks).getMonitoringInfos()));
                 consumerCaptor.getValue().accept(valueInGlobalWindow("JKL"));
+                assertEquals(
+                    createReadIndexMonitoringInfoAt(1),
+                    Iterables.getOnlyElement(
+                        Iterables.getOnlyElement(progressCallbacks).getMonitoringInfos()));
               } catch (Exception e) {
                 bundle2Future.fail(e);
               } finally {
@@ -284,6 +317,9 @@ public class BeamFnDataReadRunnerTest {
 
     readRunner.blockTillReadFinishes();
     future.get();
+    assertEquals(
+        createReadIndexMonitoringInfoAt(2),
+        Iterables.getOnlyElement(Iterables.getOnlyElement(progressCallbacks).getMonitoringInfos()));
     assertThat(values, contains(valueInGlobalWindow("GHI"), valueInGlobalWindow("JKL")));
 
     verifyNoMoreInteractions(mockBeamFnDataClient);
@@ -306,6 +342,7 @@ public class BeamFnDataReadRunnerTest {
   public void testSplittingWhenNoElementsProcessed() throws Exception {
     List<WindowedValue<String>> outputValues = new ArrayList<>();
     BeamFnDataReadRunner<String> readRunner = createReadRunner(outputValues::add);
+    readRunner.registerInputLocation();
 
     ProcessBundleSplitRequest request =
         ProcessBundleSplitRequest.newBuilder()
@@ -351,6 +388,7 @@ public class BeamFnDataReadRunnerTest {
   public void testSplittingWhenSomeElementsProcessed() throws Exception {
     List<WindowedValue<String>> outputValues = new ArrayList<>();
     BeamFnDataReadRunner<String> readRunner = createReadRunner(outputValues::add);
+    readRunner.registerInputLocation();
 
     ProcessBundleSplitRequest request =
         ProcessBundleSplitRequest.newBuilder()
@@ -407,6 +445,7 @@ public class BeamFnDataReadRunnerTest {
     when(splittingReceiver.getProgress()).thenReturn(0.3);
     when(splittingReceiver.trySplit(anyDouble())).thenReturn(splitResult);
     BeamFnDataReadRunner<String> readRunner = createReadRunner(splittingReceiver);
+    readRunner.registerInputLocation();
 
     ProcessBundleSplitRequest request =
         ProcessBundleSplitRequest.newBuilder()
@@ -484,5 +523,13 @@ public class BeamFnDataReadRunnerTest {
             (PTransformRunnerFactory.ProgressRequestCallback callback) -> {},
             null /* splitListener */,
             null /* bundleFinalizer */);
+  }
+
+  private static final MonitoringInfo createReadIndexMonitoringInfoAt(int index) {
+    return new SimpleMonitoringInfoBuilder()
+        .setUrn(MonitoringInfoConstants.Urns.DATA_CHANNEL_READ_INDEX)
+        .setLabel(MonitoringInfoConstants.Labels.PTRANSFORM, INPUT_TRANSFORM_ID)
+        .setInt64SumValue(index)
+        .build();
   }
 }

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -219,6 +219,10 @@ class DataInputOperation(RunnerIOOperation):
 
   def monitoring_infos(self, transform_id, tag_to_pcollection_id):
     # type: (str, Dict[str, str]) -> Dict[FrozenSet, metrics_pb2.MonitoringInfo]
+
+    # TODO(BEAM-9979): Fix race condition where reused DataInputOperation
+    # reports read index from last bundle since start may have not yet been
+    # called.
     all_monitoring_infos = super(DataInputOperation, self).monitoring_infos(
         transform_id, tag_to_pcollection_id)
     read_progress_info = monitoring_infos.int64_counter(
@@ -317,6 +321,7 @@ class DataInputOperation(RunnerIOOperation):
   def finish(self):
     # type: () -> None
     with self.splitting_lock:
+      self.index += 1
       self.started = False
 
 


### PR DESCRIPTION


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
