### PR TITLE
Python Katas - Remove answer placeholder checks

### DIFF
--- a/learning/katas/python/Common Transforms/Aggregation/Count/task-remote-info.yaml
+++ b/learning/katas/python/Common Transforms/Aggregation/Count/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755597
-update_date: Fri, 07 Feb 2020 13:57:24 UTC
+update_date: Sat, 16 May 2020 08:39:37 UTC

--- a/learning/katas/python/Common Transforms/Aggregation/Count/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Count/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -31,5 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Aggregation/Largest/task-remote-info.yaml
+++ b/learning/katas/python/Common Transforms/Aggregation/Largest/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755601
-update_date: Fri, 07 Feb 2020 13:57:37 UTC
+update_date: Sat, 16 May 2020 08:39:49 UTC

--- a/learning/katas/python/Common Transforms/Aggregation/Largest/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Largest/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -31,5 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Aggregation/Mean/task-remote-info.yaml
+++ b/learning/katas/python/Common Transforms/Aggregation/Mean/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755599
-update_date: Fri, 07 Feb 2020 13:57:30 UTC
+update_date: Sat, 16 May 2020 08:39:44 UTC

--- a/learning/katas/python/Common Transforms/Aggregation/Mean/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Mean/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -31,5 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Aggregation/Smallest/task-remote-info.yaml
+++ b/learning/katas/python/Common Transforms/Aggregation/Smallest/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755600
-update_date: Fri, 07 Feb 2020 13:57:34 UTC
+update_date: Sat, 16 May 2020 08:39:46 UTC

--- a/learning/katas/python/Common Transforms/Aggregation/Smallest/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Smallest/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_answer_placeholders_text_deleted, test_is_not_empty
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -31,5 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Aggregation/Sum/task-remote-info.yaml
+++ b/learning/katas/python/Common Transforms/Aggregation/Sum/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755598
-update_date: Fri, 07 Feb 2020 13:57:27 UTC
+update_date: Sat, 16 May 2020 08:39:40 UTC

--- a/learning/katas/python/Common Transforms/Aggregation/Sum/tests.py
+++ b/learning/katas/python/Common Transforms/Aggregation/Sum/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -31,5 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/Filter/Filter/task-remote-info.yaml
+++ b/learning/katas/python/Common Transforms/Filter/Filter/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755596
-update_date: Fri, 07 Feb 2020 13:57:21 UTC
+update_date: Sat, 16 May 2020 08:39:34 UTC

--- a/learning/katas/python/Common Transforms/Filter/Filter/tests.py
+++ b/learning/katas/python/Common Transforms/Filter/Filter/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_filter():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'beam.Filter' in placeholder:
-        passed()
-    else:
-        failed('Use beam.Filter')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -42,6 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_filter()
     test_output()

--- a/learning/katas/python/Common Transforms/Filter/ParDo/task-remote-info.yaml
+++ b/learning/katas/python/Common Transforms/Filter/ParDo/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755595
-update_date: Fri, 07 Feb 2020 13:57:19 UTC
+update_date: Sat, 16 May 2020 08:39:30 UTC

--- a/learning/katas/python/Common Transforms/Filter/ParDo/tests.py
+++ b/learning/katas/python/Common Transforms/Filter/ParDo/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -31,5 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Common Transforms/WithKeys/WithKeys/task-remote-info.yaml
+++ b/learning/katas/python/Common Transforms/WithKeys/WithKeys/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1124221
-update_date: Mon, 09 Mar 2020 14:34:20 UTC
+update_date: Sat, 16 May 2020 08:39:53 UTC

--- a/learning/katas/python/Common Transforms/WithKeys/WithKeys/tests.py
+++ b/learning/katas/python/Common Transforms/WithKeys/WithKeys/tests.py
@@ -14,19 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_filter():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'beam.WithKeys' in placeholder:
-        passed()
-    else:
-        failed('Use beam.WithKeys')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -44,6 +32,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_filter()
     test_output()

--- a/learning/katas/python/Core Transforms/Branching/Branching/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Branching/Branching/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755592
-update_date: Fri, 07 Feb 2020 13:57:12 UTC
+update_date: Sat, 16 May 2020 08:39:24 UTC

--- a/learning/katas/python/Core Transforms/Branching/Branching/tests.py
+++ b/learning/katas/python/Core Transforms/Branching/Branching/tests.py
@@ -14,8 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -41,5 +40,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Core Transforms/CoGroupByKey/CoGroupByKey/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/CoGroupByKey/CoGroupByKey/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755583
-update_date: Fri, 07 Feb 2020 13:56:44 UTC
+update_date: Sat, 16 May 2020 08:38:58 UTC

--- a/learning/katas/python/Core Transforms/CoGroupByKey/CoGroupByKey/tests.py
+++ b/learning/katas/python/Core Transforms/CoGroupByKey/CoGroupByKey/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -35,5 +34,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Core Transforms/Combine/Combine PerKey/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Combine/Combine PerKey/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755587
-update_date: Fri, 07 Feb 2020 13:56:58 UTC
+update_date: Sat, 16 May 2020 08:39:07 UTC

--- a/learning/katas/python/Core Transforms/Combine/Combine PerKey/tests.py
+++ b/learning/katas/python/Core Transforms/Combine/Combine PerKey/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_combine_placeholders():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'beam.CombinePerKey' in placeholder:
-        passed()
-    else:
-        failed('Use beam.CombinePerKey')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -47,6 +35,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_combine_placeholders()
     test_output()

--- a/learning/katas/python/Core Transforms/Combine/CombineFn/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Combine/CombineFn/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755585
-update_date: Fri, 07 Feb 2020 13:56:52 UTC
+update_date: Sat, 16 May 2020 08:39:05 UTC

--- a/learning/katas/python/Core Transforms/Combine/CombineFn/tests.py
+++ b/learning/katas/python/Core Transforms/Combine/CombineFn/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_combine_placeholders():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[1]
-
-    if 'beam.CombineGlobally' in placeholder:
-        passed()
-    else:
-        failed('Use beam.CombineGlobally')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -42,6 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_combine_placeholders()
     test_output()

--- a/learning/katas/python/Core Transforms/Combine/Simple Function/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Combine/Simple Function/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755584
-update_date: Fri, 07 Feb 2020 13:56:48 UTC
+update_date: Sat, 16 May 2020 08:39:01 UTC

--- a/learning/katas/python/Core Transforms/Combine/Simple Function/tests.py
+++ b/learning/katas/python/Core Transforms/Combine/Simple Function/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_combine_placeholders():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[1]
-
-    if 'beam.CombineGlobally' in placeholder:
-        passed()
-    else:
-        failed('Use beam.CombineGlobally')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -42,6 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_combine_placeholders()
     test_output()

--- a/learning/katas/python/Core Transforms/Composite Transform/Composite Transform/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Composite Transform/Composite Transform/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755593
-update_date: Fri, 07 Feb 2020 13:57:15 UTC
+update_date: Sat, 16 May 2020 08:39:27 UTC

--- a/learning/katas/python/Core Transforms/Composite Transform/Composite Transform/tests.py
+++ b/learning/katas/python/Core Transforms/Composite Transform/Composite Transform/tests.py
@@ -14,19 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_composite_expand_method():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'def expand(' in placeholder:
-        passed()
-    else:
-        failed('Override "expand" method')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -42,6 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_composite_expand_method()
     test_output()

--- a/learning/katas/python/Core Transforms/Flatten/Flatten/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Flatten/Flatten/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755588
-update_date: Fri, 07 Feb 2020 13:57:02 UTC
+update_date: Sat, 16 May 2020 08:39:12 UTC

--- a/learning/katas/python/Core Transforms/Flatten/Flatten/tests.py
+++ b/learning/katas/python/Core Transforms/Flatten/Flatten/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_flatten():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'beam.Flatten' in placeholder:
-        passed()
-    else:
-        failed('Use beam.Flatten')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -42,6 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_flatten()
     test_output()

--- a/learning/katas/python/Core Transforms/GroupByKey/GroupByKey/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/GroupByKey/GroupByKey/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755582
-update_date: Fri, 07 Feb 2020 13:56:41 UTC
+update_date: Sat, 16 May 2020 08:38:55 UTC

--- a/learning/katas/python/Core Transforms/GroupByKey/GroupByKey/tests.py
+++ b/learning/katas/python/Core Transforms/GroupByKey/GroupByKey/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -33,5 +32,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/Core Transforms/Map/FlatMap/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Map/FlatMap/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755580
-update_date: Fri, 07 Feb 2020 13:56:38 UTC
+update_date: Sat, 16 May 2020 08:38:52 UTC

--- a/learning/katas/python/Core Transforms/Map/FlatMap/tests.py
+++ b/learning/katas/python/Core Transforms/Map/FlatMap/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_flatmap():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'beam.FlatMap' in placeholder:
-        passed()
-    else:
-        failed('Use beam.FlatMap')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -42,6 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_flatmap()
     test_output()

--- a/learning/katas/python/Core Transforms/Map/Map/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Map/Map/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755579
-update_date: Fri, 07 Feb 2020 13:56:35 UTC
+update_date: Sat, 16 May 2020 08:38:48 UTC

--- a/learning/katas/python/Core Transforms/Map/Map/tests.py
+++ b/learning/katas/python/Core Transforms/Map/Map/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_map():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'beam.Map' in placeholder:
-        passed()
-    else:
-        failed('Use beam.Map')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -42,6 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_map()
     test_output()

--- a/learning/katas/python/Core Transforms/Map/ParDo OneToMany/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Map/ParDo OneToMany/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755578
-update_date: Fri, 07 Feb 2020 13:56:32 UTC
+update_date: Sat, 16 May 2020 08:38:45 UTC

--- a/learning/katas/python/Core Transforms/Map/ParDo OneToMany/tests.py
+++ b/learning/katas/python/Core Transforms/Map/ParDo OneToMany/tests.py
@@ -14,29 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_dofn_process_method():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'def process(self, element' in placeholder:
-        passed()
-    else:
-        failed('Override "process" method')
-
-
-def test_pardo():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[1]
-
-    if 'beam.ParDo(BreakIntoWordsDoFn())' in placeholder:
-        passed()
-    else:
-        failed('Use beam.ParDo')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -52,7 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_dofn_process_method()
-    test_pardo()
     test_output()

--- a/learning/katas/python/Core Transforms/Map/ParDo/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Map/ParDo/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755577
-update_date: Fri, 07 Feb 2020 13:56:29 UTC
+update_date: Sat, 16 May 2020 08:38:41 UTC

--- a/learning/katas/python/Core Transforms/Map/ParDo/tests.py
+++ b/learning/katas/python/Core Transforms/Map/ParDo/tests.py
@@ -14,29 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_dofn_process_method():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'def process(self, element' in placeholder:
-        passed()
-    else:
-        failed('Override "process" method')
-
-
-def test_pardo():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[1]
-
-    if 'beam.ParDo(MultiplyByTenDoFn())' in placeholder:
-        passed()
-    else:
-        failed('Use beam.ParDo')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -52,7 +30,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_dofn_process_method()
-    test_pardo()
     test_output()

--- a/learning/katas/python/Core Transforms/Partition/Partition/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Partition/Partition/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755589
-update_date: Fri, 07 Feb 2020 13:59:37 UTC
+update_date: Sat, 16 May 2020 08:39:15 UTC

--- a/learning/katas/python/Core Transforms/Partition/Partition/tests.py
+++ b/learning/katas/python/Core Transforms/Partition/Partition/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_partition():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[1]
-
-    if 'beam.Partition' in placeholder:
-        passed()
-    else:
-        failed('Use beam.Partition')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -51,6 +39,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_partition()
     test_output()

--- a/learning/katas/python/Core Transforms/Side Input/Side Input/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Side Input/Side Input/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755590
-update_date: Fri, 07 Feb 2020 13:57:06 UTC
+update_date: Sat, 16 May 2020 08:39:18 UTC

--- a/learning/katas/python/Core Transforms/Side Input/Side Input/tests.py
+++ b/learning/katas/python/Core Transforms/Side Input/Side Input/tests.py
@@ -22,29 +22,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_dofn_process_method():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'def process(self, element' in placeholder:
-        passed()
-    else:
-        failed('Override "process" method')
-
-
-def test_pardo():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[1]
-
-    if 'beam.ParDo(EnrichCountryDoFn(),' in placeholder:
-        passed()
-    else:
-        failed('Use beam.ParDo that accepts side input')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -66,7 +44,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_dofn_process_method()
-    test_pardo()
     test_output()

--- a/learning/katas/python/Core Transforms/Side Output/Side Output/task-remote-info.yaml
+++ b/learning/katas/python/Core Transforms/Side Output/Side Output/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755591
-update_date: Fri, 07 Feb 2020 13:57:09 UTC
+update_date: Sat, 16 May 2020 08:39:21 UTC

--- a/learning/katas/python/Core Transforms/Side Output/Side Output/tests.py
+++ b/learning/katas/python/Core Transforms/Side Output/Side Output/tests.py
@@ -14,29 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_dofn_process_method():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'pvalue.TaggedOutput' in placeholder:
-        passed()
-    else:
-        failed('Use pvalue.TaggedOutput')
-
-
-def test_pardo():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[1]
-
-    if all(['beam.ParDo(ProcessNumbersDoFn())', '.with_outputs,']) in placeholder:
-        passed()
-    else:
-        failed('Use beam.ParDo that outputs multiple outputs')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -61,7 +39,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_dofn_process_method()
-    test_pardo()
     test_output()

--- a/learning/katas/python/Examples/Word Count/Word Count/task-remote-info.yaml
+++ b/learning/katas/python/Examples/Word Count/Word Count/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755604
-update_date: Fri, 07 Feb 2020 13:57:43 UTC
+update_date: Sat, 16 May 2020 08:40:05 UTC

--- a/learning/katas/python/Examples/Word Count/Word Count/tests.py
+++ b/learning/katas/python/Examples/Word Count/Word Count/tests.py
@@ -14,8 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, get_file_output, \
-    test_is_not_empty, test_answer_placeholders_text_deleted
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -37,5 +36,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
     test_output()

--- a/learning/katas/python/IO/TextIO/ReadFromText/task-remote-info.yaml
+++ b/learning/katas/python/IO/TextIO/ReadFromText/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755602
-update_date: Fri, 07 Feb 2020 13:57:40 UTC
+update_date: Sat, 16 May 2020 08:39:56 UTC

--- a/learning/katas/python/IO/TextIO/ReadFromText/tests.py
+++ b/learning/katas/python/IO/TextIO/ReadFromText/tests.py
@@ -14,19 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_readfromtext_method():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'ReadFromText(' in placeholder:
-        passed()
-    else:
-        failed('Use beam.io.ReadFromText')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -53,6 +41,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_readfromtext_method()
     test_output()

--- a/learning/katas/python/Introduction/Hello Beam/Hello Beam/task-remote-info.yaml
+++ b/learning/katas/python/Introduction/Hello Beam/Hello Beam/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 755575
-update_date: Fri, 07 Feb 2020 13:56:26 UTC
+update_date: Sat, 16 May 2020 08:38:38 UTC

--- a/learning/katas/python/Introduction/Hello Beam/Hello Beam/tests.py
+++ b/learning/katas/python/Introduction/Hello Beam/Hello Beam/tests.py
@@ -14,18 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_answer_placeholders():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-    if 'beam.Create' in placeholder:
-        passed()
-    else:
-        failed('Use beam.Create')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -39,6 +28,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_answer_placeholders()
     test_output()

--- a/learning/katas/python/Windowing/Adding Timestamp/ParDo/task-remote-info.yaml
+++ b/learning/katas/python/Windowing/Adding Timestamp/ParDo/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1124219
-update_date: Mon, 09 Mar 2020 14:33:58 UTC
+update_date: Sat, 16 May 2020 08:39:59 UTC

--- a/learning/katas/python/Windowing/Adding Timestamp/ParDo/tests.py
+++ b/learning/katas/python/Windowing/Adding Timestamp/ParDo/tests.py
@@ -14,29 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_dofn_process_method():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'def process(self,' in placeholder:
-        passed()
-    else:
-        failed('Override "process" method')
-
-
-def test_pardo():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[1]
-
-    if 'beam.ParDo(AddTimestampDoFn())' in placeholder:
-        passed()
-    else:
-        failed('Use beam.ParDo')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -58,7 +36,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_dofn_process_method()
-    test_pardo()
     test_output()

--- a/learning/katas/python/Windowing/Fixed Time Window/Fixed Time Window/task-remote-info.yaml
+++ b/learning/katas/python/Windowing/Fixed Time Window/Fixed Time Window/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1124220
-update_date: Mon, 09 Mar 2020 14:34:10 UTC
+update_date: Sat, 16 May 2020 08:40:02 UTC

--- a/learning/katas/python/Windowing/Fixed Time Window/Fixed Time Window/tests.py
+++ b/learning/katas/python/Windowing/Fixed Time Window/Fixed Time Window/tests.py
@@ -14,19 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from test_helper import failed, passed, \
-    get_answer_placeholders, get_file_output, test_is_not_empty, \
-    test_answer_placeholders_text_deleted
-
-
-def test_fixedwindows():
-    placeholders = get_answer_placeholders()
-    placeholder = placeholders[0]
-
-    if 'FixedWindows' in placeholder:
-        passed()
-    else:
-        failed('Use FixedWindows')
+from test_helper import failed, passed, get_file_output, test_is_not_empty
 
 
 def test_output():
@@ -47,6 +35,4 @@ def test_output():
 
 if __name__ == '__main__':
     test_is_not_empty()
-    test_answer_placeholders_text_deleted()
-    test_fixedwindows()
     test_output()

--- a/learning/katas/python/course-remote-info.yaml
+++ b/learning/katas/python/course-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 54532
-update_date: Mon, 09 Mar 2020 14:33:44 UTC
+update_date: Sat, 16 May 2020 08:38:35 UTC


### PR DESCRIPTION
Remove answer placeholder checks in Python Katas

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
