### PR TITLE
[BEAM-9899] Fix some issues around storing schema `id` on user types

### DIFF
--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -134,11 +134,10 @@ class RowCoderImpl(StreamCoderImpl):
   def encode_to_stream(self, value, out, nested):
     nvals = len(self.schema.fields)
     self.SIZE_CODER.encode_to_stream(nvals, out, True)
-    attrs = [getattr(value, f.name) for f in self.schema.fields]
 
     words = array('B')
     if self.has_nullable_fields:
-      nulls = list(attr is None for attr in attrs)
+      nulls = list(attr is None for attr in value)
       if any(nulls):
         words = array('B', itertools.repeat(0, (nvals + 7) // 8))
         for i, is_null in enumerate(nulls):
@@ -146,7 +145,7 @@ class RowCoderImpl(StreamCoderImpl):
 
     self.NULL_MARKER_CODER.encode_to_stream(words.tostring(), out, True)
 
-    for c, field, attr in zip(self.components, self.schema.fields, attrs):
+    for c, field, attr in zip(self.components, self.schema.fields, value):
       if attr is None:
         if not field.type.nullable:
           raise ValueError(

--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -134,10 +134,11 @@ class RowCoderImpl(StreamCoderImpl):
   def encode_to_stream(self, value, out, nested):
     nvals = len(self.schema.fields)
     self.SIZE_CODER.encode_to_stream(nvals, out, True)
+    attrs = [getattr(value, f.name) for f in self.schema.fields]
 
     words = array('B')
     if self.has_nullable_fields:
-      nulls = list(attr is None for attr in value)
+      nulls = list(attr is None for attr in attrs)
       if any(nulls):
         words = array('B', itertools.repeat(0, (nvals + 7) // 8))
         for i, is_null in enumerate(nulls):
@@ -145,7 +146,7 @@ class RowCoderImpl(StreamCoderImpl):
 
     self.NULL_MARKER_CODER.encode_to_stream(words.tostring(), out, True)
 
-    for c, field, attr in zip(self.components, self.schema.fields, value):
+    for c, field, attr in zip(self.components, self.schema.fields, attrs):
       if attr is None:
         if not field.type.nullable:
           raise ValueError(

--- a/sdks/python/apache_beam/transforms/sql_test.py
+++ b/sdks/python/apache_beam/transforms/sql_test.py
@@ -37,10 +37,10 @@ from apache_beam.testing.util import equal_to
 from apache_beam.transforms.sql import SqlTransform
 
 SimpleRow = typing.NamedTuple(
-    "SimpleRow", [("int", int), ("str", unicode), ("flt", float)])
+    "SimpleRow", [("id", int), ("str", unicode), ("flt", float)])
 coders.registry.register_coder(SimpleRow, coders.RowCoder)
 
-Enrich = typing.NamedTuple("Enrich", [("int", int), ("metadata", unicode)])
+Enrich = typing.NamedTuple("Enrich", [("id", int), ("metadata", unicode)])
 coders.registry.register_coder(Enrich, coders.RowCoder)
 
 
@@ -71,7 +71,7 @@ class SqlTransformTest(unittest.TestCase):
     with TestPipeline() as p:
       out = p | SqlTransform(
           """SELECT
-            CAST(1 AS INT) AS `int`,
+            CAST(1 AS INT) AS `id`,
             CAST('foo' AS VARCHAR) AS `str`,
             CAST(3.14  AS DOUBLE) AS `flt`""")
       assert_that(out, equal_to([(1, "foo", 3.14)]))
@@ -80,7 +80,7 @@ class SqlTransformTest(unittest.TestCase):
     with TestPipeline() as p:
       out = (
           p | beam.Create([SimpleRow(1, "foo", 3.14)])
-          | SqlTransform("SELECT `int`, `flt` FROM PCOLLECTION"))
+          | SqlTransform("SELECT `id`, `flt` FROM PCOLLECTION"))
       assert_that(out, equal_to([(1, 3.14)]))
 
   def test_filter(self):
@@ -109,7 +109,7 @@ class SqlTransformTest(unittest.TestCase):
               SELECT
                 `str`,
                 COUNT(*) AS `count`,
-                SUM(`int`) AS `sum`,
+                SUM(`id`) AS `sum`,
                 AVG(`flt`) AS `avg`
               FROM PCOLLECTION GROUP BY `str`"""))
       assert_that(out, equal_to([("foo", 3, 3, 2), ("bar", 4, 8, 1.414)]))
@@ -131,11 +131,11 @@ class SqlTransformTest(unittest.TestCase):
              | SqlTransform(
                  """
               SELECT
-                simple.`int` AS `int`,
+                simple.`id` AS `id`,
                 enrich.metadata AS metadata
               FROM simple
               JOIN enrich
-              ON simple.`int` = enrich.`int`"""))
+              ON simple.`id` = enrich.`id`"""))
       assert_that(out, equal_to([(1, "a"), (26, "z"), (1, "a")]))
 
 

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -133,6 +133,7 @@ def typing_to_runner_api(type_):
       ]
       type_id = str(uuid4())
       schema = schema_pb2.Schema(fields=fields, id=type_id)
+      setattr(type_, _BEAM_SCHEMA_ID, type_id)
       SCHEMA_REGISTRY.add(type_, schema)
 
     return schema_pb2.FieldType(row_type=schema_pb2.RowType(schema=schema))

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -37,6 +37,7 @@ from past.builtins import unicode
 
 from apache_beam.portability.api import schema_pb2
 from apache_beam.typehints.schemas import named_tuple_from_schema
+from apache_beam.typehints.schemas import named_tuple_to_schema
 from apache_beam.typehints.schemas import typing_from_runner_api
 from apache_beam.typehints.schemas import typing_to_runner_api
 
@@ -284,6 +285,16 @@ class SchemaTest(unittest.TestCase):
     instance = user_type(name="test")
 
     self.assertEqual(instance, pickle.loads(pickle.dumps(instance)))
+
+  def test_user_type_annotated_with_id_after_conversion(self):
+    MyCuteClass = NamedTuple('MyCuteClass', [
+        ('name', unicode),
+    ])
+    self.assertFalse(hasattr(MyCuteClass, '_beam_schema_id'))
+
+    schema = named_tuple_to_schema(MyCuteClass)
+    self.assertTrue(hasattr(MyCuteClass, '_beam_schema_id'))
+    self.assertEquals(MyCuteClass._beam_schema_id, schema.id)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -294,7 +294,7 @@ class SchemaTest(unittest.TestCase):
 
     schema = named_tuple_to_schema(MyCuteClass)
     self.assertTrue(hasattr(MyCuteClass, '_beam_schema_id'))
-    self.assertEquals(MyCuteClass._beam_schema_id, schema.id)
+    self.assertEqual(MyCuteClass._beam_schema_id, schema.id)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Updates sql_test to require generating user types with an `id` field, which yields a name collision with the `id` added to generated NamedTuple types.
- ~Modifies row_coder to extract values from NamedTuple instances as plain tuples, rather than using `getattr`. This fixes the above name collision.~ Dropped this change since it's not strictly necessary
- Also, store schema id in an attribute called `_beam_schema_id` rather than `id` to avoid future name collisions.
- Adds logic to set `_beam_schema_id` for provided (non-generated) user types as well as a test of this logic. This allows us to retrieve the same schema for the type in the future, rather than re-generating it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
