### PR TITLE
[BEAM-9322] Remove passthrough_pcollection_output_ids and force_generated_pcollection_output_ids flags

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -675,30 +675,14 @@ class Pipeline(object):
           current.add_output(result, result._main_tag)
           continue
 
-        # TODO(BEAM-9322): Remove the experiment check and have this
-        # conditional be the default.
-        if self._options.view_as(DebugOptions).lookup_experiment(
-            'passthrough_pcollection_output_ids', default=False):
-          # Passthrough the PCollection output_ids from the PCollection tag.
-          # Only generate a tag if there are multiple PCollections that have a
-          # None tag. This happens when returning multiple PCollections from a
-          # composite.
-          if result.tag is None and None in current.outputs:
-            tag = len(current.outputs)
-          else:
-            tag = result.tag
-          current.add_output(result, tag)
-          continue
-
-        if self._options.view_as(DebugOptions).lookup_experiment(
-            'force_generated_pcollection_output_ids', default=False):
-          tag = len(current.outputs) if None in current.outputs else None
-        else:
-          base = tag
-          counter = 0
-          while tag in current.outputs:
-            counter += 1
-            tag = '%s_%d' % (base, counter)
+        # If there is already a tag with the same name, increase a counter for
+        # the name. This can happen, for example, when a composite outputs a
+        # list of PCollections where all the tags are None.
+        base = tag
+        counter = 0
+        while tag in current.outputs:
+          counter += 1
+          tag = '%s_%d' % (base, counter)
 
         current.add_output(result, tag)
 

--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache_test.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 import unittest
 
 from apache_beam import coders
-from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.portability.api.beam_interactive_api_pb2 import TestStreamFileHeader
 from apache_beam.portability.api.beam_interactive_api_pb2 import TestStreamFileRecord
@@ -269,8 +268,6 @@ class StreamingCacheTest(unittest.TestCase):
     cache = StreamingCache(cache_dir=None, sample_resolution_sec=1.0)
 
     options = StandardOptions(streaming=True)
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
     with TestPipeline(options=options) as p:
       records = (p | test_stream)[CACHED_RECORDS]
 
@@ -351,8 +348,6 @@ class StreamingCacheTest(unittest.TestCase):
     coder = SafeFastPrimitivesCoder()
 
     options = StandardOptions(streaming=True)
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
     with TestPipeline(options=options) as p:
       # pylint: disable=expression-not-assigned
       events = p | test_stream

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -30,7 +30,6 @@ import logging
 
 import apache_beam as beam
 from apache_beam import runners
-from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.pipeline import PipelineVisitor
 from apache_beam.runners.direct import direct_runner
 from apache_beam.runners.interactive import cache_manager as cache
@@ -138,10 +137,6 @@ class InteractiveRunner(runners.PipelineRunner):
 
   def apply(self, transform, pvalueish, options):
     # TODO(qinyeli, BEAM-646): Remove runner interception of apply.
-    # TODO(BEAM-9322): Once nested PCollection naming schemes have been ironed
-    # out, this can be removed.
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
     return self._underlying_runner.apply(transform, pvalueish, options)
 
   def run_pipeline(self, pipeline, options):

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -237,16 +237,6 @@ class TestStream(PTransform):
   Applying the PTransform will return a single PCollection if only the default
   output or only one output tag has been used. Otherwise a dictionary of output
   names to PCollections will be returned.
-
-  To use the multi-output functionality pelase use the
-  'passthrough_pcollection_output_ids' flag. See BEAM-9322 for more info.
-
-  To add flag::
-
-    from apache_beam.options.pipeline_options import DebugOptions
-    options = ...
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
   """
   def __init__(
       self,

--- a/sdks/python/apache_beam/testing/test_stream_test.py
+++ b/sdks/python/apache_beam/testing/test_stream_test.py
@@ -24,7 +24,6 @@ from __future__ import absolute_import
 import unittest
 
 import apache_beam as beam
-from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.portability import common_urns
@@ -164,8 +163,6 @@ class TestStreamTest(unittest.TestCase):
         yield (element, timestamp)
 
     options = StandardOptions(streaming=True)
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
     p = TestPipeline(options=options)
 
     main = p | test_stream
@@ -219,8 +216,6 @@ class TestStreamTest(unittest.TestCase):
                    .advance_watermark_to(30, tag='numbers')) # yapf: disable
 
     options = StandardOptions(streaming=True)
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
     p = TestPipeline(options=options)
 
     main = p | test_stream
@@ -492,8 +487,6 @@ class TestStreamTest(unittest.TestCase):
 
   def test_basic_execution_sideinputs(self):
     options = PipelineOptions()
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
     options.view_as(StandardOptions).streaming = True
     with TestPipeline(options=options) as p:
 
@@ -568,8 +561,6 @@ class TestStreamTest(unittest.TestCase):
 
   def test_basic_execution_sideinputs_fixed_windows(self):
     options = PipelineOptions()
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
     options.view_as(StandardOptions).streaming = True
     p = TestPipeline(options=options)
 
@@ -655,8 +646,6 @@ class TestStreamTest(unittest.TestCase):
                    .add_elements([4, 5, 6], tag='b')) # yapf: disable
 
     options = StandardOptions(streaming=True)
-    options.view_as(DebugOptions).add_experiment(
-        'passthrough_pcollection_output_ids')
 
     p = TestPipeline(options=options)
     p | test_stream

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -242,7 +242,7 @@ class _FinalizeMaterialization(_PValueishTransform):
       return self.visit_nested(node)
 
 
-def get_named_nested_pvalues(pvalueish, first_iteration=True):
+def get_named_nested_pvalues(pvalueish):
   if isinstance(pvalueish, tuple):
     # Check to see if it's a named tuple.
     fields = getattr(pvalueish, '_fields', None)
@@ -256,19 +256,11 @@ def get_named_nested_pvalues(pvalueish, first_iteration=True):
     tagged_values = pvalueish.items()
   else:
     if isinstance(pvalueish, (pvalue.PValue, pvalue.DoOutputsTuple)):
-      # For transforms that only have a tagged PCollection as an output,
-      # propagate that tag forward.
-      if first_iteration and isinstance(pvalueish, pvalue.PValue):
-        yield pvalueish.tag, pvalueish
-
-      # Otherwise, this PCollection is nested inside a larger structure, so
-      # return the subtag as None to get the tag from the parent structure.
-      else:
-        yield None, pvalueish
+      yield None, pvalueish
     return
 
   for tag, subvalue in tagged_values:
-    for subtag, subsubvalue in get_named_nested_pvalues(subvalue, False):
+    for subtag, subsubvalue in get_named_nested_pvalues(subvalue):
       if subtag is None:
         yield tag, subsubvalue
       else:

--- a/sdks/python/apache_beam/transforms/sideinputs_test.py
+++ b/sdks/python/apache_beam/transforms/sideinputs_test.py
@@ -348,10 +348,7 @@ class SideInputsTest(unittest.TestCase):
     # This flag is only necessary when using the multi-output TestStream b/c
     # it relies on using the PCollection output tags as the PCollection output
     # ids.
-    p = TestPipeline(
-        additional_pipeline_args=[
-            '--experiments=' + 'passthrough_pcollection_output_ids'
-        ])
+    p = TestPipeline()
 
     test_stream = (
         p


### PR DESCRIPTION
Change-Id: I8c2d660b175442d1917fe2b1ae166c0f4a1caaca

Safe to remove because the flag "passthrough_pcollection_output_ids" was only used by the InteractiveRunner and "force_generated_pcollection_output_ids" was already enabled by default.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
