### PR TITLE
[BEAM-9951] Using the builder pattern for Go synthetic config frontend

### DIFF
--- a/sdks/go/pkg/beam/io/synthetic/source_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/source_test.go
@@ -27,16 +27,14 @@ func TestSourceConfig_NumElements(t *testing.T) {
 		elms int
 		want int
 	}{
-		{elms: 0, want: 0},
-		{elms: -1, want: 0},
+		{elms: 1, want: 1},
 		{elms: 42, want: 42},
 	}
 	for _, test := range tests {
 		test := test
 		t.Run(fmt.Sprintf("(elm = %v)", test.elms), func(t *testing.T) {
 			dfn := sourceFn{}
-			cfg := DefaultSourceConfig()
-			cfg.NumElements = test.elms
+			cfg := DefaultSourceConfig().NumElements(test.elms).Build()
 
 			keys, _, err := simulateSourceFn(t, &dfn, cfg)
 			if err != nil {
@@ -62,15 +60,12 @@ func TestSourceConfig_InitialSplits(t *testing.T) {
 		}{
 			{elms: 42, splits: 10, want: 10},
 			{elms: 4, splits: 10, want: 4},
-			{elms: 42, splits: 0, want: 1},
 		}
 		for _, test := range tests {
 			test := test
 			t.Run(fmt.Sprintf("(elm = %v, splits = %v)", test.elms, test.splits), func(t *testing.T) {
 				dfn := sourceFn{}
-				cfg := DefaultSourceConfig()
-				cfg.NumElements = test.elms
-				cfg.InitialSplits = test.splits
+				cfg := DefaultSourceConfig().NumElements(test.elms).InitialSplits(test.splits).Build()
 
 				rest := dfn.CreateInitialRestriction(cfg)
 				splits := dfn.SplitRestriction(cfg, rest)
@@ -92,15 +87,12 @@ func TestSourceConfig_InitialSplits(t *testing.T) {
 		}{
 			{elms: 42, want: 42, splits: 10},
 			{elms: 4, want: 4, splits: 10},
-			{elms: -1, want: 0, splits: 10},
 		}
 		for _, test := range tests {
 			test := test
 			t.Run(fmt.Sprintf("(elm = %v)", test.elms), func(t *testing.T) {
 				dfn := sourceFn{}
-				cfg := DefaultSourceConfig()
-				cfg.NumElements = test.elms
-				cfg.InitialSplits = test.splits
+				cfg := DefaultSourceConfig().NumElements(test.elms).InitialSplits(test.splits).Build()
 
 				keys, _, err := simulateSourceFn(t, &dfn, cfg)
 				if err != nil {

--- a/sdks/go/pkg/beam/io/synthetic/step.go
+++ b/sdks/go/pkg/beam/io/synthetic/step.go
@@ -16,6 +16,7 @@
 package synthetic
 
 import (
+	"fmt"
 	"github.com/apache/beam/sdks/go/pkg/beam"
 	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
 	"math/rand"
@@ -30,13 +31,10 @@ import (
 // step, including whether that step is implemented as a splittable or
 // non-splittable DoFn.
 //
-// StepConfigs are recommended to be created via the DefaultStepConfig and
-// modified before being passed to this method. Example:
+// The recommended way to create StepConfigs is via the StepConfigBuilder.
+// Usage example:
 //
-//    cfg := synthetic.DefaultStepConfig()
-//    cfg.OutputPerInput = 1000
-//    cfg.Splittable = true
-//    cfg.InitialSplits = 2
+//    cfg := synthetic.DefaultStepConfig().OutputPerInput(10).FilterRatio(0.5).Build()
 //    step := synthetic.Step(s, cfg, input)
 func Step(s beam.Scope, cfg StepConfig, col beam.PCollection) beam.PCollection {
 	s = s.Scope("synthetic.Step")
@@ -66,11 +64,12 @@ func (fn *stepFn) Setup() {
 // outputs identical to that input based on the outputs per input configuration
 // in StepConfig.
 func (fn *stepFn) ProcessElement(key, val []byte, emit func([]byte, []byte)) {
-	if fn.cfg.FilterRatio > 0 && fn.rng.Float64() < fn.cfg.FilterRatio {
-		return
-	}
+	filtered := fn.cfg.FilterRatio > 0 && fn.rng.Float64() < fn.cfg.FilterRatio
+
 	for i := 0; i < fn.cfg.OutputPerInput; i++ {
-		emit(key, val)
+		if !filtered {
+			emit(key, val)
+		}
 	}
 }
 
@@ -144,49 +143,131 @@ func (fn *sdfStepFn) Setup() {
 // ProcessElement takes an input and either filters it or produces a number of
 // outputs identical to that input based on the restriction size.
 func (fn *sdfStepFn) ProcessElement(rt *offsetrange.Tracker, key, val []byte, emit func([]byte, []byte)) {
-	if fn.cfg.FilterRatio > 0 && fn.rng.Float64() < fn.cfg.FilterRatio {
-		return
-	}
+	filtered := fn.cfg.FilterRatio > 0 && fn.rng.Float64() < fn.cfg.FilterRatio
+
 	for i := rt.Rest.Start; rt.TryClaim(i) == true; i++ {
-		emit(key, val)
+		if !filtered {
+			emit(key, val)
+		}
 	}
 }
 
-// DefaultSourceConfig creates a SourceConfig with intended defaults for its
-// fields. SourceConfigs should be initialized with this method.
-func DefaultStepConfig() StepConfig {
-	return StepConfig{
-		OutputPerInput: 1,     // Defaults shouldn't drop elements, so at least 1.
-		FilterRatio:    0.0,   // Defaults shouldn't drop elements, so don't filter.
-		Splittable:     false, // Default to non-splittable, SDFs are situational.
-		InitialSplits:  1,     // Defaults to 1, i.e. no initial splitting.
+// StepConfigBuilder is used to initialize StepConfigs. See StepConfigBuilder's
+// methods for descriptions of the fields in a StepConfig and how they can be
+// set. The intended approach for using this builder is to begin by calling the
+// DefaultStepConfig function, followed by calling setters, followed by calling
+// Build.
+//
+// Usage example:
+//
+//    cfg := synthetic.DefaultStepConfig().OutputPerInput(10).FilterRatio(0.5).Build()
+type StepConfigBuilder struct {
+	cfg StepConfig
+}
+
+// DefaultSourceConfig creates a StepConfig with intended defaults for the
+// StepConfig fields. This function is the intended starting point for
+// initializing a StepConfig and should always be used to create
+// StepConfigBuilders.
+//
+// To see descriptions of the various StepConfig fields and their defaults, see
+// the methods to StepConfigBuilder.
+func DefaultStepConfig() *StepConfigBuilder {
+	return &StepConfigBuilder{
+		cfg: StepConfig{
+			OutputPerInput: 1,     // Defaults shouldn't drop elements, so at least 1.
+			FilterRatio:    0.0,   // Defaults shouldn't drop elements, so don't filter.
+			Splittable:     false, // Default to non-splittable, SDFs are situational.
+			InitialSplits:  1,     // Defaults to 1, i.e. no initial splitting.
+		},
 	}
+}
+
+// OutputPerInput is the number of outputs to emit per input received. Each
+// output is identical to the original input. A value of 0 drops all inputs and
+// produces no output.
+//
+// Valid values are in the range of [0, ...] and the default value is 1. Values
+// below 0 are invalid as they have no logical meaning for this field.
+func (b *StepConfigBuilder) OutputPerInput(val int) *StepConfigBuilder {
+	b.cfg.OutputPerInput = val
+	return b
+}
+
+// FilterRatio indicates the random chance that an input will be filtered
+// out, meaning that no outputs will get emitted for it. For example, a
+// FilterRatio of 0.25 means that 25% of inputs will be filtered out, a
+// FilterRatio of 0 means no elements are filtered, and a FilterRatio of 1.0
+// means every element is filtered.
+//
+// In a non-splittable step, this is performed on each input element, meaning
+// all outputs for that element would be filtered. In a splittable step, this is
+// performed on each input restriction instead of the entire element, meaning
+// that some outputs for an element may be filtered and others kept.
+//
+// Note that even when elements are filtered out, the work associated with
+// processing those elements is still performed, which differs from setting an
+// OutputPerInput of 0. Also note that if a
+//
+// Valid values are in the range if [0.0, 1.0], and the default value is 0. In
+// order to avoid precision errors, invalid values do not cause errors. Instead,
+// values below 0 are functionally equivalent to 0, and values above 1 are
+// functionally equivalent to 1.
+func (b *StepConfigBuilder) FilterRatio(val float64) *StepConfigBuilder {
+	b.cfg.FilterRatio = val
+	return b
+}
+
+// Splittable indicates whether the step should use the splittable DoFn or
+// non-splittable DoFn implementation.
+//
+// Splittable steps will split along restrictions representing the number of
+// OutputPerInput for each element, so it is most useful for steps with a high
+// OutputPerInput. Conversely, if OutputPerInput is 1, then there is no way to
+// split restrictions further, so making the step splittable will do nothing.
+func (b *StepConfigBuilder) Splittable(val bool) *StepConfigBuilder {
+	b.cfg.Splittable = val
+	return b
+}
+
+// InitialSplits is only applicable if Splittable is set to true, and determines
+// the number of initial splits to perform in the step's SplitRestriction
+// method. Restrictions in synthetic steps represent the number of elements to
+// emit for each input element, as defined by the OutputPerInput config field,
+// and this split is performed evenly across that number of elements.
+//
+// Each resulting restriction will have at least 1 element in it, and each
+// element being emitted will be contained in exactly one restriction. That
+// means that if the desired number of splits is greater than the OutputPerInput
+// N, then N initial restrictions will be created, each containing 1 element.
+//
+// Valid values are in the range of [1, ...] and the default value is 1. Values
+// of 0 (and below) are invalid as they would result in dropping elements that
+// are expected to be emitted.
+func (b *StepConfigBuilder) InitialSplits(val int) *StepConfigBuilder {
+	b.cfg.InitialSplits = val
+	return b
+}
+
+// Build constructs the StepConfig initialized by this builder. It also performs
+// error checking on the fields, and panics if any have been set to invalid
+// values.
+func (b *StepConfigBuilder) Build() StepConfig {
+	if b.cfg.InitialSplits <= 0 {
+		panic(fmt.Sprintf("StepConfig.InitialSplits must be >= 1. Got: %v", b.cfg.InitialSplits))
+	}
+	if b.cfg.OutputPerInput < 0 {
+		panic(fmt.Sprintf("StepConfig.OutputPerInput cannot be negative. Got: %v", b.cfg.OutputPerInput))
+	}
+	return b.cfg
 }
 
 // StepConfig is a struct containing all the configuration options for a
-// synthetic step.
+// synthetic step. It should be created via a StepConfigBuilder, not by directly
+// initializing it (the fields are public to allow encoding).
 type StepConfig struct {
-	// OutputPerInput is the number of outputs to emit per input received. Each
-	// output is identical to the original input. A value of 0 drops each input.
 	OutputPerInput int
-
-	// FilterRatio indicates the random chance that an input will be filtered
-	// out, meaning that no outputs will get emitted for it. For example, a
-	// FilterRatio of 0.25 means that 25% of inputs will get filtered out.
-	FilterRatio float64
-
-	// Splittable indicates whether the step should use the splittable DoFn or
-	// non-splittable DoFn implementation. Splittable steps will split the
-	// number of OutputPerInput into restrictions, so it is most useful for
-	// steps with a high OutputPerInput.
-	Splittable bool
-
-	// InitialSplits is only applicable if Splittable is set to true, and
-	// determines the number of initial splits to perform in the step's
-	// SplitRestriction method. Note that in some edge cases, the number of
-	// splits performed might differ from this config value. Each restriction
-	// will always have one element in it, and at least one restriction will
-	// always be output, so the number of splits will be in the range of [1, N]
-	// where N is the size of the original restriction.
-	InitialSplits int
+	FilterRatio    float64
+	Splittable     bool
+	InitialSplits  int
 }

--- a/sdks/go/pkg/beam/io/synthetic/step_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/step_test.go
@@ -27,14 +27,14 @@ func TestStepConfig_OutputPerInput(t *testing.T) {
 	tests := []struct {
 		outPer int
 	}{
+		{outPer: 0},
 		{outPer: 1},
 		{outPer: 10},
 	}
 	for _, test := range tests {
 		test := test
 		t.Run(fmt.Sprintf("(outPer = %v)", test.outPer), func(t *testing.T) {
-			cfg := DefaultStepConfig()
-			cfg.OutputPerInput = test.outPer
+			cfg := DefaultStepConfig().OutputPerInput(test.outPer).Build()
 
 			// Non-splittable StepFn.
 			dfn := stepFn{cfg: cfg}
@@ -51,7 +51,7 @@ func TestStepConfig_OutputPerInput(t *testing.T) {
 			}
 
 			// SDF StepFn.
-			cfg.Splittable = true
+			cfg = DefaultStepConfig().OutputPerInput(test.outPer).Splittable(true).Build()
 			sdf := sdfStepFn{cfg: cfg}
 			keys, _ = simulateSdfStepFn(t, &sdf)
 			if got := len(keys); got != test.outPer {
@@ -96,8 +96,7 @@ func TestStepConfig_FilterRatio(t *testing.T) {
 			elm := []byte{0, 0, 0, 0}
 
 			// Non-splittable StepFn.
-			cfg := DefaultStepConfig()
-			cfg.FilterRatio = test.ratio
+			cfg := DefaultStepConfig().FilterRatio(test.ratio).Build()
 			dfn := stepFn{cfg: cfg}
 			dfn.Setup()
 			dfn.rng = &fakeRand{f64: test.rand}
@@ -110,7 +109,7 @@ func TestStepConfig_FilterRatio(t *testing.T) {
 			}
 
 			// SDF StepFn.
-			cfg.Splittable = true
+			cfg = DefaultStepConfig().FilterRatio(test.ratio).Splittable(true).Build()
 			sdf := sdfStepFn{cfg: cfg}
 			keys = nil
 			rest := sdf.CreateInitialRestriction(elm, elm)
@@ -143,15 +142,16 @@ func TestStepConfig_InitialSplits(t *testing.T) {
 		}{
 			{outPer: 100, splits: 10, want: 10},
 			{outPer: 4, splits: 10, want: 4},
-			{outPer: 100, splits: 0, want: 1},
+			{outPer: 0, splits: 10, want: 0},
 		}
 		for _, test := range tests {
 			test := test
 			t.Run(fmt.Sprintf("(outPer = %v, splits = %v)", test.outPer, test.splits), func(t *testing.T) {
-				cfg := DefaultStepConfig()
-				cfg.OutputPerInput = test.outPer
-				cfg.Splittable = true
-				cfg.InitialSplits = test.splits
+				cfg := DefaultStepConfig().
+					OutputPerInput(test.outPer).
+					Splittable(true).
+					InitialSplits(test.splits).
+					Build()
 				elm := []byte{0, 0, 0, 0}
 
 				sdf := sdfStepFn{cfg: cfg}
@@ -175,15 +175,16 @@ func TestStepConfig_InitialSplits(t *testing.T) {
 		}{
 			{outPer: 100, want: 100, splits: 10},
 			{outPer: 4, want: 4, splits: 10},
-			{outPer: -1, want: 0, splits: 10},
+			{outPer: 0, want: 0, splits: 10},
 		}
 		for _, test := range tests {
 			test := test
 			t.Run(fmt.Sprintf("(outPer = %v)", test.outPer), func(t *testing.T) {
-				cfg := DefaultStepConfig()
-				cfg.OutputPerInput = test.outPer
-				cfg.Splittable = true
-				cfg.InitialSplits = test.splits
+				cfg := DefaultStepConfig().
+					OutputPerInput(test.outPer).
+					Splittable(true).
+					InitialSplits(test.splits).
+					Build()
 
 				sdf := sdfStepFn{cfg: cfg}
 				keys, _ := simulateSdfStepFn(t, &sdf)


### PR DESCRIPTION
Instead of just creating SourceConfigs and StepConfigs, have a builder
pattern to allow more user-friendly creation of those configs with
defaults.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
