### PR TITLE
[BEAM-10066] Add support for ValueProviders in RedisConnectionConfiguration

### DIFF
--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisConnectionConfiguration.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisConnectionConfiguration.java
@@ -22,7 +22,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import javax.annotation.Nullable;
-
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import redis.clients.jedis.Jedis;

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisConnectionConfiguration.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisConnectionConfiguration.java
@@ -22,6 +22,8 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import javax.annotation.Nullable;
+
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
@@ -33,54 +35,66 @@ import redis.clients.jedis.Protocol;
 @AutoValue
 public abstract class RedisConnectionConfiguration implements Serializable {
 
-  abstract String host();
+  abstract ValueProvider<String> host();
 
-  abstract int port();
+  abstract ValueProvider<Integer> port();
 
   @Nullable
-  abstract String auth();
+  abstract ValueProvider<String> auth();
 
-  abstract int timeout();
+  abstract ValueProvider<Integer> timeout();
 
-  abstract boolean ssl();
+  abstract ValueProvider<Boolean> ssl();
 
   abstract Builder builder();
 
   @AutoValue.Builder
   abstract static class Builder {
-    abstract Builder setHost(String host);
+    abstract Builder setHost(ValueProvider<String> host);
 
-    abstract Builder setPort(int port);
+    abstract Builder setPort(ValueProvider<Integer> port);
 
-    abstract Builder setAuth(String auth);
+    abstract Builder setAuth(ValueProvider<String> auth);
 
-    abstract Builder setTimeout(int timeout);
+    abstract Builder setTimeout(ValueProvider<Integer> timeout);
 
-    abstract Builder setSsl(boolean ssl);
+    abstract Builder setSsl(ValueProvider<Boolean> ssl);
 
     abstract RedisConnectionConfiguration build();
   }
 
   public static RedisConnectionConfiguration create() {
     return new AutoValue_RedisConnectionConfiguration.Builder()
-        .setHost(Protocol.DEFAULT_HOST)
-        .setPort(Protocol.DEFAULT_PORT)
-        .setTimeout(Protocol.DEFAULT_TIMEOUT)
-        .setSsl(false)
+        .setHost(ValueProvider.StaticValueProvider.of(Protocol.DEFAULT_HOST))
+        .setPort(ValueProvider.StaticValueProvider.of(Protocol.DEFAULT_PORT))
+        .setTimeout(ValueProvider.StaticValueProvider.of(Protocol.DEFAULT_TIMEOUT))
+        .setSsl(ValueProvider.StaticValueProvider.of(false))
         .build();
   }
 
   public static RedisConnectionConfiguration create(String host, int port) {
+    return create(
+        ValueProvider.StaticValueProvider.of(host), ValueProvider.StaticValueProvider.of(port));
+  }
+
+  public static RedisConnectionConfiguration create(
+      ValueProvider<String> host, ValueProvider<Integer> port) {
     return new AutoValue_RedisConnectionConfiguration.Builder()
         .setHost(host)
         .setPort(port)
-        .setTimeout(Protocol.DEFAULT_TIMEOUT)
-        .setSsl(false)
+        .setTimeout(ValueProvider.StaticValueProvider.of(Protocol.DEFAULT_TIMEOUT))
+        .setSsl(ValueProvider.StaticValueProvider.of(false))
         .build();
   }
 
   /** Define the host name of the Redis server. */
   public RedisConnectionConfiguration withHost(String host) {
+    checkArgument(host != null, "host can not be null");
+    return withHost(ValueProvider.StaticValueProvider.of(host));
+  }
+
+  /** See {@link RedisConnectionConfiguration#withHost(String)}. */
+  public RedisConnectionConfiguration withHost(ValueProvider<String> host) {
     checkArgument(host != null, "host can not be null");
     return builder().setHost(host).build();
   }
@@ -88,11 +102,23 @@ public abstract class RedisConnectionConfiguration implements Serializable {
   /** Define the port number of the Redis server. */
   public RedisConnectionConfiguration withPort(int port) {
     checkArgument(port > 0, "port can not be negative or 0");
+    return withPort(ValueProvider.StaticValueProvider.of(port));
+  }
+
+  /** See {@link RedisConnectionConfiguration#withPort(int)}. */
+  public RedisConnectionConfiguration withPort(ValueProvider<Integer> port) {
+    checkArgument(port != null, "port can not be null");
     return builder().setPort(port).build();
   }
 
   /** Define the password to authenticate on the Redis server. */
   public RedisConnectionConfiguration withAuth(String auth) {
+    checkArgument(auth != null, "auth can not be null");
+    return withAuth(ValueProvider.StaticValueProvider.of(auth));
+  }
+
+  /** See {@link RedisConnectionConfiguration#withAuth(String)}. */
+  public RedisConnectionConfiguration withAuth(ValueProvider<String> auth) {
     checkArgument(auth != null, "auth can not be null");
     return builder().setAuth(auth).build();
   }
@@ -102,19 +128,30 @@ public abstract class RedisConnectionConfiguration implements Serializable {
    */
   public RedisConnectionConfiguration withTimeout(int timeout) {
     checkArgument(timeout >= 0, "timeout can not be negative");
+    return withTimeout(ValueProvider.StaticValueProvider.of(timeout));
+  }
+
+  /** See {@link RedisConnectionConfiguration#withTimeout(int)}. */
+  public RedisConnectionConfiguration withTimeout(ValueProvider<Integer> timeout) {
+    checkArgument(timeout != null, "timeout can not be null");
     return builder().setTimeout(timeout).build();
   }
 
   /** Enable SSL connection to Redis server. */
   public RedisConnectionConfiguration enableSSL() {
-    return builder().setSsl(true).build();
+    return withSSL(ValueProvider.StaticValueProvider.of(true));
+  }
+
+  /** Define if a SSL connection to Redis server should be used. */
+  public RedisConnectionConfiguration withSSL(ValueProvider<Boolean> ssl) {
+    return builder().setSsl(ssl).build();
   }
 
   /** Connect to the Redis instance. */
   public Jedis connect() {
-    Jedis jedis = new Jedis(host(), port(), timeout(), ssl());
+    Jedis jedis = new Jedis(host().get(), port().get(), timeout().get(), ssl().get());
     if (auth() != null) {
-      jedis.auth(auth());
+      jedis.auth(auth().get());
     }
     return jedis;
   }


### PR DESCRIPTION
This pull request adds support for `ValueProvider` in RedisConnectionConfiguration.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
