### PR TITLE
[BEAM-10056] Fix validation for struct CoGBKs

### DIFF
--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -26,22 +26,26 @@ import (
 func TestNewDoFn(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		tests := []struct {
-			dfn  interface{}
-			main mainInputs
+			dfn interface{}
+			opt func(*config)
 		}{
-			{dfn: func(string) int { return 0 }, main: MainSingle},
-			{dfn: func(string, int) int { return 0 }, main: MainKv},
+			{dfn: func(string) int { return 0 }, opt: NumMainInputs(MainSingle)},
+			{dfn: func(string, int) int { return 0 }, opt: NumMainInputs(MainKv)},
 			{dfn: func(context.Context, typex.Window, typex.EventTime, reflect.Type, string, int, func(*int) bool, func() func(*int) bool, func(int)) (typex.EventTime, int, error) {
 				return 0, 0, nil
-			}, main: MainKv},
-			{dfn: &GoodDoFn{}, main: MainSingle},
-			{dfn: &GoodDoFnOmittedMethods{}, main: MainSingle},
-			{dfn: &GoodDoFnEmits{}, main: MainSingle},
-			{dfn: &GoodDoFnSideInputs{}, main: MainSingle},
-			{dfn: &GoodDoFnKv{}, main: MainKv},
-			{dfn: &GoodDoFnKvSideInputs{}, main: MainKv},
-			{dfn: &GoodDoFnAllExtras{}, main: MainKv},
-			{dfn: &GoodDoFnUnexportedExtraMethod{}, main: MainSingle},
+			}, opt: NumMainInputs(MainKv)},
+			{dfn: &GoodDoFn{}, opt: NumMainInputs(MainSingle)},
+			{dfn: &GoodDoFnOmittedMethods{}, opt: NumMainInputs(MainSingle)},
+			{dfn: &GoodDoFnEmits{}, opt: NumMainInputs(MainSingle)},
+			{dfn: &GoodDoFnSideInputs{}, opt: NumMainInputs(MainSingle)},
+			{dfn: &GoodDoFnKv{}, opt: NumMainInputs(MainKv)},
+			{dfn: &GoodDoFnKvSideInputs{}, opt: NumMainInputs(MainKv)},
+			{dfn: &GoodDoFnAllExtras{}, opt: NumMainInputs(MainKv)},
+			{dfn: &GoodDoFnUnexportedExtraMethod{}, opt: NumMainInputs(MainSingle)},
+			{dfn: &GoodDoFnCoGbk1{}, opt: NumMainInputs(MainKv)},
+			{dfn: &GoodDoFnCoGbk2{}, opt: CoGBKMainInput(3)},
+			{dfn: &GoodDoFnCoGbk7{}, opt: CoGBKMainInput(8)},
+			{dfn: &GoodDoFnCoGbk1wSide{}, opt: NumMainInputs(MainKv)},
 		}
 
 		for _, test := range tests {
@@ -50,8 +54,10 @@ func TestNewDoFn(t *testing.T) {
 				if _, err := NewDoFn(test.dfn); err != nil {
 					t.Fatalf("NewDoFn failed: %v", err)
 				}
-				if _, err := NewDoFn(test.dfn, NumMainInputs(test.main)); err != nil {
-					t.Fatalf("NewDoFn(NumMainInputs(%v)) failed: %v", test.main, err)
+				if _, err := NewDoFn(test.dfn, test.opt); err != nil {
+					cfg := defaultConfig()
+					test.opt(cfg)
+					t.Fatalf("NewDoFn(%#v) failed: %v", cfg, err)
 				}
 			})
 		}
@@ -72,10 +78,8 @@ func TestNewDoFn(t *testing.T) {
 			{dfn: &BadDoFnMismatchedEmitsStartBundle{}},
 			{dfn: &BadDoFnNoEmitsFinishBundle{}},
 			// Validate side inputs.
-			{dfn: &BadDoFnNoSideInputsStartBundle{}},
 			{dfn: &BadDoFnMissingSideInputsStartBundle{}},
 			{dfn: &BadDoFnMismatchedSideInputsStartBundle{}},
-			{dfn: &BadDoFnNoSideInputsFinishBundle{}},
 			// Validate setup/teardown.
 			{dfn: &BadDoFnParamsInSetup{}},
 			{dfn: &BadDoFnParamsInTeardown{}},
@@ -121,6 +125,11 @@ func TestNewDoFn(t *testing.T) {
 			}, main: MainKv},
 			{dfn: &BadDoFnAmbiguousMainInput{}, main: MainKv},
 			{dfn: &BadDoFnAmbiguousSideInput{}, main: MainSingle},
+			// These are ambiguous with CoGBKs, but should fail with known MainInputs.
+			{dfn: &BadDoFnNoSideInputsStartBundle{}, main: MainSingle},
+			{dfn: &BadDoFnNoSideInputsStartBundle{}, main: MainKv},
+			{dfn: &BadDoFnNoSideInputsFinishBundle{}, main: MainSingle},
+			{dfn: &BadDoFnNoSideInputsFinishBundle{}, main: MainKv},
 		}
 		for _, test := range tests {
 			t.Run(reflect.TypeOf(test.dfn).String(), func(t *testing.T) {
@@ -366,6 +375,54 @@ func (fn *GoodDoFnKvSideInputs) StartBundle(string, func(*int) bool, func() func
 }
 
 func (fn *GoodDoFnKvSideInputs) FinishBundle(string, func(*int) bool, func() func(*int) bool) {
+}
+
+type GoodDoFnCoGbk1 struct{}
+
+func (fn *GoodDoFnCoGbk1) ProcessElement(int, func(*string) bool) int {
+	return 0
+}
+
+func (fn *GoodDoFnCoGbk1) StartBundle() {
+}
+
+func (fn *GoodDoFnCoGbk1) FinishBundle() {
+}
+
+type GoodDoFnCoGbk2 struct{}
+
+func (fn *GoodDoFnCoGbk2) ProcessElement(int, func(*int) bool, func(*string) bool) int {
+	return 0
+}
+
+func (fn *GoodDoFnCoGbk2) StartBundle() {
+}
+
+func (fn *GoodDoFnCoGbk2) FinishBundle() {
+}
+
+type GoodDoFnCoGbk7 struct{}
+
+func (fn *GoodDoFnCoGbk7) ProcessElement(k int, v1, v2, v3, v4, v5, v6, v7 func(*int) bool) int {
+	return 0
+}
+
+func (fn *GoodDoFnCoGbk7) StartBundle() {
+}
+
+func (fn *GoodDoFnCoGbk7) FinishBundle() {
+}
+
+type GoodDoFnCoGbk1wSide struct{}
+
+func (fn *GoodDoFnCoGbk1wSide) ProcessElement(int, func(*string) bool, func(*int) bool) int {
+	return 0
+}
+
+func (fn *GoodDoFnCoGbk1wSide) StartBundle(func(*int) bool) {
+}
+
+func (fn *GoodDoFnCoGbk1wSide) FinishBundle(func(*int) bool) {
 }
 
 type GoodDoFnAllExtras struct{}


### PR DESCRIPTION
We were a bit too strict for CoGBKs with multiple value streams with Structural DoFns. This PR expands the validation to support precise validation at construction time, and relaxes the execution time validation.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
