### PR TITLE
[BEAM-9951] Creating a synthetic step for the Go SDK.

### DIFF
--- a/sdks/go/pkg/beam/io/synthetic/rand.go
+++ b/sdks/go/pkg/beam/io/synthetic/rand.go
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetic
+
+// randWrapper is an interface that matches the subset of math/rand.Rand that
+// is used elsewhere in this package. The reason this interface is used instead
+// of rand.Rand directly is so that tests can replace the random number
+// generator with a fake.
+type randWrapper interface {
+	Float64() float64
+	Read([]byte) (int, error)
+}

--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -53,12 +53,12 @@ func Source(s beam.Scope, col beam.PCollection) beam.PCollection {
 }
 
 // sourceFn is a splittable DoFn implementing behavior for synthetic sources.
-// For usage information, see `Source`.
+// For usage information, see synthetic.Source.
 //
 // The sourceFn is expected to receive elements of type sourceConfig and follow
 // that config to determine its behavior when splitting and emitting elements.
 type sourceFn struct {
-	rng *rand.Rand
+	rng randWrapper
 }
 
 // CreateInitialRestriction creates an offset range restriction representing
@@ -77,8 +77,7 @@ func (fn *sourceFn) CreateInitialRestriction(config SourceConfig) offsetrange.Re
 func (fn *sourceFn) SplitRestriction(config SourceConfig, rest offsetrange.Restriction) (splits []offsetrange.Restriction) {
 	if config.InitialSplits <= 1 {
 		// Don't split, just return original restriction.
-		splits = append(splits, rest)
-		return splits
+		return append(splits, rest)
 	}
 
 	// TODO(BEAM-9978) Move this implementation of the offset range restriction
@@ -140,7 +139,7 @@ func (fn *sourceFn) ProcessElement(rt *offsetrange.Tracker, config SourceConfig,
 // fields. SourceConfigs should be initialized with this method.
 func DefaultSourceConfig() SourceConfig {
 	return SourceConfig{
-		NumElements:   1, // Defaults to 1 so at least an element is output.
+		NumElements:   1, // Defaults shouldn't drop elements, so at least 1.
 		InitialSplits: 1, // Defaults to 1, i.e. no initial splitting.
 	}
 }

--- a/sdks/go/pkg/beam/io/synthetic/source_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/source_test.go
@@ -38,7 +38,7 @@ func TestSourceConfig_NumElements(t *testing.T) {
 			cfg := DefaultSourceConfig()
 			cfg.NumElements = test.elms
 
-			keys, _, err := simulateSourceFn(&dfn, cfg)
+			keys, _, err := simulateSourceFn(t, &dfn, cfg)
 			if err != nil {
 				t.Errorf("Failure processing sourceFn: %v", err)
 			}
@@ -50,6 +50,8 @@ func TestSourceConfig_NumElements(t *testing.T) {
 	}
 }
 
+// TestSourceConfig_InitialSplits tests that the InitialSplits config option
+// works correctly.
 func TestSourceConfig_InitialSplits(t *testing.T) {
 	// Test that SplitRestriction creates the expected number of restrictions.
 	t.Run("NumSplits", func(t *testing.T) {
@@ -100,7 +102,7 @@ func TestSourceConfig_InitialSplits(t *testing.T) {
 				cfg.NumElements = test.elms
 				cfg.InitialSplits = test.splits
 
-				keys, _, err := simulateSourceFn(&dfn, cfg)
+				keys, _, err := simulateSourceFn(t, &dfn, cfg)
 				if err != nil {
 					t.Errorf("Failure processing sourceFn: %v", err)
 				}
@@ -119,7 +121,9 @@ func TestSourceConfig_InitialSplits(t *testing.T) {
 // expected to accurately reflect how SDFs are executed in practice (that
 // should be done via integration tests), but to validate the implementations of
 // those methods.
-func simulateSourceFn(dfn *sourceFn, cfg SourceConfig) (keys [][]byte, vals [][]byte, err error) {
+func simulateSourceFn(t *testing.T, dfn *sourceFn, cfg SourceConfig) (keys [][]byte, vals [][]byte, err error) {
+	t.Helper()
+
 	emitFn := func(key []byte, val []byte) {
 		keys = append(keys, key)
 		vals = append(vals, key)

--- a/sdks/go/pkg/beam/io/synthetic/step.go
+++ b/sdks/go/pkg/beam/io/synthetic/step.go
@@ -1,0 +1,192 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetic
+
+import (
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
+	"math/rand"
+	"time"
+)
+
+// Step creates a synthetic step transform that receives KV<[]byte, []byte>
+// elements from other synthetic transforms, and outputs KV<[]byte, []byte>
+// elements based on its inputs.
+//
+// This function accepts a StepConfig to configure the behavior of the synthetic
+// step, including whether that step is implemented as a splittable or
+// non-splittable DoFn.
+//
+// StepConfigs are recommended to be created via the DefaultStepConfig and
+// modified before being passed to this method. Example:
+//
+//    cfg := synthetic.DefaultStepConfig()
+//    cfg.OutputPerInput = 1000
+//    cfg.Splittable = true
+//    cfg.InitialSplits = 2
+//    step := synthetic.Step(s, cfg, input)
+func Step(s beam.Scope, cfg StepConfig, col beam.PCollection) beam.PCollection {
+	s = s.Scope("synthetic.Step")
+	if cfg.Splittable {
+		return beam.ParDo(s, &sdfStepFn{cfg: cfg}, col)
+	} else {
+		return beam.ParDo(s, &stepFn{cfg: cfg}, col)
+	}
+}
+
+// stepFn is a DoFn implementing behavior for synthetic steps. For usage
+// information, see synthetic.Step.
+//
+// The stepFn is expected to be initialized with a cfg and will follow that
+// config to determine its behavior when emitting elements.
+type stepFn struct {
+	cfg StepConfig
+	rng randWrapper
+}
+
+// Setup sets up the random number generator.
+func (fn *stepFn) Setup() {
+	fn.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// ProcessElement takes an input and either filters it or produces a number of
+// outputs identical to that input based on the outputs per input configuration
+// in StepConfig.
+func (fn *stepFn) ProcessElement(key, val []byte, emit func([]byte, []byte)) {
+	if fn.cfg.FilterRatio > 0 && fn.rng.Float64() < fn.cfg.FilterRatio {
+		return
+	}
+	for i := 0; i < fn.cfg.OutputPerInput; i++ {
+		emit(key, val)
+	}
+}
+
+// sdfStepFn is a splittable DoFn implementing behavior for synthetic steps.
+// For usage information, see synthetic.Step.
+//
+// The sdfStepFn is expected to be initialized with a cfg and will follow
+// that config to determine its behavior when splitting and emitting elements.
+type sdfStepFn struct {
+	cfg StepConfig
+	rng randWrapper
+}
+
+// CreateInitialRestriction creates an offset range restriction representing
+// the number of elements to emit for this received element, as specified by
+// the output per input configuration in StepConfig.
+func (fn *sdfStepFn) CreateInitialRestriction(key, val []byte) offsetrange.Restriction {
+	return offsetrange.Restriction{
+		Start: 0,
+		End:   int64(fn.cfg.OutputPerInput),
+	}
+}
+
+// SplitRestriction splits restrictions equally according to the number of
+// initial splits specified in StepConfig. Each restriction output by this
+// method will contain at least one element, so the number of splits will not
+// exceed the number of elements.
+func (fn *sdfStepFn) SplitRestriction(key, val []byte, rest offsetrange.Restriction) (splits []offsetrange.Restriction) {
+	if fn.cfg.InitialSplits <= 1 {
+		// Don't split, just return original restriction.
+		return append(splits, rest)
+	}
+
+	// TODO(BEAM-9978) Move this implementation of the offset range restriction
+	// splitting to the restriction itself, and add testing.
+	num := int64(fn.cfg.InitialSplits)
+	offset := rest.Start
+	size := rest.End - rest.Start
+	for i := int64(0); i < num; i++ {
+		split := offsetrange.Restriction{
+			Start: offset + (i * size / num),
+			End:   offset + ((i + 1) * size / num),
+		}
+		// Skip restrictions that end up empty.
+		if split.End-split.Start <= 0 {
+			continue
+		}
+		splits = append(splits, split)
+	}
+	return splits
+}
+
+// RestrictionSize outputs the size of the restriction as the number of elements
+// that restriction will output.
+func (fn *sdfStepFn) RestrictionSize(key, val []byte, rest offsetrange.Restriction) float64 {
+	// TODO(BEAM-9978) Move this size implementation to the offset range restriction itself.
+	return float64(rest.End - rest.Start)
+}
+
+// CreateTracker creates an offset range restriction tracker for the
+// restriction.
+func (fn *sdfStepFn) CreateTracker(rest offsetrange.Restriction) *offsetrange.Tracker {
+	return offsetrange.NewTracker(rest)
+}
+
+// Setup sets up the random number generator.
+func (fn *sdfStepFn) Setup() {
+	fn.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// ProcessElement takes an input and either filters it or produces a number of
+// outputs identical to that input based on the restriction size.
+func (fn *sdfStepFn) ProcessElement(rt *offsetrange.Tracker, key, val []byte, emit func([]byte, []byte)) {
+	if fn.cfg.FilterRatio > 0 && fn.rng.Float64() < fn.cfg.FilterRatio {
+		return
+	}
+	for i := rt.Rest.Start; rt.TryClaim(i) == true; i++ {
+		emit(key, val)
+	}
+}
+
+// DefaultSourceConfig creates a SourceConfig with intended defaults for its
+// fields. SourceConfigs should be initialized with this method.
+func DefaultStepConfig() StepConfig {
+	return StepConfig{
+		OutputPerInput: 1,     // Defaults shouldn't drop elements, so at least 1.
+		FilterRatio:    0.0,   // Defaults shouldn't drop elements, so don't filter.
+		Splittable:     false, // Default to non-splittable, SDFs are situational.
+		InitialSplits:  1,     // Defaults to 1, i.e. no initial splitting.
+	}
+}
+
+// StepConfig is a struct containing all the configuration options for a
+// synthetic step.
+type StepConfig struct {
+	// OutputPerInput is the number of outputs to emit per input received. Each
+	// output is identical to the original input. A value of 0 drops each input.
+	OutputPerInput int
+
+	// FilterRatio indicates the random chance that an input will be filtered
+	// out, meaning that no outputs will get emitted for it. For example, a
+	// FilterRatio of 0.25 means that 25% of inputs will get filtered out.
+	FilterRatio float64
+
+	// Splittable indicates whether the step should use the splittable DoFn or
+	// non-splittable DoFn implementation. Splittable steps will split the
+	// number of OutputPerInput into restrictions, so it is most useful for
+	// steps with a high OutputPerInput.
+	Splittable bool
+
+	// InitialSplits is only applicable if Splittable is set to true, and
+	// determines the number of initial splits to perform in the step's
+	// SplitRestriction method. Note that in some edge cases, the number of
+	// splits performed might differ from this config value. Each restriction
+	// will always have one element in it, and at least one restriction will
+	// always be output, so the number of splits will be in the range of [1, N]
+	// where N is the size of the original restriction.
+	InitialSplits int
+}

--- a/sdks/go/pkg/beam/io/synthetic/step_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/step_test.go
@@ -1,0 +1,222 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetic
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// TestStepConfig_OutputPerInput tests that setting the number of output per
+// input works correctly, in both SDF and non-SDF synthetic steps.
+func TestStepConfig_OutputPerInput(t *testing.T) {
+	tests := []struct {
+		outPer int
+	}{
+		{outPer: 1},
+		{outPer: 10},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("(outPer = %v)", test.outPer), func(t *testing.T) {
+			cfg := DefaultStepConfig()
+			cfg.OutputPerInput = test.outPer
+
+			// Non-splittable StepFn.
+			dfn := stepFn{cfg: cfg}
+			var keys [][]byte
+			emitFn := func(key []byte, val []byte) {
+				keys = append(keys, key)
+			}
+			elm := []byte{0, 0, 0, 0}
+			dfn.Setup()
+			dfn.ProcessElement(elm, elm, emitFn)
+			if got := len(keys); got != test.outPer {
+				t.Errorf("stepFn emitted wrong number of outputs: got: %v, want: %v",
+					got, test.outPer)
+			}
+
+			// SDF StepFn.
+			cfg.Splittable = true
+			sdf := sdfStepFn{cfg: cfg}
+			keys, _ = simulateSdfStepFn(t, &sdf)
+			if got := len(keys); got != test.outPer {
+				t.Errorf("sdfStepFn emitted wrong number of outputs: got: %v, want: %v",
+					got, test.outPer)
+			}
+		})
+	}
+}
+
+// fakeRand is a rand.Rand implementation used for testing the filter ratio.
+// It outputs the stored values in their corresponding random methods.
+type fakeRand struct {
+	*rand.Rand
+	f64 float64 // Output for Float64().
+}
+
+func (r *fakeRand) Float64() float64 {
+	return r.f64
+}
+
+// TestStepConfig_FilterRatio tests that the element is filtered properly based
+// on the ratio given, in both SDF and non-SDF synthetic steps.
+func TestStepConfig_FilterRatio(t *testing.T) {
+	tests := []struct {
+		rand     float64
+		ratio    float64
+		filtered bool
+	}{
+		{ratio: 0.5, rand: 0.49, filtered: true},
+		{ratio: 0.5, rand: 0.51, filtered: false},
+		{ratio: 0, rand: 0, filtered: false},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("(ratio = %v, rand = %v)", test.ratio, test.rand), func(t *testing.T) {
+			// Set up emits and elements for running the DoFns.
+			var keys [][]byte
+			emitFn := func(key []byte, val []byte) {
+				keys = append(keys, key)
+			}
+			elm := []byte{0, 0, 0, 0}
+
+			// Non-splittable StepFn.
+			cfg := DefaultStepConfig()
+			cfg.FilterRatio = test.ratio
+			dfn := stepFn{cfg: cfg}
+			dfn.Setup()
+			dfn.rng = &fakeRand{f64: test.rand}
+			dfn.ProcessElement(elm, elm, emitFn)
+
+			got := len(keys) == 0 // True if element was filtered out.
+			if got != test.filtered {
+				t.Errorf("stepFn filtered incorrectly: got: %v, wanted: %v",
+					got, test.filtered)
+			}
+
+			// SDF StepFn.
+			cfg.Splittable = true
+			sdf := sdfStepFn{cfg: cfg}
+			keys = nil
+			rest := sdf.CreateInitialRestriction(elm, elm)
+			splits := sdf.SplitRestriction(elm, elm, rest)
+			sdf.Setup()
+			sdf.rng = &fakeRand{f64: test.rand}
+			for _, split := range splits {
+				rt := sdf.CreateTracker(split)
+				sdf.ProcessElement(rt, elm, elm, emitFn)
+			}
+
+			got = len(keys) == 0 // True if element was filtered out.
+			if got != test.filtered {
+				t.Errorf("sdfStepFn filtered incorrectly: got: %v, wanted: %v",
+					got, test.filtered)
+			}
+		})
+	}
+}
+
+// TestStepConfig_InitialSplits tests that the InitialSplits config option
+// works correctly.
+func TestStepConfig_InitialSplits(t *testing.T) {
+	// Test that SplitRestriction creates the expected number of restrictions.
+	t.Run("NumSplits", func(t *testing.T) {
+		tests := []struct {
+			outPer int
+			splits int
+			want   int
+		}{
+			{outPer: 100, splits: 10, want: 10},
+			{outPer: 4, splits: 10, want: 4},
+			{outPer: 100, splits: 0, want: 1},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(fmt.Sprintf("(outPer = %v, splits = %v)", test.outPer, test.splits), func(t *testing.T) {
+				cfg := DefaultStepConfig()
+				cfg.OutputPerInput = test.outPer
+				cfg.Splittable = true
+				cfg.InitialSplits = test.splits
+				elm := []byte{0, 0, 0, 0}
+
+				sdf := sdfStepFn{cfg: cfg}
+				rest := sdf.CreateInitialRestriction(elm, elm)
+				splits := sdf.SplitRestriction(elm, elm, rest)
+				if got := len(splits); got != test.want {
+					t.Errorf("SplitRestriction output the wrong number of splits: got: %v, want: %v",
+						got, test.want)
+				}
+			})
+		}
+	})
+
+	// Tests correctness of the splitting. In this case, that means that even
+	// after splitting, the same amount of elements are output.
+	t.Run("Correctness", func(t *testing.T) {
+		tests := []struct {
+			outPer int
+			want   int
+			splits int
+		}{
+			{outPer: 100, want: 100, splits: 10},
+			{outPer: 4, want: 4, splits: 10},
+			{outPer: -1, want: 0, splits: 10},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(fmt.Sprintf("(outPer = %v)", test.outPer), func(t *testing.T) {
+				cfg := DefaultStepConfig()
+				cfg.OutputPerInput = test.outPer
+				cfg.Splittable = true
+				cfg.InitialSplits = test.splits
+
+				sdf := sdfStepFn{cfg: cfg}
+				keys, _ := simulateSdfStepFn(t, &sdf)
+				if got := len(keys); got != test.want {
+					t.Errorf("SourceFn emitted wrong number of outputs: got: %v, want: %v",
+						got, test.want)
+				}
+			})
+		}
+	})
+}
+
+// simulateSdfStepFn calls CreateInitialRestriction, SplitRestriction,
+// CreateTracker, and ProcessElement on the given sdfStepFn with the given
+// StepConfig, and outputs the resulting output elements. This method isn't
+// expected to accurately reflect how SDFs are executed in practice (that
+// should be done via integration tests), but to validate the implementations of
+// those methods.
+func simulateSdfStepFn(t *testing.T, sdf *sdfStepFn) (keys [][]byte, vals [][]byte) {
+	t.Helper()
+
+	emitFn := func(key []byte, val []byte) {
+		keys = append(keys, key)
+		vals = append(vals, key)
+	}
+
+	elm := []byte{0, 0, 0, 0}
+	rest := sdf.CreateInitialRestriction(elm, elm)
+	splits := sdf.SplitRestriction(elm, elm, rest)
+	sdf.Setup()
+	for _, split := range splits {
+		rt := sdf.CreateTracker(split)
+		sdf.ProcessElement(rt, elm, elm, emitFn)
+	}
+	return keys, vals
+}


### PR DESCRIPTION
Building off the synthetic source, adding a synthetic step. Still need
to update the way the configs are built though.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
