### PR TITLE
[BEAM-10018] Fix timestamps in two windowing Python katas

### DIFF
--- a/learning/katas/python/Windowing/Adding Timestamp/ParDo/task-info.yaml
+++ b/learning/katas/python/Windowing/Adding Timestamp/ParDo/task-info.yaml
@@ -22,10 +22,10 @@ files:
 - name: task.py
   visible: true
   placeholders:
-  - offset: 1243
+  - offset: 1231
     length: 155
     placeholder_text: TODO()
-  - offset: 1929
+  - offset: 1917
     length: 30
     placeholder_text: TODO()
 - name: tests.py

--- a/learning/katas/python/Windowing/Adding Timestamp/ParDo/task-info.yaml
+++ b/learning/katas/python/Windowing/Adding Timestamp/ParDo/task-info.yaml
@@ -22,10 +22,10 @@ files:
 - name: task.py
   visible: true
   placeholders:
-  - offset: 1211
-    length: 163
+  - offset: 1243
+    length: 155
     placeholder_text: TODO()
-  - offset: 1740
+  - offset: 1929
     length: 30
     placeholder_text: TODO()
 - name: tests.py

--- a/learning/katas/python/Windowing/Adding Timestamp/ParDo/task.html
+++ b/learning/katas/python/Windowing/Adding Timestamp/ParDo/task.html
@@ -27,7 +27,7 @@
   outputs new elements with timestamps that you set.
 </p>
 <p>
-  <b>Kata:</b> Please assign each element a timestamp based on the the <code>Event.date</code>.
+  <b>Kata:</b> Please assign each element a timestamp based on the the <code>Event.timestamp</code>.
 </p>
 <br>
 <div class="hint">

--- a/learning/katas/python/Windowing/Adding Timestamp/ParDo/task.py
+++ b/learning/katas/python/Windowing/Adding Timestamp/ParDo/task.py
@@ -16,6 +16,7 @@
 
 import datetime
 import time
+import pytz
 
 import apache_beam as beam
 from apache_beam.transforms import window
@@ -24,30 +25,30 @@ from log_elements import LogElements
 
 
 class Event:
-    def __init__(self, id, event, date):
+    def __init__(self, id, event, timestamp):
         self.id = id
         self.event = event
-        self.date = date
+        self.timestamp = timestamp
 
     def __str__(self) -> str:
-        return f'Event({self.id}, {self.event}, {self.date})'
+        return f'Event({self.id}, {self.event}, {self.timestamp})'
 
 
 class AddTimestampDoFn(beam.DoFn):
 
     def process(self, element, **kwargs):
-        unix_timestamp = time.mktime(element.date.timetuple())
+        unix_timestamp = element.timestamp.timestamp()
         yield window.TimestampedValue(element, unix_timestamp)
 
 
 p = beam.Pipeline()
 
 (p | beam.Create([
-        Event('1', 'book-order', datetime.date(2020, 3, 4)),
-        Event('2', 'pencil-order', datetime.date(2020, 3, 5)),
-        Event('3', 'paper-order', datetime.date(2020, 3, 6)),
-        Event('4', 'pencil-order', datetime.date(2020, 3, 7)),
-        Event('5', 'book-order', datetime.date(2020, 3, 8)),
+        Event('1', 'book-order', datetime.datetime(2020, 3, 4, 0, 0, 0, 0, tzinfo=pytz.UTC)),
+        Event('2', 'pencil-order', datetime.datetime(2020, 3, 5, 0, 0, 0, 0, tzinfo=pytz.UTC)),
+        Event('3', 'paper-order', datetime.datetime(2020, 3, 6, 0, 0, 0, 0, tzinfo=pytz.UTC)),
+        Event('4', 'pencil-order', datetime.datetime(2020, 3, 7, 0, 0, 0, 0, tzinfo=pytz.UTC)),
+        Event('5', 'book-order', datetime.datetime(2020, 3, 8, 0, 0, 0, 0, tzinfo=pytz.UTC)),
      ])
    | beam.ParDo(AddTimestampDoFn())
    | LogElements(with_timestamp=True))

--- a/learning/katas/python/Windowing/Adding Timestamp/ParDo/task.py
+++ b/learning/katas/python/Windowing/Adding Timestamp/ParDo/task.py
@@ -15,7 +15,6 @@
 #   limitations under the License.
 
 import datetime
-import time
 import pytz
 
 import apache_beam as beam

--- a/learning/katas/python/Windowing/Adding Timestamp/ParDo/tests.py
+++ b/learning/katas/python/Windowing/Adding Timestamp/ParDo/tests.py
@@ -43,11 +43,11 @@ def test_output():
     output = get_file_output()
 
     answers = [
-        "Event(1, book-order, 2020-03-04), timestamp='2020-03-03T16:00:00Z'",
-        "Event(2, pencil-order, 2020-03-05), timestamp='2020-03-04T16:00:00Z'",
-        "Event(3, paper-order, 2020-03-06), timestamp='2020-03-05T16:00:00Z'",
-        "Event(4, pencil-order, 2020-03-07), timestamp='2020-03-06T16:00:00Z'",
-        "Event(5, book-order, 2020-03-08), timestamp='2020-03-07T16:00:00Z'"
+        "Event(1, book-order, 2020-03-04 00:00:00+00:00), timestamp='2020-03-04T00:00:00Z'",
+        "Event(2, pencil-order, 2020-03-05 00:00:00+00:00), timestamp='2020-03-05T00:00:00Z'",
+        "Event(3, paper-order, 2020-03-06 00:00:00+00:00), timestamp='2020-03-06T00:00:00Z'",
+        "Event(4, pencil-order, 2020-03-07 00:00:00+00:00), timestamp='2020-03-07T00:00:00Z'",
+        "Event(5, book-order, 2020-03-08 00:00:00+00:00), timestamp='2020-03-08T00:00:00Z'"
     ]
 
     if all(line in output for line in answers):

--- a/learning/katas/python/Windowing/Fixed Time Window/Fixed Time Window/task-info.yaml
+++ b/learning/katas/python/Windowing/Fixed Time Window/Fixed Time Window/task-info.yaml
@@ -22,7 +22,7 @@ files:
 - name: task.py
   visible: true
   placeholders:
-  - offset: 2074
+  - offset: 2067
     length: 85
     placeholder_text: TODO()
 - name: tests.py

--- a/learning/katas/python/Windowing/Fixed Time Window/Fixed Time Window/task.py
+++ b/learning/katas/python/Windowing/Fixed Time Window/Fixed Time Window/task.py
@@ -15,6 +15,7 @@
 #   limitations under the License.
 
 from datetime import datetime
+import pytz
 
 import apache_beam as beam
 from apache_beam.transforms import window
@@ -25,16 +26,16 @@ from log_elements import LogElements
 p = beam.Pipeline()
 
 (p | beam.Create([
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-01T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-01T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-01T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-01T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-05T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-05T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-08T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-08T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-08T00:00:00+00:00').timestamp()),
-        window.TimestampedValue("event", datetime.fromisoformat('2020-03-10T00:00:00+00:00').timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 1, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 1, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 1, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 1, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 5, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 5, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 8, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 8, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 8, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
+        window.TimestampedValue("event", datetime(2020, 3, 10, 0, 0, 0, 0, tzinfo=pytz.UTC).timestamp()),
      ])
    | beam.WindowInto(window.FixedWindows(24*60*60))
    | beam.combiners.Count.PerElement()

--- a/learning/katas/python/requirements.txt
+++ b/learning/katas/python/requirements.txt
@@ -16,3 +16,5 @@
 
 apache-beam==2.19.0
 apache-beam[test]==2.19.0
+
+pytz~=2019.3


### PR DESCRIPTION
The two Python katas about windowing fail because the timestamps for the elements are calculated based on the local timezone, and my timezone does not match the timezone hardcoded in the tests, and because parsing from strings using `fromisoformat` was failing.

In the first Kata, the timestamp was calculated from time objects, and converted to a timestamp in the local timezone. Thus, the results of the test depended on the configuration of the local timezone in the running system.

The tests were hardcoded with a timezone different to mine, and thus I always failed to pass this Kata. The changes in this commit change the type in `Event` to be a `datetime`, the timestamps are set in UTC, and the output in the tests is hardcoded in UTC too. This should ensure that the kata works regardless the timezone configured in the system running the kata.

In the second Kata, the code was failing with the following error:

```AttributeError: type object 'datetime.datetime' has no attribute 'fromisoformat'```

I changed the timestamps to be set using the `datetime` constructor, rather than parsing from strings using `fromisoformat`.

Both katas now pass with the examples hardcoded in the corresponding tests.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
