### PR TITLE
[BEAM-9978] Adding functionality and tests to Go offset range tracker.

### DIFF
--- a/sdks/go/examples/stringsplit/stringsplit.go
+++ b/sdks/go/examples/stringsplit/stringsplit.go
@@ -71,19 +71,7 @@ func (fn *StringSplitFn) CreateInitialRestriction(s string) offsetrange.Restrict
 // SplitRestriction performs initial splits so that each restriction is split
 // into 5.
 func (fn *StringSplitFn) SplitRestriction(s string, rest offsetrange.Restriction) []offsetrange.Restriction {
-	size := rest.End - rest.Start
-	splitPts := []int64{
-		rest.Start,
-		rest.Start + (size / 5),
-		rest.Start + (size * 2 / 5),
-		rest.Start + (size * 3 / 5),
-		rest.Start + (size * 4 / 5),
-		rest.End,
-	}
-	var splits []offsetrange.Restriction
-	for i := 0; i < len(splitPts)-1; i++ {
-		splits = append(splits, offsetrange.Restriction{Start: splitPts[i], End: splitPts[i+1]})
-	}
+	splits := rest.EvenSplits(5)
 	log.Debugf(context.Background(), "StringSplit SplitRestrictions: %v -> %v", rest, splits)
 	return splits
 }
@@ -91,7 +79,7 @@ func (fn *StringSplitFn) SplitRestriction(s string, rest offsetrange.Restriction
 // RestrictionSize returns the size as the difference between the restriction's
 // start and end.
 func (fn *StringSplitFn) RestrictionSize(s string, rest offsetrange.Restriction) float64 {
-	size := float64(rest.End - rest.Start)
+	size := rest.Size()
 	log.Debugf(context.Background(), "StringSplit RestrictionSize: %v -> %v", rest, size)
 	return size
 }

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package offsetrange
+
+import (
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+// TestRestriction_EvenSplits tests various splits and checks that they all
+// follow the contract for EvenSplits. This means that all restrictions are
+// evenly split, that each restriction has at least one element, and that each
+// element is present in the split restrictions.
+func TestRestriction_EvenSplits(t *testing.T) {
+	tests := []struct {
+		rest Restriction
+		num  int64
+	}{
+		{rest: Restriction{Start: 0, End: 21}, num: 4},
+		{rest: Restriction{Start: 21, End: 42}, num: 4},
+		{rest: Restriction{Start: 0, End: 5}, num: 10},
+		{rest: Restriction{Start: 0, End: 21}, num: -1},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("(rest[%v, %v], splits = %v)",
+			test.rest.Start, test.rest.End, test.num), func(t *testing.T) {
+			r := test.rest
+
+			// Get the minimum size that a split restriction can be. Max size
+			// should be min + 1. This way we can check the size of each split.
+			num := test.num
+			if num <= 1 {
+				num = 1
+			}
+			min := (r.End - r.Start) / num
+
+			splits := r.EvenSplits(test.num)
+			prevEnd := r.Start
+			for _, split := range splits {
+				size := split.End - split.Start
+				// Check: Each restriction has at least 1 element.
+				if size == 0 {
+					t.Errorf("split restriction [%v, %v] is empty, size must be greater than 0.",
+						split.Start, split.End)
+				}
+				// Check: Restrictions are evenly split.
+				if size != min && size != min+1 {
+					t.Errorf("split restriction [%v, %v] has unexpected size. got: %v, want: %v or %v",
+						split.Start, split.End, size, min, min+1)
+				}
+				// Check: All elements are still in a split restrictions. This
+				// logic assumes that the splits are returned in order which
+				// isn't guaranteed by EvenSplits, but this check is way easier
+				// with the assumption.
+				if split.Start != prevEnd {
+					t.Errorf("restriction range [%v, %v] missing after splits.",
+						prevEnd, split.Start)
+				} else {
+					prevEnd = split.End
+				}
+			}
+			if prevEnd != r.End {
+				t.Errorf("restriction range [%v, %v] missing after splits.",
+					prevEnd, r.End)
+			}
+		})
+	}
+}
+
+// TestTracker_TryClaim validates both success and failure cases for TryClaim.
+func TestTracker_TryClaim(t *testing.T) {
+	// Test that TryClaim works as expected when called correctly.
+	t.Run("Correctness", func(t *testing.T) {
+		tests := []struct {
+			rest   Restriction
+			claims []int64
+		}{
+			{rest: Restriction{Start: 0, End: 3}, claims: []int64{0, 1, 2, 3}},
+			{rest: Restriction{Start: 10, End: 40}, claims: []int64{15, 20, 50}},
+			{rest: Restriction{Start: 0, End: 3}, claims: []int64{4}},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(fmt.Sprintf("(rest[%v, %v], claims = %v)",
+				test.rest.Start, test.rest.End, test.claims), func(t *testing.T) {
+				rt := NewTracker(test.rest)
+				for _, pos := range test.claims {
+					// If TryClaim returns false, check if there was an error.
+					if !rt.TryClaim(pos) && !rt.IsDone() {
+						t.Fatalf("tracker claiming %v failed, error: %v", pos, rt.GetError())
+					}
+				}
+			})
+		}
+	})
+
+	// Test that each invalid error case actually results in an error.
+	t.Run("Errors", func(t *testing.T) {
+		tests := []struct {
+			rest   Restriction
+			claims []int64
+		}{
+			// Claiming backwards.
+			{rest: Restriction{Start: 0, End: 3}, claims: []int64{0, 2, 1}},
+			// Claiming before start of restriction.
+			{rest: Restriction{Start: 10, End: 40}, claims: []int64{8}},
+			// Claiming after tracker signalled to stop.
+			{rest: Restriction{Start: 0, End: 3}, claims: []int64{4, 5}},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(fmt.Sprintf("(rest[%v, %v], claims = %v)",
+				test.rest.Start, test.rest.End, test.claims), func(t *testing.T) {
+				rt := NewTracker(test.rest)
+				for _, pos := range test.claims {
+					// Finish successfully if we got an error.
+					if !rt.TryClaim(pos) && !rt.IsDone() && rt.GetError() != nil {
+						return
+					}
+				}
+				t.Fatal("tracker did not fail on invalid claim")
+			})
+		}
+	})
+}
+
+// TestTracker_TrySplit tests that TrySplit follows its contract, meaning that
+// splits don't lose any elements, split fractions are clamped to 0 or 1, and
+// that TrySplit always splits at the nearest integer greater than the given
+// fraction.
+func TestTracker_TrySplit(t *testing.T) {
+	tests := []struct {
+		rest     Restriction
+		claimed  int64
+		fraction float64
+		// Index where we want the split to happen. This will be the end
+		// (exclusive) of the primary and first element of the residual.
+		splitPt int64
+	}{
+		{
+			rest:     Restriction{Start: 0, End: 1},
+			claimed:  0,
+			fraction: 0.5,
+			splitPt:  1,
+		},
+		{
+			rest:     Restriction{Start: 0, End: 5},
+			claimed:  0,
+			fraction: 0.5,
+			splitPt:  3,
+		},
+		{
+			rest:     Restriction{Start: 0, End: 10},
+			claimed:  5,
+			fraction: 0.5,
+			splitPt:  8,
+		},
+		{
+			rest:     Restriction{Start: 0, End: 10},
+			claimed:  5,
+			fraction: -0.5,
+			splitPt:  5,
+		},
+		{
+			rest:     Restriction{Start: 0, End: 10},
+			claimed:  5,
+			fraction: 1.5,
+			splitPt:  10,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("(split at %v of [%v, %v])",
+			test.fraction, test.claimed, test.rest.End), func(t *testing.T) {
+			rt := NewTracker(test.rest)
+			ok := rt.TryClaim(test.claimed)
+			if !ok {
+				t.Fatalf("tracker failed on initial claim: %v", test.claimed)
+			}
+			gotP, gotR, err := rt.TrySplit(test.fraction)
+			if err != nil {
+				t.Fatalf("tracker failed on split: %v", err)
+			}
+			var wantP interface{} = Restriction{Start: test.rest.Start, End: test.splitPt}
+			var wantR interface{} = Restriction{Start: test.splitPt, End: test.rest.End}
+			if test.splitPt == test.rest.End {
+				wantR = nil // When residuals are empty we should get nil.
+			}
+			if !cmp.Equal(gotP, wantP) {
+				t.Errorf("split got incorrect primary: got: %v, want: %v", gotP, wantP)
+			}
+			if !cmp.Equal(gotR, wantR) {
+				t.Errorf("split got incorrect residual: got: %v, want: %v", gotR, wantR)
+			}
+		})
+	}
+}

--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -24,10 +24,11 @@ package synthetic
 
 import (
 	"fmt"
-	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
 	"math/rand"
 	"time"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
 )
 
 // Source creates a synthetic source transform that emits randomly
@@ -95,35 +96,13 @@ func (fn *sourceFn) CreateInitialRestriction(config SourceConfig) offsetrange.Re
 // method will contain at least one element, so the number of splits will not
 // exceed the number of elements.
 func (fn *sourceFn) SplitRestriction(config SourceConfig, rest offsetrange.Restriction) (splits []offsetrange.Restriction) {
-	if config.InitialSplits <= 1 {
-		// Don't split, just return original restriction.
-		return append(splits, rest)
-	}
-
-	// TODO(BEAM-9978) Move this implementation of the offset range restriction
-	// splitting to the restriction itself, and add testing.
-	num := int64(config.InitialSplits)
-	offset := rest.Start
-	size := rest.End - rest.Start
-	for i := int64(0); i < num; i++ {
-		split := offsetrange.Restriction{
-			Start: offset + (i * size / num),
-			End:   offset + ((i + 1) * size / num),
-		}
-		// Skip restrictions that end up empty.
-		if split.End-split.Start <= 0 {
-			continue
-		}
-		splits = append(splits, split)
-	}
-	return splits
+	return rest.EvenSplits(int64(config.InitialSplits))
 }
 
 // RestrictionSize outputs the size of the restriction as the number of elements
 // that restriction will output.
 func (fn *sourceFn) RestrictionSize(config SourceConfig, rest offsetrange.Restriction) float64 {
-	// TODO(BEAM-9978) Move this size implementation to the offset range restriction itself.
-	return float64(rest.End - rest.Start)
+	return rest.Size()
 }
 
 // CreateTracker just creates an offset range restriction tracker for the


### PR DESCRIPTION
Pretty simple. Moves some commonly desired behaviors out of the SDF
code and into the offset range tracker/restriction code + adds tests.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
