### PR TITLE
[BEAM-10036] More flexible dataframes partitioning.

### DIFF
--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -88,9 +88,19 @@ class Expression(object):
     raise NotImplementedError(type(self))
 
   def requires_partition_by(self):  # type: () -> Partitioning
+    """Returns the partitioning, if any, require to evaluate this expression.
+
+    Returns partitioning.Nothing() to require no partitioning is required.
+    """
     raise NotImplementedError(type(self))
 
   def preserves_partition_by(self):  # type: () -> Partitioning
+    """Returns the partitioning, if any, preserved by this expression.
+
+    This gives an upper bound on the partitioning of its ouput.  The actual
+    partitioning of the output may be less strict (e.g. if the input was
+    less partitioned).
+    """
     raise NotImplementedError(type(self))
 
 

--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -22,6 +22,8 @@ from typing import Iterable
 from typing import Optional
 from typing import TypeVar
 
+from apache_beam.dataframe import partitionings
+
 
 class Session(object):
   """A session represents a mapping of expressions to concrete values.
@@ -85,16 +87,10 @@ class Expression(object):
     """Returns the result of self with the bindings given in session."""
     raise NotImplementedError(type(self))
 
-  def requires_partition_by_index(self):  # type: () -> bool
-    """Whether this expression requires its argument(s) to be partitioned
-    by index."""
-    # TODO: It might be necessary to support partitioning by part of the index,
-    # for some args, which would require returning more than a boolean here.
+  def requires_partition_by(self):  # type: () -> Partitioning
     raise NotImplementedError(type(self))
 
-  def preserves_partition_by_index(self):  # type: () -> bool
-    """Whether the result of this expression will be partitioned by index
-    whenever all of its inputs are partitioned by index."""
+  def preserves_partition_by(self):  # type: () -> Partitioning
     raise NotImplementedError(type(self))
 
 
@@ -123,11 +119,11 @@ class PlaceholderExpression(Expression):
   def evaluate_at(self, session):
     return session.lookup(self)
 
-  def requires_partition_by_index(self):
-    return False
+  def requires_partition_by(self):
+    return partitionings.Nothing()
 
-  def preserves_partition_by_index(self):
-    return False
+  def preserves_partition_by(self):
+    return partitionings.Nothing()
 
 
 class ConstantExpression(Expression):
@@ -159,11 +155,11 @@ class ConstantExpression(Expression):
   def evaluate_at(self, session):
     return self._value
 
-  def requires_partition_by_index(self):
-    return False
+  def requires_partition_by(self):
+    return partitionings.Nothing()
 
-  def preserves_partition_by_index(self):
-    return False
+  def preserves_partition_by(self):
+    return partitionings.Nothing()
 
 
 class ComputedExpression(Expression):
@@ -175,8 +171,9 @@ class ComputedExpression(Expression):
       args,  # type: Iterable[Expression]
       proxy=None,  # type: Optional[T]
       _id=None,  # type: Optional[str]
-      requires_partition_by_index=True,  # type: bool
-      preserves_partition_by_index=False,  # type: bool
+      requires_partition_by=partitionings.Index(),  # type: partition.Partitioning
+      preserves_partition_by=partitionings.Nothing(),  # type: partition.Partitioning
+
   ):
     """Initialize a computed expression.
 
@@ -203,8 +200,8 @@ class ComputedExpression(Expression):
     super(ComputedExpression, self).__init__(name, proxy, _id)
     self._func = func
     self._args = args
-    self._requires_partition_by_index = requires_partition_by_index
-    self._preserves_partition_by_index = preserves_partition_by_index
+    self._requires_partition_by = requires_partition_by
+    self._preserves_partition_by = preserves_partition_by
 
   def placeholders(self):
     return frozenset.union(
@@ -216,11 +213,11 @@ class ComputedExpression(Expression):
   def evaluate_at(self, session):
     return self._func(*(session.evaluate(arg) for arg in self._args))
 
-  def requires_partition_by_index(self):
-    return self._requires_partition_by_index
+  def requires_partition_by(self):
+    return self._requires_partition_by
 
-  def preserves_partition_by_index(self):
-    return self._preserves_partition_by_index
+  def preserves_partition_by(self):
+    return self._preserves_partition_by
 
 
 def elementwise_expression(name, func, args):
@@ -228,5 +225,5 @@ def elementwise_expression(name, func, args):
       name,
       func,
       args,
-      requires_partition_by_index=False,
-      preserves_partition_by_index=True)
+      requires_partition_by=partitionings.Nothing(),
+      preserves_partition_by=partitionings.Singleton())

--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -87,14 +87,14 @@ class Expression(object):
     """Returns the result of self with the bindings given in session."""
     raise NotImplementedError(type(self))
 
-  def requires_partition_by(self):  # type: () -> Partitioning
+  def requires_partition_by(self):  # type: () -> partitionings.Partitioning
     """Returns the partitioning, if any, require to evaluate this expression.
 
     Returns partitioning.Nothing() to require no partitioning is required.
     """
     raise NotImplementedError(type(self))
 
-  def preserves_partition_by(self):  # type: () -> Partitioning
+  def preserves_partition_by(self):  # type: () -> partitionings.Partitioning
     """Returns the partitioning, if any, preserved by this expression.
 
     This gives an upper bound on the partitioning of its ouput.  The actual
@@ -181,9 +181,8 @@ class ComputedExpression(Expression):
       args,  # type: Iterable[Expression]
       proxy=None,  # type: Optional[T]
       _id=None,  # type: Optional[str]
-      requires_partition_by=partitionings.Index(),  # type: partition.Partitioning
-      preserves_partition_by=partitionings.Nothing(),  # type: partition.Partitioning
-
+      requires_partition_by=partitionings.Index(),  # type: partitionings.Partitioning
+      preserves_partition_by=partitionings.Nothing(),  # type: partitionings.Partitioning
   ):
     """Initialize a computed expression.
 

--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -45,6 +45,10 @@ class DeferredFrame(object):
   def _elementwise(self, func, name=None, other_args=(), inplace=False):
     return _elementwise_function(func, name, inplace=inplace)(self, *other_args)
 
+  @property
+  def dtypes(self):
+    return self._expr.proxy().dtypes
+
 
 def name_and_func(method):
   if isinstance(method, str):

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -109,6 +109,19 @@ class DeferredDataFrame(frame_base.DeferredFrame):
   def loc(self):
     return _DeferredLoc(self)
 
+  def aggregate(self, func, axis=0, *args, **kwargs):
+    if axis != 0:
+      raise NotImplementedError()
+    return frame_base.DeferredFrame.wrap(
+        expressions.ComputedExpression(
+            'aggregate',
+            lambda df: df.agg(func, axis, *args, **kwargs),
+            [self._expr],
+            # TODO(robertwb): Sub-aggregate when possible.
+            requires_partition_by=partitionings.Singleton()))
+
+  agg = aggregate
+
 
 for meth in ('filter', ):
   setattr(DeferredDataFrame, meth, frame_base._elementwise_method(meth))

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -23,6 +23,7 @@ import pandas as pd
 
 from apache_beam.dataframe import expressions
 from apache_beam.dataframe import frame_base
+from apache_beam.dataframe import frames  # pylint: disable=unused-import
 
 
 class DeferredFrameTest(unittest.TestCase):

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -58,9 +58,12 @@ class Index(Partitioning):
   These form a partial order, given by
 
       Nothing() < Index([i]) < Index([i, j]) < ... < Index() < Singleton()
+
+  The ordering is implemented via the is_subpartitioning_of method, where the
+  examples on the right are subpartitionings of the examples on the left above.
   """
 
-  _INDEX_PARTITIONS = 100
+  _INDEX_PARTITIONS = 10
 
   def __init__(self, levels=None):
     self._levels = levels

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from typing import Any
+from typing import Iterable
+from typing import TypeVar
+
+import pandas as pd
+
+Frame = TypeVar('Frame', bound=pd.core.generic.NDFrame)
+
+
+class Partitioning(object):
+  """A class representing a (consistent) partitioning of dataframe objects.
+  """
+  def is_subpartition_of(self, other):
+    # type: (Partitioning) -> bool
+
+    """Returns whether self is a sub-partition of other.
+
+    Specifically, returns whether something partitioned by self is necissarily
+    also partitioned by other.
+    """
+    raise NotImplementedError
+
+  def partition_fn(self, df):
+    # type: (Frame) -> Iterable[Tuple[Any, Frame]]
+
+    """A callable that actually performs the partitioning of a Frame df.
+
+    This will be invoked via a FlatMap in conjunction with a GroupKey to
+    achieve the desired partitioning.
+    """
+    raise NotImplementedError
+
+
+class Index(Partitioning):
+  """A partitioning by index (either fully or partially).
+
+  If the set of "levels" of the index to consider is not specified, the entire
+  index is used.
+
+  These form a partial order, given by
+
+      Nothing() < Index([i]) < Index([i, j]) < ... < Index() < Singleton()
+  """
+
+  _INDEX_PARTITIONS = 100
+
+  def __init__(self, levels=None):
+    self._levels = levels
+
+  def __eq__(self, other):
+    return type(self) == type(other) and self._levels == other._levels
+
+  def __hash__(self):
+    if self._levels:
+      return hash(tuple(sorted(self._levels)))
+    else:
+      return hash(type(self))
+
+  def is_subpartition_of(self, other):
+    if isinstance(other, Nothing):
+      return True
+    elif isinstance(other, Index):
+      if self._levels is None:
+        return True
+      elif other._levels is None:
+        return False
+      else:
+        return all(level in other._levels for level in self._levels)
+    else:
+      return False
+
+  def partition_fn(self, df):
+    if self._levels is None:
+      levels = list(range(df.index.nlevels))
+    else:
+      levels = self._levels
+    hashes = sum(
+        pd.util.hash_array(df.index.get_level_values(level))
+        for level in levels)
+    for key in range(self._INDEX_PARTITIONS):
+      yield key, df[hashes % self._INDEX_PARTITIONS == key]
+
+
+class Singleton(Partitioning):
+  """A partitioning co-locating all data to a singleton partition.
+  """
+  def __eq__(self, other):
+    return type(self) == type(other)
+
+  def __hash__(self):
+    return hash(type(self))
+
+  def is_subpartition_of(self, other):
+    return True
+
+  def partition_fn(self, df):
+    yield None, df
+
+
+class Nothing(Partitioning):
+  """A partitioning imposing no constraints on the actual partitioning.
+  """
+  def __eq__(self, other):
+    return type(self) == type(other)
+
+  def __hash__(self):
+    return hash(type(self))
+
+  def is_subpartition_of(self, other):
+    return not other
+
+  def __bool__(self):
+    return False
+
+  __nonzero__ = __bool__

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -28,7 +28,7 @@ Frame = TypeVar('Frame', bound=pd.core.generic.NDFrame)
 class Partitioning(object):
   """A class representing a (consistent) partitioning of dataframe objects.
   """
-  def is_subpartition_of(self, other):
+  def is_subpartitioning_of(self, other):
     # type: (Partitioning) -> bool
 
     """Returns whether self is a sub-partition of other.
@@ -74,7 +74,7 @@ class Index(Partitioning):
     else:
       return hash(type(self))
 
-  def is_subpartition_of(self, other):
+  def is_subpartitioning_of(self, other):
     if isinstance(other, Nothing):
       return True
     elif isinstance(other, Index):
@@ -108,7 +108,7 @@ class Singleton(Partitioning):
   def __hash__(self):
     return hash(type(self))
 
-  def is_subpartition_of(self, other):
+  def is_subpartitioning_of(self, other):
     return True
 
   def partition_fn(self, df):
@@ -124,7 +124,7 @@ class Nothing(Partitioning):
   def __hash__(self):
     return hash(type(self))
 
-  def is_subpartition_of(self, other):
+  def is_subpartitioning_of(self, other):
     return not other
 
   def __bool__(self):

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -103,7 +103,7 @@ class Index(Partitioning):
 
 
 class Singleton(Partitioning):
-  """A partitioning co-locating all data to a singleton partition.
+  """A partitioning of all the data into a single partition.
   """
   def __eq__(self, other):
     return type(self) == type(other)
@@ -128,9 +128,4 @@ class Nothing(Partitioning):
     return hash(type(self))
 
   def is_subpartitioning_of(self, other):
-    return not other
-
-  def __bool__(self):
-    return False
-
-  __nonzero__ = __bool__
+    return isinstance(other, Nothing)

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 
 from typing import Any
 from typing import Iterable
+from typing import Tuple
 from typing import TypeVar
 
 import pandas as pd
@@ -71,6 +72,9 @@ class Index(Partitioning):
   def __eq__(self, other):
     return type(self) == type(other) and self._levels == other._levels
 
+  def __ne__(self, other):
+    return not self == other
+
   def __hash__(self):
     if self._levels:
       return hash(tuple(sorted(self._levels)))
@@ -108,6 +112,9 @@ class Singleton(Partitioning):
   def __eq__(self, other):
     return type(self) == type(other)
 
+  def __ne__(self, other):
+    return not self == other
+
   def __hash__(self):
     return hash(type(self))
 
@@ -123,6 +130,9 @@ class Nothing(Partitioning):
   """
   def __eq__(self, other):
     return type(self) == type(other)
+
+  def __ne__(self, other):
+    return not self == other
 
   def __hash__(self):
     return hash(type(self))

--- a/sdks/python/apache_beam/dataframe/partitionings_test.py
+++ b/sdks/python/apache_beam/dataframe/partitionings_test.py
@@ -1,0 +1,81 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import unittest
+
+import pandas as pd
+
+from apache_beam.dataframe.partitionings import Index
+from apache_beam.dataframe.partitionings import Nothing
+from apache_beam.dataframe.partitionings import Singleton
+
+
+class PartitioningsTest(unittest.TestCase):
+
+  multi_index_df = pd.DataFrame({
+      'shape': ['dodecahedron', 'icosahedron'] * 12,
+      'color': ['red', 'yellow', 'blue'] * 8,
+      'size': range(24),
+      'value': range(24)
+  }).set_index(['shape', 'color', 'size'])
+
+  def test_index_is_subpartition(self):
+    ordered_list = [Nothing(), Index([3]), Index([1, 3]), Index(), Singleton()]
+    for loose, strict in zip(ordered_list[:1], ordered_list[1:]):
+      self.assertTrue(strict.is_subpartition_of(loose), (strict, loose))
+      self.assertFalse(loose.is_subpartition_of(strict), (loose, strict))
+    # Incomparable.
+    self.assertFalse(Index([1, 2]).is_subpartition_of(Index([1, 3])))
+    self.assertFalse(Index([1, 3]).is_subpartition_of(Index([1, 2])))
+
+  def _check_partition(self, partitioning, min_non_empty, max_non_empty=None):
+    if max_non_empty is None:
+      max_non_empty = min_non_empty
+    parts = list(partitioning.partition_fn(self.multi_index_df))
+    self.assertEqual(Index._INDEX_PARTITIONS, len(parts))
+    self.assertGreaterEqual(len([p for _, p in parts if len(p)]), min_non_empty)
+    self.assertLessEqual(len([p for _, p in parts if len(p)]), max_non_empty)
+    self.assertEqual(
+        sorted(self.multi_index_df.value),
+        sorted(sum((list(p.value) for _, p in parts), [])))
+
+  def test_index_partition(self):
+    try:
+      # Reduce odds of collision.
+      old, Index._INDEX_PARTITIONS = Index._INDEX_PARTITIONS, 1000
+      self._check_partition(Index([0]), 2)
+      self._check_partition(Index([0, 1]), 6)
+      self._check_partition(Index([1]), 3)
+      self._check_partition(Index([2]), 7, 24)
+      self._check_partition(Index([0, 2]), 7, 24)
+      self._check_partition(Index(), 7, 24)
+    finally:
+      Index._INDEX_PARTITIONS = old
+
+  def test_nothing_subpartition(self):
+    self.assertTrue(Nothing().is_subpartition_of(Nothing()))
+    for p in [Index([1]), Index([1, 2]), Index(), Singleton()]:
+      self.assertFalse(Nothing().is_subpartition_of(p), p)
+
+  def test_singleton_subpartition(self):
+    for p in [Nothing(), Index([1]), Index([1, 2]), Index(), Singleton()]:
+      self.assertTrue(Singleton().is_subpartition_of(p), p)
+
+  def test_singleton_partition(self):
+    parts = list(Singleton().partition_fn(pd.Series(range(10))))
+    self.assertEqual(1, len(parts))

--- a/sdks/python/apache_beam/dataframe/partitionings_test.py
+++ b/sdks/python/apache_beam/dataframe/partitionings_test.py
@@ -26,6 +26,7 @@ from apache_beam.dataframe.partitionings import Singleton
 
 
 class PartitioningsTest(unittest.TestCase):
+  # pylint: disable=range-builtin-not-iterating
 
   multi_index_df = pd.DataFrame({
       'shape': ['dodecahedron', 'icosahedron'] * 12,
@@ -79,3 +80,7 @@ class PartitioningsTest(unittest.TestCase):
   def test_singleton_partition(self):
     parts = list(Singleton().partition_fn(pd.Series(range(10))))
     self.assertEqual(1, len(parts))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/dataframe/partitionings_test.py
+++ b/sdks/python/apache_beam/dataframe/partitionings_test.py
@@ -38,11 +38,11 @@ class PartitioningsTest(unittest.TestCase):
   def test_index_is_subpartition(self):
     ordered_list = [Nothing(), Index([3]), Index([1, 3]), Index(), Singleton()]
     for loose, strict in zip(ordered_list[:1], ordered_list[1:]):
-      self.assertTrue(strict.is_subpartition_of(loose), (strict, loose))
-      self.assertFalse(loose.is_subpartition_of(strict), (loose, strict))
+      self.assertTrue(strict.is_subpartitioning_of(loose), (strict, loose))
+      self.assertFalse(loose.is_subpartitioning_of(strict), (loose, strict))
     # Incomparable.
-    self.assertFalse(Index([1, 2]).is_subpartition_of(Index([1, 3])))
-    self.assertFalse(Index([1, 3]).is_subpartition_of(Index([1, 2])))
+    self.assertFalse(Index([1, 2]).is_subpartitioning_of(Index([1, 3])))
+    self.assertFalse(Index([1, 3]).is_subpartitioning_of(Index([1, 2])))
 
   def _check_partition(self, partitioning, min_non_empty, max_non_empty=None):
     if max_non_empty is None:
@@ -69,13 +69,13 @@ class PartitioningsTest(unittest.TestCase):
       Index._INDEX_PARTITIONS = old
 
   def test_nothing_subpartition(self):
-    self.assertTrue(Nothing().is_subpartition_of(Nothing()))
+    self.assertTrue(Nothing().is_subpartitioning_of(Nothing()))
     for p in [Index([1]), Index([1, 2]), Index(), Singleton()]:
-      self.assertFalse(Nothing().is_subpartition_of(p), p)
+      self.assertFalse(Nothing().is_subpartitioning_of(p), p)
 
   def test_singleton_subpartition(self):
     for p in [Nothing(), Index([1]), Index([1, 2]), Index(), Singleton()]:
-      self.assertTrue(Singleton().is_subpartition_of(p), p)
+      self.assertTrue(Singleton().is_subpartitioning_of(p), p)
 
   def test_singleton_partition(self):
     parts = list(Singleton().partition_fn(pd.Series(range(10))))

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -158,9 +158,9 @@ class _DataframeExpressionsTransform(transforms.PTransform):
         # Within a stage, the singleton partitioning is trivially preserved.
         return True
       elif expr in stage.inputs:
-        return stage.partitioning.is_subpartition_of(partitioning)
-      elif expr.preserves_partition_by().is_subpartition_of(partitioning):
-        if expr.requires_partition_by().is_subpartition_of(partitioning):
+        return stage.partitioning.is_subpartitioning_of(partitioning)
+      elif expr.preserves_partition_by().is_subpartitioning_of(partitioning):
+        if expr.requires_partition_by().is_subpartitioning_of(partitioning):
           return True
         else:
           return all(

--- a/sdks/python/apache_beam/dataframe/transforms_test.py
+++ b/sdks/python/apache_beam/dataframe/transforms_test.py
@@ -82,6 +82,11 @@ class TransformTest(unittest.TestCase):
     self.run_scenario(
         df, lambda df: df.set_index('Animal').filter(regex='F.*', axis='index'))
 
+  def test_aggregate(self):
+    a = pd.DataFrame({'col': [1, 2, 3]})
+    self.run_scenario(a, lambda a: a.agg(sum))
+    self.run_scenario(a, lambda a: a.agg(['mean', 'min', 'max']))
+
   def test_input_output_polymorphism(self):
     one_series = pd.Series([1])
     two_series = pd.Series([2])


### PR DESCRIPTION
Also adds (naive) dataframe.agg() that uses this.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
